### PR TITLE
man page, add details for crypt_level=fips

### DIFF
--- a/docs/man/xrdp.ini.5
+++ b/docs/man/xrdp.ini.5
@@ -54,7 +54,7 @@ If set to \fB0\fR, \fBfalse\fR or \fBno\fR this option disables all channels \fB
 See section \fBCHANNELS\fP below for more fine grained options.
 
 .TP
-\fBcrypt_level\fP=\fIlow|medium|high\fP
+\fBcrypt_level\fP=\fIlow|medium|high|fips\fP
 .\" <http://blogs.msdn.com/b/openspecification/archive/2011/12/08/encryption-negotiation-in-rdp-connection.aspx>
 RDP connection are controlled by two encryption settings: \fIEncryption Level\fP and \fIEncryption Method\fP.
 The only supported \fIEncryption Method\fP is \fB40BIT_ENCRYPTION\fP, \fB128BIT_ENCRYPTION\fP and \fB56BIT_ENCRYPTION\fP are currently not supported.
@@ -70,6 +70,10 @@ All data sent between the client and the server is protected by encryption based
 .TP
 .B high
 All data sent between the client and server is protected by encryption based on the server's maximum key strength.
+.TP
+.B fips
+All data sent between the client and server is protected using Federal Information Processing Standard 140-1 validated encryption methods.
+.I This level is required for Windows clients (mstsc.exe) if the client's group policy enforces FIPS-compliance mode.
 .RE
 
 .TP


### PR DESCRIPTION
I had to read the source to get xrdp to work on a client in a strict FIPS Windows domain.
Hopefully adding this to the man page will save the next guy some time.

Cheers!
