### PR TITLE
new options for xrdp.ini disableSSlv3=yes and tls_ciphers=HIGH

### DIFF
--- a/common/ssl_calls.c
+++ b/common/ssl_calls.c
@@ -590,18 +590,21 @@ ssl_tls_print_error(const char *func, SSL *connection, int value)
 
 /*****************************************************************************/
 int APP_CC
-ssl_tls_accept(struct ssl_tls *self)
+ssl_tls_accept(struct ssl_tls *self,int disableSSLv3,char tls_ciphers[])
 {
     int connection_status;
     long options = 0;
 
     /**
-     * SSL_OP_NO_SSLv2:
-     *
-     * We only want SSLv3 and TLSv1, so disable SSLv2.
+     * SSL_OP_NO_SSLv2
      * SSLv3 is used by, eg. Microsoft RDC for Mac OS X.
+     * No SSLv3 if disableSSLv3=yes so only tls used
      */
-    options |= SSL_OP_NO_SSLv2;
+     if (disableSSLv3==1) {
+	options |= SSL_OP_NO_SSLv3;
+     } else {
+	options |= SSL_OP_NO_SSLv2;
+     }
 
 #if defined(SSL_OP_NO_COMPRESSION)
     /**
@@ -638,6 +641,14 @@ ssl_tls_accept(struct ssl_tls *self)
                      SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER |
                      SSL_MODE_ENABLE_PARTIAL_WRITE);
     SSL_CTX_set_options(self->ctx, options);
+
+    if (strlen(tls_ciphers)>1) {
+	if (SSL_CTX_set_cipher_list(self->ctx, tls_ciphers)==0) {
+	    g_writeln("ssl_tls_accept: invalid cipher options");
+            return 1;
+	}
+    }
+
     SSL_CTX_set_read_ahead(self->ctx, 1);
 
     if (self->ctx == NULL)
@@ -677,6 +688,7 @@ ssl_tls_accept(struct ssl_tls *self)
         connection_status = SSL_accept(self->ssl);
 
         if (connection_status <= 0)
+
         {
             if (ssl_tls_print_error("SSL_accept", self->ssl, connection_status))
             {

--- a/common/ssl_calls.h
+++ b/common/ssl_calls.h
@@ -96,7 +96,7 @@ struct ssl_tls
 struct ssl_tls *APP_CC
 ssl_tls_create(struct trans *trans, const char *key, const char *cert);
 int APP_CC
-ssl_tls_accept(struct ssl_tls *self);
+ssl_tls_accept(struct ssl_tls *self,int disableSSLv3,char tls_ciphers[]);
 int APP_CC
 ssl_tls_disconnect(struct ssl_tls *self);
 void APP_CC

--- a/common/trans.c
+++ b/common/trans.c
@@ -881,7 +881,7 @@ trans_get_out_s(struct trans *self, int size)
 /*****************************************************************************/
 /* returns error */
 int APP_CC
-trans_set_tls_mode(struct trans *self, const char *key, const char *cert)
+trans_set_tls_mode(struct trans *self, const char *key, const char *cert,int disableSSLv3,char tls_ciphers[64])
 {
     self->tls = ssl_tls_create(self, key, cert);
     if (self->tls == NULL)
@@ -890,7 +890,7 @@ trans_set_tls_mode(struct trans *self, const char *key, const char *cert)
         return 1;
     }
 
-    if (ssl_tls_accept(self->tls) != 0)
+    if (ssl_tls_accept(self->tls,disableSSLv3,tls_ciphers) != 0)
     {
         g_writeln("trans_set_tls_mode: ssl_tls_accept failed");
         return 1;

--- a/common/trans.h
+++ b/common/trans.h
@@ -122,7 +122,7 @@ trans_get_in_s(struct trans* self);
 struct stream* APP_CC
 trans_get_out_s(struct trans* self, int size);
 int APP_CC
-trans_set_tls_mode(struct trans *self, const char *key, const char *cert);
+trans_set_tls_mode(struct trans *self, const char *key, const char *cert,int disableSSLv3,char tls_ciphers[64]);
 int APP_CC
 trans_shutdown_tls_mode(struct trans *self);
 int APP_CC

--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -107,6 +107,8 @@ struct xrdp_client_info
   char client_port[256];
 
   int security_layer; /* 0 = rdp, 1 = tls , 2 = hybrid */
+  int disableSSLv3; /* 0 = no, 1 = yes */
+  char tls_ciphers[64];
   int multimon; /* 0 = deny , 1 = allow */
   int monitorCount; /* number of monitors detected (max = 16) */
   struct monitor_info minfo[16]; /* client monitor data */

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -160,6 +160,18 @@ xrdp_rdp_read_config(struct xrdp_client_info *client_info)
                 client_info->use_fast_path = 0;
             }
         }
+        else if (g_strcasecmp(item, "disableSSLv3") == 0)
+	{
+		if (g_strcasecmp(value, "yes") == 0) {
+			client_info->disableSSLv3 = 1;
+		} else {
+			client_info->disableSSLv3 = 0;
+		}
+	}
+	else if (g_strcasecmp(item, "tls_ciphers") == 0)
+	{
+		strcpy(client_info->tls_ciphers,value);
+	}
         else if (g_strcasecmp(item, "security_layer") == 0)
         {
             if (g_strcasecmp(value, "rdp") == 0)

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -2236,7 +2236,7 @@ xrdp_sec_incoming(struct xrdp_sec *self)
 
         if (trans_set_tls_mode(self->mcs_layer->iso_layer->trans,
                 self->rdp_layer->client_info.key_file,
-                self->rdp_layer->client_info.certificate) != 0)
+                self->rdp_layer->client_info.certificate,self->rdp_layer->client_info.disableSSLv3,self->rdp_layer->client_info.tls_ciphers) != 0)
         {
             g_writeln("xrdp_sec_incoming: trans_set_tls_mode failed");
             return 1;

--- a/xrdp/xrdp.ini
+++ b/xrdp/xrdp.ini
@@ -18,6 +18,10 @@ security_layer=rdp
 # openssl req -x509 -newkey rsa:2048 -nodes -keyout key.pem -out cert.pem -days 365
 certificate=
 key_file=
+# disable SSlv3
+#disableSSLv3=yes
+# set TLS cipher suites
+#tls_ciphers=HIGH
 
 # regulate if the listening socket use socket option tcp_nodelay
 # no buffering will be performed in the TCP stack


### PR DESCRIPTION
New options disableSSlv3 and tls_ciphers for xrdp.ini.

SSlv3 is weak and tls_ciphers option will allow ciphers to be set to high therefore disabling weak ciphers such as RC4 .

SSlv3 and RC4 will show on security scans. These are optional settings in case you have old systems which require these.