### PR TITLE
Fix absolute path in instfiles/Makefile.am

### DIFF
--- a/instfiles/Makefile.am
+++ b/instfiles/Makefile.am
@@ -29,4 +29,4 @@ startscript_DATA = \
 install-data-hook:
 	chmod 755 $(DESTDIR)$(sysconfdir)/xrdp/xrdp.sh
 	chmod 755 $(DESTDIR)$(sysconfdir)/init.d/xrdp
-	sed -i 's|__BASE__|$(prefix)|' $(sysconfdir)/init.d/xrdp;
+	sed -i 's|__BASE__|$(prefix)|' $(DESTDIR)$(sysconfdir)/init.d/xrdp;


### PR DESCRIPTION
This was causing a build break when trying to build a package for arch linux.  $(sysconfdir) was set to /etc, so it was trying to write to /etc/init.d/xrdp instead of $pkgdir/etc/init.d/xrdp.
