### PR TITLE
Disable glyph cache

### DIFF
--- a/freerdp1/xrdp-freerdp.c
+++ b/freerdp1/xrdp-freerdp.c
@@ -1332,8 +1332,10 @@ lfreerdp_pre_connect(freerdp *instance)
 
     // TODO
     //instance->settings->glyph_cache = true;
-    instance->settings->GlyphSupportLevel = GLYPH_SUPPORT_FULL;
-    instance->settings->OrderSupport[NEG_GLYPH_INDEX_INDEX] = TRUE;
+//    instance->settings->GlyphSupportLevel = GLYPH_SUPPORT_FULL;
+//    instance->settings->OrderSupport[NEG_GLYPH_INDEX_INDEX] = TRUE;
+    instance->settings->GlyphSupportLevel = GLYPH_SUPPORT_NONE;
+    instance->settings->OrderSupport[NEG_GLYPH_INDEX_INDEX] = FALSE;
     instance->settings->OrderSupport[NEG_FAST_GLYPH_INDEX] = FALSE;
     instance->settings->OrderSupport[NEG_FAST_INDEX_INDEX] = FALSE;
     instance->settings->OrderSupport[NEG_SCRBLT_INDEX] = TRUE;


### PR DESCRIPTION
With the current xrdp head the display is getting corrupted when scrolling long lines, I suspect the glyph cache is not being updated on the client machine properly. This disables the glyph cache capability when using the freerdp1 plugin. This is not the long term solution as it has a performamce impact.

