### PR TITLE
Support for invalidate request sent from clients added

### DIFF
--- a/freerdp1/xrdp-freerdp.c
+++ b/freerdp1/xrdp-freerdp.c
@@ -214,9 +214,48 @@ lxrdp_event(struct mod* mod, int msg, long param1, long param2,
     case 110:
       break;
     case 200:
-      /* Currently there are no (?) invalidate API in freeRDP that can receive this request*/	
-      LLOGLN(0, ("Invalidate request sent from client - Ignored"));	
-      break ;
+      LLOGLN(10, ("Invalidate request sent from client"));
+      RECTANGLE_16 *rectangle = (RECTANGLE_16 *) g_malloc(sizeof(RECTANGLE_16), 0);
+      /* The parameters are coded as follows param1 = MAKELONG(y, x), param2 =MAKELONG(h, w)
+       * #define MAKELONG(lo, hi) ((((hi) & 0xffff) << 16) | ((lo) & 0xffff))
+       */
+      rectangle->left = (param1 >> 16) & 0xffff;
+      rectangle->top = param1 & 0xffff;
+      rectangle->right = (param2 >> 16) & 0xffff + rectangle->left - 1;
+      rectangle->bottom = param2 & 0xffff + rectangle->top - 1;
+      if (mod->inst->settings->refresh_rect)
+      {
+        if (mod->inst->update != NULL)
+        {
+          if (mod->inst->update->RefreshRect != NULL)
+          {
+            if (mod->inst->context != NULL)
+            {
+              LLOGLN(0, ("update rectangle left: %d top: %d bottom: %d right: %d",
+                rectangle->left, rectangle->top, rectangle->bottom, rectangle->right));
+              mod->inst->update->RefreshRect(mod->inst->context, 1, rectangle); 
+            }
+            else
+            {
+              LLOGLN(0, ("Invalidate request -The context is null"));
+            }
+          }
+          else
+          {
+            LLOGLN(0, ("Invalidate request - RefreshRect is Null"));
+          }
+        }
+        else
+        {
+          LLOGLN(0, ("Invalidate request -the update pointer is null"));
+        }
+      }
+      else
+      {
+        LLOGLN(0, ("Invalidate request - warning - update rectangle is disabled"));
+      }
+      g_free(rectangle);
+      break;
     case 0x5555:
       chanid = LOWORD(param1);
       flags = HIWORD(param1);

--- a/sesman/tools/sesadmin.c
+++ b/sesman/tools/sesadmin.c
@@ -142,7 +142,7 @@ int main(int argc, char** argv)
   g_tcp_close(sock);
   scp_session_destroy(s);
   scp_connection_destroy(c);
-  log_end(&logging);
+  log_end();
 
   return 0;
 }


### PR DESCRIPTION
Without this fix, for the freerdp1 module, clients can get a blank screen if they first minimize the window and than show the window again.
