### PR TITLE
More makefile cleanup

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@ ACLOCAL_AMFLAGS = -I m4
 AM_DISTCHECK_CONFIGURE_FLAGS = --without-systemdsystemunitdir
 
 EXTRA_DIST = bootstrap COPYING coding_style.md design.txt faq-compile.txt \
-  faq-general.txt file-loc.txt install.txt prog_std.txt readme.txt
+  faq-general.txt file-loc.txt install.txt m4 prog_std.txt readme.txt
 
 if XRDP_NEUTRINORDP
 NEUTRINORDPDIR = neutrinordp

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -1,24 +1,3 @@
-EXTRA_DIST = \
-  arch.h \
-  defines.h \
-  file.h \
-  file_loc.h \
-  list.h \
-  list16.h \
-  fifo.h \
-  log.h \
-  os_calls.h \
-  os_calls.h \
-  parse.h \
-  rail.h \
-  ssl_calls.h \
-  thread_calls.h \
-  trans.h \
-  xrdp_client_info.h \
-  xrdp_constants.h \
-  xrdp_rail.h \
-  crc16.h
-
 AM_CPPFLAGS = \
   -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
@@ -30,15 +9,34 @@ module_LTLIBRARIES = \
   libcommon.la
 
 libcommon_la_SOURCES = \
-  file.c \
-  list.c \
-  list16.c \
+  arch.h \
+  crc16.h \
+  defines.h \
   fifo.c \
+  fifo.h \
+  file.c \
+  file.h \
+  file_loc.h \
+  list.c \
+  list.h \
+  list16.c \
+  list16.h \
   log.c \
+  log.h \
   os_calls.c \
+  os_calls.h \
+  os_calls.h \
+  parse.h \
+  rail.h \
   ssl_calls.c \
+  ssl_calls.h \
   thread_calls.c \
-  trans.c
+  thread_calls.h \
+  trans.c \
+  trans.h \
+  xrdp_client_info.h \
+  xrdp_constants.h \
+  xrdp_rail.h
 
 libcommon_la_LIBADD = \
   -lcrypto \

--- a/libxrdp/Makefile.am
+++ b/libxrdp/Makefile.am
@@ -1,5 +1,3 @@
-EXTRA_DIST = libxrdp.h libxrdpinc.h xrdp_orders_rail.h
-
 EXTRA_DEFINES =
 EXTRA_INCLUDES =
 EXTRA_LIBS =
@@ -42,19 +40,22 @@ module_LTLIBRARIES = \
 
 libxrdp_la_SOURCES = \
   libxrdp.c \
-  xrdp_channel.c \
-  xrdp_iso.c \
-  xrdp_mcs.c \
-  xrdp_orders.c \
-  xrdp_rdp.c \
-  xrdp_sec.c \
-  xrdp_bitmap_compress.c \
+  libxrdp.h \
+  libxrdpinc.h \
   xrdp_bitmap32_compress.c \
-  xrdp_jpeg_compress.c \
-  xrdp_orders_rail.c \
-  xrdp_mppc_enc.c \
+  xrdp_bitmap_compress.c \
+  xrdp_caps.c \
+  xrdp_channel.c \
   xrdp_fastpath.c \
-  xrdp_caps.c
+  xrdp_iso.c \
+  xrdp_jpeg_compress.c \
+  xrdp_mcs.c \
+  xrdp_mppc_enc.c \
+  xrdp_orders.c \
+  xrdp_orders_rail.c \
+  xrdp_orders_rail.h \
+  xrdp_rdp.c \
+  xrdp_sec.c
 
 libxrdp_la_LDFLAGS = \
   $(EXTRA_FLAGS)

--- a/mc/Makefile.am
+++ b/mc/Makefile.am
@@ -1,5 +1,3 @@
-EXTRA_DIST = mc.h
-
 AM_CPPFLAGS = \
   -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
@@ -10,7 +8,9 @@ AM_CPPFLAGS = \
 module_LTLIBRARIES = \
   libmc.la
 
-libmc_la_SOURCES = mc.c
+libmc_la_SOURCES = \
+  mc.c \
+  mc.h
 
 libmc_la_LIBADD = \
   $(top_builddir)/common/libcommon.la

--- a/neutrinordp/Makefile.am
+++ b/neutrinordp/Makefile.am
@@ -1,4 +1,3 @@
-EXTRA_DIST = xrdp-neutrinordp.h
 EXTRA_DEFINES =
  
 if XRDP_DEBUG
@@ -19,7 +18,10 @@ AM_CPPFLAGS = \
 module_LTLIBRARIES = \
   libxrdpneutrinordp.la
 
-libxrdpneutrinordp_la_SOURCES = xrdp-neutrinordp.c xrdp-color.c
+libxrdpneutrinordp_la_SOURCES = \
+  xrdp-color.c \
+  xrdp-neutrinordp.c \
+  xrdp-neutrinordp.h
 
 libxrdpneutrinordp_la_LIBADD = \
   $(top_builddir)/common/libcommon.la \

