### PR TITLE
Fix rpmlint warning about W: devel-file-in-non-devel-package

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -42,3 +42,6 @@ libcommon_la_LIBADD = \
   -lcrypto \
   -lssl \
   -lpthread
+
+libcommon_la_LDFLAGS = \
+  -avoid-version -module

--- a/libxrdp/Makefile.am
+++ b/libxrdp/Makefile.am
@@ -58,7 +58,8 @@ libxrdp_la_SOURCES = \
   xrdp_sec.c
 
 libxrdp_la_LDFLAGS = \
-  $(EXTRA_FLAGS)
+  $(EXTRA_FLAGS) \
+  -avoid-version -module
 
 libxrdp_la_LIBADD = \
   $(top_builddir)/common/libcommon.la \

--- a/mc/Makefile.am
+++ b/mc/Makefile.am
@@ -14,3 +14,6 @@ libmc_la_SOURCES = \
 
 libmc_la_LIBADD = \
   $(top_builddir)/common/libcommon.la
+
+libmc_la_LDFLAGS = \
+  -avoid-version -module

--- a/rdp/Makefile.am
+++ b/rdp/Makefile.am
@@ -31,3 +31,6 @@ librdp_la_SOURCES = \
 
 librdp_la_LIBADD = \
   $(top_builddir)/common/libcommon.la
+
+librdp_la_LDFLAGS = \
+  -avoid-version -module

--- a/sesman/libscp/Makefile.am
+++ b/sesman/libscp/Makefile.am
@@ -40,3 +40,6 @@ libscp_la_SOURCES = \
 libscp_la_LIBADD = \
   $(top_builddir)/common/libcommon.la \
   -lpthread
+
+libscp_la_LDFLAGS = \
+  -avoid-version -module

--- a/vnc/Makefile.am
+++ b/vnc/Makefile.am
@@ -14,3 +14,7 @@ libvnc_la_SOURCES = \
 
 libvnc_la_LIBADD = \
   $(top_builddir)/common/libcommon.la
+
+libvnc_la_LDFLAGS = \
+  -avoid-version -module
+

--- a/xrdpapi/Makefile.am
+++ b/xrdpapi/Makefile.am
@@ -19,3 +19,6 @@ libxrdpapi_la_LDFLAGS = \
 
 libxrdpapi_la_LIBADD = \
   $(EXTRA_LIBS)
+
+libxrdpapi_la_LDFLAGS = \
+  -avoid-version -module

--- a/xup/Makefile.am
+++ b/xup/Makefile.am
@@ -14,3 +14,7 @@ libxup_la_SOURCES = \
 
 libxup_la_LIBADD = \
   $(top_builddir)/common/libcommon.la
+
+libxup_la_LDFLAGS = \
+  -avoid-version -module
+


### PR DESCRIPTION
It is common way not to embed version for loadable module.
Without this change, rpmlint reports it as a warning.

For example, https://en.opensuse.org/openSUSE:Packaging_checks#devel-file-in-non-devel-package
