### PR TITLE
chansrv: explicit include in chansrv_fuse.c

### DIFF
--- a/sesman/chansrv/chansrv_fuse.c
+++ b/sesman/chansrv/chansrv_fuse.c
@@ -56,6 +56,7 @@ char g_fuse_clipboard_path[256] = ""; /* for clipboard use */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include "arch.h"
 #include "chansrv_fuse.h"


### PR DESCRIPTION
chansrv_fuse.c includes chansrv_fuse.h even if XRDP_FUSE is not
defined. However, time_t is used in chansrv_fuse.h.  This causes
build failure on FreeBSD.

```
gmake[1]: Entering directory '/home/meta/github/metalefty/xrdp/sesman/chansrv'
gcc -DHAVE_CONFIG_H -I. -I../.. -I../../common    -DXRDP_CFG_PATH=\"/etc/xrdp\" -DXRDP_SBIN_PATH=\"/usr/local/sbin\" -DXRDP_SHARE_PATH=\"/usr/local/share/xrdp\" -DXRDP_PID_PATH=\"/var/run\"   -I/usr/local/include -MT chansrv_fuse.o -MD -MP -MF .deps/chansrv_fuse.Tpo -c -o chansrv_fuse.o chansrv_fuse.c
In file included from chansrv_fuse.c:61:
chansrv_fuse.h:34: error: expected specifier-qualifier-list before 'time_t'
Makefile:473: recipe for target 'chansrv_fuse.o' failed
gmake[1]: *** [chansrv_fuse.o] Error 1
gmake[1]: Leaving directory '/home/meta/github/metalefty/xrdp/sesman/chansrv'
Makefile:601: recipe for target 'all-recursive' failed
gmake: *** [all-recursive] Error 1
```