### PR TITLE
disable glyph_cache for neutrinordp to workaround corupption

### DIFF
--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -1379,8 +1379,12 @@ lfreerdp_pre_connect(freerdp *instance)
 
     instance->settings->glyph_cache = true;
     /* GLYPH_SUPPORT_FULL and GLYPH_SUPPORT_PARTIAL seem to be the same */
-    instance->settings->glyphSupportLevel = GLYPH_SUPPORT_FULL;
-    instance->settings->order_support[NEG_GLYPH_INDEX_INDEX] = 1;
+    /* disabled as workaround for corrupted display like black bars left of cmd */
+    /* instance->settings->glyphSupportLevel = GLYPH_SUPPORT_FULL; */
+    /* instance->settings->order_support[NEG_GLYPH_INDEX_INDEX] = 1; */
+    instance->settings->glyphSupportLevel = GLYPH_SUPPORT_NONE;
+    instance->settings->order_support[NEG_GLYPH_INDEX_INDEX] = 0;
+
     instance->settings->order_support[NEG_FAST_GLYPH_INDEX] = 0;
     instance->settings->order_support[NEG_FAST_INDEX_INDEX] = 0;
     instance->settings->order_support[NEG_SCRBLT_INDEX] = 1;


### PR DESCRIPTION
please review or fix glyph cache or make option in config file?

https://github.com/neutrinolabs/NeutrinoRDP/issues/1
