### PR TITLE
pulse: fix build pulseaudio 6.0 or higher

### DIFF
--- a/sesman/chansrv/pulse/module-xrdp-sink.c
+++ b/sesman/chansrv/pulse/module-xrdp-sink.c
@@ -440,7 +440,11 @@ static void thread_func(void *userdata) {
             pa_rtpoll_set_timer_disabled(u->rtpoll);
         }
 
+#if defined(PA_CHECK_VERSION) && PA_CHECK_VERSION(6, 0, 0)
+        if ((ret = pa_rtpoll_run(u->rtpoll)) < 0) {
+#else
         if ((ret = pa_rtpoll_run(u->rtpoll, TRUE)) < 0) {
+#endif
             goto fail;
         }
 

--- a/sesman/chansrv/pulse/module-xrdp-source.c
+++ b/sesman/chansrv/pulse/module-xrdp-source.c
@@ -339,8 +339,13 @@ static void thread_func(void *userdata) {
         }
 
         /* Hmm, nothing to do. Let's sleep */
-        if ((ret = pa_rtpoll_run(u->rtpoll, TRUE)) < 0)
+#if defined(PA_CHECK_VERSION) && PA_CHECK_VERSION(6, 0, 0)
+        if ((ret = pa_rtpoll_run(u->rtpoll)) < 0) {
+#else
+        if ((ret = pa_rtpoll_run(u->rtpoll, TRUE)) < 0) {
+#endif
             goto fail;
+        }
 
         if (ret == 0)
             goto finish;


### PR DESCRIPTION
Discovered in #321.  The number of argument for pa_rtpoll_run have
been changed since 6.0.

\>=6.0 : int pa_rtpoll_run(pa_rtpoll *f);
<6.0  : int pa_rtpoll_run(pa_rtpoll *f, bool wait);

Check pulseaudio version by PA_CHECK_VERSION macro introduced since
pulseaudio 0.9.16.  In case PA_CHECK_VERSION is not defined,
pa_rtpoll_run takes 2 arguments.