### PR TITLE
pam configuration file for redhat

### DIFF
--- a/instfiles/pam.d/xrdp-sesman.redhat
+++ b/instfiles/pam.d/xrdp-sesman.redhat
@@ -1,0 +1,4 @@
+#%PAM-1.0
+auth       include      password-auth
+account    include      password-auth
+session    include      password-auth


### PR DESCRIPTION
This comes from my X11RDP-RH-Matic work.

We need to install another `/etc/pam.d/xrdp-sesman` file on Red Hat and its clones.  I don't know how should I modify the `Makefile.am` but following changes are needed in addition to my commit.
- check if distribution is redhat (ex. existence of `/etc/redhat-release`)
- generate makefile which installs `instfiles/pam.d/xrdp-sesman.redhat` instead of `instfiles/pam.d/xrdp-sesman`
