### PR TITLE
instfiles: init.d/xrdp shouldn't be installed on systemd system

### DIFF
--- a/instfiles/Makefile.am
+++ b/instfiles/Makefile.am
@@ -4,7 +4,6 @@ xrdp.service
 
 SUBDIRS = \
   pam.d \
-  default \
   pulse
 
 if HAVE_SYSTEMD
@@ -13,6 +12,7 @@ systemdsystemunit_DATA = \
         xrdp.service
 else
 SUBDIRS+=
+  default \
   init.d
 endif
 

--- a/instfiles/Makefile.am
+++ b/instfiles/Makefile.am
@@ -4,7 +4,6 @@ xrdp.service
 
 SUBDIRS = \
   pam.d \
-  init.d \
   default \
   pulse
 
@@ -12,6 +11,9 @@ if HAVE_SYSTEMD
 systemdsystemunit_DATA = \
         xrdp-sesman.service \
         xrdp.service
+else
+SUBDIRS+=
+  init.d
 endif
 
 startscriptdir=$(sysconfdir)/xrdp
@@ -34,5 +36,7 @@ startscript_DATA = \
 # must be tab below
 install-data-hook:
 	chmod 755 $(DESTDIR)$(sysconfdir)/xrdp/xrdp.sh
-	chmod 755 $(DESTDIR)$(sysconfdir)/init.d/xrdp
-	sed -i 's|__BASE__|$(prefix)|' $(DESTDIR)$(sysconfdir)/init.d/xrdp;
+	if [ -f $(DESTDIR)$(sysconfdir)/init.d/xrdp ]; then \
+		chmod 755 $(DESTDIR)$(sysconfdir)/init.d/xrdp; \
+		sed -i 's|__BASE__|$(prefix)|' $(DESTDIR)$(sysconfdir)/init.d/xrdp; \
+	fi

--- a/instfiles/init.d/Makefile.am
+++ b/instfiles/init.d/Makefile.am
@@ -1,4 +1,4 @@
 EXTRA_DIST = xrdp
 startscriptdir=$(sysconfdir)/init.d
 startscript_DATA = xrdp
-		   
+


### PR DESCRIPTION
On systemd system, at least CentOS 7, `service foo start` command
works as wrapper of `systemctl start foo`.  However, xrdp installs
init script into /etc/init.d/xrdp.  This script is not necessary
for systemd system, and, what is worse,  if init.d/xrdp exists,
`service xrdp start` works as wrapper to run init.d/xrdp. Maybe
this is inconvinient for many users.