### PR TITLE
Add missing freerdp1 library to xrdp (libxrdp) build

### DIFF
--- a/libxrdp/Makefile.am
+++ b/libxrdp/Makefile.am
@@ -13,7 +13,7 @@ endif
 
 if XRDP_FREERDP1
 EXTRA_DEFINES += -DXRDP_FREERDP1
-EXTRA_LIBS += -lfreerdp-codec
+EXTRA_LIBS += -lfreerdp-codec -lfreerdp-utils
 endif
 
 if XRDP_JPEG


### PR DESCRIPTION
There is a missing freerdp1 library required to link libxrdp. This change adds freerdp-utils to makefile.am
