### PR TITLE
Include stdint.h, don't redefine MAX/MIN constants if already defined

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -1,10 +1,10 @@
-
-EXTRA_FILES =
-
 if XRDP_PIXMAN
+  PIXMAN_SOURCES =
 else
-  EXTRA_FILES += pixman-region16.c pixman-region.h
+  PIXMAN_SOURCES = pixman-region16.c pixman-region.h
 endif
+
+EXTRA_DIST = pixman-region.c
 
 AM_CPPFLAGS = \
   -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
@@ -45,7 +45,7 @@ libcommon_la_SOURCES = \
   xrdp_client_info.h \
   xrdp_constants.h \
   xrdp_rail.h \
-  $(EXTRA_FILES)
+  $(PIXMAN_SOURCES)
 
 libcommon_la_LIBADD = \
   -lcrypto \

--- a/common/pixman-region16.c
+++ b/common/pixman-region16.c
@@ -27,13 +27,20 @@
    altered to compile without all of pixman */
 
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include "pixman-region.h"
 
+#if !defined(UINT32_MAX)
 #define UINT32_MAX  (4294967295U)
+#endif
+#if !defined(INT16_MIN)
 #define INT16_MIN   (-32767-1)
+#endif
+#if !defined(INT16_MAX)
 #define INT16_MAX   (32767)
+#endif
 
 #define PIXMAN_EXPORT
 #define FALSE 0


### PR DESCRIPTION
Safer version of the original patch. The constants are defined only if they are not defined in stdint.h or elsewhere.