### PR TITLE
Simplify session match logic.

### DIFF
--- a/sesman/session.c
+++ b/sesman/session.c
@@ -144,27 +144,9 @@ session_get_bydata(char *name, int width, int height, int bpp, int type, char *c
             tmp->item->client_ip);
 #endif
 
-        if ((type == SESMAN_SESSION_TYPE_XRDP) || (type == SESMAN_SESSION_TYPE_XORG))
-        {
-            /* only name and bpp need to match for X11rdp, it can resize */
-            if (g_strncmp(name, tmp->item->name, 255) == 0 &&
-                (!(policy & SESMAN_CFG_SESS_POLICY_D) ||
-                 (tmp->item->width == width && tmp->item->height == height)) &&
-                (!(policy & SESMAN_CFG_SESS_POLICY_I) ||
-                 (g_strncmp_d(client_ip, tmp->item->client_ip, ':', 255) == 0)) &&
-                (!(policy & SESMAN_CFG_SESS_POLICY_C) ||
-                 (g_strncmp(client_ip, tmp->item->client_ip, 255) == 0)) &&
-                tmp->item->bpp == bpp &&
-                tmp->item->type == type)
-            {
-                /*THREAD-FIX release chain lock */
-                lock_chain_release();
-                return tmp->item;
-            }
-        }
-
         if (g_strncmp(name, tmp->item->name, 255) == 0 &&
-            (tmp->item->width == width && tmp->item->height == height) &&
+            (!(policy & SESMAN_CFG_SESS_POLICY_D) ||
+             (tmp->item->width == width && tmp->item->height == height)) &&
             (!(policy & SESMAN_CFG_SESS_POLICY_I) ||
              (g_strncmp_d(client_ip, tmp->item->client_ip, ':', 255) == 0)) &&
             (!(policy & SESMAN_CFG_SESS_POLICY_C) ||


### PR DESCRIPTION
The session match logic had two versions - one for the
SESMAN_SESSION_TYPE_XRDP and SESMAN_SESSION_TYPE_XORG sessions and one
for every other type. The only difference was, that different display
sizes where ignored when searching for sessions to reconnect if the
policy does not have the SESMAN_CFG_SESS_POLICY_D flag set and the type
is SESMAN_SESSION_TYPE_XRDP or SESMAN_SESSION_TYPE_XORG.

The reason was that xvnc cannot resize and the others can do. This two
versions where not necessary because we set the
SESMAN_CFG_SESS_POLICY_D flag every time we have a xvnc session a few
lines above. So the two branches for the different types can be reduced
to one.

Signed-off-by: Jan Losinski <losinski@wh2.tu-dresden.de>