--- a/rdp/Makefile.am
+++ b/rdp/Makefile.am
@@ -1,4 +1,3 @@
-EXTRA_DIST = rdp.h
 EXTRA_DEFINES =
  
 if XRDP_DEBUG
@@ -20,6 +19,7 @@ module_LTLIBRARIES = \
 
 librdp_la_SOURCES = \
   rdp.c \
+  rdp.h \
   rdp_bitmap.c \
   rdp_iso.c \
   rdp_lic.c \

--- a/sesman/Makefile.am
+++ b/sesman/Makefile.am
@@ -1,6 +1,5 @@
 
-EXTRA_DIST = sesman.ini startwm.sh sesman.h access.h auth.h config.h env.h \
-scp.h scp_v0.h scp_v1.h scp_v1_mng.h session.h sig.h
+EXTRA_DIST = sesman.ini startwm.sh
 
 AM_CPPFLAGS = \
   -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
@@ -37,16 +36,27 @@ sbin_PROGRAMS = \
   xrdp-sesman
 
 xrdp_sesman_SOURCES = \
-  scp.c \
-  scp_v0.c \
-  scp_v1.c \
-  scp_v1_mng.c \
-  sesman.c \
-  session.c \
-  sig.c \
   access.c \
+  access.h \
+  auth.h \
   config.c \
+  config.h \
   env.c \
+  env.h \
+  scp.c \
+  scp.h \
+  scp_v0.c \
+  scp_v0.h \
+  scp_v1.c \
+  scp_v1.h \
+  scp_v1_mng.c \
+  scp_v1_mng.h \
+  sesman.c \
+  sesman.h \
+  session.c \
+  session.h \
+  sig.c \
+  sig.h \
   $(AUTH_C)
 
 xrdp_sesman_LDADD = \

--- a/sesman/chansrv/Makefile.am
+++ b/sesman/chansrv/Makefile.am
@@ -1,21 +1,3 @@
-EXTRA_DIST = \
-  chansrv.h \
-  chansrv_fuse.h \
-  clipboard.h \
-  clipboard_common.h \
-  clipboard_file.h \
-  devredir.h \
-  drdynvc.h \
-  rail.h \
-  sound.h \
-  xcommon.h \
-  mlog.h \
-  chansrv_common.h \
-  irp.h \
-  smartcard.h \
-  smartcard_pcsc.h \
-  fifo.h
-
 EXTRA_DEFINES =
 EXTRA_INCLUDES =
 EXTRA_LIBS =
@@ -47,19 +29,35 @@ sbin_PROGRAMS = \
 
 xrdp_chansrv_SOURCES = \
   chansrv.c \
-  sound.c \
-  clipboard.c \
-  clipboard_file.c \
-  devredir.c \
-  smartcard.c \
-  smartcard_pcsc.c \
-  rail.c \
-  xcommon.c \
-  drdynvc.c \
+  chansrv.h \
+  chansrv_common.c \
+  chansrv_common.h \
   chansrv_fuse.c \
-  irp.c \
+  chansrv_fuse.h \
+  clipboard.c \
+  clipboard.h \
+  clipboard_common.h \
+  clipboard_file.c \
+  clipboard_file.h \
+  devredir.c \
+  devredir.h \
+  drdynvc.c \
+  drdynvc.h \
   fifo.c \
-  chansrv_common.c
+  fifo.h \
+  irp.c \
+  irp.h \
+  mlog.h \
+  rail.c \
+  rail.h \
+  smartcard.c \
+  smartcard.h \
+  smartcard_pcsc.c \
+  smartcard_pcsc.h \
+  sound.c \
+  sound.h \
+  xcommon.c \
+  xcommon.h
 
 xrdp_chansrv_LDFLAGS = \
   $(X_LIBS) \

--- a/sesman/libscp/Makefile.am
+++ b/sesman/libscp/Makefile.am
@@ -1,6 +1,3 @@
-EXTRA_DIST = libscp_connection.h libscp_commands.h libscp.h libscp_session.h libscp_types_mng.h libscp_v1c_mng.h libscp_vX.h libscp_commands_mng.h libscp_init.h libscp_tcp.h libscp_v0.h libscp_v1s.h libscp_lock.h \
-libscp_types.h libscp_v1c.h libscp_v1s_mng.h
-
 AM_CPPFLAGS = \
   -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
@@ -12,17 +9,33 @@ module_LTLIBRARIES = \
   libscp.la
 
 libscp_la_SOURCES = \
+  libscp.h \
+  libscp_commands.h \
+  libscp_commands_mng.h \
   libscp_connection.c \
+  libscp_connection.h \
   libscp_init.c \
+  libscp_init.h \
   libscp_lock.c \
+  libscp_lock.h \
   libscp_session.c \
+  libscp_session.h \
   libscp_tcp.c \
+  libscp_tcp.h \
+  libscp_types.h \
+  libscp_types_mng.h \
   libscp_v0.c \
+  libscp_v0.h \
   libscp_v1c.c \
-  libscp_v1s.c \
+  libscp_v1c.h \
   libscp_v1c_mng.c \
