### PR TITLE
Allows use the xkb options that for example allows  specify a key combination to change the layouts.

### DIFF
--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -338,6 +338,15 @@ xrdp_load_keyboard_layout(struct xrdp_client_info *client_info)
                             g_strncpy(client_info->variant, value, bytes - 1);
                         }
                     }
+                    else if (g_strcasecmp(item, "options") == 0)
+                    {
+                        if (section_found != -1 && section_found == index)
+                        {
+                            bytes = sizeof(client_info->options);
+                            g_memset(client_info->options, 0, bytes);
+                            g_strncpy(client_info->options, value, bytes - 1);
+                        }
+                    }
                     else
                     {
                         /*


### PR DESCRIPTION
Example of xrdp_keyboard.ini for russian keyboard

[default_rdp_layouts]
rdp_layout_us=0x00000409
rdp_layout_de=0x00000407
rdp_layout_fr=0x0000040C
rdp_layout_it=0x00000410
rdp_layout_jp=0x00000411
rdp_layout_jp2=0xe0010411
rdp_layout_jp3=0xe0200411
rdp_layout_jp4=0xe0210411
rdp_layout_ru=0x00000419
rdp_layout_se=0x0000041D
rdp_layout_pt=0x00000816
rdp_layout_br=0x00000416
rdp_layout_pl=0x00000415

[rdp_keyboard_ru]
keyboard_type=4
keyboard_subtype=1
model=pc105
options=grp:alt_shift_toggle
rdp_layouts=default_rdp_layouts
layouts_map=layouts_map_ru

[layouts_map_ru]
rdp_layout_us=us,ru
rdp_layout_ru=us,ru