### PR TITLE
Numlock out of sync fix

### DIFF
--- a/neutrinordp/xrdp-neutrinordp.h
+++ b/neutrinordp/xrdp-neutrinordp.h
@@ -172,6 +172,8 @@ struct mod
   int vrev;
   char username[256];
   char password[256];
+  int bool_keyBoardSynced ; /*Numlock can be out of sync, we hold state here to resolve */
+  int keyBoardLockInfo ; /* Holds initial numlock capslock state */
 
   struct xrdp_client_info client_info;
 


### PR DESCRIPTION
When connecting and disconnecting to the same remote RDP session in a windows machine, numlock and capslock can come out of sync. This fix make sure that numlock and capslock are always synchronized when connecting to existing sessions.
