### PR TITLE
xrdp_keyboard.ini: Fix jp keyboard model

### DIFF
--- a/xrdp/xrdp_keyboard.ini
+++ b/xrdp/xrdp_keyboard.ini
@@ -98,6 +98,7 @@ layouts_map=rdp_layouts_map_mac
 [rdp_keyboard_jp]
 keyboard_type=7
 keyboard_subtype=2
+model=jp106
 rdp_layouts=default_rdp_layouts
 layouts_map=default_layouts_map
 


### PR DESCRIPTION
When layout is "pc105", the Henkan_Mode key is overwritten, and becomes the XF86AudioMedia key.
