### PR TITLE
Fix "unable to find 'distinguished_name' in config" with older openssl

### DIFF
--- a/keygen/Makefile.am
+++ b/keygen/Makefile.am
@@ -1,3 +1,4 @@
+EXTRA_DIST = openssl.conf
 
 AM_CPPFLAGS = \
   -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
@@ -18,8 +19,18 @@ xrdpsysconfdir = $(sysconfdir)/xrdp
 
 install-data-hook:
 	umask 077 && \
-	  if [ ! -f $(DESTDIR)$(xrdpsysconfdir)/rsakeys.ini ]; then ./xrdp-keygen xrdp $(DESTDIR)$(xrdpsysconfdir)/rsakeys.ini; fi && \
-	  if [ ! -f $(DESTDIR)$(xrdpsysconfdir)/cert.pem ]; then openssl req -x509 -newkey rsa:2048 -sha256 -nodes -keyout $(DESTDIR)$(xrdpsysconfdir)/key.pem -out $(DESTDIR)$(xrdpsysconfdir)/cert.pem -days 365 -subj /C=US/ST=CA/L=Sunnyvale/O=xrdp/CN=www.xrdp.org; fi
+	if [ ! -f $(DESTDIR)$(xrdpsysconfdir)/rsakeys.ini ]; then \
+	  ./xrdp-keygen xrdp $(DESTDIR)$(xrdpsysconfdir)/rsakeys.ini; \
+	fi && \
+	if [ ! -f $(DESTDIR)$(xrdpsysconfdir)/cert.pem ]; then \
+	  openssl req -x509 -newkey rsa:2048 -sha256 -nodes \
+	    -keyout $(DESTDIR)$(xrdpsysconfdir)/key.pem -out \
+	    $(DESTDIR)$(xrdpsysconfdir)/cert.pem -days 365 \
+	    -subj /C=US/ST=CA/L=Sunnyvale/O=xrdp/CN=www.xrdp.org \
+	    -config $(srcdir)/openssl.conf; \
+	fi
 
 uninstall-hook:
 	rm -f $(DESTDIR)$(xrdpsysconfdir)/rsakeys.ini
+	rm -f $(DESTDIR)$(xrdpsysconfdir)/cert.pem
+	rm -f $(DESTDIR)$(xrdpsysconfdir)/key.pem

--- a/keygen/openssl.conf
+++ b/keygen/openssl.conf
@@ -1,0 +1,4 @@
+[req]
+distinguished_name = req_distinguished_name
+
+[req_distinguished_name]


### PR DESCRIPTION
This also fixes "make distcheck", which expects "make uninstall" to
remove all installed files.