### PR TITLE
Security level fixes

### DIFF
--- a/libxrdp/xrdp_iso.c
+++ b/libxrdp/xrdp_iso.c
@@ -20,6 +20,7 @@
  */
 
 #include "libxrdp.h"
+#include "log.h"
 
 #define LOG_LEVEL 1
 #define LLOG(_level, _args) \
@@ -109,8 +110,8 @@ xrdp_iso_negotiate_security(struct xrdp_iso *self)
             break;
     }
 
-    LLOGLN(10, ("xrdp_iso_negotiate_security: server security layer %d , client security layer %d",
-            self->selectedProtocol, self->requestedProtocol));
+    log_message(LOG_LEVEL_DEBUG, "Security layer: requested %d, selected %d",
+                self->requestedProtocol, self->selectedProtocol);
     return rv;
 }
 

--- a/libxrdp/xrdp_iso.c
+++ b/libxrdp/xrdp_iso.c
@@ -98,7 +98,9 @@ xrdp_iso_negotiate_security(struct xrdp_iso *self)
         case PROTOCOL_HYBRID:
         case PROTOCOL_HYBRID_EX:
         default:
-            if (self->requestedProtocol & PROTOCOL_SSL)
+            if ((self->requestedProtocol & PROTOCOL_SSL) &&
+                g_file_exist(client_info->certificate) &&
+                g_file_exist(client_info->key_file))
             {
                 /* that's a patch since we don't support CredSSP for now */
                 self->selectedProtocol = PROTOCOL_SSL;

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -182,10 +182,15 @@ xrdp_rdp_read_config(struct xrdp_client_info *client_info)
             {
                 client_info->security_layer = PROTOCOL_SSL | PROTOCOL_HYBRID;
             }
+            else if (g_strcasecmp(value, "negotiate") == 0)
+            {
+                client_info->security_layer = PROTOCOL_SSL | PROTOCOL_HYBRID | PROTOCOL_HYBRID_EX;
+            }
             else
             {
-                log_message(LOG_LEVEL_ALWAYS,"Warning: Your configured security layer is "
-                          "undefined, xrdp will negotiate client compatible");
+                log_message(LOG_LEVEL_ERROR, "security_layer=%s is not "
+                            "recognized, will use security_layer=negotiate",
+                            value);
                 client_info->security_layer = PROTOCOL_SSL | PROTOCOL_HYBRID | PROTOCOL_HYBRID_EX;
             }
         }


### PR DESCRIPTION
Fixing some important issues with the security level negotiation.

`security_layer=negotiate` is not just documented, it's the default now. But the code fails to recognize that. Stop xrdp complaining about its default config file.

Log the security negotiation information - what was requested and what was decided. The only reason I settled for the DEBUG and not INFO level is because we don't have a function to print the flags in human readable format.

Don't select SSL if the SSL keys are missing and both the config file and the client allow RDP connections. Selecting SSL and failing is not a reasonable behavior.