### PR TITLE
xrdp: set default encryption level to high

### DIFF
--- a/xrdp/xrdp.ini
+++ b/xrdp/xrdp.ini
@@ -3,7 +3,7 @@
 bitmap_cache=yes
 bitmap_compression=yes
 port=3389
-crypt_level=low
+crypt_level=high
 allow_channels=true
 max_bpp=24
 fork=yes


### PR DESCRIPTION
It's time to set default encryption level to high.  We know basic RDP encryption is still vulnerable to man-in-the-middle attack however relatively secure setting should be default.
