### PR TITLE
added connect error messages for freerdp1

### DIFF
--- a/freerdp1/xrdp-freerdp.c
+++ b/freerdp1/xrdp-freerdp.c
@@ -69,7 +69,61 @@ lxrdp_connect(struct mod* mod)
 
   if (!ok)
   {
-    return 1;
+      LLOGLN(0, ("Failure to connect"));
+      if(connectErrorCode){
+          char buf[128];
+          if(connectErrorCode<ERRORSTART){
+              if(strerror_r(connectErrorCode,buf,128)!=0){                
+                  snprintf(buf,128,"Errorcode from connect : %d",connectErrorCode);     
+              }
+          }else{
+              switch(connectErrorCode){
+                  case PREECONNECTERROR:{
+                      snprintf(buf,128,"The error code from connect is PREECONNECTERROR");
+                      break ;
+                  }
+                  case UNDEFINEDCONNECTERROR:{
+                      snprintf(buf,128,"The error code from connect is UNDEFINEDCONNECTERROR");
+                      break ;
+                  }
+                  case POSTCONNECTERROR:{
+                      snprintf(buf,128,"The error code from connect is POSTCONNECTERROR");
+                      break ;
+                  }
+                  case DNSERROR:{
+                      snprintf(buf,128,"The DNS system generated an error");
+                      break ;
+                  }
+                  case DNSNAMENOTFOUND:{
+                      snprintf(buf,128,"The DNS system could not find the specified name");
+                      break ;
+                  }
+                  case CONNECTERROR:{
+                      snprintf(buf,128,"A general connect error was returned");
+                      break ;
+                  }
+                  case MCSCONNECTINITIALERROR:{
+                      snprintf(buf,128,"The error code from connect is MCSCONNECTINITIALERROR");
+                      break ;
+                  }
+                  case TLSCONNECTERROR:{
+                      snprintf(buf,128,"Error in TLS handshake");
+                      break ;
+                  }
+                  case AUTHENTICATIONERROR:{
+                      snprintf(buf,128,"Authentication error check your password and username");
+                      break ;
+                  }
+                  
+                  default:{
+                      snprintf(buf,128,"Unhandled Errorcode from connect : %d",connectErrorCode); 
+                      break ;
+                  }
+              }                    
+          }
+          mod->server_msg(mod,buf,0);
+      }
+      return 1;
   }
   return 0;
 }


### PR DESCRIPTION
Support for this patch is now added in Freerdp. This patch gives the user error messages during establishment of new freerdp1 sessions.
