### PR TITLE
Fix compile warnings for non-default authentication methods

### DIFF
--- a/sesman/verify_user.c
+++ b/sesman/verify_user.c
@@ -26,8 +26,8 @@
 
 #include "sesman.h"
 
-#define _XOPEN_SOURCE
 #include <stdio.h>
+#include <string.h>
 #include <sys/types.h>
 #include <crypt.h>
 #include <shadow.h>
@@ -40,7 +40,7 @@
 extern struct config_sesman *g_cfg; /* in sesman.c */
 
 static int DEFAULT_CC
-auth_crypt_pwd(char *pwd, char *pln, char *crp);
+auth_crypt_pwd(const char *pwd, const char *pln, char *crp);
 
 static int DEFAULT_CC
 auth_account_disabled(struct spwd *stp);
@@ -256,7 +256,7 @@ auth_change_pwd(const char *user, const char *newpwd)
  */
 
 static int DEFAULT_CC
-auth_crypt_pwd(char *pwd, char *pln, char *crp)
+auth_crypt_pwd(const char *pwd, const char *pln, char *crp)
 {
     char salt[13] = "$1$";
     int saltcnt = 0;

--- a/sesman/verify_user_bsd.c
+++ b/sesman/verify_user_bsd.c
@@ -101,7 +101,7 @@ auth_stop_session(long in_val)
  */
 
 static int DEFAULT_CC
-auth_crypt_pwd(char* pwd, char* pln, char* crp)
+auth_crypt_pwd(const char *pwd, const char *pln, char *crp)
 {
     return 0;
 }

--- a/sesman/verify_user_kerberos.c
+++ b/sesman/verify_user_kerberos.c
@@ -67,8 +67,8 @@ struct k5_data
 
 struct user_info
 {
-    char *name;
-    char *pass;
+    const char *name;
+    const char *pass;
 };
 
 /******************************************************************************/
@@ -221,7 +221,7 @@ kinit_prompter(krb5_context ctx, void *data, const char *name,
 static int
 k5_kinit(struct k_opts *opts, struct k5_data *k5, struct user_info *u_info)
 {
-    char *doing;
+    const char *doing;
     int notix = 1;
     krb5_keytab keytab = 0;
     krb5_creds my_creds;
@@ -425,7 +425,7 @@ auth_userpass(const char *user, const char *pass, int *errorcode)
 /******************************************************************************/
 /* returns error */
 int DEFAULT_CC
-auth_start_session(void)
+auth_start_session(long in_val, int in_display)
 {
     return 0;
 }
@@ -440,14 +440,14 @@ auth_stop_session(long in_val)
 
 /******************************************************************************/
 int DEFAULT_CC
-auth_end(void)
+auth_end(long in_val)
 {
     return 0;
 }
 
 /******************************************************************************/
 int DEFAULT_CC
-auth_set_env(void)
+auth_set_env(long in_val)
 {
     return 0;
 }

--- a/sesman/verify_user_pam_userpass.c
+++ b/sesman/verify_user_pam_userpass.c
@@ -85,7 +85,7 @@ auth_userpass(const char *user, const char *pass, int *errorcode)
 /******************************************************************************/
 /* returns error */
 int DEFAULT_CC
-auth_start_session(void)
+auth_start_session(long in_val, int in_display)
 {
     return 0;
 }
@@ -100,14 +100,14 @@ auth_stop_session(long in_val)
 
 /******************************************************************************/
 int DEFAULT_CC
-auth_end(void)
+auth_end(long in_val)
 {
     return 0;
 }
 
 /******************************************************************************/
 int DEFAULT_CC
-auth_set_env(void)
+auth_set_env(long in_val)
 {
     return 0;
 }


### PR DESCRIPTION
Include string.h for strcmp(). Don't define _XOPEN_SOURCE, it conflicts
with libc headers and hides putpwent(). Make input strings constant. Fix
functions to match their declarations.