### PR TITLE
Fix mouse pointer sprites

### DIFF
--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -87,6 +87,7 @@ struct xrdp_client_info
   char jpeg_prop[64];
   int v3_codec_id;
   int use_bulk_comp;
+  int fix_mouse_pointer_sprites;
 };
 
 #endif

--- a/libxrdp/xrdp_orders.c
+++ b/libxrdp/xrdp_orders.c
@@ -1872,9 +1872,9 @@ xrdp_orders_send_raw_bitmap(struct xrdp_orders *self,
             if (Bpp == 3)
             {
                 pixel = GETPIXEL32(data, j, i, width);
-                out_uint8(self->out_s, pixel >> 16);
-                out_uint8(self->out_s, pixel >> 8);
                 out_uint8(self->out_s, pixel);
+                out_uint8(self->out_s, pixel >> 8);
+                out_uint8(self->out_s, pixel >> 16);
             }
             else if (Bpp == 2)
             {
@@ -2093,9 +2093,9 @@ xrdp_orders_send_raw_bitmap2(struct xrdp_orders *self,
             if (Bpp == 3)
             {
                 pixel = GETPIXEL32(data, j, i, width);
-                out_uint8(self->out_s, pixel >> 16);
-                out_uint8(self->out_s, pixel >> 8);
                 out_uint8(self->out_s, pixel);
+                out_uint8(self->out_s, pixel >> 8);
+                out_uint8(self->out_s, pixel >> 16);
             }
             else if (Bpp == 2)
             {

--- a/libxrdp/xrdp_orders.c
+++ b/libxrdp/xrdp_orders.c
@@ -1872,9 +1872,9 @@ xrdp_orders_send_raw_bitmap(struct xrdp_orders *self,
             if (Bpp == 3)
             {
                 pixel = GETPIXEL32(data, j, i, width);
-                out_uint8(self->out_s, pixel);
-                out_uint8(self->out_s, pixel >> 8);
                 out_uint8(self->out_s, pixel >> 16);
+                out_uint8(self->out_s, pixel >> 8);
+                out_uint8(self->out_s, pixel);
             }
             else if (Bpp == 2)
             {
@@ -2093,9 +2093,9 @@ xrdp_orders_send_raw_bitmap2(struct xrdp_orders *self,
             if (Bpp == 3)
             {
                 pixel = GETPIXEL32(data, j, i, width);
-                out_uint8(self->out_s, pixel);
-                out_uint8(self->out_s, pixel >> 8);
                 out_uint8(self->out_s, pixel >> 16);
+                out_uint8(self->out_s, pixel >> 8);
+                out_uint8(self->out_s, pixel);
             }
             else if (Bpp == 2)
             {

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -98,6 +98,10 @@ xrdp_rdp_read_config(struct xrdp_client_info *client_info)
         {
             client_info->use_bulk_comp = text2bool(value);
         }
+        else if (g_strcasecmp(item, "fix_mouse_pointer_sprites") == 0)
+        {
+            client_info->fix_mouse_pointer_sprites = text2bool(value);
+        }
         else if (g_strcasecmp(item, "crypt_level") == 0)
         {
             if (g_strcasecmp(value, "low") == 0)

--- a/xorg/X11R7.6/rdp/cursors.h
+++ b/xorg/X11R7.6/rdp/cursors.h
@@ -1,0 +1,1057 @@
+
+#ifndef _CURSORS_H
+#define _CURSORS_H
+
+#define CACHED_MP_DATA(d, m) *data = d; *mask = m; break;
+
+char data_2382[32 * (32 * 3)];
+char mask_2382[32 * (32 / 8)];
+const char *shape_2382 = \
+"                        " \
+"                        " \
+"      B                 " \
+"      BB                " \
+"      BFB               " \
+"      BFFB              " \
+"      BFFFB             " \
+"      BFFFFB            " \
+"      BFFFFFB           " \
+"      BFFFFFFB          " \
+"      BFFFFFFFB         " \
+"      BFFFFFFFFB        " \
+"      BFFFFFFFFFB       " \
+"      BFFFFFFFFFFB      " \
+"      BFFFFFFBBBBBB     " \
+"      BFFFBFFB          " \
+"      BFFBBFFB          " \
+"      BFFB BFFB         " \
+"      BFB  BFFB         " \
+"      BB    BFFB        " \
+"      B     BBBB        " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_1103[32 * (32 * 3)];
+char mask_1103[32 * (32 / 8)];
+const char *shape_1103 = \
+"                        " \
+"                        " \
+"                        " \
+"                        " \
+"         BBBBBBB        " \
+"         BFFFFFB        " \
+"         BBBFBBB        " \
+"           BFB          " \
+"           BFB          " \
+"           BFB          " \
+"           BFB          " \
+"           BFB          " \
+"           BFB          " \
+"           BFB          " \
+"           BFB          " \
+"           BFB          " \
+"           BFB          " \
+"         BBBFBBB        " \
+"         BFFFFFB        " \
+"         BBBBBBB        " \
+"                        " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_3307[32 * (32 * 3)];
+char mask_3307[32 * (32 / 8)];
+const char *shape_3307 = \
+"                        " \
+"                        " \
+"                        " \
+"   BBBBBBBBBBBBBBBBB    " \
+"   BFFFFFFFFFFFFFFFB    " \
+"   BFFFFFFFFFFFFFFFB    " \
+"   BFFBBBBBBBBBBBBBB    " \
+"   BFFB                 " \
+"   BFFB BBBBBBBBBBB     " \
+"   BFFB BFFFFFFFFB      " \
+"   BFFB BFFFFFFFB       " \
+"   BFFB BFFFFFFB        " \
+"   BFFB BFFFFFB         " \
+"   BFFB BFFFFFFB        " \
+"   BFFB BFFFBFFFB       " \
+"   BFFB BFFB BFFFB      " \
+"   BFFB BFB   BFFFB     " \
+"   BFFB BB     BFFFB    " \
+"   BBBB B       BFB     " \
+"                 B      " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_2926[32 * (32 * 3)];
+char mask_2926[32 * (32 / 8)];
+const char *shape_2926 = \
+"                        " \
+"                        " \
+"                        " \
+"     BBBBBBBBBBBBBBB    " \
+"    BFFFFFFFFFFFFFFFB   " \
+"    BFFFFFFFFFFFFFFFB   " \
+"    BBBBBBBBBBBBBBBBB   " \
+"          BFFFB         " \
+"         BFFFFFB        " \
+"        BFFFFFFFB       " \
+"       BFFFFFFFFFB      " \
+"      BFFFFFFFFFFFB     " \
+"     BBBBBBFFFBBBBBB    " \
+"          BFFFB         " \
+"          BFFFB         " \
+"          BFFFB         " \
+"          BFFFB         " \
+"          BFFFB         " \
+"          BFFFB         " \
+"          BFFFB         " \
+"          BBBBB         " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_3153[32 * (32 * 3)];
+char mask_3153[32 * (32 / 8)];
+const char *shape_3153 = \
+"                        " \
+"                        " \
+"                        " \
+"   BBBBBBBBBBBBBBBBB    " \
+"   BFFFFFFFFFFFFFFFB    " \
+"   BFFFFFFFFFFFFFFFB    " \
+"   BBBBBBBBBBBBBBFFB    " \
+"                BFFB    " \
+"    BBBBBBBBBBB BFFB    " \
+"     BFFFFFFFFB BFFB    " \
+"      BFFFFFFFB BFFB    " \
+"       BFFFFFFB BFFB    " \
+"        BFFFFFB BFFB    " \
+"       BFFFFFFB BFFB    " \
+"      BFFFBFFFB BFFB    " \
+"     BFFFB BFFB BFFB    " \
+"    BFFFB   BFB BFFB    " \
+"   BFFFB     BB BFFB    " \
+"    BFB       B BBBB    " \
+"     B                  " \
+"                        " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_3373[32 * (32 * 3)];
+char mask_3373[32 * (32 / 8)];
+const char *shape_3373 = \
+"                        " \
+"                        " \
+"                        " \
+"                        " \
+"    BBBB                " \
+"    BFFB     B          " \
+"    BFFB    BB          " \
+"    BFFB   BFB          " \
+"    BFFB  BFFB          " \
+"    BFFB BFFFB          " \
+"    BFFBBFFFFBBBBBBBB   " \
+"    BFFBFFFFFFFFFFFFFB  " \
+"    BFFFFFFFFFFFFFFFFB  " \
+"    BFFBFFFFFFFFFFFFFB  " \
+"    BFFBBFFFFBBBBBBBB   " \
+"    BFFB BFFFB          " \
+"    BFFB  BFFB          " \
+"    BFFB   BFB          " \
+"    BFFB    BB          " \
+"    BFFB     B          " \
+"    BBBB                " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_3794[32 * (32 * 3)];
+char mask_3794[32 * (32 / 8)];
+const char *shape_3794 = \
+"                        " \
+"                        " \
+"                        " \
+"                        " \
+"                  B     " \
+"    BBBB B       BFB    " \
+"    BFFB BB     BFFFB   " \
+"    BFFB BFB   BFFFB    " \
+"    BFFB BFFB BFFFB     " \
+"    BFFB BFFFBFFFB      " \
+"    BFFB BFFFFFFB       " \
+"    BFFB BFFFFFB        " \
+"    BFFB BFFFFFFB       " \
+"    BFFB BFFFFFFFB      " \
+"    BFFB BFFFFFFFFB     " \
+"    BFFB BBBBBBBBBBB    " \
+"    BFFB                " \
+"    BFFBBBBBBBBBBBBBB   " \
+"    BFFFFFFFFFFFFFFFB   " \
+"    BFFFFFFFFFFFFFFFB   " \
+"    BBBBBBBBBBBBBBBBB   " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_2905[32 * (32 * 3)];
+char mask_2905[32 * (32 / 8)];
+const char *shape_2905 = \
+"                        " \
+"                        " \
+"          BBBBB         " \
+"          BFFFB         " \
+"          BFFFB         " \
+"          BFFFB         " \
+"          BFFFB         " \
+"          BFFFB         " \
+"          BFFFB         " \
+"          BFFFB         " \
+"     BBBBBBFFFBBBBBB    " \
+"      BFFFFFFFFFFFB     " \
+"       BFFFFFFFFFB      " \
+"        BFFFFFFFB       " \
+"         BFFFFFB        " \
+"          BFFFB         " \
+"    BBBBBBBBBBBBBBBBB   " \
+"    BFFFFFFFFFFFFFFFB   " \
+"    BFFFFFFFFFFFFFFFB   " \
+"     BBBBBBBBBBBBBBB    " \
+"                        " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_3063[32 * (32 * 3)];
+char mask_3063[32 * (32 / 8)];
+const char *shape_3063 = \
+"                        " \
+"                        " \
+"                        " \
+"                        " \
+"      B                 " \
+"     BFB       B BBBB   " \
+"    BFFFB     BB BFFB   " \
+"     BFFFB   BFB BFFB   " \
+"      BFFFB BFFB BFFB   " \
+"       BFFFBFFFB BFFB   " \
+"        BFFFFFFB BFFB   " \
+"         BFFFFFB BFFB   " \
+"        BFFFFFFB BFFB   " \
+"       BFFFFFFFB BFFB   " \
+"      BFFFFFFFFB BFFB   " \
+"     BBBBBBBBBBB BFFB   " \
+"                 BFFB   " \
+"    BBBBBBBBBBBBBBFFB   " \
+"    BFFFFFFFFFFFFFFFB   " \
+"    BFFFFFFFFFFFFFFFB   " \
+"    BBBBBBBBBBBBBBBBB   " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_2711[32 * (32 * 3)];
+char mask_2711[32 * (32 / 8)];
+const char *shape_2711 = \
+"                        " \
+"                        " \
+"                        " \
+"                        " \
+"                 BBBB   " \
+"           B     BFFB   " \
+"           BB    BFFB   " \
+"           BFB   BFFB   " \
+"           BFFB  BFFB   " \
+"           BFFFB BFFB   " \
+"    BBBBBBBBFFFFBBFFB   " \
+"   BFFFFFFFFFFFFFBFFB   " \
+"   BFFFFFFFFFFFFFFFFB   " \
+"   BFFFFFFFFFFFFFBFFB   " \
+"    BBBBBBBBFFFFBBFFB   " \
+"           BFFFB BFFB   " \
+"           BFFB  BFFB   " \
+"           BFB   BFFB   " \
+"           BB    BFFB   " \
+"           B     BFFB   " \
+"                 BBBB   " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_3128[32 * (32 * 3)];
+char mask_3128[32 * (32 / 8)];
+const char *shape_3128 = \
+"                        " \
+"                        " \
+"                        " \
+"                        " \
+"        B               " \
+"       BB      B        " \
+"      BBB      BB       " \
+"     BBFB      BFB      " \
+"    BBFFB      BFFB     " \
+"   BBFFFBBBBBBBBFFFB    " \
+"  BBFFFFFFFFFFFFFFFFB   " \
+"  BFFFFFFFFFFFFFFFFFFB  " \
+"  BBFFFFFFFFFFFFFFFFB   " \
+"   BFFFFFBBBBBBBFFFB    " \
+"    BBFFB      BFFB     " \
+"     BFFB      BFB      " \
+"      BBB      BB       " \
+"       BB      B        " \
+"        B               " \
+"                        " \
+"                        " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_3484[32 * (32 * 3)];
+char mask_3484[32 * (32 / 8)];
+const char *shape_3484 = \
+"                        " \
+"                        " \
+"                B       " \
+"               BB       " \
+"              BFB       " \
+"             BFFB       " \
+"            BFFFB       " \
+"           BFFFFB       " \
+"          BFFFFFB       " \
+"         BFFFFFFB       " \
+"        BFFFFFFFB       " \
+"       BFFFFFFFFB       " \
+"      BFFFFFFFFFB       " \
+"     BFFFFFFFFFFB       " \
+"     BBBBBBFFFFFB       " \
+"         BFFFFFFB       " \
+"         BFFFBFFB       " \
+"         BFFFBFFB       " \
+"        BFFFB BFB       " \
+"       BFFFB   BB       " \
+"        BFB     B       " \
+"         B              " \
+"                        " \
+"                        ";
+
+char data_1268[32 * (32 * 3)];
+char mask_1268[32 * (32 / 8)];
+const char *shape_1268 = \
+"                        " \
+"         BBBB           " \
+"         BFFB           " \
+"         BFFB           " \
+"         BFFB           " \
+"         BFFB           " \
+"         BFFB           " \
+"         BFFB           " \
+"         BFFB           " \
+" BBBBBBBBBFFBBBBBBBBB   " \
+" BFFFFFFFFFFFFFFFFFFB   " \
+" BFFFFFFFFFFFFFFFFFFB   " \
+" BBBBBBBBBFFBBBBBBBBB   " \
+"         BFFB           " \
+"         BFFB           " \
+"         BFFB           " \
+"         BFFB           " \
+"         BFFB           " \
+"         BFFB           " \
+"         BFFB           " \
+"         BBBB           " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_2494[32 * (32 * 3)];
+char mask_2494[32 * (32 / 8)];
+const char *shape_2494 = \
+"                                " \
+"                                " \
+"   FF                           " \
+"   FBF                          " \
+"   FBBF                         " \
+"   FBBBF                        " \
+"   FBBBBF                       " \
+"   FBBBBBF                      " \
+"   FBBBBBBF                     " \
+"   FBBBBBBBF                    " \
+"   FBBBBBBBBF                   " \
+"   FBBBBBBBBBF                  " \
+"   FBBBBBFFFFFF                 " \
+"   FBBBFBBF                     " \
+"   FBBFFBBF                     " \
+"   FBF FBBF                     " \
+"   FF   FBBF                    " \
+"        FBBF                 B F" \
+"        FFFF                B F " \
+"                           B F  " \
+"                          B F   " \
+"                         B F    " \
+"                  B F   B F     " \
+"                   B F B F      " \
+"                    B F F       " \
+"                     B F        " \
+"                    B B F       " \
+"                   B F B F      " \
+"                  B F   B F     " \
+"                 B F     B F    " \
+"                B F       B F   " \
+"                                ";
+
+char data_4223[32 * (32 * 3)];
+char mask_4223[32 * (32 / 8)];
+const char *shape_4223 = \
+"                        " \
+"                        " \
+"                        " \
+"                        " \
+"                        " \
+"                        " \
+"          BBB           " \
+"        BBBFFBBB        " \
+"       BFFBFFBFFB       " \
+"       BFFBFFBFFBB      " \
+"     BBBFFFFFFFFBFBB    " \
+"     BFBFFFFFFFFFFFB    " \
+"    BFFBFFFFFFFFFFFB    " \
+"    BFFFFFFFFFFFFFFB    " \
+"    BFFFFFFFFFFFFFFB    " \
+"    BFFFFFFFFFFFFFFB    " \
+"    BFFFFFFFFFFFFFFB    " \
+"     BFFFFFFFFFFFFFB    " \
+"     FBBBBBBBBBBBBB     " \
+"                        " \
+"                        " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_3728[32 * (32 * 3)];
+char mask_3728[32 * (32 / 8)];
+const char *shape_3728 = \
+"                        " \
+"                        " \
+"                        " \
+"        BB              " \
+"       BFFB             " \
+"       BFFB             " \
+"       BFFB             " \
+"       BFFB             " \
+"       BFFBFBBBBB       " \
+"       BFFFFFBFFBB      " \
+"     BBBFFFFFFFFBFBB    " \
+"     BFBFFFFFFFFFFFB    " \
+"    BFFBFFFFFFFFFFFB    " \
+"    BFFBFFFFFFFFFFFB    " \
+"    BFFFFFFFFFFFFFFB    " \
+"    BFFFFFFFFFFFFFFB    " \
+"    BFFFFFFFFFFFFFFB    " \
+"    BFFFFFFFFFFFFFFB    " \
+"     BBBBBBBBBBBBBB     " \
+"                        " \
+"                        " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_4838[32 * (32 * 3)];
+char mask_4838[32 * (32 / 8)];
+const char *shape_4838 = \
+"                        " \
+"                        " \
+"                        " \
+"        BBBBBBBB        " \
+"       BBFBFBFBBB       " \
+"      BBFBFBFBFFBB      " \
+"     BBFBFBBBFBFBFB     " \
+"    BBFBFBFBFBFBFFFB    " \
+"   BBFBFBBBBBFBBBFFBB   " \
+"   BFFFFFBFBFBFBFFFBB   " \
+"   BFFFFBFBFBFBFBFFFB   " \
+"   BFFFBFFFFFFFBFBFFB   " \
+"   BFFBFBFFFFFBBBFFFB   " \
+"   BFFFFFFFFFBFFFFFFB   " \
+"   BFFFFFFFBBFBBFFFFB   " \
+"   BFFFFFFFBBFFBFFFFB   " \
+"    BFFFFFFBBFFFFFFB    " \
+"     BFFFFFBFFFFFFB     " \
+"      BFFFFFFFFFFB      " \
+"       BFFFFFFFFB       " \
+"        BBBBBBBB        " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_5185[32 * (32 * 3)];
+char mask_5185[32 * (32 / 8)];
+const char *shape_5185 = \
+"                        " \
+"                        " \
+"                        " \
+"        BBBBBBBB        " \
+"       BBFBFBFBBB       " \
+"      BBFBFBFBFFFB      " \
+"     BBFBFBBBFBFBFB     " \
+"    BBFBFBFBFBFBFFFB    " \
+"   BBFBFBBBBBFBBBFFBB   " \
+"   BFFFFFBFBFBFBFFFBB   " \
+"   BBFFFBFBFBFBFBFFFB   " \
+"   BFFFFFFFFFFFBFBFFB   " \
+"   BFFFFBFFFFFBBBFFFB   " \
+"   BFFFFFBFFFFFFFFFFB   " \
+"   BBFFFBBBFBFBFFFFFB   " \
+"   BFFFFBBFBBFFBFFFBB   " \
+"    BFFFBFFBBFFFFFBB    " \
+"     BFFFFFBFFFFFFB     " \
+"      BFFFFFFFFFFB      " \
+"       BFBFFFFFBB       " \
+"        BBBBBBBB        " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_4976[32 * (32 * 3)];
+char mask_4976[32 * (32 / 8)];
+const char *shape_4976 = \
+"                        " \
+"                        " \
+"                        " \
+"        BBBBBBBB        " \
+"       BBFBFBFBBB       " \
+"      BBFBFBFBFFFB      " \
+"     BBFBFBBBFBFBFB     " \
+"    BBFBFBFBFBFBFFFB    " \
+"   BFFBFBFBBBFBBBFFBB   " \
+"   BFFFFFBFBFBFBFFFBB   " \
+"   BBFFFBFBFBFBFBFFFB   " \
+"   BFFFBBBFFFFFBFFFFB   " \
+"   BFFBBBBFFFFBFBFFFB   " \
+"   BFFFFFBFFFBFFFFFFB   " \
+"   BBFFFBBBFBFBFFFFFB   " \
+"   BFFFFBBFBFFFBFFFBB   " \
+"    BFFFBFFBBFFFFFBB    " \
+"     BFFFFFBFFFFFFB     " \
+"      BFFFFFFFFFFB      " \
+"       BFBFFFFFFB       " \
+"        BBBBBBBB        " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_4877[32 * (32 * 3)];
+char mask_4877[32 * (32 / 8)];
+const char *shape_4877 = \
+"                        " \
+"                        " \
+"                        " \
+"        BBBBBBBB        " \
+"       BBFBFBFBBB       " \
+"      BBFBFBFBFFFB      " \
+"     BBFBFBBBFBFBFB     " \
+"    BBFBFBFBFBFBFFFB    " \
+"   BBFBBBBBBBFBBBFFBB   " \
+"   BFFFFBBFBFBFBFFFBB   " \
+"   BBFFFBBBFBFBFBFFFB   " \
+"   BFFFBFBFFFFFBFFFFB   " \
+"   BFFBBBBFFFFBFBFFFB   " \
+"   BFFFFFBFFFFFFFFFFB   " \
+"   BBFFFBBBFBFBFFFFFB   " \
+"   BFFFFFBFBFFFBFFFB    " \
+"    BFFFBFFBBFFFFFBB    " \
+"     BFFFFFBFFFFFFB     " \
+"      BFFFFFFFFFFB      " \
+"       BFFFFFFFFB       " \
+"        BBBBBBBB        " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_5008[32 * (32 * 3)];
+char mask_5008[32 * (32 / 8)];
+const char *shape_5008 = \
+"                        " \
+"                        " \
+"                        " \
+"        BBBBBBBB        " \
+"       BBFBFBFBBB       " \
+"      BBFBFBFBFFFB      " \
+"     BBFBFBBBFBFBFB     " \
+"    BBFBFBFBBBFBFFFB    " \
+"   BBFBBBBBBBFBFBFFBB   " \
+"   BFFFFFBFBFBFBFFFBB   " \
+"   BBFFFBBBFBFBFBFFFB   " \
+"   BFFFBFBFFFFFBFFFFB   " \
+"   BFFBBBFFFFFBFBFFFB   " \
+"   BFFFFFBFFFFFFFFFFB   " \
+"   BBFFFBBBFBFBFFFFFB   " \
+"   BFFFFFBFBFFFBFFFFB   " \
+"    BFFFBFFFBFFFFFFB    " \
+"     BFFFFFFFFFFFFB     " \
+"      BFFFFFFFFFFB      " \
+"       BFFFFFFFFB       " \
+"        BBBBBBBB        " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_5180[32 * (32 * 3)];
+char mask_5180[32 * (32 / 8)];
+const char *shape_5180 = \
+"                        " \
+"                        " \
+"                        " \
+"        BBBBBBBB        " \
+"       BBFBFBFBBB       " \
+"      BBFBFBFBFFFB      " \
+"     BBFBFBBBFBFBFB     " \
+"    BBFBFBFBBBFBFFFB    " \
+"   BBFBFBBBBBFBBBFFBB   " \
+"   BFFFFFBFBFBBBFFFBB   " \
+"   BBFFFBBBFBBBFBFFFB   " \
+"   BFFFBFBFFFFFFFFFFB   " \
+"   BFFBBBFFFFFBFBFFFB   " \
+"   BFFFFFFFFFFFFFFFFB   " \
+"   BBFFFBFBFBFBFFFFFB   " \
+"   BFFFFFBFFFFFFFFFFB   " \
+"    BFFFBFFFBFFFFFFB    " \
+"     BFFFFFFFFFFFFB     " \
+"      BFFFFFFFFFFB      " \
+"       BFFFFFFFFB       " \
+"        BBBBBBBB        " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_5068[32 * (32 * 3)];
+char mask_5068[32 * (32 / 8)];
+const char *shape_5068 = \
+"                        " \
+"                        " \
+"                        " \
+"        BBBBBBBB        " \
+"       BBFBFBFBBB       " \
+"      BBFBFBFBFFFB      " \
+"     BBFBFBBBFBFBFB     " \
+"    BBFBFBFBBBFBFFFB    " \
+"   BBFBFBBBBBFBBBFFBB   " \
+"   BFFFFFBFBFBBBFFFBB   " \
+"   BBFFFBBBFBBBFBFFFB   " \
+"   BFFFBFBFFFFFBBBFFB   " \
+"   BFFBFBFFFFFBBBFFFB   " \
+"   BFFFFFFFFFFFFFFFFB   " \
+"   BBFFFBFBFFFBFFFFFB   " \
+"   BFFFFFFFFFFFFFFFFB   " \
+"    BFFFFFFFFFFFFFFB    " \
+"     BFFFFFFFFFFFFB     " \
+"      BFFFFFFFFFFB      " \
+"       BFFFFFFFFB       " \
+"        BBBBBBBB        " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_4866[32 * (32 * 3)];
+char mask_4866[32 * (32 / 8)];
+const char *shape_4866 = \
+"                        " \
+"                        " \
+"                        " \
+"        BBBBBBBB        " \
+"       FBFBFBFBBB       " \
+"      BBFBFBFBFFFB      " \
+"     BBFBFBBBFBFBFB     " \
+"    BBFBFBFBBBFBFFFB    " \
+"   BBFBFBBBBBFBBBFFBB   " \
+"   BFFFFFBFBFBFBFFFBB   " \
+"   BBFFFBFBFBFBFBFFFB   " \
+"   BFFFBFBFFFFFBBBFFB   " \
+"   BFFBFBFFFFFBBBFFFB   " \
+"   BFFFFFFFFFBFFFFFFB   " \
+"   BBFFFBFFFFBBBFFFFB   " \
+"   BFFFFFFFFFFFBFFFBB   " \
+"    BFFFFFFFFFFFFFBB    " \
+"     BFFFFFFFFFFFFB     " \
+"      BFFFFFFFFFFB      " \
+"       BFFFFFFFFB       " \
+"        BBBBBBBB        " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_3501[32 * (32 * 3)];
+char mask_3501[32 * (32 / 8)];
+const char *shape_3501 = \
+"                        " \
+"                        " \
+"          BBBB          " \
+"        BBFFFFBB        " \
+"       BFFFFFFFFB       " \
+"      BFFFFFFFFFFB      " \
+"      BFFFBBBFFFFB      " \
+"     BFFFB   BFFFB      " \
+"     BFFFB   BFFFB      " \
+"     BBBBB   BFFFB      " \
+"            BFFFB       " \
+"           BFFFB        " \
+"          BFFFBB        " \
+"          BFFFFB        " \
+"         BFFFFB         " \
+"      BBBBFFFBBBB       " \
+"      BFFFFFFFFFB       " \
+"       BFFFFFFFB        " \
+"        BFFFFBB         " \
+"         BFFFB          " \
+"          BBB           " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_1848[32 * (32 * 3)];
+char mask_1848[32 * (32 / 8)];
+const char *shape_1848 = \
+"                        " \
+"           B            " \
+"          BFB           " \
+"         BFFFB          " \
+"        BFFFFFB         " \
+"       BFFFFFFFB        " \
+"      BFFFFFFFFFB       " \
+"     BBBBBFFFBBBBB      " \
+"         BFFFB          " \
+"         BFFFB          " \
+"         BFFFB          " \
+"         BFFFB          " \
+"         BFFFB          " \
+"         BFFFB          " \
+"    BBBBBBFFFBBBBBB     " \
+"     BFFFFFFFFFFFB      " \
+"      BFFFFFFFFFB       " \
+"       BFFFFFFFB        " \
+"        BFFFFFB         " \
+"         BFFFB          " \
+"          BBB           " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_2760[32 * (32 * 3)];
+char mask_2760[32 * (32 / 8)];
+const char *shape_2760 = \
+"                        " \
+"                        " \
+"                        " \
+"       BBB              " \
+"     BBFBFBB            " \
+"    BBFFFFFB            " \
+"   BBBFFFFFFB           " \
+"   BFBFFFFFFFB          " \
+"   BFFFFFFFFFB          " \
+"   BFFFFFFFFFB          " \
+"   BBFFFFFFFFB          " \
+"     BBBBBBBB   FFFF    " \
+"                FBBF    " \
+"                FBBF    " \
+"             FFFFBBFFFF " \
+"             FBBBBBBBBF " \
+"             FBBBBBBBBF " \
+"             FFFFBBFFFF " \
+"                FBBF    " \
+"                FBBF    " \
+"                FFFF    " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_5150[32 * (32 * 3)];
+char mask_5150[32 * (32 / 8)];
+const char *shape_5150 = \
+"                         " \
+"                         " \
+"                         " \
+"       BBB               " \
+"     BBFBFBB             " \
+"     BFFFFFB             " \
+"    BBFFFFFFB            " \
+"   BFBFFFFFFFB           " \
+"   BFFFFFFFFFB           " \
+"   BFFFFFFFFFB           " \
+"    BFFFFFFFFBBBBBBBBBBF " \
+"     BBBBBBBBBFBFFFFBBBF " \
+"           FBFBBFBBFBBBF " \
+"           BBBFBFBFFFBBF " \
+"           BBFFFFBBFFFFF " \
+"           BFFBBBBBBBBFF " \
+"           BBFBBBBBBBBFF " \
+"           BBFFFFBFFFFFF " \
+"           BBBBBFBBFBBBF " \
+"           BBBBBFBFFFBFF " \
+"           BBBBBFFFFBBBF " \
+"           BBBBBBBFBFBFF " \
+"           BBBBBBBBBBBBF " \
+"           BBBBBBBBBBBFF " \
+"                         ";
+
+char data_5583[32 * (32 * 3)];
+char mask_5583[32 * (32 / 8)];
+const char *shape_5583 = \
+"                             " \
+"                             " \
+"                             " \
+"                             " \
+"                             " \
+"                             " \
+"          BBB                " \
+"       BBBFFFBBB             " \
+"      BFFFFFBFFB             " \
+"      BFFFFFFFFBBB           " \
+"    BBBFFFFFFFFFFFB          " \
+"   BFFBFFFFFFFFFFFB          " \
+"   BFFBFFFFFFFFFFFBBBBBBBBBF " \
+"   BFFFFFFFFFFFFFFBBFBBBBBBF " \
+"   BFFFFFFBFFFBFFFBFBBBBBBBF " \
+"   BFFFFFFFFFFFFFFBFFBBBBBBF " \
+"    BFFFFFFFFFFFFFBFBBBBBBBF " \
+"     BFFFFFFFFFFFBFFFBBBBBBF " \
+"     BBBBBBBBBBBBBBFBBBBBBBF " \
+"               FFFFBFBFBBBFF " \
+"               BBBBBBBBBBBBF " \
+"               BBBBBBBFBFBFF " \
+"               BBBBBBBBFBBBF " \
+"               BBBBBBBFBFBFF " \
+"               BBBBBBBBBBBBF " \
+"               BBBBBBBBBBBFF " \
+"                             " \
+"                             " \
+"                             ";
+
+char data_5144[32 * (32 * 3)];
+char mask_5144[32 * (32 / 8)];
+const char *shape_5144 = \
+"                         " \
+"                         " \
+"                         " \
+"       BFB               " \
+"     BBFBFB              " \
+"     BFFFFFB             " \
+"    BBFFFFFFB            " \
+"   BFBFFFFFFFB           " \
+"   BFFFFFFFFFB           " \
+"   BFFFFFFFFFB           " \
+"    BFFFFFFFFBBBBBBBBBBF " \
+"     BBBBBBBBBFBBBBBBBBF " \
+"           BBFBBBBBBBBBF " \
+"           BBFFFFFFFFBBF " \
+"           BBFBBBBBBFBBF " \
+"           BBFBBBBBBFBBF " \
+"           BBFBBBFFFFBBF " \
+"           BBFBBFBFFFBFF " \
+"           BBFBBFBBBFFBF " \
+"           BBFFBFFFBFFFF " \
+"           BBFFFFFFFFFBF " \
+"           BBBBBBBFFFBFF " \
+"           BBBBBBBBBBBBF " \
+"           BBBBBBBBBBBBF " \
+"                         ";
+
+char data_2949[32 * (32 * 3)];
+char mask_2949[32 * (32 / 8)];
+const char *shape_2949 = \
+"                        " \
+"                        " \
+"      F                 " \
+"      FF                " \
+"      FBF               " \
+"      FBBF              " \
+"      FBBBF             " \
+"      FBBBBF            " \
+"      FBBBBBF           " \
+"      FBBBBBBF          " \
+"      FBBBBBBBF         " \
+"      FBBBBBBBBF        " \
+"      FBBBBBBBBBF       " \
+"      FBBBBBBBBBBF      " \
+"      FBBBBBFFFFFF      " \
+"      FBBBFBBF          " \
+"      FBBFFBBF          " \
+"      FBBF FBBF         " \
+"      FBF  FBBF         " \
+"      FF    FBBF        " \
+"      F     FFFF        " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_1662[32 * (32 * 3)];
+char mask_1662[32 * (32 / 8)];
+const char *shape_1662 = \
+"                        " \
+"                        " \
+"                        " \
+"                        " \
+"         FFFFFFF        " \
+"         FBBBBBF        " \
+"         FFFBFFF        " \
+"           FBF          " \
+"           FBF          " \
+"           FBF          " \
+"           FBF          " \
+"           FBF          " \
+"           FBF          " \
+"           FBF          " \
+"           FBF          " \
+"           FBF          " \
+"           FBF          " \
+"         FFFBFFF        " \
+"         FBBBBBF        " \
+"         FFFFFFF        " \
+"                        " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_1721[32 * (32 * 3)];
+char mask_1721[32 * (32 / 8)];
+const char *shape_1721 = \
+"                        " \
+"                        " \
+"                        " \
+"                        " \
+"                 FFFF   " \
+"           F     FBBF   " \
+"           FF    FBBF   " \
+"           FBF   FBBF   " \
+"           FBBF  FBBF   " \
+"           FBBBF FBBF   " \
+"    FFFFFFFFBBBBFFBBF   " \
+"   FFBBBBBBBBBBBFFBBF   " \
+"   FBBBBBBBBBBBBBFBBF   " \
+"   FFBBBBBBBBBBBFFBBF   " \
+"    FFFFFFFFBBBBFFBBF   " \
+"           FBBBF FBBF   " \
+"           FBBF  FBBF   " \
+"           FBF   FBBF   " \
+"           FF    FBBF   " \
+"           F     FBBF   " \
+"                 FFFF   " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_3007[32 * (32 * 3)];
+char mask_3007[32 * (32 / 8)];
+const char *shape_3007 = \
+"                        " \
+"                        " \
+"                        " \
+"       FFF              " \
+"       FBBF             " \
+"       FBBF             " \
+"       FBBF             " \
+"       FBBFFF           " \
+"       FBBFBBFFFF       " \
+"       FBBFBFFFBFF      " \
+"     FFFBBBBBFBBBBBF    " \
+"     FFFBBBBBBBBFBBF    " \
+"    FBBFBBBBBBBBBBBF    " \
+"    FBBFBBFBBBBBFBBF    " \
+"    FBBBBFBBBFBFBBBF    " \
+"    FBBBBBBBBBBBBBBF    " \
+"    FBBBBBBBBBBBBBBF    " \
+"    FBBBBBBBBBBBBBBF    " \
+"    FFFFFFFFFFFFFFF     " \
+"                        " \
+"                        " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_4045[32 * (32 * 3)];
+char mask_4045[32 * (32 / 8)];
+const char *shape_4045 = \
+"                        " \
+"                        " \
+"     B                  " \
+"     BB                 " \
+"     BBB                " \
+"     BFFB               " \
+"     BFFFB              " \
+"     BFFFB B BBB        " \
+"     BFFFFBFBFFFBB      " \
+"     BFFFFFFFBFFFFB     " \
+"     BFFFFBFBBBFBFBB    " \
+"     BFFFFFBFBFBFBFB    " \
+"     BFFFFBFBBBBBFFFB   " \
+"     BFFFFFBFFFBFBFFB   " \
+"     BFFFFBFBFFBBBBFB   " \
+"     BFFFFFFFBFBFFFFB   " \
+"     BFFBFFFFBBBBFFFB   " \
+"     BFBBFFFFBBFFFFB    " \
+"     BB  BFFFFBFFFB     " \
+"     B    BBFFFFFB      " \
+"           BBBBBB       " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_4153[32 * (32 * 3)];
+char mask_4153[32 * (32 / 8)];
+const char *shape_4153 = \
+"                        " \
+"                        " \
+"     B                  " \
+"     BB                 " \
+"     BFB                " \
+"     BFFB               " \
+"     BFFFB              " \
+"     BFFFB B BBB        " \
+"     BFFFFBFBFFFBB      " \
+"     BFFFFFFFBFFFFB     " \
+"     BFFFFBFBBBFBFBB    " \
+"     BFFFFFBFBFBFBFB    " \
+"     BFFFFBFBFBBBFFFB   " \
+"     BFFFFFFFFFBFBFFB   " \
+"     BFFFFBFBFFBBBBFB   " \
+"     BFFFFFBBBFBFFFFB   " \
+"     BFFBFBBBBBFBFFFB   " \
+"     BFBBFFBFBBFFFFB    " \
+"     BB  BFFFFBFFFB     " \
+"     B    BBFFFFFB      " \
+"           BBBBBB       " \
+"                        " \
+"                        " \
+"                        ";
+
+char data_4483[32 * (32 * 3)];
+char mask_4483[32 * (32 / 8)];
+const char *shape_4483 = \
+"                        " \
+"                        " \
+"     B                  " \
+"     BB                 " \
+"     BFB                " \
+"     BFFB               " \
+"     BFFBB              " \
+"     BFFFB B BBB        " \
+"     BFFFFBFBFFFBB      " \
+"     BFFFFFFFBFFFFB     " \
+"     BFFFFBFBFBFBFBB    " \
+"     BFFFFFBFBFBFBFB    " \
+"     BFFFFBFBFBFBFFFB   " \
+"     BFFFBBBFFFBFBFFB   " \
+"     BFFFBBBBFFFBFBFB   " \
+"     BFFFFFBBBFBFFFFB   " \
+"     BFFBFBBBBBFBFFFB   " \
+"     BFBBFFBFBFFFFFB    " \
+"     BB  BFFFFBFFFB     " \
+"     B    BBFFFFFB      " \
+"           BBBBBB       " \
+"                        " \
+"                        " \
+"                        ";
+
+#endif

--- a/xrdp/xrdp.ini
+++ b/xrdp/xrdp.ini
@@ -25,6 +25,7 @@ tcp_keepalive=yes
 #autorun=xrdp1
 #hidelogwindow=yes
 #bulk_compression=yes
+#fix_mouse_pointer_sprites=yes
 
 [Logging]
 LogFile=xrdp.log


### PR DESCRIPTION

The mouse pointer sprites tend to be not sharp and have loose pixels around the sprite. This was also an issue with some vnc (I believe tightvnc). I've changed the implementation to have a configuration switch to use a set of common X cursors which have a fix-up. The cursor is calculated from the used mask which seems to be unique enough to determine the right cursor. I've also made some minor performance optimizations based on not setting the mask if it is the already known value (0) and use some bit shifts instead of calculated offsets.