### PR TITLE
Install headers used by X11rdp and xorgxrdp

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -6,6 +6,11 @@ endif
 
 EXTRA_DIST = pixman-region.c
 
+include_HEADERS = \
+  xrdp_client_info.h \
+  xrdp_constants.h \
+  xrdp_rail.h
+
 AM_CPPFLAGS = \
   -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
@@ -42,9 +47,6 @@ libcommon_la_SOURCES = \
   thread_calls.h \
   trans.c \
   trans.h \
-  xrdp_client_info.h \
-  xrdp_constants.h \
-  xrdp_rail.h \
   $(PIXMAN_SOURCES)
 
 libcommon_la_LIBADD = \


### PR DESCRIPTION
Installing the headers makes it possible to compile xorgxrdp as a
separate package, without xrdp sources.