### PR TITLE
Make it possible to use Xvnc with 32 bpp

### DIFF
--- a/sesman/libscp/libscp_session.c
+++ b/sesman/libscp/libscp_session.c
@@ -137,6 +137,7 @@ scp_session_set_bpp(struct SCP_SESSION *s, tui8 bpp)
         case 15:
         case 16:
         case 24:
+        case 32:
             s->bpp = bpp;
         default:
             return 1;

--- a/sesman/libscp/libscp_v0.c
+++ b/sesman/libscp/libscp_v0.c
@@ -252,7 +252,14 @@ scp_v0s_accept(struct SCP_CONNECTION *c, struct SCP_SESSION **s, int skipVchk)
         scp_session_set_height(session, sz);
         /* bpp */
         in_uint16_be(c->in_s, sz);
-        scp_session_set_bpp(session, (tui8)sz);
+        if (0 != scp_session_set_bpp(session, (tui8)sz))
+        {
+            scp_session_destroy(session);
+            log_message(LOG_LEVEL_WARNING,
+                        "[v0:%d] connection aborted: unsupported bpp: %d",
+                        __LINE__, (tui8)sz);
+            return SCP_SERVER_STATE_INTERNAL_ERR;
+        }
 
         if (s_check_rem(c->in_s, 2))
         {

--- a/sesman/libscp/libscp_v1s.c
+++ b/sesman/libscp/libscp_v1s.c
@@ -131,6 +131,14 @@ enum SCP_SERVER_STATES_E scp_v1s_accept(struct SCP_CONNECTION *c, struct SCP_SES
     in_uint16_be(c->in_s, cmd);
     scp_session_set_height(session, cmd);
     in_uint8(c->in_s, sz);
+    if (0 != scp_session_set_bpp(session, sz))
+    {
+        scp_session_destroy(session);
+        log_message(LOG_LEVEL_WARNING,
+                    "[v1s:%d] connection aborted: unsupported bpp: %d",
+                    __LINE__, sz);
+        return SCP_SERVER_STATE_INTERNAL_ERR;
+    }
     scp_session_set_bpp(session, sz);
     in_uint8(c->in_s, sz);
     scp_session_set_rsr(session, sz);

--- a/vnc/vnc.c
+++ b/vnc/vnc.c
@@ -993,12 +993,18 @@ lib_mod_connect(struct vnc *v)
     v->server_msg(v, "VNC started connecting", 0);
     check_sec_result = 1;
 
-    /* only support 8 and 16 bpp connections from rdp client */
-    if ((v->server_bpp != 8) && (v->server_bpp != 15) &&
-            (v->server_bpp != 16) && (v->server_bpp != 24))
+    /* check if bpp is supported for rdp connection */
+    switch (v->server_bpp)
     {
-        v->server_msg(v, "VNC error - only supporting 8, 15, 16 and 24 bpp rdp "
-                      "connections", 0);
+        case 8:
+        case 15:
+        case 16:
+        case 24:
+        case 32:
+            break;
+        default:
+            v->server_msg(v, "VNC error - only supporting 8, 15, 16, 24 and 32 "
+                          "bpp rdp connections", 0);
         return 1;
     }
 


### PR DESCRIPTION
The support is not ideal, acceptable. For some clients, 32 bpp is the only option.

scp_session_set_bpp() was essentially setting bpp to 0 if 32 bpp was requested. Check the error now, log errors, don't continue with "0 bpp".

Allow 32 bpp in scp_session_set_bpp() - that's the global switch.

Allow 32 bpp in VNC, use switch statement for readability.