### PR TITLE
Update man pages and config files

### DIFF
--- a/docs/man/sesman.ini.5
+++ b/docs/man/sesman.ini.5
@@ -1,5 +1,5 @@
 .\"
-.TH "sesman.ini" "5" "0.1.0" "xrdp team" ""
+.TH "sesman.ini" "5" "0.9.0" "xrdp team" ""
 .SH "NAME"
 \fBsesman.ini\fR \- Configuration file for \fBxrdp-sesman\fR(8)
 

--- a/docs/man/sesman.ini.5
+++ b/docs/man/sesman.ini.5
@@ -55,7 +55,7 @@ xrdp-sesman listening address. If not specified, defaults to \fI0.0.0.0\fR
 xrdp-sesman listening port. If not specified, defaults to \fI3350\fR.
 
 .TP
-\fBEnableUserWindowManager\fR=\fI[0|1]\fR
+\fBEnableUserWindowManager\fR=\fI[true|false]\fR
 If set to \fB1\fR, \fBtrue\fR or \fByes\fR, this option enables user
 specific startup script. That is, xrdp-sesman will execute the script
 specified by \fBUserWindowManager\fR if it exists.
@@ -96,7 +96,7 @@ logged \fIregardless\fR of the selected logging level.
 debug mode, this options will output many more low\-level messages.
 
 .TP
-\fBEnableSyslog\fR=\fI[0|1]\fR
+\fBEnableSyslog\fR=\fI[true|false]\fR
 If set to \fB1\fR, \fBtrue\fR or \fByes\fR, this option enables logging to
 syslog.
 
@@ -121,7 +121,7 @@ Sets the maximum number of simultaneous sessions. If not set or set to
 \fI0\fR, unlimited session are allowed.
 
 .TP
-\fBKillDisconnected\fR=\fI[0|1]\fR
+\fBKillDisconnected\fR=\fI[true|false]\fR
 If set to \fB1\fR, \fBtrue\fR or \fByes\fR, every session will be killed
 within 60 seconds after the user disconnects.
 
@@ -165,7 +165,7 @@ off. For Xvnc connections, \fBDisplaySize\fR is always enabled as well.
 Following parameters can be used in the \fB[Security]\fR section.
 
 .TP
-\fBAllowRootLogin\fR=\fI[0|1]\fR
+\fBAllowRootLogin\fR=\fI[true|false]\fR
 If set to \fB1\fR, \fBtrue\fR or \fByes\fR, enables root login on the
 terminal server.
 
@@ -187,7 +187,7 @@ login for all users is enabled.
 have session management rights.
 
 .TP
-\fBAlwaysGroupCheck\fR=\fI[0|1]\fR
+\fBAlwaysGroupCheck\fR=\fI[true|false]\fR
 If set to \fB1\fR, \fBtrue\fR or \fByes\fR, require group membership even
 if the group specified in \fBTerminalServerUsers\fR doesn't exist.
 

--- a/docs/man/sesman.ini.5
+++ b/docs/man/sesman.ini.5
@@ -222,4 +222,4 @@ environment variables in the user's session.
 .BR xrdp (8),
 .BR xrdp.ini (5)
 
-For more info on \fBxrdp\fR see http://xrdp.sf.net
+For more info on \fBxrdp\fR see http://www.xrdp.org/

--- a/docs/man/sesman.ini.5
+++ b/docs/man/sesman.ini.5
@@ -47,11 +47,12 @@ Following parameters can be used in the \fB[Globals]\fR section.
 
 .TP
 \fBListenAddress\fR=\fIip address\fR
-xrdp-sesman listening address. Default is 0.0.0.0 (all interfaces).
+xrdp-sesman listening address. If not specified, defaults to \fI0.0.0.0\fR
+(all interfaces).
 
 .TP
 \fBListenPort\fR=\fIport number\fR
-xrdp-sesman listening port. Default is 3350.
+xrdp-sesman listening port. If not specified, defaults to \fI3350\fR.
 
 .TP
 \fBEnableUserWindowManager\fR=\fI[0|1]\fR
@@ -75,8 +76,8 @@ Following parameters can be used in the \fB[Logging]\fR section.
 
 .TP
 \fBLogFile\fR=\fIfilename\fR
-Log file path. It can be either absolute or relative. The default is
-\fI./sesman.log\fR
+Log file path. It can be either absolute or relative. If not specified,
+defaults to \fI./sesman.log\fR
 
 .TP
 \fBLogLevel\fR=\fIlevel\fR
@@ -111,7 +112,8 @@ Following parameters can be used in the \fB[Sessions]\fR section.
 .TP
 \fBX11DisplayOffset\fR=\fInumber\fR
 The first X display number available for xrdp-sesman. This prevents
-xrdp-sesman from interfering with real X11 servers. The default is 10.
+xrdp-sesman from interfering with real X11 servers. If not specified,
+defaults to \fI10\fR.
 
 .TP
 \fBMaxSessions\fR=\fInumber\fR
@@ -170,8 +172,8 @@ terminal server.
 .TP
 \fBMaxLoginRetry\fR=\fInumber\fR
 The number of login attempts that are allowed on terminal server. If set
-to \fI0\fR, unlimited attempts are allowed. The default value for this
-field is \fI3\fR.
+to \fI0\fR, unlimited attempts are allowed. If not specified, defaults to
+\fI3\fR.
 
 .TP
 \fBTerminalServerUsers\fR=\fIgroup\fR
@@ -207,10 +209,10 @@ Following parameters can be used in the \fB[Chansrv]\fR section.
 .TP
 \fBFuseMountName\fR=\fIstring\fR
 Directory for drive redirection, relative to the user home directory.
-Created if it doesn't exist. Defaults to \fIxrdp_client\fR
+Created if it doesn't exist. If not specified, defaults to \fIxrdp_client\fR.
 
 .SH "SESSIONS VARIABLES"
-All entries it the \fB[SessionVariables]\fR section are set as
+All entries in the \fB[SessionVariables]\fR section are set as
 environment variables in the user's session.
 
 .SH "FILES"

--- a/docs/man/xrdp-chansrv.8
+++ b/docs/man/xrdp-chansrv.8
@@ -1,4 +1,4 @@
-.TH "xrdp\-chansrv" "8" "0.7.0" "xrdp team" ""
+.TH "xrdp\-chansrv" "8" "0.9.0" "xrdp team" ""
 .SH "NAME"
 \fBxrdp\-chansrv\fR \- \fBxrdp\fR channel server
 

--- a/docs/man/xrdp-chansrv.8
+++ b/docs/man/xrdp-chansrv.8
@@ -43,4 +43,4 @@ Log file used by \fBxrdp\-chansrv\fP(8).
 .BR xrdp\-sesman (8),
 .BR sesman.ini (5).
 
-for more info on \fBxrdp\fR see http://xrdp.sf.net
+for more info on \fBxrdp\fR see http://www.xrdp.org/

--- a/docs/man/xrdp-dis.1
+++ b/docs/man/xrdp-dis.1
@@ -1,4 +1,4 @@
-.TH "xrdp-dis" "8" "0.7.0" "xrdp team"
+.TH "xrdp-dis" "8" "0.9.0" "xrdp team"
 .SH NAME
 xrdp\-dis \- xrdp disconnect utility
 

--- a/docs/man/xrdp-dis.1
+++ b/docs/man/xrdp-dis.1
@@ -1,4 +1,4 @@
-.TH "xrdp-dis" "8" "0.9.0" "xrdp team"
+.TH "xrdp-dis" "1" "0.9.0" "xrdp team"
 .SH NAME
 xrdp\-dis \- xrdp disconnect utility
 
@@ -19,5 +19,9 @@ to get the default host and display number.
 .I /tmp/.xrdp/xrdp_disconnect_display_*
 UNIX socket used to communicate with the \fBxrdp\fP(8) session manager.
 
+.SH KNOWN ISSUES
+.TP
+This utility doesn't support disconnecting xorgxrdp sessions so far.
+
 .SH SEE ALSO
-.BR xrdp (1).
+.BR xrdp (8).

--- a/docs/man/xrdp-genkeymap.8
+++ b/docs/man/xrdp-genkeymap.8
@@ -64,4 +64,4 @@ Simone Fedele <ilsimo@users.sourceforge.net>
 .BR unicode (7),
 .URL "https://github.com/FreeRDP/FreeRDP/wiki/Keyboard" "Description of Keyboard Input mapping" .
 
-for more info on \fBxrdp\fR see http://xrdp.sf.net
+for more info on \fBxrdp\fR see http://www.xrdp.org/

