### PR TITLE
comment code causing distorted picture for neutrinordp like black lines ...

### DIFF
--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -794,13 +794,14 @@ lfreerdp_glyph_index(rdpContext *context, GLYPH_INDEX_ORDER *glyph_index)
 #if 1
     /* workarounds for freerdp not using fOpRedundant in
        glyph.c::update_gdi_glyph_index */
-    if (glyph_index->fOpRedundant)
+    /* disabled as causing problems using neutrinordp */
+/*    if (glyph_index->fOpRedundant)
     {
         opLeft = glyph_index->bkLeft;
         opTop = glyph_index->bkTop;
         opRight = glyph_index->bkRight;
         opBottom =glyph_index->bkBottom;
-    }
+    }*/
 #endif
     mod->server_draw_text(mod, glyph_index->cacheId, glyph_index->flAccel,
                           glyph_index->fOpRedundant,


### PR DESCRIPTION
...left of cmd windows.

I nailed it down to this peace of code what seems to have been introduced as workaround for freerdp but causing problems for neutrinordp-modul now using Microsoft MSTSC Client:

"workarounds for freerdp not using fOpRedundant in glyph.c::update_gdi_glyph_index"

It was introduced with this commit:
https://github.com/neutrinolabs/xrdp/commit/2aad1b2d5da9d7412092d8c76601fa9bca95685d

So this area needs attention. 

I don't know if commenting this section has any effect for freerdp now.

