### PR TITLE
Fix warnings reported by gcc 5.3.0 on Mac OS

### DIFF
--- a/sesman/chansrv/clipboard.c
+++ b/sesman/chansrv/clipboard.c
@@ -2382,6 +2382,11 @@ clipboard_event_property_notify(XEvent *xevent)
                                 AnyPropertyType, &actual_type_return, &actual_format_return,
                                 &nitems_returned, &bytes_left, &data);
 
+        if (rv != Success)
+        {
+            return 1;
+        }
+
         if (data != 0)
         {
             XFree(data);
@@ -2424,6 +2429,11 @@ clipboard_event_property_notify(XEvent *xevent)
             rv = XGetWindowProperty(g_display, g_wnd, g_clip_s2c.property, 0, bytes_left, 0,
                                     AnyPropertyType, &actual_type_return, &actual_format_return,
                                     &nitems_returned, &bytes_left, &data);
+
+            if (rv != Success)
+            {
+                return 1;
+            }
 
             format_in_bytes = FORMAT_TO_BYTES(actual_format_return);
             new_data_len = nitems_returned * format_in_bytes;

--- a/sesman/chansrv/devredir.c
+++ b/sesman/chansrv/devredir.c
@@ -1474,7 +1474,6 @@ devredir_cvt_from_unicode_len(char *path, char *unicode, int len)
     char *dest;
     char *dest_saved;
     char *src;
-    int   rv;
     int   i;
     int   bytes_to_alloc;
     int   max_bytes;
@@ -1499,7 +1498,7 @@ devredir_cvt_from_unicode_len(char *path, char *unicode, int len)
     max_bytes = wcstombs(NULL, (wchar_t *) dest_saved, 0);
     if (max_bytes > 0)
     {
-        rv = wcstombs(path, (wchar_t *) dest_saved, max_bytes);
+        wcstombs(path, (wchar_t *) dest_saved, max_bytes);
         path[max_bytes] = 0;
     }
 

--- a/sesman/chansrv/devredir.c
+++ b/sesman/chansrv/devredir.c
@@ -890,21 +890,13 @@ dev_redir_proc_query_dir_response(IRP *irp,
     XRDP_INODE *xinode;
 
     tui32 Length;
-    tui32 NextEntryOffset;
     tui64 CreationTime;
     tui64 LastAccessTime;
     tui64 LastWriteTime;
-    tui64 ChangeTime;
     tui64 EndOfFile;
     tui32 FileAttributes;
     tui32 FileNameLength;
     tui32 status;
-
-#ifdef USE_SHORT_NAMES_IN_DIR_LISTING
-    tui32 EaSize;
-    tui8  ShortNameLength;
-    tui8  Reserved;
-#endif
 
     char  filename[256];
     int   i = 0;
@@ -935,21 +927,21 @@ dev_redir_proc_query_dir_response(IRP *irp,
     {
         log_debug("processing FILE_DIRECTORY_INFORMATION structs");
 
-        xstream_rd_u32_le(s_in, NextEntryOffset);
+        xstream_seek(s_in, 4);  /* NextEntryOffset */
         xstream_seek(s_in, 4);  /* FileIndex */
         xstream_rd_u64_le(s_in, CreationTime);
         xstream_rd_u64_le(s_in, LastAccessTime);
         xstream_rd_u64_le(s_in, LastWriteTime);
-        xstream_rd_u64_le(s_in, ChangeTime);
+        xstream_seek(s_in, 8);  /* ChangeTime */
         xstream_rd_u64_le(s_in, EndOfFile);
         xstream_seek(s_in, 8);  /* AllocationSize */
         xstream_rd_u32_le(s_in, FileAttributes);
         xstream_rd_u32_le(s_in, FileNameLength);
 
 #ifdef USE_SHORT_NAMES_IN_DIR_LISTING
-        xstream_rd_u32_le(s_in, EaSize);
-        xstream_rd_u8(s_in, ShortNameLength);
-        xstream_rd_u8(s_in, Reserved);
+        xstream_seek(s_in, 4); /* EaSize */
+        xstream_seek(s_in, 1); /* ShortNameLength */
+        xstream_seek(s_in, 1); /* Reserved */
         xstream_seek(s_in, 23);  /* ShortName in Unicode */
 #endif
         devredir_cvt_from_unicode_len(filename, s_in->p, FileNameLength);
@@ -959,11 +951,9 @@ dev_redir_proc_query_dir_response(IRP *irp,
 #else
         i += 64 + FileNameLength;
 #endif
-        //log_debug("NextEntryOffset:   0x%x", NextEntryOffset);
         //log_debug("CreationTime:      0x%llx", CreationTime);
         //log_debug("LastAccessTime:    0x%llx", LastAccessTime);
         //log_debug("LastWriteTime:     0x%llx", LastWriteTime);
-        //log_debug("ChangeTime:        0x%llx", ChangeTime);
         //log_debug("EndOfFile:         %lld", EndOfFile);
         //log_debug("FileAttributes:    0x%x", FileAttributes);
 #ifdef USE_SHORT_NAMES_IN_DIR_LISTING

--- a/xrdpapi/xrdpapi.c
+++ b/xrdpapi/xrdpapi.c
@@ -480,17 +480,11 @@ get_display_num_from_display(char *display_text)
 {
     int index;
     int mode;
-    int host_index;
     int disp_index;
-    int scre_index;
-    char host[256];
     char disp[256];
-    char scre[256];
 
     index = 0;
-    host_index = 0;
     disp_index = 0;
-    scre_index = 0;
     mode = 0;
 
     while (display_text[index] != 0)
@@ -503,27 +497,15 @@ get_display_num_from_display(char *display_text)
         {
             mode = 2;
         }
-        else if (mode == 0)
-        {
-            host[host_index] = display_text[index];
-            host_index++;
-        }
         else if (mode == 1)
         {
             disp[disp_index] = display_text[index];
             disp_index++;
         }
-        else if (mode == 2)
-        {
-            scre[scre_index] = display_text[index];
-            scre_index++;
-        }
 
         index++;
     }
 
-    host[host_index] = 0;
     disp[disp_index] = 0;
-    scre[scre_index] = 0;
     return atoi(disp);
 }

--- a/xup/xup.c
+++ b/xup/xup.c
@@ -1236,7 +1236,7 @@ process_server_paint_rect_shmem_ex(struct mod *amod, struct stream *s)
     g_free(lcrects);
     g_free(ldrects);
 
-    return 0;
+    return rv;
 }
 
 /******************************************************************************/


### PR DESCRIPTION
This should make xrdp warning-free and set a higher standard for new code contributions.