### PR TITLE
Change default Xorg logfile to .xorgxrdp.%s.log

### DIFF
--- a/sesman/sesman.ini
+++ b/sesman/sesman.ini
@@ -85,7 +85,7 @@ param=-noreset
 param=-nolisten
 param=tcp
 param=-logfile
-param=/dev/null
+param=.xorgxrdp.%s.log
 
 [Chansrv]
 ; drive redirection, defaults to xrdp_client if not set


### PR DESCRIPTION
The log file is created in the home directory, %s is replaced with the
display number (e.g. 10).

If Xorg is run setuid root, it can refuse to run if the log path is
absolute.