### PR TITLE
Document xserverbpp, add it to Xvnc section, remove from Xorg section

### DIFF
--- a/docs/man/xrdp.ini.5
+++ b/docs/man/xrdp.ini.5
@@ -288,6 +288,12 @@ Specifies the ip address of the host to connect to.
 Specifies the port number to connect to. If set to \fI\-1\fR, the default port for the specified library is used.
 
 .TP
+\fBxserverbpp\fR=\fI<number>\fR
+Specifies color depth of the backend X server. The default is the color
+depth of the client. Only Xvnc and X11rdp use that setting. Xorg runs at
+\fI24\fR bpp.
+
+.TP
 \fBcode\fR=\fI<number>\fR|\fI\-1\fR
 Specifies the session type, the default, \fI\0\fR, is Xvnc, \fI\10\fR, is X11rdp, and \fI\20\fR, uses Xorg driver mode.
 

--- a/xrdp/xrdp.ini
+++ b/xrdp/xrdp.ini
@@ -162,7 +162,6 @@ username=ask
 password=ask
 ip=127.0.0.1
 port=-1
-xserverbpp=24
 code=20
 
 [Xvnc]
@@ -172,6 +171,7 @@ username=ask
 password=ask
 ip=127.0.0.1
 port=-1
+#xserverbpp=24
 #delay_ms=2000
 
 [console]


### PR DESCRIPTION
xserverbpp affects X11rdp and Xvnc, but not Xorg. No need to have xserverbpp in the Xorg section where it has no effect. Add commented out xserverbpp to Xvnc, some users may want to experiment with that setting.