### PR TITLE
chansrv: change chansrv log path to ${XDG_DATA_HOME}/xrdp

### DIFF
--- a/docs/man/xrdp-chansrv.8
+++ b/docs/man/xrdp-chansrv.8
@@ -36,7 +36,7 @@ UNIX socket used by external programs to implement channels.
 .I /tmp/.xrdp/xrdp_api_*
 UNIX socket used by \fBxrdp\-chansrv\fP to communicate with \fBxrdp\-sesman\fP.
 .TP
-.I $HOME/xrdp-chansrv.log
+.I $XDG_DATA_HOME/xrdp/xrdp-chansrv.log
 Log file used by \fBxrdp\-chansrv\fP(8).
 
 .SH "SEE ALSO"

--- a/sesman/chansrv/chansrv.c
+++ b/sesman/chansrv/chansrv.c
@@ -1391,12 +1391,52 @@ static char* APP_CC
 get_log_path()
 {
     char* log_path = 0;
+    char* cp = 0;
 
     log_path = g_getenv("CHANSRV_LOG_PATH");
+
+    if (log_path == 0)
+    {
+        log_path = g_getenv("XDG_DATA_HOME");
+        if (log_path != 0)
+        {
+            cp = malloc(strlen(log_path) + strlen("/xrdp") + 1);
+
+            if (cp != 0)
+            {
+                memcpy(cp, log_path, strlen(log_path));
+                memcpy(cp + strlen(log_path), "/xrdp", strlen("/xrdp") + 1);
+                if (g_directory_exist(cp) || g_mkdir(cp))
+		{
+                    log_path = cp;
+		}
+                else
+		{
+                    free(cp);
+		}
+            }
+        }
+    }
+
     if (log_path == 0)
     {
         log_path = g_getenv("HOME");
+        if (log_path != 0)
+        {
+            cp = malloc(strlen(log_path) + strlen("/.local/share/xrdp") + 1);
+
+            if (cp != 0)
+            {
+                memcpy(cp, log_path, strlen(log_path));
+                memcpy(cp + strlen(log_path), "/.local/share/xrdp", strlen("/.local/share/xrdp") + 1);
+                if (g_directory_exist(cp) || g_mkdir(cp))
+                    log_path = cp;
+                else
+                    free(cp);
+            }
+        }
     }
+
     return log_path;
 }
 


### PR DESCRIPTION
like Xorg's logfile is written to ${XDG_DATA_HOME}/xorg/Xorg.n.log.

If XDG_DATA_HOME is not defined, the log path will be
${HOME}/.local/share/xrdp.
