### PR TITLE
Pixman fixes

### DIFF
--- a/common/pixman-region.c
+++ b/common/pixman-region.c
@@ -204,7 +204,7 @@ alloc_data (size_t n)
     if (!sz)
         return NULL;
 
-    return malloc (sz);
+    return (region_data_type_t *) malloc(sz);
 }
 
 #define FREE_DATA(reg) if ((reg)->data && (reg)->data->size) free ((reg)->data)
@@ -1703,7 +1703,7 @@ validate (region_type_t * badreg)
 
             if (ri == stack_regions)
             {
-                rit = malloc (data_size);
+                rit = (region_info_t *) malloc(data_size);
                 if (!rit)
                     goto bail;
                 memcpy (rit, ri, num_ri * sizeof (region_info_t));

--- a/common/pixman-region16.c
+++ b/common/pixman-region16.c
@@ -27,13 +27,10 @@
    altered to compile without all of pixman */
 
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include "pixman-region.h"
-
-#define UINT32_MAX  (4294967295U)
-#define INT16_MIN   (-32767-1)
-#define INT16_MAX   (32767)
 
 #define PIXMAN_EXPORT
 #define FALSE 0

--- a/common/pixman-region16.c
+++ b/common/pixman-region16.c
@@ -39,8 +39,6 @@
 #define MIN(x1, x2) ((x1) < (x2) ? (x1) : (x2))
 #define MAX(x1, x2) ((x1) > (x2) ? (x1) : (x2))
 
-typedef int pixman_bool_t;
-
 typedef pixman_box16_t                  box_type_t;
 typedef pixman_region16_data_t          region_data_type_t;
 typedef pixman_region16_t               region_type_t;

--- a/configure.ac
+++ b/configure.ac
@@ -114,7 +114,7 @@ AC_ARG_ENABLE(mp3lame, AS_HELP_STRING([--enable-mp3lame],
 AM_CONDITIONAL(XRDP_MP3LAME, [test x$enable_mp3lame = xyes])
 AC_ARG_ENABLE(pixman, AS_HELP_STRING([--enable-pixman],
               [Use pixman library (default: no)]),
-              [], [enable_pimanno])
+              [], [enable_pixman=no])
 AM_CONDITIONAL(XRDP_PIXMAN, [test x$enable_pixman = xyes])
 
 # checking for openssl


### PR DESCRIPTION
The recent commits introduced an error message from configure (`enable_pimanno: command not found`), C compile warnings (redefined constants) and C++ warnings (pointer casts). This pull request fixes them all.