### PR TITLE
fix timeout when using Xvnc

### DIFF
--- a/instfiles/xrdp-sesman.service
+++ b/instfiles/xrdp-sesman.service
@@ -2,6 +2,7 @@
 Description=xrdp session manager
 After=syslog.target network.target
 StopWhenUnneeded=true
+BindTo=xrdp.service
 
 [Service]
 Type=forking

--- a/instfiles/xrdp.service
+++ b/instfiles/xrdp.service
@@ -7,7 +7,7 @@ After=syslog.target network.target xrdp-sesman.service
 Type=forking
 PIDFile=/var/run/xrdp.pid
 EnvironmentFile=/etc/sysconfig/xrdp
-ExecStart=/usr/sbin/xrdp $XRDP_OPTIONS
+ExecStart=/usr/sbin/xrdp $XRDP_OPTIONS --nodaemon
 ExecStop=/usr/sbin/xrdp $XRDP_OPTIONS --kill
 
 [Install]

--- a/vnc/vnc.c
+++ b/vnc/vnc.c
@@ -1011,7 +1011,13 @@ lib_mod_connect(struct vnc *v)
     v->trans->si = si;
     v->trans->my_source = XRDP_SOURCE_MOD;
 
-    error = trans_connect(v->trans, v->ip, con_port, 3000);
+    int count;
+    for (count = 0; count < 10; count++) {
+       error = trans_connect(v->trans, v->ip, con_port, 3000);
+       if (error == 0)
+         break;
+       g_sleep(1000);
+    }
 
     if (error == 0)
     {


### PR DESCRIPTION
Hello, 

for some reason when using Xvnc, its timeout, please take a look in this screenshoot.

https://itamarjp.fedorapeople.org/tmp/Xvnc-timeout.png

alot of people complained about it in redhat bugzilla

After this patch the error stopped, but I don't know if this is the best solution.

what do you think about ?

do you have a better solution ? how about setting up a socket timeout in g_tcp_connect ? 
