### PR TITLE
Fix clipboard when text/filename contains non-ASCII characters

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -136,7 +136,21 @@ g_init(const char *app_name)
 
     WSAStartup(2, &wsadata);
 #endif
-    setlocale(LC_CTYPE, "");
+
+    /* In order to get g_mbstowcs and g_wcstombs to work properly with
+       UTF-8 non-ASCII characters, LC_CTYPE cannot be "C" or blank.
+       To select UTF-8 encoding without specifying any countries/languages,
+       "C.UTF-8" is used but provided in few systems.
+
+       See also: https://sourceware.org/glibc/wiki/Proposals/C.UTF-8 */
+    char *lc_ctype;
+    lc_ctype = setlocale(LC_CTYPE, "C.UTF-8");
+    if (lc_ctype == NULL)
+    {
+        /* use en_US.UTF-8 instead if not available */
+        setlocale(LC_CTYPE, "en_US.UTF-8");
+    }
+
     g_mk_temp_dir(app_name);
 }
 


### PR DESCRIPTION
broken by #314. This is compatible with the fix introduced in #314.

To use non-ASCII text/filename in clipboard, chansrv needs to be run
with LC_CTYPE=\*.UTF-8 because the behaviour of mbstowcs(3) function
called in chansrv depends on LC_CTYPE[1].  However #314 made
LC_CTYPE=C in chansrv context.  Even if LANG and LC_\* are set in
.bashrc, /etc/profile, /etc/locale.conf or something like that,
it doesn't affect in chansrv context because chansrv doesn't source
any of them unlike sesman.

So do not set LC_CTYPE to blank or "C" in g_init() in order to get
g_mbstowcs and g_wcstombs to work properly with non-ASCII UTF-8
characters in any context.

Setting LC_CTYPE to *.UTF-8 doesn't obstruct applying system
language in RHEL [2].

[1] Linux man page says:
      The behavior of mbstowcs() depends on the LC_CTYPE category of
      the current locale.

[2] https://bugzilla.redhat.com/show_bug.cgi?id=1290820