### PR TITLE
X11rdp: disable fontconfig docs

### DIFF
--- a/xorg/X11R7.6/x11_file_list.txt
+++ b/xorg/X11R7.6/x11_file_list.txt
@@ -12,7 +12,7 @@ libxml2-sources-2.7.8.tar.gz                    :  libxml2-2.7.8                
 libpng-1.2.46.tar.gz                            :  libpng-1.2.46                            :
 pixman-0.30.0.tar.bz2                           :  pixman-0.30.0                            : --disable-gtk
 freetype-2.4.6.tar.bz2                          :  freetype-2.4.6                           :
-fontconfig-2.8.0.tar.gz                         :  fontconfig-2.8.0                         :
+fontconfig-2.8.0.tar.gz                         :  fontconfig-2.8.0                         : --disable-docs
 cairo-1.8.8.tar.gz                              :  cairo-1.8.8                              :
 expat-2.0.1.tar.gz                              :  expat-2.0.1                              :
 xextproto-7.1.2.tar.bz2                         :  xextproto-7.1.2                          :


### PR DESCRIPTION
as it rarely fails to build. Nobody actually needs fontconfig docs
to build and run x11rdp even if it builds successfully. Thus we can
just disable it.

Reported in scarygliders/X11RDP-o-Matic#53.