### PR TITLE
Change to allow authentication against all authentication methods.

### DIFF
--- a/instfiles/pam.d/xrdp-sesman.other
+++ b/instfiles/pam.d/xrdp-sesman.other
@@ -1,4 +1,5 @@
 #%PAM-1.0
-auth       required     pam_unix.so shadow nullok
-auth       required     pam_env.so readenv=1
-account    required     pam_unix.so
+auth       include     system-auth
+account    include     system-auth
+password   include     system-auth
+session    include     system-auth


### PR DESCRIPTION
The specified pam file content works only for plain Unix authentication.
It does not work for LDAP, NIS+, Kerberos, Radius...
Authentication configuration utility of RedHat/Fedora writes system-auth/password-auth files to include all necessary pam libraries.
A service pam file shall include those files (look at sshd for example) to be independent of the used authentication method.
As xrdp as service does not require any specific pam library configuration, it is sufficient to just use the system-auth file for all pam types.
With this change, pam authentication will work with any authentication method, which can be set through the authentication configuration utilities, regardless of gnome and/or command line.
