### PR TITLE
sesman: do not hardcode Xorg/X11rdp/Xvnc executables

### DIFF
--- a/sesman/config.h
+++ b/sesman/config.h
@@ -220,16 +220,14 @@ struct config_sesman
    */
   struct list* rdp_params;
   /**
-   * @var log
-   * @brief Log configuration struct
+   * @var xorg_params
+   * @brief Xorg additional parameter list
    */
-
   struct list* xorg_params;
   /**
    * @var log
    * @brief Log configuration struct
    */
-
   //struct log_config log;
   /**
    * @var sec

--- a/sesman/sesman.ini
+++ b/sesman/sesman.ini
@@ -63,6 +63,7 @@ EnableSyslog=1
 SyslogLevel=DEBUG
 
 [X11rdp]
+param0=X11rdp
 param1=-bs
 param2=-ac
 param3=-nolisten
@@ -70,6 +71,7 @@ param4=tcp
 param5=-uds
 
 [Xvnc]
+param0=Xvnc
 param1=-bs
 param2=-ac
 param3=-nolisten
@@ -79,6 +81,7 @@ param6=-dpi
 param7=96
 
 [Xorg]
+param0=Xorg
 param1=-config
 param2=xrdp/xorg.conf
 param3=-logfile

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -412,9 +412,10 @@ session_start_fork(int width, int height, int bpp, char *username,
     int pampid = 0;
     int xpid = 0;
     int i = 0;
+    char **xserver; /* absolute/relative path to Xorg/X11rdp/Xvnc */
     char geometry[32];
     char depth[32];
-    char screen[32];
+    char screen[32]; /* display number */
     char text[256];
     char passwd_file[256];
     char *pfile;
@@ -652,8 +653,12 @@ session_start_fork(int width, int height, int bpp, char *username,
                     xserver_params = list_create();
                     xserver_params->auto_free = 1;
 
+		    /* get path of Xorg from config */
+		    xserver = g_strdup(list_get_item(g_cfg->xorg_params, 0));
+		    list_remove_item(g_cfg->xorg_params, 0);
+
                     /* these are the must have parameters */
-                    list_add_item(xserver_params, (tintptr) g_strdup("Xorg"));
+                    list_add_item(xserver_params, (tintptr) g_strdup(xserver));
                     list_add_item(xserver_params, (tintptr) g_strdup(screen));
 
                     /* additional parameters from sesman.ini file */
@@ -674,7 +679,7 @@ session_start_fork(int width, int height, int bpp, char *username,
                     g_setenv("XRDP_START_HEIGHT", geometry, 1);
 
                     /* fire up Xorg */
-                    g_execvp("Xorg", pp1);
+                    g_execvp(xserver, pp1);
                 }
                 else if (type == SESMAN_SESSION_TYPE_XVNC)
                 {
@@ -682,8 +687,12 @@ session_start_fork(int width, int height, int bpp, char *username,
                     xserver_params = list_create();
                     xserver_params->auto_free = 1;
 
+		    /* get path of Xvnc from config */
+		    xserver = g_strdup(list_get_item(g_cfg->vnc_params, 0));
+		    list_remove_item(g_cfg->vnc_params, 0);
+
                     /* these are the must have parameters */
-                    list_add_item(xserver_params, (tintptr)g_strdup("Xvnc"));
+                    list_add_item(xserver_params, (tintptr)g_strdup(xserver));
                     list_add_item(xserver_params, (tintptr)g_strdup(screen));
                     list_add_item(xserver_params, (tintptr)g_strdup("-geometry"));
                     list_add_item(xserver_params, (tintptr)g_strdup(geometry));
@@ -701,15 +710,19 @@ session_start_fork(int width, int height, int bpp, char *username,
                     list_add_item(xserver_params, 0);
                     pp1 = (char **)xserver_params->items;
                     log_message(LOG_LEVEL_INFO, "%s", dumpItemsToString(xserver_params, execvpparams, 2048));
-                    g_execvp("Xvnc", pp1);
+                    g_execvp(xserver, pp1);
                 }
                 else if (type == SESMAN_SESSION_TYPE_XRDP)
                 {
                     xserver_params = list_create();
                     xserver_params->auto_free = 1;
 
+		    /* get path of X11rdp from config */
+		    xserver = g_strdup(list_get_item(g_cfg->rdp_params, 0));
+		    list_remove_item(g_cfg->rdp_params, 0);
+
                     /* these are the must have parameters */
-                    list_add_item(xserver_params, (tintptr)g_strdup("X11rdp"));
+                    list_add_item(xserver_params, (tintptr)g_strdup(xserver));
                     list_add_item(xserver_params, (tintptr)g_strdup(screen));
                     list_add_item(xserver_params, (tintptr)g_strdup("-geometry"));
                     list_add_item(xserver_params, (tintptr)g_strdup(geometry));
@@ -725,7 +738,7 @@ session_start_fork(int width, int height, int bpp, char *username,
                     list_add_item(xserver_params, 0);
                     pp1 = (char **)xserver_params->items;
                     log_message(LOG_LEVEL_INFO, "%s", dumpItemsToString(xserver_params, execvpparams, 2048));
-                    g_execvp("X11rdp", pp1);
+                    g_execvp(xserver, pp1);
                 }
                 else
                 {


### PR DESCRIPTION
In RHEL and its clones, /usr/bin/Xorg is set suid-root. To execute
Xorg with user privileges, /etc/pam.d/xserver needs be edited [1],
or suid bit of Xorg binary needs to be dropped.

In order to keep Xorg and /etc/pam.d/xserver untouched, preparing
non-suid version of Xorg as /usr/bin/Xorg.non-suid for example is
the simplest solution. However, Xorg.non-suid cannot be executed
since it is hardcoded to execute Xorg in sesman.

This change makes more flexible to execute Xorg with non-standard
name or not in PATH environment variable.

[1] https://www.centos.org/forums/viewtopic.php?t=21185