### PR TITLE
Recognize "security_layer=negotiate", improve security layer negotiation

### DIFF
--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -178,15 +178,24 @@ xrdp_rdp_read_config(struct xrdp_client_info *client_info)
             {
                 client_info->security_layer = PROTOCOL_SSL;
             }
+            else if (g_strcasecmp(value, "negotiate") == 0)
+            {
+                client_info->security_layer = PROTOCOL_HYBRID;
+            }
             else if (g_strcasecmp(value, "hybrid") == 0)
             {
-                client_info->security_layer = PROTOCOL_SSL | PROTOCOL_HYBRID;
+                client_info->security_layer = PROTOCOL_HYBRID;
+            }
+            else if (g_strcasecmp(value, "") == 0)
+            {
+                client_info->security_layer = PROTOCOL_HYBRID;
             }
             else
             {
-                log_message(LOG_LEVEL_ALWAYS,"Warning: Your configured security layer is "
-                          "undefined, xrdp will negotiate client compatible");
-                client_info->security_layer = PROTOCOL_SSL | PROTOCOL_HYBRID | PROTOCOL_HYBRID_EX;
+                log_message(LOG_LEVEL_ERROR, "security_layer=%s is not "
+                            "recognized, using \"negotiate\" instead",
+                            value);
+                client_info->security_layer = PROTOCOL_HYBRID;
             }
         }
         else if (g_strcasecmp(item, "certificate") == 0)


### PR DESCRIPTION
This change is bigger than I would like, but it fixes a real issue that created trouble to my colleagues. A smaller change would leave gaps in a critical security code.

Distros are not going to ship generated certificates. It's not secure to have the same certificate on every system. Generation on install has its issues. Not every system knows its external DNS name, which is needed for a proper certificate.

If security_layer=negotiate is used (our new default), the client is OK with RDP and TLS (most clients are), and the certificates are missing (because distros won't ship dummy certificates), the connection would fail. Many users would be affected. Distros may have to change security_layer back to rdp.

Also, the client can force a tls connection onto a server configured to use rdp only. Not good, to put it mildly.

It turns out the code doesn't even know of the "negotiate" setting that is our new default! It uses "hybrid" and complains about unconfigured security layer. Let's support both.

---

The documentation has "negotiate" for security_layer, but the code used
"hybrid". Allow both. Treat empty security_layer as "negotiate". Log an
error only for unrecognized values of security_layer.

Rewrite xrdp_iso_negotiate_security() to have careful treatment of all
combinations or requested and configured security layers.

Accept only known security layers from the clients. Return
INCONSISTENT_FLAGS in all other cases.

For "rdp" on the server and "tls" on the client, reject connection and
return SSL_NOT_ALLOWED_BY_SERVER.

For "negotiate" ("hybrid") on both sides, downgrade to RDP quietly if the
certificates are missing. That would allow distros to ship xrdp without
certificates and have it work with hybrid-capable clients.

Log all outcomes, security negotiation is important to be logged.