### PR TITLE
Update allowed channel lists from entries in the connection entry prefix...

### DIFF
--- a/xrdp/xrdp.ini
+++ b/xrdp/xrdp.ini
@@ -102,3 +102,10 @@ port=ask3389
 username=ask
 password=ask
 
+channel.rdpdr=true
+channel.rdpsnd=true
+channel.drdynvc=true
+channel.cliprdr=true
+channel.rail=true
+channel.xrdpvr=true
+


### PR DESCRIPTION
Update allowed channel lists from entries in the connection entry prefixed channel. Allows different settings for each preset connection.

This looks in the connection section for entries named channel.<channel name> and these can override the global settings in the [channel] section of the configuration file.

Renamed is_name_in_lists -> is_channel_enabled
Factored out find_name_in_lists
Added update_allowed_channel_names 
