### PR TITLE
Omit numbers from the "param" keys, they are not needed

### DIFF
--- a/sesman/sesman.ini
+++ b/sesman/sesman.ini
@@ -63,33 +63,33 @@ EnableSyslog=1
 SyslogLevel=DEBUG
 
 [X11rdp]
-param0=X11rdp
-param1=-bs
-param2=-ac
-param3=-nolisten
-param4=tcp
-param5=-uds
+param=X11rdp
+param=-bs
+param=-ac
+param=-nolisten
+param=tcp
+param=-uds
 
 [Xvnc]
-param0=Xvnc
-param1=-bs
-param2=-ac
-param3=-nolisten
-param4=tcp
-param5=-localhost
-param6=-dpi
-param7=96
+param=Xvnc
+param=-bs
+param=-ac
+param=-nolisten
+param=tcp
+param=-localhost
+param=-dpi
+param=96
 
 [Xorg]
-param0=Xorg
-param1=-config
-param2=xrdp/xorg.conf
-param3=-noreset
-param4=-ac
-param5=-nolisten
-param6=tcp
-param7=-logfile
-param8=/dev/null
+param=Xorg
+param=-config
+param=xrdp/xorg.conf
+param=-noreset
+param=-ac
+param=-nolisten
+param=tcp
+param=-logfile
+param=/dev/null
 
 [Chansrv]
 # drive redirection, defaults to xrdp_client if not set


### PR DESCRIPTION
Users assume that they need to renumber the parameters. That makes
parameter editing more involved than it needs to be.