### PR TITLE
Fix potential buffer overflow in strncat() invocation

### DIFF
--- a/sesman/chansrv/chansrv_fuse.c
+++ b/sesman/chansrv/chansrv_fuse.c
@@ -2200,7 +2200,7 @@ static void xfuse_remove_dir_or_file(fuse_req_t req, fuse_ino_t parent,
     }
 
     strcat(full_path, "/");
-    strncat(full_path, name, sizeof(full_path) - strlen(full_path));
+    strncat(full_path, name, sizeof(full_path) - strlen(full_path) - 1);
 
     if (xinode->is_loc_resource)
     {


### PR DESCRIPTION
strncat() will copy at most the specified number of characters and append the null character on top of that. strlen() doesn't count the final null character.

This code will only be compiled if FUSE is enabled. I'm sure FUSE support needs a big cleanup. Even strcat() just about strncat() can have some issues.

However, I believe this misuse of strncat() should be fixed before the next release, because it sets a bad example and it's an antipattern detected by static code checkers.