### PR TITLE
Configure fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,7 @@ AM_INIT_AUTOMAKE([1.6 foreign])
 AC_PROG_CC
 AC_C_CONST
 AC_PROG_LIBTOOL
+PKG_PROG_PKG_CONFIG
 AC_ARG_WITH([systemdsystemunitdir],
         AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files]),
         [], [with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])


### PR DESCRIPTION
Fixes for a few major issues with the configure script:
1. `--disable-` options weren't respected correctly (instead, they enabled the feature),
2. replaced `--enable-nopam` with `--disable-pam` that is easier to comprehend,
3. added missing `PKG_PROG_PKG_CONFIG` call needed before `$PKG_CONFIG` is used directly.
