### PR TITLE
Remove "-ac" from X server parameters, it's insecure and unnecessary

### DIFF
--- a/sesman/sesman.ini
+++ b/sesman/sesman.ini
@@ -64,7 +64,6 @@ SyslogLevel=DEBUG
 [X11rdp]
 param=X11rdp
 param=-bs
-param=-ac
 param=-nolisten
 param=tcp
 param=-uds
@@ -72,7 +71,6 @@ param=-uds
 [Xvnc]
 param=Xvnc
 param=-bs
-param=-ac
 param=-nolisten
 param=tcp
 param=-localhost
@@ -84,7 +82,6 @@ param=Xorg
 param=-config
 param=xrdp/xorg.conf
 param=-noreset
-param=-ac
 param=-nolisten
 param=tcp
 param=-logfile


### PR DESCRIPTION
Fedora patches sesman.ini to remove "-ac", and that doesn't cause any ill
effects.