### PR TITLE
Bug/xrdp orders text 2

### DIFF
--- a/libxrdp/xrdp_orders.c
+++ b/libxrdp/xrdp_orders.c
@@ -205,10 +205,21 @@ xrdp_orders_check(struct xrdp_orders *self, int max_size)
     }
 
     size = (int)(self->out_s->p - self->order_count_ptr);
-
-    if ((size < 0) || (size > max_packet_size))
+    if (size < 0)
     {
+        g_writeln("error in xrdp_orders_check, size too small, its %d", size);
         return 1;
+    }
+    if (size > max_packet_size)
+    {
+        // this suggests someone calls this function without passing the correct
+        // max_size so we end up putting more into the buffer than we indicate we can
+        g_writeln("error in xrdp_orders_check, size too big, its %d", size);
+        // We where getting called with size allready greater than max_packet_size
+        // Which I suspect was because the sending of text did not include the text len
+        // to check the buffer size. So attempt to send the data anyway.
+        // Lets write the data anyway, somewhere else may barf.
+        //    return 1;
     }
 
     if ((size + max_size + 100) > max_packet_size)
@@ -1591,7 +1602,8 @@ xrdp_orders_text(struct xrdp_orders *self,
     char *present_ptr = (char *)NULL;
     char *order_flags_ptr = (char *)NULL;
 
-    xrdp_orders_check(self, 100);
+    //xrdp_orders_check(self, 100);
+    xrdp_orders_check(self, 44+data_len);
     self->order_count++;
     order_flags = RDP_ORDER_STANDARD;
 


### PR DESCRIPTION
This fixes a couple of issues that resulted in heap corruption and protocol errors when sending text. The issues whoes up when opening a large text file in notepad and jumping back and forth in the file. I suspect that a small font and large screen exacerbates the issue as you can end up with 8-16K characters on the screen,

i) it takes into account the text length when checking for buffer room.
ii) If the length is greate than buffer_size in check send it still attempts to do the send. This later results in the buffer content keeping growing.

Lawrence.