+  libscp_v1c_mng.h \
+  libscp_v1s.c \
+  libscp_v1s.h \
   libscp_v1s_mng.c \
-  libscp_vX.c
+  libscp_v1s_mng.h \
+  libscp_vX.c \
+  libscp_vX.h
 
 libscp_la_LIBADD = \
   $(top_builddir)/common/libcommon.la \

--- a/sesman/tools/Makefile.am
+++ b/sesman/tools/Makefile.am
@@ -1,5 +1,3 @@
-EXTRA_DIST = tcp.h
-
 AM_CPPFLAGS = \
   -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
@@ -21,9 +19,10 @@ noinst_PROGRAMS = \
   xrdp-xcon
 
 xrdp_sesrun_SOURCES = \
+  config.c \
   sesrun.c \
   tcp.c \
-  config.c
+  tcp.h
 
 xrdp_sestest_SOURCES = \
   sestest.c

--- a/vnc/Makefile.am
+++ b/vnc/Makefile.am
@@ -1,5 +1,3 @@
-EXTRA_DIST = vnc.h
-
 AM_CPPFLAGS = \
   -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
@@ -10,7 +8,9 @@ AM_CPPFLAGS = \
 module_LTLIBRARIES = \
   libvnc.la
 
-libvnc_la_SOURCES = vnc.c
+libvnc_la_SOURCES = \
+  vnc.c \
+  vnc.h
 
 libvnc_la_LIBADD = \
   $(top_builddir)/common/libcommon.la

--- a/xrdp/Makefile.am
+++ b/xrdp/Makefile.am
@@ -1,5 +1,4 @@
-EXTRA_DIST = xrdp.ini ad24b.bmp ad256.bmp xrdp24b.bmp xrdp256.bmp xrdp_logo.bmp sans-10.fv1 cursor0.cur cursor1.cur xrdp.h xrdp_types.h \
-xrdp_encoder.h xrdp_keyboard.ini
+EXTRA_DIST = $(xrdpsysconf_DATA) $(xrdppkgdata_DATA)
 
 EXTRA_INCLUDES =
 EXTRA_LIBS =
@@ -35,9 +34,12 @@ sbin_PROGRAMS = \
 xrdp_SOURCES = \
   funcs.c \
   lang.c \
-  xrdp_bitmap.c \
   xrdp.c \
+  xrdp.h \
+  xrdp_bitmap.c \
   xrdp_cache.c \
+  xrdp_encoder.c \
+  xrdp_encoder.h \
   xrdp_font.c \
   xrdp_listen.c \
   xrdp_login_wnd.c \
@@ -45,8 +47,8 @@ xrdp_SOURCES = \
   xrdp_painter.c \
   xrdp_process.c \
   xrdp_region.c \
-  xrdp_wm.c \
-  xrdp_encoder.c
+  xrdp_types.h \
+  xrdp_wm.c
 
 xrdp_LDADD = \
   $(top_builddir)/common/libcommon.la \

--- a/xrdpapi/Makefile.am
+++ b/xrdpapi/Makefile.am
@@ -1,5 +1,3 @@
-EXTRA_DIST = xrdpapi.h
-
 EXTRA_DEFINES =
 EXTRA_INCLUDES =
 EXTRA_LIBS =
@@ -13,7 +11,8 @@ module_LTLIBRARIES = \
   libxrdpapi.la
 
 libxrdpapi_la_SOURCES = \
-  xrdpapi.c
+  xrdpapi.c \
+  xrdpapi.h
 
 libxrdpapi_la_LDFLAGS = \
   $(EXTRA_FLAGS)

--- a/xrdpvr/Makefile.am
+++ b/xrdpvr/Makefile.am
@@ -1,5 +1,3 @@
-EXTRA_DIST = xrdpvr.h
-
 EXTRA_DEFINES =
 EXTRA_INCLUDES =
 EXTRA_LIBS =
@@ -13,7 +11,8 @@ module_LTLIBRARIES = \
   libxrdpvr.la
 
 libxrdpvr_la_SOURCES = \
-  xrdpvr.c
+  xrdpvr.c \
+  xrdpvr.h
 
 libxrdpvr_la_LDFLAGS = \
   $(EXTRA_FLAGS)

--- a/xup/Makefile.am
+++ b/xup/Makefile.am
@@ -1,5 +1,3 @@
-EXTRA_DIST = xup.h
-
 AM_CPPFLAGS = \
   -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
@@ -10,7 +8,9 @@ AM_CPPFLAGS = \
 module_LTLIBRARIES = \
   libxup.la
 
-libxup_la_SOURCES = xup.c
+libxup_la_SOURCES = \
+  xup.c \
+  xup.h
 
 libxup_la_LIBADD = \
   $(top_builddir)/common/libcommon.la


### PR DESCRIPTION
It's better to have headers in the same lists as the *.c files. Automake distributes sources by default and doesn't generate any compile rules for header files listed as sources, so there should be no functional difference.

While testing with older versions of Automake, I found that m4 is not distributed, so I added it to EXTRA_DIST.