### PR TITLE
Unbreak IPv6 on FreeBSD and add IPv6-only option

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -463,7 +463,7 @@ g_tcp_socket(void)
     unsigned int option_len;
 #endif
 
-#if defined(XRDP_ENABLE_IPV6) && !defined(NO_ARPA_INET_H_IP6)
+#if defined(XRDP_ENABLE_IPV6)
     rv = (int)socket(AF_INET6, SOCK_STREAM, 0);
 #else
     rv = (int)socket(AF_INET, SOCK_STREAM, 0);
@@ -472,7 +472,7 @@ g_tcp_socket(void)
     {
         return -1;
     }
-#if defined(XRDP_ENABLE_IPV6) && !defined(NO_ARPA_INET_H_IP6)
+#if defined(XRDP_ENABLE_IPV6)
     option_len = sizeof(option_value);
     if (getsockopt(rv, IPPROTO_IPV6, IPV6_V6ONLY, (char*)&option_value,
                    &option_len) == 0)
@@ -711,7 +711,7 @@ g_tcp_close(int sck)
 
 /*****************************************************************************/
 /* returns error, zero is good */
-#if defined(XRDP_ENABLE_IPV6) && !defined(NO_ARPA_INET_H_IP6)
+#if defined(XRDP_ENABLE_IPV6)
 int APP_CC
 g_tcp_connect(int sck, const char *address, const char *port)
 {

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -479,7 +479,11 @@ g_tcp_socket(void)
     {
         if (option_value != 0)
         {
+#if defined(XRDP_ENABLE_IPV6ONLY)
+            option_value = 1;
+#else
             option_value = 0;
+#endif
             option_len = sizeof(option_value);
             if (setsockopt(rv, IPPROTO_IPV6, IPV6_V6ONLY, (char*)&option_value,
                        option_len) < 0)

--- a/configure.ac
+++ b/configure.ac
@@ -111,11 +111,6 @@ then
   AC_DEFINE([XRDP_ENABLE_IPV6],1,[Enable IPv6])
 fi
 
-AC_CHECK_MEMBER([struct in6_addr.s6_addr],
-                [],
-                [AC_DEFINE(NO_ARPA_INET_H_IP6, 1, [for IPv6])],
-                [#include <arpa/inet.h>])
-
 if test "x$enable_pam" != "xyes" || test "x$bsd" = "xtrue"
 then
   AC_DEFINE([USE_NOPAM],1,[Disable PAM])

--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,9 @@ AM_CONDITIONAL(SESMAN_NOPAM, [test x$enable_pam != xyes])
 AC_ARG_ENABLE(ipv6, AS_HELP_STRING([--enable-ipv6],
               [Build IPv6 support (default: no, experimental)]),
               [], [enable_ipv6=no])
+AC_ARG_ENABLE(ipv6only, AS_HELP_STRING([--enable-ipv6only],
+              [Build IPv6-only (default: no)]),
+              [], [enable_ipv6only=no])
 AC_ARG_ENABLE(kerberos, AS_HELP_STRING([--enable-kerberos],
               [Build kerberos support (default: no)]),
               [], [enable_kerberos=no])
@@ -104,6 +107,12 @@ then
         [AC_MSG_ERROR([please install libpam0g-dev or pam-devel])])
     fi
   fi
+fi
+
+if test "x$enable_ipv6only" = "xyes"
+then
+  enable_ipv6=yes
+  AC_DEFINE([XRDP_ENABLE_IPV6ONLY],1,[Enable IPv6 only])
 fi
 
 if test "x$enable_ipv6" = "xyes"


### PR DESCRIPTION
Checking `struct in6_addr.s6_addr` is only valid for GNU/Linux. This is the reason why IPv6 not working on FreeBSD.  Another fix is still needed for OpenBSD.  I'm still working on OpenBSD issue at #30.

And one more thing, add `--enable-ipv6only` option for debug. This can be `--disable-ipv4`. Which do you like? I think `--disable-ipv4` is better if IPv6 is enabled by default but it is disabled now.