### PR TITLE
Hot fix for recent autotools changes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_PREREQ(2.59)
 AC_INIT([xrdp], [0.9.0], [xrdp-devel@googlegroups.com])
 AC_CONFIG_HEADERS(config_ac.h:config_ac-h.in)
 AM_INIT_AUTOMAKE([1.6 foreign])
-AC_CONFIG_MACRO_DIRS([m4])
+AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_CC
 AC_C_CONST
 AC_PROG_LIBTOOL


### PR DESCRIPTION
The fix for AC_CONFIG_MACRO_DIRS is important, even though it only affects those who compile from the git repository.

AC_CONFIG_MACRO_DIR is much more portable than AC_CONFIG_MACRO_DIRS. AC_CONFIG_MACRO_DIR comes from from Autoconf, AC_CONFIG_MACRO_DIRS comes from Automake (as strange as it sounds) and requires a very recent version of Automake. Developers on RHEL and other conservative systems will be inconvenienced if it's not fixed.
