### PR TITLE
common: the last pointer in the array environ must be null

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -2907,7 +2907,7 @@ g_clearenv(void)
 {
 #if defined(_WIN32)
 #else
-    environ = 0;
+    environ[0] = NULL;
 #endif
 }
 


### PR DESCRIPTION
IMHO, clearing environments should be done by setting the last pointer as NULL.  The original code may work on Linux that is GNU userland. But doesn't work at least on FreeBSD and so far it was locally patched for FreeBSD [1].  The new code works both on Linux and FreeBSD.

[1] http://svnweb.freebsd.org/ports/head/net/xrdp/files/patch-common__os_calls.c?revision=192780&view=markup
