### PR TITLE
The RGB ordering in uncompressed bitmaps reversed

### DIFF
--- a/libxrdp/xrdp_orders.c
+++ b/libxrdp/xrdp_orders.c
@@ -1872,9 +1872,9 @@ xrdp_orders_send_raw_bitmap(struct xrdp_orders *self,
             if (Bpp == 3)
             {
                 pixel = GETPIXEL32(data, j, i, width);
-                out_uint8(self->out_s, pixel >> 16);
-                out_uint8(self->out_s, pixel >> 8);
                 out_uint8(self->out_s, pixel);
+                out_uint8(self->out_s, pixel >> 8);
+                out_uint8(self->out_s, pixel >> 16);
             }
             else if (Bpp == 2)
             {
@@ -2093,9 +2093,9 @@ xrdp_orders_send_raw_bitmap2(struct xrdp_orders *self,
             if (Bpp == 3)
             {
                 pixel = GETPIXEL32(data, j, i, width);
-                out_uint8(self->out_s, pixel >> 16);
-                out_uint8(self->out_s, pixel >> 8);
                 out_uint8(self->out_s, pixel);
+                out_uint8(self->out_s, pixel >> 8);
+                out_uint8(self->out_s, pixel >> 16);
             }
             else if (Bpp == 2)
             {


### PR DESCRIPTION
According to the specs the first 8 bits (0-7) contain red, and the current shift pattern switches red and blue. See ms-rdpbcgr p192 on bit ordering. To test, set the compress bitmap flag in xrdp.ini to no, login and see on the intro screen the R and B colors switched in the xrdp logo in the right lower corner (normally red X, blue D). After the patch this is correct. Also logging in and using X11rdp you see the correct colors now on the bitmaps.
