### PR TITLE
Cleaning up bogus messages about closing "established" connections to NULL:NULL

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -332,13 +332,8 @@ int APP_CC
 g_tcp_set_no_delay(int sck)
 {
     int ret = 1; /* error */
-#if defined(_WIN32)
     int option_value;
-    int option_len;
-#else
-    int option_value;
-    unsigned int option_len;
-#endif
+    socklen_t option_len;
 
     option_len = sizeof(option_value);
 
@@ -376,13 +371,8 @@ int APP_CC
 g_tcp_set_keepalive(int sck)
 {
     int ret = 1; /* error */
-#if defined(_WIN32)
     int option_value;
-    int option_len;
-#else
-    int option_value;
-    unsigned int option_len;
-#endif
+    socklen_t option_len;
 
     option_len = sizeof(option_value);
 
@@ -422,11 +412,7 @@ g_tcp_socket(void)
 {
     int rv;
     int option_value;
-#if defined(_WIN32)
-    int option_len;
-#else
-    unsigned int option_len;
-#endif
+    socklen_t option_len;
 
 #if defined(XRDP_ENABLE_IPV6)
     rv = (int)socket(AF_INET6, SOCK_STREAM, 0);
@@ -500,11 +486,7 @@ int APP_CC
 g_sck_set_send_buffer_bytes(int sck, int bytes)
 {
     int option_value;
-#if defined(_WIN32)
-    int option_len;
-#else
-    unsigned int option_len;
-#endif
+    socklen_t option_len;
 
     option_value = bytes;
     option_len = sizeof(option_value);
@@ -522,11 +504,7 @@ int APP_CC
 g_sck_get_send_buffer_bytes(int sck, int *bytes)
 {
     int option_value;
-#if defined(_WIN32)
-    int option_len;
-#else
-    unsigned int option_len;
-#endif
+    socklen_t option_len;
 
     option_value = 0;
     option_len = sizeof(option_value);
@@ -545,11 +523,7 @@ int APP_CC
 g_sck_set_recv_buffer_bytes(int sck, int bytes)
 {
     int option_value;
-#if defined(_WIN32)
-    int option_len;
-#else
-    unsigned int option_len;
-#endif
+    socklen_t option_len;
 
     option_value = bytes;
     option_len = sizeof(option_value);
@@ -567,11 +541,7 @@ int APP_CC
 g_sck_get_recv_buffer_bytes(int sck, int *bytes)
 {
     int option_value;
-#if defined(_WIN32)
-    int option_len;
-#else
-    unsigned int option_len;
-#endif
+    socklen_t option_len;
 
     option_value = 0;
     option_len = sizeof(option_value);
@@ -601,11 +571,7 @@ int APP_CC
 g_sck_get_peer_cred(int sck, int *pid, int *uid, int *gid)
 {
 #if defined(SO_PEERCRED)
-#if defined(_WIN32)
-    int ucred_length;
-#else
-    unsigned int ucred_length;
-#endif
+    socklen_t ucred_length;
     struct myucred
     {
         pid_t pid;
@@ -1056,11 +1022,7 @@ g_tcp_accept(int sck)
     int ret ;
     char ipAddr[256] ;
     struct sockaddr_in s;
-#if defined(_WIN32)
-    signed int i;
-#else
-    unsigned int i;
-#endif
+    socklen_t i;
 
     i = sizeof(struct sockaddr_in);
     memset(&s, 0, i);
@@ -1081,11 +1043,7 @@ g_sck_accept(int sck, char *addr, int addr_bytes, char *port, int port_bytes)
     int ret;
     char ipAddr[256];
     struct sockaddr_in s;
-#if defined(_WIN32)
-    signed int i;
-#else
-    unsigned int i;
-#endif
+    socklen_t i;
 
     i = sizeof(struct sockaddr_in);
     memset(&s, 0, i);
@@ -1115,11 +1073,7 @@ g_write_ip_address(int rcv_sck, char *ip_address, int bytes)
 {
     struct sockaddr_in s;
     struct in_addr in;
-#if defined(_WIN32)
-    int len;
-#else
-    unsigned int len;
-#endif
+    socklen_t len;
     int ip_port;
     int ok;
 
@@ -1196,13 +1150,8 @@ g_sck_send(int sck, const void *ptr, int len, int flags)
 int APP_CC
 g_sck_socket_ok(int sck)
 {
-#if defined(_WIN32)
     int opt;
-    int opt_len;
-#else
-    int opt;
-    unsigned int opt_len;
-#endif
+    socklen_t opt_len;
 
     opt_len = sizeof(opt);
 

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -763,6 +763,13 @@ g_tcp_connect(int sck, const char *address, const char *port)
             }
         }
     }
+
+    /* Mac OSX connect() returns -1 for already established connections */
+    if (res == -1 && errno == EISCONN)
+    {
+        res = 0;
+    }
+
     return res;
 }
 #else
@@ -771,6 +778,7 @@ g_tcp_connect(int sck, const char* address, const char* port)
 {
     struct sockaddr_in s;
     struct hostent* h;
+    int res;
 
     g_memset(&s, 0, sizeof(struct sockaddr_in));
     s.sin_family = AF_INET;
@@ -793,7 +801,15 @@ g_tcp_connect(int sck, const char* address, const char* port)
             }
         }
     }
-    return connect(sck, (struct sockaddr*)&s, sizeof(struct sockaddr_in));
+    res = connect(sck, (struct sockaddr*)&s, sizeof(struct sockaddr_in));
+
+    /* Mac OSX connect() returns -1 for already established connections */
+    if (res == -1 && errno == EISCONN)
+    {
+        res = 0;
+    }
+
+    return res;
 }
 #endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -16,6 +16,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AX_CFLAGS_WARN_ALL
 AX_APPEND_COMPILE_FLAGS([-Wwrite-strings])
 AX_GCC_FUNC_ATTRIBUTE([format])
+AX_TYPE_SOCKLEN_T
 
 case $host_os in
 	*linux*)

--- a/m4/ax_type_socklen_t.m4
+++ b/m4/ax_type_socklen_t.m4
@@ -1,0 +1,61 @@
+# ===========================================================================
+#     http://www.gnu.org/software/autoconf-archive/ax_type_socklen_t.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_TYPE_SOCKLEN_T
+#
+# DESCRIPTION
+#
+#   Check whether sys/socket.h defines type socklen_t. Please note that some
+#   systems require sys/types.h to be included before sys/socket.h can be
+#   compiled.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Lars Brinkhoff <lars@nocrew.org>
+#
+#   This program is free software; you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation; either version 2 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 5
+
+AU_ALIAS([TYPE_SOCKLEN_T], [AX_TYPE_SOCKLEN_T])
+AC_DEFUN([AX_TYPE_SOCKLEN_T],
+[AC_CACHE_CHECK([for socklen_t], ac_cv_ax_type_socklen_t,
+[
+  AC_TRY_COMPILE(
+  [#include <sys/types.h>
+   #include <sys/socket.h>],
+  [socklen_t len = 42; return 0;],
+  ac_cv_ax_type_socklen_t=yes,
+  ac_cv_ax_type_socklen_t=no)
+])
+  if test $ac_cv_ax_type_socklen_t != yes; then
+    AC_DEFINE(socklen_t, int, [Substitute for socklen_t])
+  fi
+])

--- a/sesman/scp.c
+++ b/sesman/scp.c
@@ -91,7 +91,6 @@ scp_process_start(void *sck)
             log_message(LOG_LEVEL_ALWAYS, "unknown return from scp_vXs_accept()");
     }
 
-    g_tcp_close(scon.in_sck);
     free_stream(scon.in_s);
     free_stream(scon.out_s);
     return 0;

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -484,7 +484,7 @@ session_start_fork(int width, int height, int bpp, char *username,
     }
     else if (pid == 0)
     {
-        g_tcp_close(g_term_event);
+        g_delete_wait_obj(g_term_event);
         g_tcp_close(g_sck);
         g_sprintf(geometry, "%dx%d", width, height);
         g_sprintf(depth, "%d", bpp);

--- a/sesman/sig.c
+++ b/sesman/sig.c
@@ -51,8 +51,6 @@ sig_sesman_shutdown(int sig)
 
     g_set_wait_obj(g_term_event);
 
-    g_tcp_close(g_sck);
-
     session_sigkill_all();
 
     g_snprintf(pid_file, 255, "%s/xrdp-sesman.pid", XRDP_PID_PATH);

--- a/sesman/tools/sesrun.c
+++ b/sesman/tools/sesrun.c
@@ -27,8 +27,6 @@
 #include "sesman.h"
 #include "tcp.h"
 
-int g_sck;
-int g_pid;
 struct config_sesman g_cfg; /* config.h */
 
 /******************************************************************************/
@@ -55,8 +53,6 @@ main(int argc, char **argv)
         g_printf("sesrun: error reading config. quitting.\n");
         return 1;
     }
-
-    g_pid = g_getpid();
 
     if (argc == 1)
     {

--- a/tests/gtcp_proxy/gtcp.c
+++ b/tests/gtcp_proxy/gtcp.c
@@ -26,12 +26,7 @@ int tcp_socket_create(void)
 {
     int rv;
     int option_value;
-
-#if defined(_WIN32)
-    int option_len;
-#else
-    unsigned int option_len;
-#endif
+    socklen_t option_len;
 
     /* in win32 a socket is an unsigned int, in linux, it's an int */
     if ((rv = (int) socket(PF_INET, SOCK_STREAM, 0)) < 0)
@@ -133,12 +128,7 @@ int tcp_accept(int skt)
     int ret ;
     char ipAddr[256] ;
     struct sockaddr_in s;
-
-#if defined(_WIN32)
-    int i;
-#else
-    unsigned int i;
-#endif
+    socklen_t i;
 
     i = sizeof(struct sockaddr_in);
     memset(&s, 0, i);
@@ -186,12 +176,7 @@ int tcp_socket(void)
 {
     int rv;
     int option_value;
-
-#if defined(_WIN32)
-    int option_len;
-#else
-    unsigned int option_len;
-#endif
+    socklen_t option_len;
 
     /* in win32 a socket is an unsigned int, in linux, it's an int */
     if ((rv = (int) socket(PF_INET, SOCK_STREAM, 0)) < 0)
@@ -305,14 +290,7 @@ int tcp_can_send(int skt, int millis)
 int tcp_socket_ok(int skt)
 {
     int opt;
-
-#if defined(_WIN32)
-    int opt_len;
-#else
-    unsigned int opt_len;
-#endif
-
-    opt_len = sizeof(opt);
+    socklen_t opt_len = sizeof(opt);
 
     if (getsockopt(skt, SOL_SOCKET, SO_ERROR, (char *) (&opt), &opt_len) == 0)
     {

--- a/tests/tcp_proxy/main.c
+++ b/tests/tcp_proxy/main.c
@@ -121,7 +121,7 @@ g_tcp_socket(void)
 {
     int rv;
     int option_value;
-    unsigned int option_len;
+    socklen_t option_len;
 
     rv = (int)socket(AF_INET, SOCK_STREAM, 0);
     if (rv < 0)
@@ -336,9 +336,7 @@ static int APP_CC
 g_tcp_socket_ok(int sck)
 {
     int opt;
-    unsigned int opt_len;
-
-    opt_len = sizeof(opt);
+    socklen_t opt_len = sizeof(opt);
 
     if (getsockopt(sck, SOL_SOCKET, SO_ERROR, (char *)(&opt), &opt_len) == 0)
     {

--- a/xrdp/xrdp_listen.c
+++ b/xrdp/xrdp_listen.c
@@ -457,8 +457,8 @@ xrdp_listen_main_loop(struct xrdp_listen *self)
                 if (trans_get_wait_objs(self->listen_trans, robjs,
                                         &robjs_count) != 0)
                 {
-                    log_message(LOG_LEVEL_ERROR,"Listening socket is in wrong state we "
-                              "terminate listener");
+                    log_message(LOG_LEVEL_ERROR,"Listening socket is in wrong state, "
+                              "terminating listener");
                     break;
                 }
             }


### PR DESCRIPTION
Make g_sck_close() do the right thing (check errors, make sure it's actually a closing socket, use proper debug levels) and add actually useful debug information (address family, local address and port).

Make fixes based on the information from g_sck_close()

Fix closing the listening socket twice in xrdp-sesman.

Use correct function to close g_term_event. It's not even a valid a file descriptor.

Cleanup useless references to g_sck in sesrun, also remove g_pid.