### PR TITLE
X11rdp: update python 2.7 -> 2.7.11

### DIFF
--- a/xorg/X11R7.6/x11_file_list.txt
+++ b/xorg/X11R7.6/x11_file_list.txt
@@ -1,4 +1,4 @@
-Python-2.7.tar.bz2                              :  Python-2.7                               :
+Python-2.7.11.tar.xz                            :  Python-2.7.11                            :
 util-macros-1.11.0.tar.bz2                      :  util-macros-1.11.0                       :
 xf86driproto-2.1.0.tar.bz2                      :  xf86driproto-2.1.0                       :
 dri2proto-2.3.tar.bz2                           :  dri2proto-2.3                            :


### PR DESCRIPTION
Python 2.7 cannot build with OpenSSL 1.0.2h pointed out in #399.
Python-2.7.11.tar.xz needs to be uploaded to server1.xrdp.org.

I've confirmed X11rdp successfully builds with python 2.7.11 and built X11rdp properly works.
Please don't forget to upload tarball to server1.xrdp.org before merge this.