### PR TITLE
Conditionally Use size for session allocation policy

### DIFF
--- a/sesman/session.c
+++ b/sesman/session.c
@@ -164,7 +164,8 @@ session_get_bydata(char *name, int width, int height, int bpp, int type, char *c
         }
 
         if (g_strncmp(name, tmp->item->name, 255) == 0 &&
-            (tmp->item->width == width && tmp->item->height == height) &&
+            (!(policy & SESMAN_CFG_SESS_POLICY_D) ||
+             (tmp->item->width == width && tmp->item->height == height)) &&
             (!(policy & SESMAN_CFG_SESS_POLICY_I) ||
              (g_strncmp_d(client_ip, tmp->item->client_ip, ':', 255) == 0)) &&
             (!(policy & SESMAN_CFG_SESS_POLICY_C) ||


### PR DESCRIPTION
The DisplaySize was unconditionally used to decide if a new session
should be created or a old one should reused. This fixes this behaviour
to match the configured policy.

fixes #291

Signed-off-by: Jan Losinski <losinski@wh2.tu-dresden.de>