### PR TITLE
If auth fails, call pam_end so PAM backends can call _cleanup

### DIFF
--- a/sesman/verify_user_pam.c
+++ b/sesman/verify_user_pam.c
@@ -122,6 +122,7 @@ auth_userpass(char *user, char *pass, int *errorcode)
 		*errorcode = error ;
 	}
         g_printf("pam_start failed: %s\r\n", pam_strerror(auth_info->ph, error));
+        pam_end(auth_info->ph, error);
         g_free(auth_info);
         return 0;
     }
@@ -135,6 +136,7 @@ auth_userpass(char *user, char *pass, int *errorcode)
 	}
         g_printf("pam_authenticate failed: %s\r\n",
                  pam_strerror(auth_info->ph, error));
+        pam_end(auth_info->ph, error);
         g_free(auth_info);
         return 0;
     }
@@ -153,6 +155,7 @@ auth_userpass(char *user, char *pass, int *errorcode)
 	}
         g_printf("pam_acct_mgmt failed: %s\r\n",
                  pam_strerror(auth_info->ph, error));
+        pam_end(auth_info->ph, error);
         g_free(auth_info);
         return 0;
     }


### PR DESCRIPTION
This patch fix issue #171 and #169 
If the authentication fails, calling pam_end informs PAM module , and they can take care of cleanup of theirs resources
