### PR TITLE
Apply xkb options for x11rdp

### DIFF
--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -237,6 +237,9 @@ xrdp_load_keyboard_layout(struct xrdp_client_info *client_info)
     char rdp_layout[256] = { 0 };
 
     LLOGLN(0, ("xrdp_load_keyboard_layout:"));
+    LLOGLN(0, ("xrdp_load_keyboard_layout: keyboard_type [%d] keyboard_subtype [%d]",
+               client_info->keyboard_type, client_info->keyboard_subtype));
+
     /* infer model/variant */
     /* TODO specify different X11 keyboard models/variants */
     g_memset(client_info->model, 0, sizeof(client_info->model));

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -422,8 +422,8 @@ xrdp_load_keyboard_layout(struct xrdp_client_info *client_info)
         list_delete(values);
 
         LLOGLN(0, ("xrdp_load_keyboard_layout: model [%s] variant [%s] "
-               "layout [%s]", client_info->model, client_info->variant,
-               client_info->layout));
+               "layout [%s] options [%s]", client_info->model,
+               client_info->variant, client_info->layout, client_info->options));
         g_file_close(fd);
     }
     else

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -236,7 +236,6 @@ xrdp_load_keyboard_layout(struct xrdp_client_info *client_info)
     char keyboard_cfg_file[256] = { 0 };
     char rdp_layout[256] = { 0 };
 
-    LLOGLN(0, ("xrdp_load_keyboard_layout:"));
     LLOGLN(0, ("xrdp_load_keyboard_layout: keyboard_type [%d] keyboard_subtype [%d]",
                client_info->keyboard_type, client_info->keyboard_subtype));
 

--- a/xorg/X11R7.6/rdp/rdpinput.c
+++ b/xorg/X11R7.6/rdp/rdpinput.c
@@ -325,6 +325,10 @@ rdpLoadLayout(struct xrdp_client_info *client_info)
     {
         set.layout = client_info->layout;
     }
+    if (strlen(client_info->options) > 0)
+    {
+        set.options = client_info->options;
+    }
 
  retry:
     /* free some stuff so we can call InitKeyboardDeviceStruct again */


### PR DESCRIPTION
Setting xkb options is added  in #364 but options are not applied to x11rdp.
This is already implemented for xorgxrdp.

And some more logs.