### PR TITLE
Find openssl by pkg-config, add -ldl if needed

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -52,4 +52,5 @@ libcommon_la_SOURCES = \
 libcommon_la_LIBADD = \
   -lcrypto \
   -lssl \
-  -lpthread
+  -lpthread \
+  $(DLOPEN_LIBS)

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -18,6 +18,8 @@ AM_CPPFLAGS = \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \
   -DXRDP_LOG_PATH=\"${localstatedir}/log\"
 
+AM_CFLAGS = $(OPENSSL_CFLAGS)
+
 module_LTLIBRARIES = \
   libcommon.la
 
@@ -50,7 +52,6 @@ libcommon_la_SOURCES = \
   $(PIXMAN_SOURCES)
 
 libcommon_la_LIBADD = \
-  -lcrypto \
-  -lssl \
   -lpthread \
+  $(OPENSSL_LIBS) \
   $(DLOPEN_LIBS)

--- a/configure.ac
+++ b/configure.ac
@@ -118,6 +118,12 @@ AC_ARG_ENABLE(pixman, AS_HELP_STRING([--enable-pixman],
               [], [enable_pixman=no])
 AM_CONDITIONAL(XRDP_PIXMAN, [test x$enable_pixman = xyes])
 
+# Check if -ldl is needed to use dlopen()
+DLOPEN_LIBS=
+AC_CHECK_FUNC(dlopen, [],
+              [AC_CHECK_LIB(dl, dlopen, [DLOPEN_LIBS=-ldl])])
+AC_SUBST(DLOPEN_LIBS)
+
 # checking for openssl
 AC_CHECK_HEADER([openssl/rc4.h], [],
   [AC_MSG_ERROR([please install libssl-dev or openssl-devel])],

--- a/configure.ac
+++ b/configure.ac
@@ -125,9 +125,8 @@ AC_CHECK_FUNC(dlopen, [],
 AC_SUBST(DLOPEN_LIBS)
 
 # checking for openssl
-AC_CHECK_HEADER([openssl/rc4.h], [],
-  [AC_MSG_ERROR([please install libssl-dev or openssl-devel])],
-  [#include <stdlib.h>])
+PKG_CHECK_MODULES([OPENSSL], [openssl >= 0], [],
+  [AC_MSG_ERROR([please install libssl-dev or openssl-devel])])
 
 # checking for pam variation
 # Linux-PAM is used in Linux systems


### PR DESCRIPTION
I checked OpenSSL as far back as 0.9.8e, and it has the openssl.pc file (generated by Makefile). The oldest supported version is 1.0.1u.

Some systems need `-ldl` to use `dlopen()`. libcommon calls `dlopen()`, it should not rely on other libraries linking `-ldl`.