### PR TITLE
Color and bitmap convert fix for 15 bpp

### DIFF
--- a/freerdp/xrdp-color.c
+++ b/freerdp/xrdp-color.c
@@ -186,6 +186,10 @@ convert_bitmap(int in_bpp, int out_bpp, char* bmpdata,
   if ((in_bpp == 32) && (out_bpp == 32))
   {
     return bmpdata;
+  }    
+  if ((in_bpp == 15) && (out_bpp == 15))
+  {
+    return bmpdata;
   }
   g_writeln("convert_bitmap: error unknown conversion from %d to %d",
             in_bpp, out_bpp);
@@ -262,6 +266,10 @@ convert_color(int in_bpp, int out_bpp, int in_color, int* palette)
     return in_color;
   }
   if ((in_bpp == 32) && (out_bpp == 32))
+  {
+    return in_color;
+  }  
+  if ((in_bpp == 15) && (out_bpp == 15))
   {
     return in_color;
   }


### PR DESCRIPTION
When I use XRDP as a gateway together with FreeRDP when both the client and server run Windows 7 I get converting errors. This fix solves these problems.
