### PR TITLE
Preserve rsakeys.ini if it already exists

### DIFF
--- a/keygen/Makefile.am
+++ b/keygen/Makefile.am
@@ -16,9 +16,14 @@ xrdp_keygen_LDADD = \
 
 xrdpsysconfdir = $(sysconfdir)/xrdp
 
+KEYFILE = $(DESTDIR)$(xrdpsysconfdir)/rsakeys.ini
+
 install-data-hook:
-	umask 077 && \
-	  ./xrdp-keygen xrdp $(DESTDIR)$(xrdpsysconfdir)/rsakeys.ini
+	@if test -s $(KEYFILE); then \
+	  echo "Preserving $(KEYFILE)"; \
+	else \
+	  umask 077 && ./xrdp-keygen xrdp $(KEYFILE); \
+	fi
 
 uninstall-hook:
-	rm -f $(DESTDIR)$(xrdpsysconfdir)/rsakeys.ini
+	rm -f $(KEYFILE)


### PR DESCRIPTION
"make install" can be used to upgrade an existing installation, in which
case regenerating rsakeys.ini is unnecessary and could lead to warnings
on the client side.

This is an alternative to pull request 334. The differences:

- The whole command is not printed, it obscures more important messages.
- Instead, the user is told when the key is preserved.
- Empty key is replaced.
- Using KEYFILE variable for shorter code.
- "test" is preferred over brackets in makefiles
