### PR TITLE
buildx.sh: fix clean option

### DIFF
--- a/xorg/X11R7.6/buildx.sh
+++ b/xorg/X11R7.6/buildx.sh
@@ -59,10 +59,8 @@ remove_modules()
 
     while IFS=: read mod_file mod_dir mod_args
     do
-        if [ -d build_dir/$mod_dir ]; then
-            rm -rf build_dir/$mod_dir
-        fi
-    done < ../$data_file
+        (cd build_dir; [ -d $mod_dir ] && rm -rf $mod_dir)
+    done < $data_file
 }
 
 extract_it()


### PR DESCRIPTION
./buildx.sh clean results
`./buildx.sh: line 47: ../x11_file_list.txt: No such file or directory`
- fix the use of $mod_dir
  "build_dir/$mod_dir" was evaluated as "build_dir/ Python-2.7" as
  variable mod_dir has leading whitespace
- fix the path of x11_file_list.txt
