### PR TITLE
Use g_get_strerror() instead of strerror(errno) for portability

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -687,7 +687,7 @@ g_sck_close(int sck)
     else
     {
         log_message(LOG_LEVEL_WARNING, "getsockname() failed on socket %d: %s",
-                    sck, strerror(errno));
+                    sck, g_get_strerror());
 
         if (errno == EBADF || errno == ENOTSOCK)
         {
@@ -704,7 +704,7 @@ g_sck_close(int sck)
     else
     {
         log_message(LOG_LEVEL_WARNING, "Cannot close socket %d (%s): %s", sck,
-                    sockname, strerror(errno));
+                    sockname, g_get_strerror());
     }
 
 #endif


### PR DESCRIPTION
g_get_strerror() is simply returning strerror(errno) for now, except Windows. strerror() is not thread safe, we should replace it across the board. This PR simply restores consistency.