### PR TITLE
TLS: log TLS version and cipher

### DIFF
--- a/common/ssl_calls.c
+++ b/common/ssl_calls.c
@@ -891,3 +891,17 @@ ssl_tls_can_recv(struct ssl_tls *tls, int sck, int millis)
     return g_sck_can_recv(sck, millis);
 }
 
+
+/*****************************************************************************/
+const char*
+ssl_get_version(const struct ssl_st *ssl)
+{
+    return SSL_get_version(ssl);
+}
+
+/*****************************************************************************/
+const char*
+ssl_get_cipher_name(const struct ssl_st *ssl)
+{
+    return SSL_get_cipher_name(ssl);
+}

--- a/common/ssl_calls.c
+++ b/common/ssl_calls.c
@@ -893,14 +893,14 @@ ssl_tls_can_recv(struct ssl_tls *tls, int sck, int millis)
 
 
 /*****************************************************************************/
-const char*
+const char *
 ssl_get_version(const struct ssl_st *ssl)
 {
     return SSL_get_version(ssl);
 }
 
 /*****************************************************************************/
-const char*
+const char *
 ssl_get_cipher_name(const struct ssl_st *ssl)
 {
     return SSL_get_cipher_name(ssl);

--- a/common/ssl_calls.h
+++ b/common/ssl_calls.h
@@ -109,4 +109,7 @@ ssl_tls_write(struct ssl_tls *tls, const char *data, int length);
 int APP_CC
 ssl_tls_can_recv(struct ssl_tls *tls, int sck, int millis);
 
+const char *ssl_get_version(const struct ssl_st *ssl);
+const char *ssl_get_cipher_name(const struct ssl_st *ssl);
+
 #endif

--- a/common/trans.c
+++ b/common/trans.c
@@ -902,6 +902,9 @@ trans_set_tls_mode(struct trans *self, const char *key, const char *cert,
     self->trans_send = trans_tls_send;
     self->trans_can_recv = trans_tls_can_recv;
 
+    self->ssl_protocol = ssl_get_version(self->tls->ssl);
+    self->cipher_name = ssl_get_cipher_name(self->tls->ssl);
+
     return 0;
 }
 

--- a/common/trans.h
+++ b/common/trans.h
@@ -79,6 +79,8 @@ struct trans
     int no_stream_init_on_data_in;
     int extra_flags; /* user defined */
     struct ssl_tls *tls;
+    const char *ssl_protocol; /* e.g. TLSv1, TLSv1.1, TLSv1.2, unknown */
+    const char *cipher_name;  /* e.g. AES256-GCM-SHA384 */
     trans_recv_proc trans_recv;
     trans_send_proc trans_send;
     trans_can_recv_proc trans_can_recv;

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -830,6 +830,7 @@ xrdp_rdp_incoming(struct xrdp_rdp *self)
 
     /* log TLS version and cipher when TLS is used */
     /* TODO: client_addr, client_port is empty when IPv6 enabled */
+
     if (iso->selectedProtocol > PROTOCOL_RDP)
     {
         log_message(LOG_LEVEL_INFO,
@@ -837,6 +838,13 @@ xrdp_rdp_incoming(struct xrdp_rdp *self)
                     self->client_info.client_addr,
                     iso->trans->ssl_protocol,
                     iso->trans->cipher_name);
+    }
+    else
+    {
+        log_message(LOG_LEVEL_INFO,
+                    "Non-TLS connection established from %s: "
+                    "encrypted with standard RDP security",
+                     self->client_info.client_addr);
     }
 
     return 0;

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -834,17 +834,19 @@ xrdp_rdp_incoming(struct xrdp_rdp *self)
     if (iso->selectedProtocol > PROTOCOL_RDP)
     {
         log_message(LOG_LEVEL_INFO,
-                    "TLS connection established from %s: %s with cipher %s",
+                    "TLS connection established from %s port %s: %s with cipher %s",
                     self->client_info.client_addr,
+                    self->client_info.client_port,
                     iso->trans->ssl_protocol,
                     iso->trans->cipher_name);
     }
     else
     {
         log_message(LOG_LEVEL_INFO,
-                    "Non-TLS connection established from %s: "
+                    "Non-TLS connection established from %s port %s: "
                     "encrypted with standard RDP security",
-                     self->client_info.client_addr);
+                    self->client_info.client_addr,
+                    self->client_info.client_port);
     }
 
     return 0;


### PR DESCRIPTION
Hi, I've implemented logging of TLS version and cipher suggested at #422.

The purpose to log it is to know which client use which SSL/TLS version and cipher suites and confirm how safe it is.  For example, the feature to disable SSLv3 and choose cipher suite has been implemented. Disabling vulnerable SSL protocols or cipher suites affects some clients.   Logging help us to know which client is affected when vulnerable SSL protocols or cipher suites are disabled.

I know all SSL or encryption relevant codes are written in `common/ssl_calls.c` and `libxrdp/xrdp_sec.c` , however, in order to log client's IP address and TLS information together, there's only option for me to implement it in `libxrdp/xrdp_rdp.c`.  

This is really a draft.  If there's better way to log it, please leave comment and help me.
