### PR TITLE
fuse: use EIO instead of EREMOTEIO for BSDs

### DIFF
--- a/sesman/chansrv/chansrv_fuse.c
+++ b/sesman/chansrv/chansrv_fuse.c
@@ -107,6 +107,10 @@ void xfuse_devredir_cb_file_close(void *vp)                                  {}
 #include "list.h"
 #include "fifo.h"
 
+#ifndef EREMOTEIO
+#define EREMOTEIO EIO
+#endif
+
 #define min(x, y) ((x) < (y) ? (x) : (y))
 
 #define XFUSE_ATTR_TIMEOUT      1.0


### PR DESCRIPTION
FreeBSD/OpenBSD/NetBSD and OS X don't have errno EREMOTEIO.