### PR TITLE
Fix clipboard fle when directory name contains non-ASCII or ASCII non-alphanumeric chars

### DIFF
--- a/sesman/chansrv/clipboard_file.c
+++ b/sesman/chansrv/clipboard_file.c
@@ -200,6 +200,7 @@ clipboard_get_file(char* file, int bytes)
     }
     g_memcpy(filename, file + pindex + 1, (bytes - 1) - pindex);
     /* this should replace %20 with space */
+    clipboard_check_file(pathname);
     clipboard_check_file(filename);
     g_snprintf(full_fn, 255, "%s/%s", pathname, filename);
     if (g_directory_exist(full_fn))


### PR DESCRIPTION
Hi, I fixed one more clipboard bug.

## Bug description

Can't copy&paste file when the file is located in a directory its name contains non-ASCII or ASCII non-alphanumeric chars.

For example:
* /home/centos/directory name contains whitespace/somefile.bin
* /home/centos/ダウンロード/日本語のファイル.bin

## Environment

Built by RH-Matic. Client is Windows 10's mstsc.exe.
~~~
$ rpm -qa |grep xrdp
xrdp-0.9.0.git5cd61ff+devel-1.el7.centos.x86_64
xorg-x11-drv-xrdp-0.9.0.gita0add6c+fix_utf8_clipboard-1.el7.centos.x86_64
~~~

## How reproducible

Always.

## What's happening?

### when directory name contains whitespace

Copy these two files to clipboard.
* $HOME/space directory/space filename.jpeg
* $HOME/space directory/space filename (コピー 1).jpeg

~~~
[3651253284]: CLIPFILE   clipboard_get_file: 215 : ERROR: clipboard_get_file: file [/home/centos/space%20directory/space filename.jpeg] does not exist
[3651253284]: CLIPFILE   clipboard_get_file: 215 : ERROR: clipboard_get_file: file [/home/centos/space%20directory/space filename (コピー 1).jpeg] does not exist
~~~

Filename contains whitespace and non-ASCII but correctly handled.
Directory name is incorrect.

### when directory and filename contains non-ASCII
Copy this file to clipboard.
* $HOME/ダウンロード/日本語を含む.bin

~~~
[3650147703]: CLIPFILE   clipboard_get_file: 215 : ERROR: clipboard_get_file: file [/home/centos/%E3%83%80%E3%82%A6%E3%83%B3%E3%83%AD%E3%83%BC%E3%83%89/日本語を含む.bin] does not exist
~~~

Filename contains non-ASCII but correctly handled.
Directory name is incorrect.

## How to fix

URL decode pathname not only filename by calling `clipboard_check_file()` for pathname.

