### PR TITLE
keygen: Do not overwrite rsakeys.ini

### DIFF
--- a/keygen/Makefile.am
+++ b/keygen/Makefile.am
@@ -17,8 +17,8 @@ xrdp_keygen_LDADD = \
 xrdpsysconfdir = $(sysconfdir)/xrdp
 
 install-data-hook:
-	umask 077 && \
-	  ./xrdp-keygen xrdp $(DESTDIR)$(xrdpsysconfdir)/rsakeys.ini
+	[ ! -f $(DESTDIR)$(xrdpsysconfdir)/rsakeys.ini ] && umask 077 && \
+	./xrdp-keygen xrdp $(DESTDIR)$(xrdpsysconfdir)/rsakeys.ini || :
 
 uninstall-hook:
 	rm -f $(DESTDIR)$(xrdpsysconfdir)/rsakeys.ini


### PR DESCRIPTION
Check the existence of rsakeys.ini before generating it.