### PR TITLE
Set lock when adding new displays to the chain

### DIFF
--- a/sesman/session.c
+++ b/sesman/session.c
@@ -669,9 +669,15 @@ session_start_fork(int width, int height, int bpp, char *username,
         temp->item->type = type;
         temp->item->status = SESMAN_SESSION_STATUS_ACTIVE;
 
+        /*THREAD-FIX require chain lock */
+        lock_chain_acquire();
+
         temp->next = g_sessions;
         g_sessions = temp;
         g_session_count++;
+
+        /*THREAD-FIX release chain lock */
+        lock_chain_release();
     }
 
     return display;


### PR DESCRIPTION
Hi Jay,

Excuse me for the previous pull request. I've cleaned up master and supplied a clean pull request. I think adding things to the display chain requires a lock as well. This was not the case.

Regards,

B.
