### PR TITLE
xrdp: fix -h -v option if xrdp.ini is invalid

### DIFF
--- a/xrdp/xrdp.c
+++ b/xrdp/xrdp.c
@@ -319,7 +319,6 @@ main(int argc, char **argv)
     test = 1;
     host_be = !((int)(*(unsigned char *)(&test)));
 #if defined(B_ENDIAN)
-
     if (!host_be)
 #endif
 #if defined(L_ENDIAN)
@@ -357,6 +356,51 @@ main(int argc, char **argv)
 
     g_snprintf(cfg_file, 255, "%s/xrdp.ini", XRDP_CFG_PATH);
 
+    startup_params = (struct xrdp_startup_params *)
+                     g_malloc(sizeof(struct xrdp_startup_params), 1);
+
+    if (xrdp_process_params(argc, argv, startup_params) != 0)
+    {
+        g_writeln("Unknown Parameter");
+        g_writeln("xrdp -h for help");
+        g_writeln("");
+        g_deinit();
+        g_exit(0);
+    }
+
+    g_snprintf(pid_file, 255, "%s/xrdp.pid", XRDP_PID_PATH);
+    no_daemon = 0;
+
+    if (startup_params->help)
+    {
+        g_writeln("");
+        g_writeln("xrdp: A Remote Desktop Protocol server.");
+        g_writeln("Copyright (C) Jay Sorg 2004-2014");
+        g_writeln("See http://www.xrdp.org for more information.");
+        g_writeln("");
+        g_writeln("Usage: xrdp [options]");
+        g_writeln("   --help: show help");
+        g_writeln("   --nodaemon: don't fork into background");
+        g_writeln("   --kill: shut down xrdp");
+        g_writeln("   --port: tcp listen port");
+        g_writeln("   --fork: fork on new connection");
+        g_writeln("");
+        g_deinit();
+        g_exit(0);
+    }
+
+    if (startup_params->version)
+    {
+        g_writeln("");
+        g_writeln("xrdp: A Remote Desktop Protocol server.");
+        g_writeln("Copyright (C) Jay Sorg 2004-2014");
+        g_writeln("See http://www.xrdp.org for more information.");
+        g_writeln("Version %s", PACKAGE_VERSION);
+        g_writeln("");
+        g_deinit();
+        g_exit(0);
+    }
+
     /* starting logging subsystem */
     error = log_start(cfg_file, "XRDP");
 
@@ -380,20 +424,15 @@ main(int argc, char **argv)
         g_exit(1);
     }
 
-    startup_params = (struct xrdp_startup_params *)
-                     g_malloc(sizeof(struct xrdp_startup_params), 1);
 
-    if (xrdp_process_params(argc, argv, startup_params) != 0)
+
+    if (g_file_exist(pid_file)) /* xrdp.pid */
     {
-        g_writeln("Unknown Parameter");
-        g_writeln("xrdp -h for help");
-        g_writeln("");
+        g_writeln("It looks like xrdp is allready running,");
+        g_writeln("if not delete the xrdp.pid file and try again");
         g_deinit();
         g_exit(0);
     }
-
-    g_snprintf(pid_file, 255, "%s/xrdp.pid", XRDP_PID_PATH);
-    no_daemon = 0;
 
     if (startup_params->kill)
     {
@@ -435,43 +474,6 @@ main(int argc, char **argv)
         no_daemon = 1;
     }
 
-    if (startup_params->help)
-    {
-        g_writeln("");
-        g_writeln("xrdp: A Remote Desktop Protocol server.");
-        g_writeln("Copyright (C) Jay Sorg 2004-2014");
-        g_writeln("See http://www.xrdp.org for more information.");
-        g_writeln("");
-        g_writeln("Usage: xrdp [options]");
-        g_writeln("   --help: show help");
-        g_writeln("   --nodaemon: don't fork into background");
-        g_writeln("   --kill: shut down xrdp");
-        g_writeln("   --port: tcp listen port");
-        g_writeln("   --fork: fork on new connection");
-        g_writeln("");
-        g_deinit();
-        g_exit(0);
-    }
-
-    if (startup_params->version)
-    {
-        g_writeln("");
-        g_writeln("xrdp: A Remote Desktop Protocol server.");
-        g_writeln("Copyright (C) Jay Sorg 2004-2014");
-        g_writeln("See http://www.xrdp.org for more information.");
-        g_writeln("Version %s", PACKAGE_VERSION);
-        g_writeln("");
-        g_deinit();
-        g_exit(0);
-    }
-
-    if (g_file_exist(pid_file)) /* xrdp.pid */
-    {
-        g_writeln("It looks like xrdp is allready running,");
-        g_writeln("if not delete the xrdp.pid file and try again");
-        g_deinit();
-        g_exit(0);
-    }
 
     if (!no_daemon)
     {


### PR DESCRIPTION
- log_start should be after help and version
- Fixes neutrinolabs/xrdp#33.

Test result
-----------------
Build and ensure xrdp.ini does not exist.
```
$ ./bootstrap && ./configure && make
$ ls /etc/xrdp/xrdp.ini
ls: cannot access /etc/xrdp/xrdp.ini: No such file or directory
```

Executing xrdp fails as xrdp.ini does not exist.
```
$ xrdp/xrdp
We could not open the configuration file to read log parameters
Error reading configuration for log based on config: /etc/xrdp/xrdp.ini
log_start error
```
`-h` and `-v` should always succeed even if xrdp.ini does not exist.
```
$ xrdp/xrdp -h

xrdp: A Remote Desktop Protocol server.
Copyright (C) Jay Sorg 2004-2014
See http://www.xrdp.org for more information.

Usage: xrdp [options]
   --help: show help
   --nodaemon: don't fork into background
   --kill: shut down xrdp
   --port: tcp listen port
   --fork: fork on new connection

$ xrdp/xrdp -v

xrdp: A Remote Desktop Protocol server.
Copyright (C) Jay Sorg 2004-2014
See http://www.xrdp.org for more information.
Version 0.9.0

```

Other options fail as xrdp.ini does not exist.
```
$ xrdp/xrdp --nodaemon
We could not open the configuration file to read log parameters
Error reading configuration for log based on config: /etc/xrdp/xrdp.ini
log_start error
$ xrdp/xrdp --kill
We could not open the configuration file to read log parameters
Error reading configuration for log based on config: /etc/xrdp/xrdp.ini
log_start error
$ xrdp/xrdp --nodaemon --fork --port 13389
--fork parameter found, ini override
--port parameter found, ini override [13389]
We could not open the configuration file to read log parameters
Error reading configuration for log based on config: /etc/xrdp/xrdp.ini
log_start error
```