### PR TITLE
Use km-0000yyyy.ini if km-xxxxyyyy.ini doen't exist

### DIFF
--- a/xrdp/lang.c
+++ b/xrdp/lang.c
@@ -226,22 +226,34 @@ int APP_CC
 get_keymaps(int keylayout, struct xrdp_keymap *keymap)
 {
     int fd;
+    int basic_key_layout = keylayout & 0x0000ffff;
     char *filename;
     struct xrdp_keymap *lkeymap;
 
     filename = (char *)g_malloc(256, 0);
-    /* check if there is a keymap file */
+
+    /* check if there is a keymap file e.g. km-e00100411.ini */
     g_snprintf(filename, 255, "%s/km-%08x.ini", XRDP_CFG_PATH, keylayout);
 
-    /* if the file does not exist, try again with 'en-us' as fallback */
+    /* if the file does not exist, use only lower 16 bits instead */
     if (!g_file_exist(filename))
     {
+        log_message(LOG_LEVEL_INFO, "Cannot find keymap file %s", filename);
+        /* e.g. km-00000411.ini */
+        g_snprintf(filename, 255, "%s/km-%08x.ini", XRDP_CFG_PATH, basic_key_layout);
+    }
+
+    /* finally, use 'en-us' */
+    if (!g_file_exist(filename))
+    {
+        log_message(LOG_LEVEL_INFO, "Cannot find keymap file %s", filename);
         g_snprintf(filename, 255, "%s/km-00000409.ini", XRDP_CFG_PATH);
     }
 
     if (g_file_exist(filename))
     {
         fd = g_file_open(filename);
+        log_message(LOG_LEVEL_INFO, "Loading keymap file %s", filename);
 
         if (fd != -1)
         {


### PR DESCRIPTION
upper 16 bits of keylayout value indicates keyboard layout.
lower 16 bits of keylayout value indicates country/language.

If the keymap file doesn't match exactly to keylayout value,
the typical keyboard of the country/language should be used.

For example [1]:
  0x00000409: US English
  0x00010409: US Dvorak
  0x00020409: US International
  0x00030409: US Dvorak for left hand
  0x00040409: US Dvorak for right hang
  0x0000040e: Hungarian
  0x0001040e: Hungarian 101-key

[1] https://msdn.microsoft.com/windows/hardware/commercialize/manufacture/desktop/windows-language-pack-default-values
