### PR TITLE
X11rdp: remove python as it isn't really needed these days

### DIFF
--- a/xorg/X11R7.6/x11_file_list.txt
+++ b/xorg/X11R7.6/x11_file_list.txt
@@ -1,4 +1,3 @@
-Python-2.7.11.tar.xz                            :  Python-2.7.11                            :
 util-macros-1.11.0.tar.bz2                      :  util-macros-1.11.0                       :
 xf86driproto-2.1.0.tar.bz2                      :  xf86driproto-2.1.0                       :
 dri2proto-2.3.tar.bz2                           :  dri2proto-2.3                            :


### PR DESCRIPTION
Closes #399.