### PR TITLE
configure: use PKG_CHECK_MODULES to check fuse

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -129,9 +129,8 @@ fi
 # checking for fuse
 if test "x$enable_fuse" = "xyes"
 then
-  AC_CHECK_HEADER([fuse.h], [],
-    [AC_MSG_ERROR([please install libfuse-dev or fuse-devel])],
-    [#define _FILE_OFFSET_BITS 64])
+  PKG_CHECK_MODULES([FUSE], [fuse >= 2.6], [],
+    [AC_MSG_ERROR([please install libfuse-dev or fuse-devel])])
 fi
 
 # checking for opus


### PR DESCRIPTION
fuse has fuse.pc file for pkg-config. this is more reliable.


Tested on CentOS 7.

If fuse-devel is not installed, configure fails.
```
$ ./bootstrap && ./configure --enable-fuse
(snip)
checking security/pam_appl.h presence... yes
checking for security/pam_appl.h... yes
checking for struct in6_addr.s6_addr... yes
checking for FUSE... no
configure: error: please install libfuse-dev or fuse-devel
```

If fuse-devel is installed.
```
$ sudo yum -y install fuse-devel
$ ./bootstrap && ./configure --enable-fuse
(snip)
checking security/pam_appl.h usability... yes
checking security/pam_appl.h presence... yes
checking for security/pam_appl.h... yes
checking for struct in6_addr.s6_addr... yes
checking for FUSE... yes
(snip)
$ make clean
$ make >/dev/null 2>&1 && echo 'build success!!'
build success!!
```