### PR TITLE
Key install

### DIFF
--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -1,4 +1,4 @@
-man_MANS = \
+dist_man_MANS = \
   xrdp-dis.1 \
   sesman.ini.5 \
   xrdp.ini.5 \
@@ -14,4 +14,4 @@ man_MANS = \
 noinst_man_MANS = \
   xrdp-xcon.8
 
-EXTRA_DIST = $(man_MANS) $(noinst_man_MANS)
+EXTRA_DIST = $(noinst_man_MANS)

--- a/instfiles/Makefile.am
+++ b/instfiles/Makefile.am
@@ -36,7 +36,7 @@ if LINUX
 SUBDIRS += \
   pam.d \
   pulse
-dist_startscript_DATA += xrdp.sh
+dist_startscript_SCRIPTS = xrdp.sh
 if HAVE_SYSTEMD
 dist_systemdsystemunit_DATA = \
   xrdp-sesman.service \
@@ -61,9 +61,7 @@ endif
 if LINUX
 # must be tab below
 install-data-hook:
-	chmod 755 $(DESTDIR)$(sysconfdir)/xrdp/xrdp.sh
 	if [ -f $(DESTDIR)$(sysconfdir)/init.d/xrdp ]; then \
-		chmod 755 $(DESTDIR)$(sysconfdir)/init.d/xrdp; \
 		sed -i 's|__BASE__|$(prefix)|' $(DESTDIR)$(sysconfdir)/init.d/xrdp; \
 	fi
 endif
@@ -71,6 +69,5 @@ endif
 if FREEBSD
 # must be tab below
 install-data-hook:
-	chmod 755 $(DESTDIR)$(sysconfdir)/rc.d/xrdp
 	sed -i '' 's|%%PREFIX%%|$(prefix)|g' $(DESTDIR)$(sysconfdir)/rc.d/xrdp
 endif

--- a/instfiles/Makefile.am
+++ b/instfiles/Makefile.am
@@ -1,15 +1,14 @@
 EXTRA_DIST = \
    xrdp.sh \
    xrdp-sesman.service \
-   xrdp.service \
-   $(startscript_DATA)
+   xrdp.service
 
 #
 # files for all platforms
 #
 startscriptdir=$(sysconfdir)/xrdp
 
-startscript_DATA = \
+dist_startscript_DATA = \
   km-0407.ini \
   km-0409.ini \
   km-040c.ini \
@@ -37,9 +36,9 @@ if LINUX
 SUBDIRS += \
   pam.d \
   pulse
-startscript_DATA += xrdp.sh
+dist_startscript_DATA += xrdp.sh
 if HAVE_SYSTEMD
-systemdsystemunit_DATA = \
+dist_systemdsystemunit_DATA = \
   xrdp-sesman.service \
   xrdp.service
 else

--- a/instfiles/default/Makefile.am
+++ b/instfiles/default/Makefile.am
@@ -1,3 +1,2 @@
-EXTRA_DIST = xrdp
-startscriptdir=$(sysconfdir)/default
-startscript_DATA = xrdp
+startscriptdir = $(sysconfdir)/default
+dist_startscript_DATA = xrdp

--- a/instfiles/init.d/Makefile.am
+++ b/instfiles/init.d/Makefile.am
@@ -1,4 +1,2 @@
-EXTRA_DIST = xrdp
-startscriptdir=$(sysconfdir)/init.d
-startscript_DATA = xrdp
-
+startscriptdir = $(sysconfdir)/init.d
+dist_startscript_DATA = xrdp

--- a/instfiles/init.d/Makefile.am
+++ b/instfiles/init.d/Makefile.am
@@ -1,2 +1,2 @@
 startscriptdir = $(sysconfdir)/init.d
-dist_startscript_DATA = xrdp
+dist_startscript_SCRIPTS = xrdp

--- a/instfiles/init.d/xrdp
+++ b/instfiles/init.d/xrdp
@@ -23,7 +23,6 @@ SESMAN_START=yes
 #USERID=xrdp
 # the X11rdp backend only works as root at the moment - GH 20/03/2013
 USERID=root
-RSAKEYS=/etc/xrdp/rsakeys.ini
 NAME=xrdp
 DESC="Remote Desktop Protocol server"
 
@@ -67,18 +66,6 @@ if [ "$(id -u)" = "0" ]; then
         mkdir $PIDDIR
     fi
     chown $USERID:$USERID $PIDDIR
-
-    # Check for rsa key 
-    if [ ! -f $RSAKEYS ] ; then
-        log_action_begin_msg "Generating xrdp RSA keys..."
-        (umask 077 ; xrdp-keygen xrdp $RSAKEYS)
-        chown $USERID:$USERID $RSAKEYS
-        if [ ! -f $RSAKEYS ] ; then
-            log_action_end_msg 1 "could not create $RSAKEYS"
-            exit 1
-        fi
-        log_action_end_msg 0 "done"
-    fi
 fi
 
 

