### PR TITLE
Fix pc105-jp-Henkan key.

### DIFF
--- a/xorg/X11R7.6/xkeyboard-config-2.0.patch
+++ b/xorg/X11R7.6/xkeyboard-config-2.0.patch
@@ -1,0 +1,88 @@
+diff -rupP xkeyboard-config-2.0.orig/rules/HDR xkeyboard-config-2.0/rules/HDR
+--- xkeyboard-config-2.0.orig/rules/HDR	2016-06-28 19:31:02.814647638 +0900
++++ xkeyboard-config-2.0/rules/HDR	2016-06-28 19:33:58.251517616 +0900
+@@ -15,6 +15,7 @@
+ ! model		layout[3]	variant[3]	=	symbols
+ ! model		layout[4]	variant[4]	=	symbols
+ ! model		=	symbols
++! model		layout		=	symbols
+ ! layout	variant		=	compat
+ ! layout[1]	variant[1]	=	compat
+ ! layout[2]	variant[2]	=	compat
+diff -rupP xkeyboard-config-2.0.orig/rules/Makefile.am xkeyboard-config-2.0/rules/Makefile.am
+--- xkeyboard-config-2.0.orig/rules/Makefile.am	2016-06-28 19:31:02.814647638 +0900
++++ xkeyboard-config-2.0/rules/Makefile.am	2016-06-28 20:58:22.276629031 +0900
+@@ -41,6 +41,7 @@ HDR compat/base.ml2v2_s.part  extras/bas
+ HDR compat/base.ml3v3_s.part  extras/base.ml3v3_s.part \
+ HDR compat/base.ml4v4_s.part  extras/base.ml4v4_s.part \
+ HDR base.m_s.part \
++HDR base.ml_s1.part \
+ HDR compat/base.lv_c.part   \
+ HDR compat/base.l1v1_c.part \
+ HDR compat/base.l2v2_c.part \
+@@ -114,6 +115,7 @@ HDR extras/base.ml2v2_s.part \
+ HDR extras/base.ml3v3_s.part \
+ HDR extras/base.ml4v4_s.part \
+ HDR base.m_s.part \
++HDR base.ml_s1.part \
+ HDR \
+ HDR \
+ HDR \
+@@ -183,6 +185,7 @@ base.ml2_s.part \
+ base.ml3_s.part \
+ base.ml4_s.part \
+ base.m_s.part \
++base.ml_s1.part \
+ base.ml_c.part \
+ base.ml1_c.part \
+ base.m_t.part \
+diff -rupP xkeyboard-config-2.0.orig/rules/Makefile.in xkeyboard-config-2.0/rules/Makefile.in
+--- xkeyboard-config-2.0.orig/rules/Makefile.in	2016-06-28 19:31:02.850647811 +0900
++++ xkeyboard-config-2.0/rules/Makefile.in	2016-06-28 21:00:57.569398853 +0900
+@@ -239,6 +239,7 @@ SUBDIRS = bin compat extras
+ @USE_COMPAT_RULES_FALSE@HDR extras/base.ml3v3_s.part \
+ @USE_COMPAT_RULES_FALSE@HDR extras/base.ml4v4_s.part \
+ @USE_COMPAT_RULES_FALSE@HDR base.m_s.part \
++@USE_COMPAT_RULES_FALSE@HDR base.ml_s1.part \
+ @USE_COMPAT_RULES_FALSE@HDR \
+ @USE_COMPAT_RULES_FALSE@HDR \
+ @USE_COMPAT_RULES_FALSE@HDR \
+@@ -275,6 +276,7 @@ SUBDIRS = bin compat extras
+ @USE_COMPAT_RULES_TRUE@HDR compat/base.ml3v3_s.part  extras/base.ml3v3_s.part \
+ @USE_COMPAT_RULES_TRUE@HDR compat/base.ml4v4_s.part  extras/base.ml4v4_s.part \
+ @USE_COMPAT_RULES_TRUE@HDR base.m_s.part \
++@USE_COMPAT_RULES_TRUE@HDR base.ml_s1.part \
+ @USE_COMPAT_RULES_TRUE@HDR compat/base.lv_c.part   \
+ @USE_COMPAT_RULES_TRUE@HDR compat/base.l1v1_c.part \
+ @USE_COMPAT_RULES_TRUE@HDR compat/base.l2v2_c.part \
+@@ -378,6 +380,7 @@ base.ml2_s.part \
+ base.ml3_s.part \
+ base.ml4_s.part \
+ base.m_s.part \
++base.ml_s1.part \
+ base.ml_c.part \
+ base.ml1_c.part \
+ base.m_t.part \
+diff -rupP xkeyboard-config-2.0.orig/rules/base.ml_s1.part xkeyboard-config-2.0/rules/base.ml_s1.part
+--- xkeyboard-config-2.0.orig/rules/base.ml_s1.part	1970-01-01 09:00:00.000000000 +0900
++++ xkeyboard-config-2.0/rules/base.ml_s1.part	2016-06-28 19:59:05.238990192 +0900
+@@ -0,0 +1 @@
++  $inetkbds	jp		=	+jp(henkan)
+diff -rupP xkeyboard-config-2.0.orig/symbols/jp xkeyboard-config-2.0/symbols/jp
+--- xkeyboard-config-2.0.orig/symbols/jp	2016-06-28 19:31:03.046648788 +0900
++++ xkeyboard-config-2.0/symbols/jp	2016-06-28 19:32:57.367215702 +0900
+@@ -105,6 +105,14 @@ xkb_symbols "common" {
+     };
+ };
+ 
++partial alphanumeric_keys
++xkb_symbols "henkan" {
++    key <XFER> {
++        type[Group1]= "PC_ALT_LEVEL2",
++        symbols[Group1]= [ Henkan, Mode_switch ]
++    };
++};
++
+ // OADG109A map
+ partial alphanumeric_keys
+ xkb_symbols "OADG109A" {

--- a/xrdp/xrdp_keyboard.ini
+++ b/xrdp/xrdp_keyboard.ini
@@ -100,7 +100,7 @@ layouts_map=rdp_layouts_map_mac
 [rdp_keyboard_jp]
 keyboard_type=7
 keyboard_subtype=2
-model=jp106
+model=pc105
 rdp_layouts=default_rdp_layouts
 layouts_map=default_layouts_map
 


### PR DESCRIPTION
PC105-jp keyboard need xkeyboard-config version 2.11 or later. 
xkeyboard-config version 2.11 or later need libX11 version 1.4.3 or later. 

I was build XRDP with xkeyboard-config-2.11 and libX11-1.4.3.
But it was not accept keyboard.
I was done backport because there is no way.
This is the interim fix.

Please build someone X11 by the newer libraries.
