### PR TITLE
Fix regression in domain to session type mapping

### DIFF
--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -583,7 +583,8 @@ xrdp_wm_init(struct xrdp_wm *self)
                 /* if autorun is configured in xrdp.ini, we enforce that module to be loaded */
                 g_strncpy(section_name, autorun_name, 255);
             }
-            else if (self->session->client_info->domain[0] != '_')
+            else if (self->session->client_info->domain[0] != '\0' &&
+                     self->session->client_info->domain[0] != '_')
             {
                 /* domain names that starts with '_' are reserved for IP/DNS to
                  * simplify for the user in a proxy setup */


### PR DESCRIPTION
If no domain is passed, self->session->client_info->domain is an empty
string that is incorrectly treated as if the domain were passed by the
client.

The regression was introduced in fc753a95, when an incorrect check for
non-empty domain was added. That check was removed in 67119ecc based on
coverity report, leaving no trace of the original intention.

Check domain both for '_' and '\0' as the initial character. In either
case, select the first session type section in xrdp.ini.