--- a/docs/man/xrdp-genkeymap.8
+++ b/docs/man/xrdp-genkeymap.8
@@ -26,31 +26,31 @@ Files containing the keyboard mapping for language \fIXXXXXXXX\fP, which is a 8 
 .RS 8
 .TP
 .B 00000405
-cs czech
+cs Czech
 .TP
 .B 00000407
-de german
+de German
 .TP
 .B 00000409
-en-us us english
+en-us US English
 .TP
 .B 0000040c
-fr french
+fr French
 .TP
 .B 00000410
-it italy
+it Italy
 .TP
 .B 00000416
 br Portuguese (Brazil)
 .TP
 .B 00000419
-ru russian
+ru Russian
 .TP
 .B 0000041d
-se swedish
+se Swedish
 .TP
 .B 00000809
-en-uk uk english
+en-uk UK English
 .RE
 
 .SH "AUTHORS"

--- a/docs/man/xrdp-genkeymap.8
+++ b/docs/man/xrdp-genkeymap.8
@@ -1,4 +1,4 @@
-.TH "xrdp\-genkeymap" "8" "0.1.0" "xrdp team" ""
+.TH "xrdp\-genkeymap" "8" "0.9.0" "xrdp team" ""
 .de URL
 . \\$2 \(laURL: \\$1 \(ra\\$3
 ..

--- a/docs/man/xrdp-genkeymap.8
+++ b/docs/man/xrdp-genkeymap.8
@@ -38,7 +38,7 @@ en-us US English
 fr French
 .TP
 .B 00000410
-it Italy
+it Italian
 .TP
 .B 00000416
 br Portuguese (Brazil)

--- a/docs/man/xrdp-keygen.8
+++ b/docs/man/xrdp-keygen.8
@@ -3,7 +3,7 @@
 .\" Copyright © 2007, 2008 Vincent Bernat <bernat@debian.org>
 .\" License: GPL-2+
 .\"-
-.TH xrdp\-keygen 8 "0.7.0" "xrdp team"
+.TH xrdp\-keygen 8 "0.9.0" "xrdp team"
 .SH NAME
 xrdp\-keygen \- xrdp RSA key generation utility
 

--- a/docs/man/xrdp-sesman.8
+++ b/docs/man/xrdp-sesman.8
@@ -44,4 +44,4 @@ Simone Fedele <ilsimo@users.sourceforge.net>
 .BR xrdp (8),
 .BR xrdp.ini (5)
 
-for more info on \fBxrdp\fR see http://xrdp.sf.net
+for more info on \fBxrdp\fR see http://www.xrdp.org/

--- a/docs/man/xrdp-sesman.8
+++ b/docs/man/xrdp-sesman.8
@@ -8,34 +8,34 @@ xrdp\-sesman \- \fBxrdp\fR(8) session manager
 
 .SH "DESCRIPTION"
 \fBxrdp\-sesman\fR is \fBxrdp\fR(8) session manager.
-.br 
-It manages user sessions by authenticating the user and starting the appropriate Xserver
+.br
+It manages user sessions by authenticating the user and starting the appropriate Xserver.
 
 .SH "OPTIONS"
-.TP 
-\fB\-n\fR, \fB\-\-nodaemon\fR 
+.TP
+\fB\-n\fR, \fB\-\-nodaemon\fR
 Starts \fBxrdp\-sesman\fR in foreground instead of starting it as a daemon.
-.TP 
+.TP
 \fB\-k\fR, \fB\-\-kill\fR
 Kills running \fBxrdp\-sesman\fR daemon.
-.TP 
+.TP
 \fB\-h\fR, \fB\-\-help\fR
 Output help information and exit.
 
 .SH "FILES"
 ${SESMAN_BIN_DIR}/sesman
-.br 
+.br
 ${SESMAN_BIN_DIR}/sesrun
-.br 
+.br
 ${SESMAN_CFG_DIR}/sesman.ini
-.br 
+.br
 ${SESMAN_LOG_DIR}/sesman.log
-.br 
+.br
 ${SESMAN_PID_DIR}/sesman.pid
 
 .SH "AUTHORS"
 Jay Sorg <jsorg71@users.sourceforge.net>
-.br 
+.br
 Simone Fedele <ilsimo@users.sourceforge.net>
 
 .SH "SEE ALSO"

--- a/docs/man/xrdp-sesman.8
+++ b/docs/man/xrdp-sesman.8
@@ -1,4 +1,4 @@
-.TH "xrdp\-sesman" "8" "0.1.0" "xrdp team" ""
+.TH "xrdp\-sesman" "8" "0.9.0" "xrdp team" ""
 .SH "NAME"
 xrdp\-sesman \- \fBxrdp\fR(8) session manager
 

--- a/docs/man/xrdp-sesrun.8
+++ b/docs/man/xrdp-sesrun.8
@@ -8,37 +8,37 @@ xrdp\-sesrun \- \fBsesman\fR(8) session launcher
 
 .SH "DESCRIPTION"
 \fBxrdp\-sesrun\fR starts a session using \fBxrdp\-sesman\fR(8).
-.br 
+.br
 This is a tool useful for testing, it simply behaves like xrdp when some user logs in a new session and authenticates, thus starting a new session.
 
 .SH "OPTIONS"
-.TP 
+.TP
 .I server
 Server on which sesman is running
-.TP 
+.TP
 .I username
 user name of the session being started
-.TP 
+.TP
 .I password
 user password
-.TP 
+.TP
 .I width
 Screen width
-.TP  
+.TP
 .I height
 Screen height
-.TP 
+.TP
 .I bpp
 Session color depth
 
 .SH "FILES"
 ${SESMAN_BIN_DIR}/sesman
-.br 
+.br
 ${SESMAN_BIN_DIR}/sesrun
 
 .SH "AUTHORS"
 Jay Sorg <jsorg71@users.sourceforge.net>
-.br 
+.br
 Simone Fedele <ilsimo@users.sourceforge.net>
 
 .SH "SEE ALSO"

--- a/docs/man/xrdp-sesrun.8
+++ b/docs/man/xrdp-sesrun.8
@@ -1,4 +1,4 @@
-.TH "xrdp\-sesrun" "8" "0.7.0" "xrdp team" ""
+.TH "xrdp\-sesrun" "8" "0.9.0" "xrdp team" ""
 .SH "NAME"
 xrdp\-sesrun \- \fBsesman\fR(8) session launcher
 

--- a/docs/man/xrdp-sesrun.8
+++ b/docs/man/xrdp-sesrun.8
@@ -47,4 +47,4 @@ Simone Fedele <ilsimo@users.sourceforge.net>
 .BR xrdp (8),
 .BR xrdp.ini (5)
 
-for more info on \fBxrdp\fR see http://xrdp.sf.net
+for more info on \fBxrdp\fR see http://www.xrdp.org/

--- a/docs/man/xrdp-sessvc.8
+++ b/docs/man/xrdp-sessvc.8
@@ -23,4 +23,4 @@ The process ID of the forked Window Manager to monitor.
 .SH "SEE ALSO"
 .BR xrdp\-sesrun (8).
 
-for more info on \fBxrdp\fR see http://xrdp.sf.net
+for more info on \fBxrdp\fR see http://www.xrdp.org/

--- a/docs/man/xrdp-sessvc.8
+++ b/docs/man/xrdp-sessvc.8
@@ -1,4 +1,4 @@
-.TH "xrdp\-sessvc" "8" "0.7.0" "xrdp team" ""
+.TH "xrdp\-sessvc" "8" "0.9.0" "xrdp team" ""
 .SH "NAME"
 xrdp\-sessvc \- \fBxrdp\fR session supervisor
 

--- a/docs/man/xrdp-xcon.8
+++ b/docs/man/xrdp-xcon.8
@@ -1,4 +1,4 @@
-.TH "xrdp-xcon" "8" "0.7.0" "xrdp team"
+.TH "xrdp-xcon" "8" "0.9.0" "xrdp team"
 .SH NAME
 xrdp\-xcon \- X11 event loop debugging helper for XRDP
 

--- a/docs/man/xrdp.8
+++ b/docs/man/xrdp.8
@@ -1,4 +1,4 @@
-.TH "xrdp" "8" "0.1.0" "xrdp team" ""
+.TH "xrdp" "8" "0.9.0" "xrdp team" ""
 .SH "NAME"
 \fBxrdp\fR \- a Remote Desktop Protocol (RDP) server
 

--- a/docs/man/xrdp.8
+++ b/docs/man/xrdp.8
@@ -43,4 +43,4 @@ Simone Fedele <ilsimo@users.sourceforge.net>
 .BR sesman.ini (5),
 .BR sesrun (8)
 
-for more info on \fBxrdp\fR see http://xrdp.sf.net
+for more info on \fBxrdp\fR see http://www.xrdp.org/

--- a/docs/man/xrdp.ini.5
+++ b/docs/man/xrdp.ini.5
@@ -20,7 +20,7 @@ It is composed by a number of sections, each one composed by a section name, enc
 .TP
 \fI[Connection]\fP \-  contain the info on which services \fBxrdp\fR(8) can connect to.
 
-.LP 
+.LP
 All options and values (except for file names and paths) are case insensitive, and are described in detail below.
 
 .SH "GLOBALS"
@@ -189,29 +189,29 @@ If set to \fB1\fR, \fBtrue\fR or \fByes\fR using the RDP channel for XRDP Video 
 .SH "CONNECTIONS"
 A connection section is made of a section name, enclosed in square brackets, and the following entries:
 
-.TP 
+.TP
 \fBname\fR=\fI<session name>\fR
 The name displayed in \fBxrdp\fR(8) login window's combo box.
 
-.TP 
+.TP
 \fBlib\fR=\fI../vnc/libvnc.so\fR
 Sets the library to be used with this connection.
 
-.TP 
+.TP
 \fBusername\fR=\fI<username>\fR|\fIask\fR
 Specifies the username used for authenticating in the connection.
 If set to \fIask\fR, user name should be provided in the login window.
 
-.TP 
+.TP
 \fBpassword\fR=\fI<password>\fR|\fIask\fR
 Specifies the password used for authenticating in the connection.
 If set to \fIask\fR, password should be provided in the login window.
 
-.TP 
+.TP
 \fBip\fR=\fI127.0.0.1\fR
 Specifies the ip address of the host to connect to.
 
-.TP 
+.TP
 \fBport\fR=\fI<number>\fR|\fI\-1\fR
 Specifies the port number to connect to. If set to \fI\-1\fR, the default port for the specified library is used.
 

--- a/docs/man/xrdp.ini.5
+++ b/docs/man/xrdp.ini.5
@@ -110,6 +110,25 @@ If set to \fB1\fP, \fBtrue\fP or \fByes\fP, no buffering will be performed in th
 Specify send/recv buffer sizes in bytes.  The default value depends on operating system.
 
 .TP
+\fBsecurity_layer\fP=\fI[tls|rdp|negotiate]\fP
+Regulate security methods. If not specified, defaults to \fBnegotiate\fP.
+.RS 8
+.TP
+.B tls
+Enhanced RDP Security is used. All security operations (encryption, decryption, data integrity
+verification, and server authentication) are implemented by TLS.
+
+.TP
+.B rdp
+Standard RDP Security, which is not safe from man-in-the-middle attack, is used. The encryption level
+of Standard RDP Security is controlled by \fBcrypt_level\fP.
+
+.TP
+.B negotiate
+Negotiate these security methods with clients.
+.RE
+
+.TP
 \fBdisableSSLv3\fP=\fI[true|false]\fP
 If set to \fB1\fP, \fBtrue\fP or \fByes\fP, \fBxrdp\fP will not accept SSLv3 connections.
 If not specified, defaults to \fBfalse\fP.

--- a/docs/man/xrdp.ini.5
+++ b/docs/man/xrdp.ini.5
@@ -74,6 +74,11 @@ All data sent between the client and server is protected using Federal Informati
 .RE
 
 .TP
+\fBdisableSSLv3\fP=\fI[true|false]\fP
+If set to \fB1\fP, \fBtrue\fP or \fByes\fP, \fBxrdp\fP will not accept SSLv3 connections.
+If not specified, defaults to \fBfalse\fP.
+
+.TP
 \fBfork\fP=\fI[true|false]\fP
 If set to \fB1\fR, \fBtrue\fR or \fByes\fR for each incoming connection \fBxrdp\fR(8) forks a sub-process instead of using threads.
 
@@ -88,26 +93,19 @@ Limit the color depth by specifying the maximum number of bits per pixel.
 If not specified or set to \fB0\fP, unlimited.
 
 .TP
+\fBpamerrortxt\fP=\fIerror_text\fP
+Specify text passed to PAM when authentication failed. The maximum length is \fB256\fP.
+
+.TP
 \fBport\fP=\fIport\fP
 Specify TCP port to listen on for incoming connections.
 The default for RDP is \fB3389\fP.
 
 .TP
-\fBtcp_keepalive\fP=\fI[true|false]\fP
-Regulate if the listening socket uses socket option \fBSO_KEEPALIVE\fP.
-If set to \fB1\fP, \fBtrue\fP or \fByes\fP and the network connection disappears
-without closing messages, the connection will be closed.
-
-.TP
-\fBtcp_nodelay\fP=\fI[true|false]\fP
-Regulate if the listening socket uses socket option \fBTCP_NODELAY\fP.
-If set to \fB1\fP, \fBtrue\fP or \fByes\fP, no buffering will be performed in the TCP stack.
-
-.TP
-\fBtcp_send_buffer_bytes\fP=\fIbuffer_size\fP
-.TP
-\fBtcp_recv_buffer_bytes\fP=\fIbuffer_size\fP
-Specify send/recv buffer sizes in bytes.  The default value depends on operating system.
+\fBrequire_credentials\fP=\fI[true|false]\fP
+If set to \fB1\fP, \fBtrue\fP or \fByes\fP, \fBxrdp\fP requires clients to include username and
+password initial connection phase. In other words, xrdp doesn't allow clients to show login
+screen if set to true. If not specified, defaults to \fBfalse\fP.
 
 .TP
 \fBsecurity_layer\fP=\fI[tls|rdp|negotiate]\fP
@@ -129,9 +127,21 @@ Negotiate these security methods with clients.
 .RE
 
 .TP
-\fBdisableSSLv3\fP=\fI[true|false]\fP
-If set to \fB1\fP, \fBtrue\fP or \fByes\fP, \fBxrdp\fP will not accept SSLv3 connections.
-If not specified, defaults to \fBfalse\fP.
+\fBtcp_keepalive\fP=\fI[true|false]\fP
+Regulate if the listening socket uses socket option \fBSO_KEEPALIVE\fP.
+If set to \fB1\fP, \fBtrue\fP or \fByes\fP and the network connection disappears
+without closing messages, the connection will be closed.
+
+.TP
+\fBtcp_nodelay\fP=\fI[true|false]\fP
+Regulate if the listening socket uses socket option \fBTCP_NODELAY\fP.
+If set to \fB1\fP, \fBtrue\fP or \fByes\fP, no buffering will be performed in the TCP stack.
+
+.TP
+\fBtcp_send_buffer_bytes\fP=\fIbuffer_size\fP
+.TP
+\fBtcp_recv_buffer_bytes\fP=\fIbuffer_size\fP
+Specify send/recv buffer sizes in bytes.  The default value depends on operating system.
 
 .TP
 \fBtls_ciphers\fP=\fIcipher_suite\fP
@@ -143,16 +153,6 @@ Specifies TLS cipher suite.  The format of this parameter is equivalent to which
 .TP
 \fBuse_fastpath\fP=\fI[input|output|both|none]\fP
 If not specified, defaults to \fBnone\fP.
-
-.TP
-\fBrequire_credentials\fP=\fI[true|false]\fP
-If set to \fB1\fP, \fBtrue\fP or \fByes\fP, \fBxrdp\fP requires clients to include username and
-password initial connection phase. In other words, xrdp doesn't allow clients to show login
-screen if set to true. If not specified, defaults to \fBfalse\fP.
-
-.TP
-\fBpamerrortxt\fP=\fIerror_text\fP
-Specify text passed to PAM when authentication failed. The maximum length is \fB256\fP.
 
 .TP
 \fBblack\fP=\fI000000\fP

--- a/docs/man/xrdp.ini.5
+++ b/docs/man/xrdp.ini.5
@@ -104,6 +104,12 @@ Regulate if the listening socket uses socket option \fBTCP_NODELAY\fP.
 If set to \fB1\fP, \fBtrue\fP or \fByes\fP, no buffering will be performed in the TCP stack.
 
 .TP
+\fBtcp_send_buffer_bytes\fP=\fIbuffer_size\fP
+.TP
+\fBtcp_recv_buffer_bytes\fP=\fIbuffer_size\fP
+Specify send/recv buffer sizes in bytes.  The default value depends on operating system.
+
+.TP
 \fBdisableSSLv3\fP=\fI[true|false]\fP
 If set to \fB1\fP, \fBtrue\fP or \fByes\fP, \fBxrdp\fP will not accept SSLv3 connections.
 

--- a/docs/man/xrdp.ini.5
+++ b/docs/man/xrdp.ini.5
@@ -37,19 +37,19 @@ By default a drop-down list with all available connections is shown.
 A connection can also be chosen by the connecting client by setting the \fBLOGIN DOMAIN\fP to a valid \fIsession name\fP.
 
 .TP
-\fBbitmap_cache\fR=\fI[0|1]\fR
+\fBbitmap_cache\fR=\fI[true|false]\fR
 If set to \fB1\fR, \fBtrue\fR or \fByes\fR this option enables bitmap caching in \fBxrdp\fR(8).
 
 .TP
-\fBbitmap_compression\fR=\fI[0|1]\fR
+\fBbitmap_compression\fR=\fI[true|false]\fR
 If set to \fB1\fR, \fBtrue\fR or \fByes\fR this option enables bitmap compression in \fBxrdp\fR(8).
 
 .TP
-\fBbulk_compression\fP=\fI[0|1]\fP
+\fBbulk_compression\fP=\fI[true|false]\fP
 If set to \fB1\fR, \fBtrue\fR or \fByes\fR this option enables compression of bulk data in \fBxrdp\fR(8).
 
 .TP
-\fBchannel_code\fP=\fI[0|1]\fP
+\fBchannel_code\fP=\fI[true|false]\fP
 If set to \fB0\fR, \fBfalse\fR or \fBno\fR this option disables all channels \fBxrdp\fR(8).
 See section \fBCHANNELS\fP below for more fine grained options.
 
@@ -77,11 +77,11 @@ All data sent between the client and server is protected using Federal Informati
 .RE
 
 .TP
-\fBfork\fP=\fI[0|1]\fP
+\fBfork\fP=\fI[true|false]\fP
 If set to \fB1\fR, \fBtrue\fR or \fByes\fR for each incoming connection \fBxrdp\fR(8) forks a sub-process instead of using threads.
 
 .TP
-\fBhidelogwindow\fP=\fI[0|1]\fP
+\fBhidelogwindow\fP=\fI[true|false]\fP
 If set to \fB1\fP, \fBtrue\fP or \fByes\fP, \fBxrdp\fP will not show a window for log messages.
 
 .TP
@@ -94,17 +94,17 @@ Specify TCP port to listen on for incoming connections.
 The default for RDP is \fB3389\fP.
 
 .TP
-\fBtcp_keepalive\fP=\fI[yes|no]\fP
+\fBtcp_keepalive\fP=\fI[true|false]\fP
 Regulate if the listening socket uses socket option \fBSO_KEEPALIVE\fP.
 If set to \fB1\fP, \fBtrue\fP or \fByes\fP and the network connection disappears without closing messages, the connection will be closed.
 
 .TP
-\fBtcp_nodelay\fP=\fI[yes|no]\fP
+\fBtcp_nodelay\fP=\fI[true|false]\fP
 Regulate if the listening socket uses socket option \fBTCP_NODELAY\fP.
 If set to \fB1\fP, \fBtrue\fP or \fByes\fP, no buffering will be performed in the TCP stack.
 
 .TP
-\fBdisableSSLv3\fP=\fI[yes|no]\fP
+\fBdisableSSLv3\fP=\fI[true|false]\fP
 If set to \fB1\fP, \fBtrue\fP or \fByes\fP, \fBxrdp\fP will not accept SSLv3 connections.
 
 .TP
@@ -158,7 +158,7 @@ This option can have one of the following values:
 \fBDEBUG\fR or \fB4\fR \- Log everything. If \fBsesman\fR is compiled in debug mode, this options will output many more low\-level message, useful for developers
 
 .TP
-\fBEnableSyslog\fR=\fI[0|1]\fR
+\fBEnableSyslog\fR=\fI[true|false]\fR
 If set to \fB1\fR, \fBtrue\fR or \fByes\fR this option enables logging to syslog. Otherwise syslog is disabled.
 
 .TP
@@ -173,27 +173,27 @@ Not all channels are supported in all cases, so setting a value to \fItrue\fP is
 Channels can also be enabled or disabled on a per connection basis by prefixing each setting with \fBchannel.\fP in the channel section.
 
 .TP
-\fBrdpdr\fP=\fI[0|1]\fP
+\fBrdpdr\fP=\fI[true|false]\fP
 If set to \fB1\fR, \fBtrue\fR or \fByes\fR using the RDP channel for device redirection is allowed.
 
 .TP
-\fBrdpsnd\fP=\fI[0|1]\fP
+\fBrdpsnd\fP=\fI[true|false]\fP
 If set to \fB1\fR, \fBtrue\fR or \fByes\fR using the RDP channel for sound is allowed.
 
 .TP
-\fBdrdynvc\fP=\fI[0|1]\fP
+\fBdrdynvc\fP=\fI[true|false]\fP
 If set to \fB1\fR, \fBtrue\fR or \fByes\fR using the RDP channel to initiate additional dynamic virtual channels is allowed.
 
 .TP
-\fBcliprdr\fP=\fI[0|1]\fP
+\fBcliprdr\fP=\fI[true|false]\fP
 If set to \fB1\fR, \fBtrue\fR or \fByes\fR using the RDP channel for clipboard redirection is allowed.
 
 .TP
-\fBrail\fP=\fI[0|1]\fP
+\fBrail\fP=\fI[true|false]\fP
 If set to \fB1\fR, \fBtrue\fR or \fByes\fR using the RDP channel for remote applications integrated locally (RAIL) is allowed.
 
 .TP
-\fBxrdpvr\fP=\fI[0|1]\fP
+\fBxrdpvr\fP=\fI[true|false]\fP
 If set to \fB1\fR, \fBtrue\fR or \fByes\fR using the RDP channel for XRDP Video streaming is allowed.
 
 .SH "CONNECTIONS"

--- a/docs/man/xrdp.ini.5
+++ b/docs/man/xrdp.ini.5
@@ -117,6 +117,18 @@ Specifies TLS cipher suite.  The format of this parameter is equivalent to which
 (ex. $ openssl ciphers 'HIGH:!ADH:!SHA1')
 
 .TP
+\fBuse_fastpath\fP=\fI[input|output|both|none]\fP
+If not specified, defaults to \fBnone\fP.
+
+.TP
+\fBrequire_credentials\fP=\fI[true|false]\fP
+If set to \fB1\fP, \fBtrue\fP or \fByes\fP, \fBxrdp\fP requires clients to include username and password initial connection phase.  In other words, xrdp doesn't allow clients to show login screen if set to true.
+
+.TP
+\fBpamerrortxt\fP=\fIerror_text\fP
+Specify text passed to PAM when authentication failed. The maximum length is \fB256\fP.
+
+.TP
 \fBblack\fP=\fI000000\fP
 .TP
 \fBgrey\fP=\fIc0c0c0\fP

--- a/docs/man/xrdp.ini.5
+++ b/docs/man/xrdp.ini.5
@@ -143,7 +143,7 @@ The lowest value that can be given to one of the light sources is 0 (hex 00).
 The highest value is 255 (hex FF).
 
 .SH "LOGGING"
-The following parameters can be used in the \fB[logging]\fR section:
+The following parameters can be used in the \fB[Logging]\fR section:
 
 .TP
 \fBLogFile\fR=\fI${SESMAN_LOG_DIR}/sesman.log\fR

--- a/docs/man/xrdp.ini.5
+++ b/docs/man/xrdp.ini.5
@@ -25,7 +25,7 @@ The options to be specified in the \fB[Globals]\fR section are the following:
 
 .TP
 \fBaddress\fP=\fIip address\fP
-Specifies xrdp listening address. Default is 0.0.0.0 (all interfaces)
+Specify xrdp listening address. If not specified, defaults to 0.0.0.0 (all interfaces).
 
 .TP
 \fBautorun\fP=\fIsession_name\fP
@@ -80,10 +80,12 @@ If set to \fB1\fR, \fBtrue\fR or \fByes\fR for each incoming connection \fBxrdp\
 .TP
 \fBhidelogwindow\fP=\fI[true|false]\fP
 If set to \fB1\fP, \fBtrue\fP or \fByes\fP, \fBxrdp\fP will not show a window for log messages.
+If not specified, defaults to \fBfalse\fP.
 
 .TP
 \fBmax_bpp\fP=\fI[8|15|16|24|32]\fP
 Limit the color depth by specifying the maximum number of bits per pixel.
+If not specified or set to \fB0\fP, unlimited.
 
 .TP
 \fBport\fP=\fIport\fP
@@ -93,7 +95,8 @@ The default for RDP is \fB3389\fP.
 .TP
 \fBtcp_keepalive\fP=\fI[true|false]\fP
 Regulate if the listening socket uses socket option \fBSO_KEEPALIVE\fP.
-If set to \fB1\fP, \fBtrue\fP or \fByes\fP and the network connection disappears without closing messages, the connection will be closed.
+If set to \fB1\fP, \fBtrue\fP or \fByes\fP and the network connection disappears
+without closing messages, the connection will be closed.
 
 .TP
 \fBtcp_nodelay\fP=\fI[true|false]\fP
@@ -109,10 +112,12 @@ Specify send/recv buffer sizes in bytes.  The default value depends on operating
 .TP
 \fBdisableSSLv3\fP=\fI[true|false]\fP
 If set to \fB1\fP, \fBtrue\fP or \fByes\fP, \fBxrdp\fP will not accept SSLv3 connections.
+If not specified, defaults to \fBfalse\fP.
 
 .TP
 \fBtls_ciphers\fP=\fIcipher_suite\fP
-Specifies TLS cipher suite.  The format of this parameter is equivalent to which \fBopenssl\fP(1) ciphers subcommand accepts.
+Specifies TLS cipher suite.  The format of this parameter is equivalent to which
+\fBopenssl\fP(1) ciphers subcommand accepts.
 
 (ex. $ openssl ciphers 'HIGH:!ADH:!SHA1')
 
@@ -122,7 +127,9 @@ If not specified, defaults to \fBnone\fP.
 
 .TP
 \fBrequire_credentials\fP=\fI[true|false]\fP
-If set to \fB1\fP, \fBtrue\fP or \fByes\fP, \fBxrdp\fP requires clients to include username and password initial connection phase.  In other words, xrdp doesn't allow clients to show login screen if set to true.
+If set to \fB1\fP, \fBtrue\fP or \fByes\fP, \fBxrdp\fP requires clients to include username and
+password initial connection phase. In other words, xrdp doesn't allow clients to show login
+screen if set to true. If not specified, defaults to \fBfalse\fP.
 
 .TP
 \fBpamerrortxt\fP=\fIerror_text\fP

--- a/docs/man/xrdp.ini.5
+++ b/docs/man/xrdp.ini.5
@@ -46,37 +46,56 @@ If set to \fB1\fR, \fBtrue\fR or \fByes\fR this option enables bitmap compressio
 If set to \fB1\fR, \fBtrue\fR or \fByes\fR this option enables compression of bulk data in \fBxrdp\fR(8).
 
 .TP
+\fBcertificate\fP=\fI/path/to/certificate\fP
+.TP
+\fBkey_file\fP=\fI/path/to/private_key\fP
+Set location of TLS certificate and private key. They must be written in PEM format.
+If not specified, defaults to \fB${XRDP_CFG_DIR}/cert.pem\fP, \fB${XRDP_CFG_DIR}/key.pem\fP.
+
+This parameter is effective only if \fBsecurity_layer\fP is set to \fBtls\fP or \fBnegotiate\fP.
+
+.TP
 \fBchannel_code\fP=\fI[true|false]\fP
 If set to \fB0\fR, \fBfalse\fR or \fBno\fR this option disables all channels \fBxrdp\fR(8).
 See section \fBCHANNELS\fP below for more fine grained options.
 
 .TP
-\fBcrypt_level\fP=\fIlow|medium|high|fips\fP
+\fBcrypt_level\fP=\fI[low|medium|high|fips]\fP
 .\" <http://blogs.msdn.com/b/openspecification/archive/2011/12/08/encryption-negotiation-in-rdp-connection.aspx>
-RDP connection are controlled by two encryption settings: \fIEncryption Level\fP and \fIEncryption Method\fP.
-The only supported \fIEncryption Method\fP is \fB40BIT_ENCRYPTION\fP, \fB128BIT_ENCRYPTION\fP and \fB56BIT_ENCRYPTION\fP are currently not supported.
+Regulate encryption level of Standard RDP Security.
+This parameter is effective only if \fBsecurity_layer\fP is set to \fBrdp\fP or \fBnegotiate\fP.
+
+Encryption in Standard RDP Security is controlled by two settings: \fIEncryption Level\fP
+and \fIEncryption Method\fP.  The only supported \fIEncryption Method\fP are \fB40BIT_ENCRYPTION\fP
+and \fB128BIT_ENCRYPTION\fP. \fB56BIT_ENCRYPTION\fP is not supported.
 This option controls the \fIEncryption Level\fP:
 .RS 8
 .TP
 .B low
-All data sent from the client to the server is protected by encryption based on the maximum key strength supported by the client.
+All data sent from the client to the server is protected by encryption based on
+the maximum key strength supported by the client.
 .I This is the only level that the traffic sent by the server to client is not encrypted.
 .TP
 .B medium
-All data sent between the client and the server is protected by encryption based on the maximum key strength supported by the client.
+All data sent between the client and the server is protected by encryption based on
+the maximum key strength supported by the client (client compatible).
 .TP
 .B high
-All data sent between the client and server is protected by encryption based on the server's maximum key strength.
+All data sent between the client and the server is protected by encryption based on
+the server's maximum key strength (sever compatible).
 .TP
 .B fips
-All data sent between the client and server is protected using Federal Information Processing Standard 140-1 validated encryption methods.
-.I This level is required for Windows clients (mstsc.exe) if the client's group policy enforces FIPS-compliance mode.
+All data sent between the client and server is protected using Federal Information
+Processing Standard 140-1 validated encryption methods.
+.I This level is required for Windows clients (mstsc.exe) if the client's group policy
+.I enforces FIPS-compliance mode.
 .RE
 
 .TP
 \fBdisableSSLv3\fP=\fI[true|false]\fP
 If set to \fB1\fP, \fBtrue\fP or \fByes\fP, \fBxrdp\fP will not accept SSLv3 connections.
 If not specified, defaults to \fBfalse\fP.
+This parameter is effective only if \fBsecurity_layer\fP is set to \fBtls\fP or \fBnegotiate\fP.
 
 .TP
 \fBfork\fP=\fI[true|false]\fP
@@ -149,6 +168,8 @@ Specifies TLS cipher suite.  The format of this parameter is equivalent to which
 \fBopenssl\fP(1) ciphers subcommand accepts.
 
 (ex. $ openssl ciphers 'HIGH:!ADH:!SHA1')
+
+This parameter is effective only if \fBsecurity_layer\fP is set to \fBtls\fP or \fBnegotiate\fP.
 
 .TP
 \fBuse_fastpath\fP=\fI[input|output|both|none]\fP

--- a/docs/man/xrdp.ini.5
+++ b/docs/man/xrdp.ini.5
@@ -1,4 +1,4 @@
-.TH "xrdp.ini" "5" "0.7.0" "xrdp team" ""
+.TH "xrdp.ini" "5" "0.9.0" "xrdp team" ""
 .SH "NAME"
 \fBxrdp.ini\fR \- Configuration file for \fBxrdp\fR(8)
 

--- a/docs/man/xrdp.ini.5
+++ b/docs/man/xrdp.ini.5
@@ -85,7 +85,7 @@ If set to \fB1\fR, \fBtrue\fR or \fByes\fR for each incoming connection \fBxrdp\
 If set to \fB1\fP, \fBtrue\fP or \fByes\fP, \fBxrdp\fP will not show a window for log messages.
 
 .TP
-\fBmax_bpp\fP=\fI[8|15|16|24]\fP
+\fBmax_bpp\fP=\fI[8|15|16|24|32]\fP
 Limit the color depth by specifying the maximum number of bits per pixel.
 
 .TP

--- a/docs/man/xrdp.ini.5
+++ b/docs/man/xrdp.ini.5
@@ -17,9 +17,6 @@ It is composed by a number of sections, each one composed by a section name, enc
 .TP
 \fB[Channels]\fP \- channel subsystem parameters
 
-.TP
-\fB[Connection]\fP \-  contain the info on which services \fBxrdp\fR(8) can connect to.
-
 .LP
 All options and values (except for file names and paths) are case insensitive, and are described in detail below.
 

--- a/docs/man/xrdp.ini.5
+++ b/docs/man/xrdp.ini.5
@@ -249,8 +249,8 @@ This is an example \fBxrdp.ini\fR:
 
 .nf
 [Globals]
-bitmap_cache=yes
-bitmap_compression=yes
+bitmap_cache=true
+bitmap_compression=true
 
 [vnc1]
 name=sesman

--- a/docs/man/xrdp.ini.5
+++ b/docs/man/xrdp.ini.5
@@ -18,7 +18,7 @@ It is composed by a number of sections, each one composed by a section name, enc
 \fB[Channels]\fP \- channel subsystem parameters
 
 .TP
-\fI[Connection]\fP \-  contain the info on which services \fBxrdp\fR(8) can connect to.
+\fB[Connection]\fP \-  contain the info on which services \fBxrdp\fR(8) can connect to.
 
 .LP
 All options and values (except for file names and paths) are case insensitive, and are described in detail below.

--- a/docs/man/xrdp.ini.5
+++ b/docs/man/xrdp.ini.5
@@ -245,4 +245,4 @@ ${XRDP_CFG_DIR}/xrdp.ini
 .BR sesrun (8),
 .BR sesman.ini (5)
 
-for more info on \fBxrdp\fR see http://xrdp.sf.net
+for more info on \fBxrdp\fR see http://www.xrdp.org/

--- a/docs/man/xrdp.ini.5
+++ b/docs/man/xrdp.ini.5
@@ -104,6 +104,16 @@ Regulate if the listening socket uses socket option \fBTCP_NODELAY\fP.
 If set to \fB1\fP, \fBtrue\fP or \fByes\fP, no buffering will be performed in the TCP stack.
 
 .TP
+\fBdisableSSLv3\fP=\fI[yes|no]\fP
+If set to \fB1\fP, \fBtrue\fP or \fByes\fP, \fBxrdp\fP will not accept SSLv3 connections.
+
+.TP
+\fBtls_ciphers\fP=\fIcipher_suite\fP
+Specifies TLS cipher suite.  The format of this parameter is equivalent to which \fBopenssl\fP(1) ciphers subcommand accepts.
+
+(ex. $ openssl ciphers 'HIGH:!ADH:!SHA1')
+
+.TP
 \fBblack\fP=\fI000000\fP
 .TP
 \fBgrey\fP=\fIc0c0c0\fP

--- a/genkeymap/dump-keymaps.sh
+++ b/genkeymap/dump-keymaps.sh
@@ -19,7 +19,7 @@ setxkbmap -model pc105 -layout gb
 setxkbmap -model pc104 -layout de
 ./xrdp-genkeymap ../instfiles/km-00000407.ini
 
-# Italy 'it' 0x00000410
+# Italian 'it' 0x00000410
 setxkbmap -model pc104 -layout it
 ./xrdp-genkeymap ../instfiles/km-00000410.ini
 

--- a/sesman/sesman.ini
+++ b/sesman/sesman.ini
@@ -10,49 +10,49 @@ AllowRootLogin=true
 MaxLoginRetry=4
 TerminalServerUsers=tsusers
 TerminalServerAdmins=tsadmins
-# When AlwaysGroupCheck = false access will be permitted
-# if the group TerminalServerUsers is not defined.
+; When AlwaysGroupCheck=false access will be permitted
+; if the group TerminalServerUsers is not defined.
 AlwaysGroupCheck=false
 
 [Sessions]
-## X11DisplayOffset - x11 display number offset
-# Type: integer
-# Default: 10
+;; X11DisplayOffset - x11 display number offset
+; Type: integer
+; Default: 10
 X11DisplayOffset=10
 
-## MaxSessions - maximum number of connections to an xrdp server
-# Type: integer
-# Default: 0
+;; MaxSessions - maximum number of connections to an xrdp server
+; Type: integer
+; Default: 0
 MaxSessions=50
 
-## KillDisconnected - kill disconnected sessions
-# Type: boolean
-# Default: false
-# if 1, true, or yes, kill session after 60 seconds
+;; KillDisconnected - kill disconnected sessions
+; Type: boolean
+; Default: false
+; if 1, true, or yes, kill session after 60 seconds
 KillDisconnected=false
 
-## IdleTimeLimit - when to disconnect idle sessions
-# Type: integer
-# Default: 0
-# if not zero, the seconds without mouse or keyboard input before disconnect
-# not complete yet
+;; IdleTimeLimit - when to disconnect idle sessions
+; Type: integer
+; Default: 0
+; if not zero, the seconds without mouse or keyboard input before disconnect
+; not complete yet
 IdleTimeLimit=0
 
-## DisconnectedTimeLimit - when to kill idle sessions
-# Type: integer
-# Default: 0
-# if not zero, the seconds before a disconnected session is killed
-# min 60 seconds
+;; DisconnectedTimeLimit - when to kill idle sessions
+; Type: integer
+; Default: 0
+; if not zero, the seconds before a disconnected session is killed
+; min 60 seconds
 DisconnectedTimeLimit=0
 
-## Policy - session allocation policy
-# Type: enum [ "Default" | "UBD" | "UBI" | "UBC" | "UBDI" | "UBDC" ]
-# Default: Xrdp:<User,BitPerPixel> and Xvnc:<User,BitPerPixel,DisplaySize>
-# "UBD" session per <User,BitPerPixel,DisplaySize>
-# "UBI" session per <User,BitPerPixel,IPAddr>
-# "UBC" session per <User,BitPerPixel,Connection>
-# "UBDI" session per <User,BitPerPixel,DisplaySize,IPAddr>
-# "UBDC" session per <User,BitPerPixel,DisplaySize,Connection>
+;; Policy - session allocation policy
+; Type: enum [ "Default" | "UBD" | "UBI" | "UBC" | "UBDI" | "UBDC" ]
+; Default: Xrdp:<User,BitPerPixel> and Xvnc:<User,BitPerPixel,DisplaySize>
+; "UBD" session per <User,BitPerPixel,DisplaySize>
+; "UBI" session per <User,BitPerPixel,IPAddr>
+; "UBC" session per <User,BitPerPixel,Connection>
+; "UBDI" session per <User,BitPerPixel,DisplaySize,IPAddr>
+; "UBDC" session per <User,BitPerPixel,DisplaySize,Connection>
 Policy=Default
 
 [Logging]
@@ -91,7 +91,7 @@ param=-logfile
 param=/dev/null
 
 [Chansrv]
-# drive redirection, defaults to xrdp_client if not set
+; drive redirection, defaults to xrdp_client if not set
 FuseMountName=thinclient_drives
 
 [SessionVariables]

--- a/sesman/sesman.ini
+++ b/sesman/sesman.ini
@@ -1,21 +1,20 @@
 [Globals]
 ListenAddress=127.0.0.1
 ListenPort=3350
-EnableUserWindowManager=1
+EnableUserWindowManager=true
 UserWindowManager=startwm.sh
 DefaultWindowManager=startwm.sh
 
 [Security]
-AllowRootLogin=1
+AllowRootLogin=true
 MaxLoginRetry=4
 TerminalServerUsers=tsusers
 TerminalServerAdmins=tsadmins
 # When AlwaysGroupCheck = false access will be permitted
 # if the group TerminalServerUsers is not defined.
-AlwaysGroupCheck = false
+AlwaysGroupCheck=false
 
 [Sessions]
-
 ## X11DisplayOffset - x11 display number offset
 # Type: integer
 # Default: 10
@@ -27,10 +26,10 @@ X11DisplayOffset=10
 MaxSessions=50
 
 ## KillDisconnected - kill disconnected sessions
-# Type: integer
-# Default: 0
+# Type: boolean
+# Default: false
 # if 1, true, or yes, kill session after 60 seconds
-KillDisconnected=0
+KillDisconnected=false
 
 ## IdleTimeLimit - when to disconnect idle sessions
 # Type: integer

--- a/xrdp/xrdp.ini
+++ b/xrdp/xrdp.ini
@@ -25,7 +25,7 @@ crypt_level=high
 ; openssl req -x509 -newkey rsa:2048 -nodes -keyout key.pem -out cert.pem -days 365
 certificate=
 key_file=
-; regulate xrdp if to accept SSLv3 connections
+; specify whether SSLv3 should be disabled
 #disableSSLv3=true
 ; set TLS cipher suites
 #tls_ciphers=HIGH

--- a/xrdp/xrdp.ini
+++ b/xrdp/xrdp.ini
@@ -2,42 +2,56 @@
 ; xrdp.ini file version number
 ini_version=1
 
-bitmap_cache=true
-bitmap_compression=true
-port=3389
-allow_channels=true
-max_bpp=32
+; fork a new process for each incoming connection
 fork=true
-; minimum security level allowed for client
-; can be 'none', 'low', 'medium', 'high', 'fips'
-crypt_level=high
+; tcp port to listen
+port=3389
+; regulate if the listening socket use socket option tcp_nodelay
+; no buffering will be performed in the TCP stack
+tcp_nodelay=true
+; regulate if the listening socket use socket option keepalive
+; if the network connection disappear without close messages the connection will be closed
+tcp_keepalive=true
+#tcp_send_buffer_bytes=32768
+#tcp_recv_buffer_bytes=32768
+
 ; security layer can be 'tls', 'rdp' or 'negotiate'
 ; for client compatible layer
 security_layer=negotiate
+; minimum security level allowed for client
+; can be 'none', 'low', 'medium', 'high', 'fips'
+crypt_level=high
 ; X.509 certificate and private key
 ; openssl req -x509 -newkey rsa:2048 -nodes -keyout key.pem -out cert.pem -days 365
 certificate=
 key_file=
-; disable SSlv3
+; regulate xrdp if to accept SSLv3 connections
 #disableSSLv3=true
 ; set TLS cipher suites
 #tls_ciphers=HIGH
 
-; regulate if the listening socket use socket option tcp_nodelay
-; no buffering will be performed in the TCP stack
-tcp_nodelay=true
+; Section name to use for automatic login if the client sends username
+; and password
+autorun=X11rdp
 
-; regulate if the listening socket use socket option keepalive
-; if the network connection disappear without close messages the connection will be closed
-tcp_keepalive=true
-
-#tcp_send_buffer_bytes=32768
-#tcp_recv_buffer_bytes=32768
+allow_channels=true
+allow_multimon=true
+bitmap_cache=true
+bitmap_compression=true
+bulk_compression=true
+#hidelogwindow=true
+max_bpp=32
+new_cursors=true
+; fastpath - can be 'input', 'output', 'both', 'none'
+use_fastpath=both
+; when true, userid/password *must* be passed on cmd line
+#require_credentials=true
+; You can set the PAM error text in a gateway setup (MAX 256 chars)
+#pamerrortxt=change your password according to policy at http://url
 
 ;
 ; colors used by windows in RGB format
 ;
-
 blue=009cb5
 grey=dedede
 #black=000000
@@ -49,24 +63,6 @@ grey=dedede
 #green=00ff00
 #background=626c72
 
-#hidelogwindow=true
-
-; when true, userid/password *must* be passed on cmd line
-# require_credentials=true
-
-; Section name to use for automatic login if the client sends username
-; and password
-autorun=X11rdp
-
-bulk_compression=true
-
-; You can set the PAM error text in a gateway setup (MAX 256 chars)
-#pamerrortxt=change your password according to policy at http://url
-new_cursors=true
-allow_multimon=true
-
-; fastpath - can be set to input / output / both / none
-use_fastpath=both
 ;
 ; configure login screen
 ;
@@ -143,6 +139,11 @@ tcutils=true
 
 ; for debugging xrdp, add following line to section xrdp1
 #chansrvport=/tmp/.xrdp/xrdp_chansrv_socket_7210
+
+
+;
+; Session types
+;
 
 [X11rdp]
 name=X11rdp

--- a/xrdp/xrdp.ini
+++ b/xrdp/xrdp.ini
@@ -2,12 +2,12 @@
 # xrdp.ini file version number
 ini_version=1
 
-bitmap_cache=yes
-bitmap_compression=yes
+bitmap_cache=true
+bitmap_compression=true
 port=3389
 allow_channels=true
 max_bpp=32
-fork=yes
+fork=true
 # minimum security level allowed for client
 # can be 'none', 'low', 'medium', 'high', 'fips'
 crypt_level=high
@@ -19,17 +19,17 @@ security_layer=negotiate
 certificate=
 key_file=
 # disable SSlv3
-#disableSSLv3=yes
+#disableSSLv3=true
 # set TLS cipher suites
 #tls_ciphers=HIGH
 
 # regulate if the listening socket use socket option tcp_nodelay
 # no buffering will be performed in the TCP stack
-tcp_nodelay=yes
+tcp_nodelay=true
 
 # regulate if the listening socket use socket option keepalive
 # if the network connection disappear without close messages the connection will be closed
-tcp_keepalive=yes
+tcp_keepalive=true
 
 #tcp_send_buffer_bytes=32768
 #tcp_recv_buffer_bytes=32768
@@ -49,20 +49,20 @@ grey=dedede
 #green=00ff00
 #background=626c72
 
-#hidelogwindow=yes
+#hidelogwindow=true
 
 # when true, userid/password *must* be passed on cmd line
-# require_credentials=yes
+# require_credentials=true
 
 # Section name to use for automatic login if the client sends username
 # and password
 autorun=X11rdp
 
-bulk_compression=yes
+bulk_compression=true
 
 # You can set the PAM error text in a gateway setup (MAX 256 chars)
 #pamerrortxt=change your password according to policy at http://url
-new_cursors=yes
+new_cursors=true
 allow_multimon=true
 
 # fastpath - can be set to input / output / both / none
@@ -119,7 +119,7 @@ ls_btn_cancel_height=30
 [Logging]
 LogFile=xrdp.log
 LogLevel=DEBUG
-EnableSyslog=1
+EnableSyslog=true
 SyslogLevel=DEBUG
 # LogLevel and SysLogLevel could by any of: core, error, warning, info or debug
 

--- a/xrdp/xrdp.ini
+++ b/xrdp/xrdp.ini
@@ -1,4 +1,4 @@
-[globals]
+[Globals]
 # xrdp.ini file version number
 ini_version=1
 
@@ -123,7 +123,7 @@ EnableSyslog=true
 SyslogLevel=DEBUG
 # LogLevel and SysLogLevel could by any of: core, error, warning, info or debug
 
-[channels]
+[Channels]
 # Channel names not listed here will be blocked by XRDP.
 # You can block any channel by setting its value to false.
 # IMPORTANT! All channels are not supported in all use

--- a/xrdp/xrdp.ini
+++ b/xrdp/xrdp.ini
@@ -1,5 +1,5 @@
 [Globals]
-# xrdp.ini file version number
+; xrdp.ini file version number
 ini_version=1
 
 bitmap_cache=true
@@ -8,35 +8,35 @@ port=3389
 allow_channels=true
 max_bpp=32
 fork=true
-# minimum security level allowed for client
-# can be 'none', 'low', 'medium', 'high', 'fips'
+; minimum security level allowed for client
+; can be 'none', 'low', 'medium', 'high', 'fips'
 crypt_level=high
-# security layer can be 'tls', 'rdp' or 'negotiate'
-# for client compatible layer
+; security layer can be 'tls', 'rdp' or 'negotiate'
+; for client compatible layer
 security_layer=negotiate
-# X.509 certificate and private key
-# openssl req -x509 -newkey rsa:2048 -nodes -keyout key.pem -out cert.pem -days 365
+; X.509 certificate and private key
+; openssl req -x509 -newkey rsa:2048 -nodes -keyout key.pem -out cert.pem -days 365
 certificate=
 key_file=
-# disable SSlv3
+; disable SSlv3
 #disableSSLv3=true
-# set TLS cipher suites
+; set TLS cipher suites
 #tls_ciphers=HIGH
 
-# regulate if the listening socket use socket option tcp_nodelay
-# no buffering will be performed in the TCP stack
+; regulate if the listening socket use socket option tcp_nodelay
+; no buffering will be performed in the TCP stack
 tcp_nodelay=true
 
-# regulate if the listening socket use socket option keepalive
-# if the network connection disappear without close messages the connection will be closed
+; regulate if the listening socket use socket option keepalive
+; if the network connection disappear without close messages the connection will be closed
 tcp_keepalive=true
 
 #tcp_send_buffer_bytes=32768
 #tcp_recv_buffer_bytes=32768
 
-#
-# colors used by windows in RGB format
-#
+;
+; colors used by windows in RGB format
+;
 
 blue=009cb5
 grey=dedede
@@ -51,66 +51,66 @@ grey=dedede
 
 #hidelogwindow=true
 
-# when true, userid/password *must* be passed on cmd line
+; when true, userid/password *must* be passed on cmd line
 # require_credentials=true
 
-# Section name to use for automatic login if the client sends username
-# and password
+; Section name to use for automatic login if the client sends username
+; and password
 autorun=X11rdp
 
 bulk_compression=true
 
-# You can set the PAM error text in a gateway setup (MAX 256 chars)
+; You can set the PAM error text in a gateway setup (MAX 256 chars)
 #pamerrortxt=change your password according to policy at http://url
 new_cursors=true
 allow_multimon=true
 
-# fastpath - can be set to input / output / both / none
+; fastpath - can be set to input / output / both / none
 use_fastpath=both
-#
-# configure login screen
-#
+;
+; configure login screen
+;
 
-# Login Screen Window Title
+; Login Screen Window Title
 #ls_title=My Login Title
 
-# top level window background color in RGB format
+; top level window background color in RGB format
 ls_top_window_bg_color=009cb5
 
-# width and height of login screen
+; width and height of login screen
 ls_width=350
 ls_height=430
 
-# login screen background color in RGB format
+; login screen background color in RGB format
 ls_bg_color=dedede
 
-# optional background image filename (bmp format).
+; optional background image filename (bmp format).
 #ls_background_image=
 
-# logo
-# full path to bmp-file or file in shared folder
+; logo
+; full path to bmp-file or file in shared folder
 ls_logo_filename=
 ls_logo_x_pos=55
 ls_logo_y_pos=50
 
-# for positioning labels such as username, password etc
+; for positioning labels such as username, password etc
 ls_label_x_pos=30
 ls_label_width=60
 
-# for positioning text and combo boxes next to above labels
+; for positioning text and combo boxes next to above labels
 ls_input_x_pos=110
 ls_input_width=210
 
-# y pos for first label and combo box
+; y pos for first label and combo box
 ls_input_y_pos=220
 
-# OK button
+; OK button
 ls_btn_ok_x_pos=142
 ls_btn_ok_y_pos=370
 ls_btn_ok_width=85
 ls_btn_ok_height=30
 
-# Cancel button
+; Cancel button
 ls_btn_cancel_x_pos=237
 ls_btn_cancel_y_pos=370
 ls_btn_cancel_width=85
@@ -121,15 +121,15 @@ LogFile=xrdp.log
 LogLevel=DEBUG
 EnableSyslog=true
 SyslogLevel=DEBUG
-# LogLevel and SysLogLevel could by any of: core, error, warning, info or debug
+; LogLevel and SysLogLevel could by any of: core, error, warning, info or debug
 
 [Channels]
-# Channel names not listed here will be blocked by XRDP.
-# You can block any channel by setting its value to false.
-# IMPORTANT! All channels are not supported in all use
-# cases even if you set all values to true.
-# You can override these settings on each session type
-# These settings are only used if allow_channels=true
+; Channel names not listed here will be blocked by XRDP.
+; You can block any channel by setting its value to false.
+; IMPORTANT! All channels are not supported in all use
+; cases even if you set all values to true.
+; You can override these settings on each session type
+; These settings are only used if allow_channels=true
 rdpdr=true
 rdpsnd=true
 drdynvc=true
@@ -138,11 +138,11 @@ rail=true
 xrdpvr=true
 tcutils=true
 
-# for debugging xrdp, in section xrdp1, change port=-1 to this:
-# port=/tmp/.xrdp/xrdp_display_10
+; for debugging xrdp, in section xrdp1, change port=-1 to this:
+#port=/tmp/.xrdp/xrdp_display_10
 
-# for debugging xrdp, add following line to section xrdp1
-# chansrvport=/tmp/.xrdp/xrdp_chansrv_socket_7210
+; for debugging xrdp, add following line to section xrdp1
+#chansrvport=/tmp/.xrdp/xrdp_chansrv_socket_7210
 
 [X11rdp]
 name=X11rdp
@@ -217,7 +217,7 @@ port=ask3389
 username=ask
 password=ask
 
-# You can override the common channel settings for each session type
+; You can override the common channel settings for each session type
 #channel.rdpdr=true
 #channel.rdpsnd=true
 #channel.drdynvc=true

--- a/xrdp/xrdp_keyboard.ini
+++ b/xrdp/xrdp_keyboard.ini
@@ -1,59 +1,59 @@
-#
-# RDP Keyboard <-> X11 Keyboard layout map
-#
-# How this file works:
-#   1. load the file and scan each section to find matching "keyboard_type"
-#      and "keyboard_subtype" based on the values received from the client.
-#      If not found, then jump to default section.
-#   2. in the selected section, look for "rdp_layouts" and "layouts_map".
-#      Based on the "keylayout" value from the client, find the right x11
-#      layout value.
-#   3. model/variant are inferred based on the "keyboard_type" and
-#      "keyboard_subtype", but they can be overridden. 
-#
+;
+; RDP Keyboard <-> X11 Keyboard layout map
+;
+; How this file works:
+;   1. load the file and scan each section to find matching "keyboard_type"
+;      and "keyboard_subtype" based on the values received from the client.
+;      If not found, then jump to default section.
+;   2. in the selected section, look for "rdp_layouts" and "layouts_map".
+;      Based on the "keylayout" value from the client, find the right x11
+;      layout value.
+;   3. model/variant are inferred based on the "keyboard_type" and
+;      "keyboard_subtype", but they can be overridden. 
+;
 
-#
-# RDP Keyboard Type (http://msdn.microsoft.com/en-us/library/cc240563.aspx)
-#
-# 0 is not a valid value
-#
-# 1 - IBM PC/XT or compatible (83-key) keyboard
-# 2 - Olivetti "ICO" (102-key) keyboard
-# 3 - IBM PC/AT (84-key) or similar keyboard
-# 4 - IBM enhanced (101- or 102-key) keyboard
-# 5 - Nokia 1050 and similar keyboards
-# 6 - Nokia 9140 and similar keyboards
-# 7 - Japanese keyboard
-#
-# RDP Keyboard Subtype is vendor dependent. XRDP defines as follows:
-#
-# 0 is not a valid value
-#
-# 1 - Standard
-# 2 - FreeRDP JP keyboard
-# 3 - Macintosh
-# ... - < any vendor dependent subtype >
-#
-# The list can be augmented.
-#
+;
+; RDP Keyboard Type (http://msdn.microsoft.com/en-us/library/cc240563.aspx)
+;
+; 0 is not a valid value
+;
+; 1 - IBM PC/XT or compatible (83-key) keyboard
+; 2 - Olivetti "ICO" (102-key) keyboard
+; 3 - IBM PC/AT (84-key) or similar keyboard
+; 4 - IBM enhanced (101- or 102-key) keyboard
+; 5 - Nokia 1050 and similar keyboards
+; 6 - Nokia 9140 and similar keyboards
+; 7 - Japanese keyboard
+;
+; RDP Keyboard Subtype is vendor dependent. XRDP defines as follows:
+;
+; 0 is not a valid value
+;
+; 1 - Standard
+; 2 - FreeRDP JP keyboard
+; 3 - Macintosh
+; ... - < any vendor dependent subtype >
+;
+; The list can be augmented.
+;
 
 
-# default
+; default
 [default]
-# keyboard_type and keyboard_subtype is not read for default section. It
-# is only a placeholder to keep consistency. Default model/variant are
-# platform dependent, and could be overridden if needed.
+; keyboard_type and keyboard_subtype is not read for default section. It
+; is only a placeholder to keep consistency. Default model/variant are
+; platform dependent, and could be overridden if needed.
 keyboard_type=0
 keyboard_subtype=0
 
-# user could override variant and model, but generally they should be inferred
-# automatically based on keyboard type and subtype
-#variant=
-#model=
+; user could override variant and model, but generally they should be inferred
+; automatically based on keyboard type and subtype
+;variant=
+;model=
 
-# A list of supported RDP keyboard layouts
+; A list of supported RDP keyboard layouts
 rdp_layouts=default_rdp_layouts
-# The map from RDP keyboard layout to X11 keyboard layout
+; The map from RDP keyboard layout to X11 keyboard layout
 layouts_map=default_layouts_map
 
 [default_rdp_layouts]
@@ -72,7 +72,7 @@ rdp_layout_pt=0x00000816
 rdp_layout_br=0x00000416
 rdp_layout_pl=0x00000415
 
-# <rdp layout name> = <X11 keyboard layout value>
+; <rdp layout name> = <X11 keyboard layout value>
 [default_layouts_map]
 rdp_layout_us=us
 rdp_layout_de=de
@@ -89,8 +89,8 @@ rdp_layout_pt=pt
 rdp_layout_br=br(abnt2)
 rdp_layout_pl=pl
 
-# if two sections have the same keyboard_type and keyboard_subtype, then
-# the latter could override the former.
+; if two sections have the same keyboard_type and keyboard_subtype, then
+; the latter could override the former.
 [rdp_keyboard_mac]
 keyboard_type=4
 keyboard_subtype=3


### PR DESCRIPTION
Lots of changes. Topics are:

- Add missing descriptions
- Update version
- Replace xrdp website links
- Use two different symbols to comment out *.ini files
  - semicolon for descriptions in config files
  - number sign for actual configurations
- Change order of parameters in xrdp.ini
  - put same layer configuration parameters together
    - TCP
    - security layer
    - RDP features (such as bpp, channels, compression, fast path, multimon)
  - bring lower layer earlier
- Unify mixed boolean value expression to true/false

Documents are not still complete but big one step to keep up-to-date.