### PR TITLE
Warning fixes

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -219,22 +219,6 @@ g_snprintf(char *dest, int len, const char *format, ...)
 
 /*****************************************************************************/
 void DEFAULT_CC
-g_writeln(const char *format, ...)
-{
-    va_list ap;
-
-    va_start(ap, format);
-    vfprintf(stdout, format, ap);
-    va_end(ap);
-#if defined(_WIN32)
-    g_printf("\r\n");
-#else
-    g_printf("\n");
-#endif
-}
-
-/*****************************************************************************/
-void DEFAULT_CC
 g_write(const char *format, ...)
 {
     va_list ap;

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -2717,17 +2717,6 @@ g_signal_user_interrupt(void (*func)(int))
 /*****************************************************************************/
 /* does not work in win32 */
 void APP_CC
-g_signal_kill(void (*func)(int))
-{
-#if defined(_WIN32)
-#else
-    signal(SIGKILL, func);
-#endif
-}
-
-/*****************************************************************************/
-/* does not work in win32 */
-void APP_CC
 g_signal_terminate(void (*func)(int))
 {
 #if defined(_WIN32)

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -41,6 +41,16 @@
 #define g_tcp_select g_sck_select
 #define g_close_wait_obj g_delete_wait_obj
 
+#if defined(_WIN32)
+#define G_NEWLINE "\r\n"
+#else
+#define G_NEWLINE "\n"
+#endif
+
+#define g_writeln(fmt, ...) do { \
+  g_write(fmt G_NEWLINE, ##__VA_ARGS__); \
+} while (0)
+
 int APP_CC      g_rm_temp_dir(void);
 int APP_CC      g_mk_temp_dir(const char* app_name);
 void APP_CC     g_init(const char* app_name);
@@ -50,7 +60,6 @@ void APP_CC     g_free(void* ptr);
 void DEFAULT_CC g_printf(const char *format, ...);
 void DEFAULT_CC g_sprintf(char* dest, const char* format, ...);
 void DEFAULT_CC g_snprintf(char* dest, int len, const char* format, ...);
-void DEFAULT_CC g_writeln(const char* format, ...);
 void DEFAULT_CC g_write(const char* format, ...);
 void APP_CC     g_hexdump(char* p, int len);
 void APP_CC     g_memset(void* ptr, int val, int size);

--- a/libxrdp/libxrdp.c
+++ b/libxrdp/libxrdp.c
@@ -253,8 +253,8 @@ libxrdp_process_data(struct xrdp_session *session, struct stream *s)
         {
             /*This situation can happen and this is a workaround*/
             cont = 0;
-            g_writeln("Serious programming error we were locked in a deadly loop") ;
-            g_writeln("remaining :%d", s->end - s->next_packet);
+            g_writeln("Serious programming error: we were locked in a deadly loop");
+            g_writeln("Remaining: %td", s->end - s->next_packet);
             s->next_packet = 0;
         }
 
@@ -1298,7 +1298,6 @@ libxrdp_fastpath_send_surface(struct xrdp_session *session,
     struct stream ls;
     struct stream *s;
     struct xrdp_rdp *rdp;
-    int rv;
     int sec_bytes;
     int rdp_bytes;
     int max_bytes;

--- a/libxrdp/xrdp_caps.c
+++ b/libxrdp/xrdp_caps.c
@@ -562,7 +562,8 @@ xrdp_caps_process_confirm_active(struct xrdp_rdp *self, struct stream *s)
         in_uint16_le(s, len);
         if ((len < 4) || !s_check_rem(s, len - 4))
         {
-            g_writeln("xrdp_caps_process_confirm_active: error len %d", len, s->end - s->p);
+            g_writeln("xrdp_caps_process_confirm_active: error: len %d, "
+                      "remaining %td", len, s->end - s->p);
             return 1;
         }
         len -= 4;

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -419,7 +419,7 @@ xrdp_load_keyboard_layout(struct xrdp_client_info *client_info)
     }
     else
     {
-        LLOGLN(0, ("xrdp_load_keyboard_layout: error opening %d",
+        LLOGLN(0, ("xrdp_load_keyboard_layout: error opening %s",
                keyboard_cfg_file));
     }
 }

--- a/rdp/rdp_lic.c
+++ b/rdp/rdp_lic.c
@@ -73,6 +73,7 @@ rdp_lic_generate_hwid(struct rdp_lic *self, char *hwid)
               LICENCE_HWID_SIZE - 4);
 }
 
+#if 0
 /*****************************************************************************/
 /* Present an existing licence to the server */
 static void APP_CC
@@ -112,6 +113,7 @@ rdp_lic_present(struct rdp_lic *self, char *client_random, char *rsa_data,
     rdp_sec_send(self->sec_layer, s, sec_flags);
     free_stream(s);
 }
+#endif
 
 /*****************************************************************************/
 /* Send a licence request packet */
@@ -161,13 +163,7 @@ rdp_lic_process_demand(struct rdp_lic *self, struct stream *s)
 {
     char null_data[SEC_MODULUS_SIZE];
     char *server_random;
-    char signature[LICENCE_SIGNATURE_SIZE];
-    char hwid[LICENCE_HWID_SIZE];
-    char *licence_data;
-    int licence_size;
-    void *crypt_key;
 
-    licence_data = 0;
     /* Retrieve the server random from the incoming packet */
     in_uint8p(s, server_random, SEC_RANDOM_SIZE);
     /* We currently use null client keys. This is a bit naughty but, hey,
@@ -176,10 +172,17 @@ rdp_lic_process_demand(struct rdp_lic *self, struct stream *s)
     rdp_lic_generate_keys(self, null_data, server_random, null_data);
 
 #if 0
+    int licence_size;
+    char *licence_data;
+
     licence_size = 0; /* todo load_licence(&licence_data); */
 
     if (licence_size > 0)
     {
+        void *crypt_key;
+        char hwid[LICENCE_HWID_SIZE];
+        char signature[LICENCE_SIGNATURE_SIZE];
+
         /* Generate a signature for the HWID buffer */
         rdp_lic_generate_hwid(self, hwid);
         rdp_sec_sign(signature, 16, self->licence_sign_key, 16,

--- a/rdp/rdp_orders.c
+++ b/rdp/rdp_orders.c
@@ -326,15 +326,13 @@ rdp_orders_process_bmpcache(struct rdp_orders *self, struct stream *s,
     int bpp = 0;
     int Bpp = 0;
     int bufsize = 0;
-    int pad1 = 0;
-    int pad2 = 0;
     int row_size = 0;
     int final_size = 0;
     struct rdp_bitmap *bitmap = (struct rdp_bitmap *)NULL;
     struct stream *rec_s = (struct stream *)NULL;
 
     in_uint8(s, cache_id);
-    in_uint8(s, pad1);
+    in_uint8s(s, 1); /* pad */
     in_uint8(s, width);
     in_uint8(s, height);
     in_uint8(s, bpp);
@@ -348,7 +346,7 @@ rdp_orders_process_bmpcache(struct rdp_orders *self, struct stream *s,
     }
     else
     {
-        in_uint16_le(s, pad2);
+        in_uint8s(s, 2); /* pad */
         in_uint16_le(s, size);
         in_uint16_le(s, row_size);
         in_uint16_le(s, final_size);
@@ -1115,8 +1113,8 @@ static void APP_CC
 rdp_orders_process_desksave(struct rdp_orders *self, struct stream *s,
                             int present, int delta)
 {
-    int width = 0;
-    int height = 0;
+    // int width = 0;
+    // int height = 0;
 
     if (present & 0x01)
     {

--- a/sesman/chansrv/chansrv.c
+++ b/sesman/chansrv/chansrv.c
@@ -1525,7 +1525,6 @@ main(int argc, char **argv)
 
     LOGM((LOG_LEVEL_ALWAYS, "main: app started pid %d(0x%8.8x)", pid, pid));
     /*  set up signal handler  */
-    g_signal_kill(term_signal_handler); /* SIGKILL */
     g_signal_terminate(term_signal_handler); /* SIGTERM */
     g_signal_user_interrupt(term_signal_handler); /* SIGINT */
     g_signal_pipe(nil_signal_handler); /* SIGPIPE */

--- a/sesman/sesman.c
+++ b/sesman/sesman.c
@@ -331,7 +331,6 @@ main(int argc, char **argv)
 #if 1
     g_signal_hang_up(sig_sesman_reload_cfg); /* SIGHUP  */
     g_signal_user_interrupt(sig_sesman_shutdown); /* SIGINT  */
-    g_signal_kill(sig_sesman_shutdown); /* SIGKILL */
     g_signal_terminate(sig_sesman_shutdown); /* SIGTERM */
     g_signal_child_stop(sig_sesman_session_end); /* SIGCHLD */
 #endif

--- a/sesman/sesman.c
+++ b/sesman/sesman.c
@@ -46,7 +46,6 @@ sesman_main_loop(void)
     int error;
     int robjs_count;
     int cont;
-    int pid;
     tbus sck_obj;
     tbus robjs[8];
 

--- a/sesman/sessvc/sessvc.c
+++ b/sesman/sessvc/sessvc.c
@@ -93,7 +93,6 @@ main(int argc, char **argv)
         return 1;
     }
 
-    g_signal_kill(term_signal_handler); /* SIGKILL */
     g_signal_terminate(term_signal_handler); /* SIGTERM */
     g_signal_user_interrupt(term_signal_handler); /* SIGINT */
     g_signal_pipe(nil_signal_handler); /* SIGPIPE */

--- a/sesman/tools/sesrun.c
+++ b/sesman/tools/sesrun.c
@@ -115,7 +115,7 @@ main(int argc, char **argv)
                         {
                             in_uint16_be(in_s, data);
                             in_uint16_be(in_s, display);
-                            g_printf("ok %d display %d\n", data, display);
+                            g_printf("ok %ld display %d\n", data, display);
                         }
                     }
                 }

--- a/sesman/tools/sestest.c
+++ b/sesman/tools/sestest.c
@@ -201,8 +201,8 @@ int inputSession(struct SCP_SESSION *s)
     }
 
     g_printf("session type:\n");
-    g_printf("0: Xvnc\n", SCP_SESSION_TYPE_XVNC);
-    g_printf("1: x11rdp\n", SCP_SESSION_TYPE_XRDP);
+    g_printf("%d: Xvnc\n", SCP_SESSION_TYPE_XVNC);
+    g_printf("%d: x11rdp\n", SCP_SESSION_TYPE_XRDP);
     integer = menuSelect(1);
 
     if (integer == 1)

--- a/xrdp/xrdp.c
+++ b/xrdp/xrdp.c
@@ -107,7 +107,7 @@ xrdp_shutdown(int sig)
 
     threadid = tc_get_threadid();
     g_writeln("shutting down");
-    g_writeln("signal %d threadid %p", sig, threadid);
+    g_writeln("signal %d threadid %lld", sig, (long long)threadid);
 
     if (!g_is_wait_obj_set(g_term_event))
     {

--- a/xrdp/xrdp.c
+++ b/xrdp/xrdp.c
@@ -563,7 +563,6 @@ main(int argc, char **argv)
     g_threadid = tc_get_threadid();
     g_listen = xrdp_listen_create();
     g_signal_user_interrupt(xrdp_shutdown); /* SIGINT */
-    g_signal_kill(xrdp_shutdown); /* SIGKILL */
     g_signal_pipe(pipe_sig); /* SIGPIPE */
     g_signal_terminate(xrdp_shutdown); /* SIGTERM */
     g_signal_child_stop(xrdp_child); /* SIGCHLD */

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -2658,7 +2658,7 @@ server_msg(struct xrdp_mod *mod, char *msg, int code)
 
     if (code == 1)
     {
-        g_writeln(msg);
+        g_writeln("%s", msg);
         return 0;
     }
 

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -1867,7 +1867,7 @@ void add_string_to_logwindow(char *msg, struct list *log)
     do
     {
         new_part_message = g_strndup(current_pointer, LOG_WINDOW_CHAR_PER_LINE) ;
-        g_writeln(new_part_message);
+        g_writeln("%s", new_part_message);
         list_add_item(log, (long)new_part_message);
         processedlen = processedlen + g_strlen(new_part_message);
         current_pointer = current_pointer + g_strlen(new_part_message) ;

--- a/xrdp/xrdpwin.c
+++ b/xrdp/xrdpwin.c
@@ -618,7 +618,6 @@ main(int argc, char **argv)
     g_threadid = tc_get_threadid();
     g_listen = xrdp_listen_create();
     g_signal_user_interrupt(xrdp_shutdown); /* SIGINT */
-    g_signal_kill(xrdp_shutdown); /* SIGKILL */
     g_signal_pipe(pipe_sig); /* SIGPIPE */
     g_signal_terminate(xrdp_shutdown); /* SIGTERM */
     g_sync_mutex = tc_mutex_create();


### PR DESCRIPTION
It's important to fix compiler warnings. Many warnings indicate real problems with the code. In particular, unused variables often indicate remote date that is read but not used. Those warnings are not fixed. They should be fixed by those who can improve the code.

What is fixed is the easy stuff, the warnings that obscure bigger problems.

In addition to the compiler warnings, a warning from Valgrind has been fixed. Intercepting SIGKILL doesn't work and should not be done.