### PR TITLE
Apply aa983d2b to v0.6 branch

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -2115,7 +2115,11 @@ g_clearenv(void)
 {
 #if defined(_WIN32)
 #else
+#if defined(BSD)
+  environ[0] = 0;
+#else
   environ = 0;
+#endif
 #endif
 }
 


### PR DESCRIPTION
Just a cherry-pick.  As v0.6 is the latest version works on FreeBSD, BSD specific changes needs to be merged to v0.6 branch.
