### PR TITLE
Disable privilege elevation by setuid for the X server

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -262,6 +262,8 @@ fi
 
 PKG_INSTALLDIR
 
+AC_CHECK_HEADERS([sys/prctl.h])
+
 AC_CONFIG_FILES([
   common/Makefile
   docs/Makefile


### PR DESCRIPTION
The solution is not universal, but handy anyway, and it improves security. Using PR_SET_NO_NEW_PRIVS ensures that the setuid bit on Xorg would be ignored. Xorg can fail if run with root permissions, but the original user has no console access, as reported by PAM.

Tested on AWS t2.micro with Amazon Linux 2016.09.