### PR TITLE
Simplify names of xrdp.ini sections, rename "Session Manager" to "Xorg"

### DIFF
--- a/xrdp/xrdp.ini
+++ b/xrdp/xrdp.ini
@@ -56,7 +56,7 @@ grey=dedede
 
 # Section name to use for automatic login if the client sends username
 # and password
-autorun=xrdp1
+autorun=X11rdp
 
 bulk_compression=yes
 
@@ -144,8 +144,8 @@ tcutils=true
 # for debugging xrdp, add following line to section xrdp1
 # chansrvport=/tmp/.xrdp/xrdp_chansrv_socket_7210
 
-[xrdp1]
-name=sesman-X11rdp
+[X11rdp]
+name=X11rdp
 lib=libxup.so
 username=ask
 password=ask
@@ -154,8 +154,18 @@ port=-1
 xserverbpp=24
 code=10
 
-[xrdp2]
-name=sesman-Xvnc
+[Xorg]
+name=Xorg
+lib=libxup.so
+username=ask
+password=ask
+ip=127.0.0.1
+port=-1
+xserverbpp=24
+code=20
+
+[Xvnc]
+name=Xvnc
 lib=libvnc.so
 username=ask
 password=ask
@@ -163,7 +173,7 @@ ip=127.0.0.1
 port=-1
 #delay_ms=2000
 
-[xrdp3]
+[console]
 name=console
 lib=libvnc.so
 ip=127.0.0.1
@@ -172,7 +182,7 @@ username=na
 password=ask
 #delay_ms=2000
 
-[xrdp4]
+[vnc-any]
 name=vnc-any
 lib=libvnc.so
 ip=ask
@@ -184,7 +194,7 @@ password=ask
 #pamsessionmng=127.0.0.1
 #delay_ms=2000
 
-[xrdp5]
+[sesman-any]
 name=sesman-any
 lib=libvnc.so
 ip=ask
@@ -193,29 +203,19 @@ username=ask
 password=ask
 #delay_ms=2000
 
-[xrdp6]
+[rdp-any]
 name=rdp-any
 lib=librdp.so
 ip=ask
 port=ask3389
 
-[xrdp7]
+[neutrinordp-any]
 name=neutrinordp-any
 lib=libxrdpneutrinordp.so
 ip=ask
 port=ask3389
 username=ask
 password=ask
-
-[Session manager]
-name=Session manager
-lib=libxup.so
-username=ask
-password=ask
-ip=127.0.0.1
-port=-1
-xserverbpp=24
-code=20
 
 # You can override the common channel settings for each session type
 #channel.rdpdr=true


### PR DESCRIPTION
Make section names equal to the names in the "name=" setting to avoid
confusion and the need to renumber sections. Avoid "sesman-" in the
names, it's not helpful to the user. Move "Xorg" just below "X11rdp",
that would give xorgxrdp more visibility.