--- a/instfiles/pulse/Makefile.am
+++ b/instfiles/pulse/Makefile.am
@@ -1,3 +1,2 @@
-EXTRA_DIST = default.pa
-pulsedir=$(sysconfdir)/xrdp/pulse
-pulse_DATA = default.pa
+pulsedir = $(sysconfdir)/xrdp/pulse
+dist_pulse_DATA = default.pa

--- a/instfiles/rc.d/Makefile.am
+++ b/instfiles/rc.d/Makefile.am
@@ -1,2 +1,2 @@
 startscriptdir = $(sysconfdir)/rc.d
-dist_startscript_DATA = xrdp
+dist_startscript_SCRIPTS = xrdp

--- a/instfiles/rc.d/Makefile.am
+++ b/instfiles/rc.d/Makefile.am
@@ -1,4 +1,2 @@
-EXTRA_DIST = xrdp
-startscriptdir=$(sysconfdir)/rc.d
-startscript_DATA = xrdp
-
+startscriptdir = $(sysconfdir)/rc.d
+dist_startscript_DATA = xrdp

--- a/instfiles/rc.d/xrdp
+++ b/instfiles/rc.d/xrdp
@@ -61,10 +61,6 @@ xrdp_cmd() {
     if [ "${rc_arg}" = "stop" ] ; then
 	xrdp_daemons=$(reverse_list ${xrdp_daemons})
     fi
-    # Generate rsakeys.ini on start
-    if [ "${rc_arg}" = "start" -a ! -f %%PREFIX%%/etc/xrdp/rsakeys.ini ] ; then
-        %%PREFIX%%/bin/xrdp-keygen xrdp %%PREFIX%%/etc/xrdp/rsakeys.ini
-    fi
 
     # Apply to all the daemons.
     for name in ${xrdp_daemons}; do

--- a/keygen/Makefile.am
+++ b/keygen/Makefile.am
@@ -13,3 +13,12 @@ xrdp_keygen_SOURCES = keygen.c
 
 xrdp_keygen_LDADD = \
   $(top_builddir)/common/libcommon.la
+
+xrdpsysconfdir = $(sysconfdir)/xrdp
+
+install-data-hook:
+	umask 077 && \
+	  ./xrdp-keygen xrdp $(DESTDIR)$(xrdpsysconfdir)/rsakeys.ini
+
+uninstall-hook:
+	rm -f $(DESTDIR)$(xrdpsysconfdir)/rsakeys.ini

--- a/sesman/Makefile.am
+++ b/sesman/Makefile.am
@@ -65,7 +65,9 @@ xrdp_sesman_LDADD = \
 sesmansysconfdir=$(sysconfdir)/xrdp
 
 dist_sesmansysconf_DATA = \
-  sesman.ini \
+  sesman.ini
+
+dist_sesmansysconf_SCRIPTS = \
   startwm.sh
 
 SUBDIRS = \
@@ -73,7 +75,3 @@ SUBDIRS = \
   tools \
   sessvc \
   chansrv
-
-# must be tab below
-install-data-hook:
-	chmod 755 $(DESTDIR)$(sysconfdir)/xrdp/startwm.sh

--- a/sesman/Makefile.am
+++ b/sesman/Makefile.am
@@ -1,6 +1,3 @@
-
-EXTRA_DIST = sesman.ini startwm.sh
-
 AM_CPPFLAGS = \
   -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
@@ -67,7 +64,7 @@ xrdp_sesman_LDADD = \
 
 sesmansysconfdir=$(sysconfdir)/xrdp
 
-sesmansysconf_DATA = \
+dist_sesmansysconf_DATA = \
   sesman.ini \
   startwm.sh
 

--- a/xrdp/Makefile.am
+++ b/xrdp/Makefile.am
@@ -1,5 +1,3 @@
-EXTRA_DIST = $(xrdpsysconf_DATA) $(xrdppkgdata_DATA)
-
 EXTRA_INCLUDES =
 EXTRA_LIBS =
 EXTRA_FLAGS =
@@ -60,13 +58,13 @@ xrdp_LDFLAGS = \
 
 xrdpsysconfdir=$(sysconfdir)/xrdp
 
-xrdpsysconf_DATA = \
+dist_xrdpsysconf_DATA = \
   xrdp.ini \
   xrdp_keyboard.ini
 
 xrdppkgdatadir=$(datadir)/xrdp
 
-xrdppkgdata_DATA = \
+dist_xrdppkgdata_DATA = \
   ad24b.bmp \
   ad256.bmp \
   xrdp24b.bmp \


### PR DESCRIPTION
The big thing - installing rsakeys.ini by "make install". Not need to remember to do that for manual install. No need to rely on the init scripts.

More Automake cleanups. Using standard Automake features for installing scripts and making data files distributable.
