### PR TITLE
chansrv: avoid chansrv SEGV when xinode is NULL

### DIFF
--- a/sesman/chansrv/chansrv_fuse.c
+++ b/sesman/chansrv/chansrv_fuse.c
@@ -780,6 +780,11 @@ int xfuse_add_clip_dir_item(char *filename, int flags, int size, int lindex)
                                                       2,    /* parent inode */
                                                       filename,
                                                       S_IFREG);
+    if (xinode == NULL)
+    {
+        log_debug("failed to create file in xrdp filesystem");
+        return -1;
+    }
     xinode->size = size;
     xinode->lindex = lindex;
     xinode->is_loc_resource = 1;

--- a/sesman/chansrv/clipboard_file.c
+++ b/sesman/chansrv/clipboard_file.c
@@ -660,7 +660,11 @@ clipboard_c2s_in_files(struct stream *s, char *file_list)
                        "supported [%s]", cfd->cFileName);
             continue;
         }
-        xfuse_add_clip_dir_item(cfd->cFileName, 0, cfd->fileSizeLow, lindex);
+        if (xfuse_add_clip_dir_item(cfd->cFileName, 0, cfd->fileSizeLow, lindex) == -1)
+        {
+            log_error("clipboard_c2s_in_files: failed to add clip dir item");
+            continue;
+        }
 
         if (file_count > 0)
         {


### PR DESCRIPTION
When xfuse_create_file_in_xrdp_fs is failed, it returns NULL.

Without this fix, xinode->size causes SEGV, so implementation is changed
to return -1 and check the return value in caller.