### PR TITLE
Don't use colon to separate IPv6 address from the port

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -681,7 +681,7 @@ g_sck_close(int sck)
                 char addr[48];
                 struct sockaddr_in6 *sock_addr_in6 = &sock_info.sock_addr_in6;
 
-                g_snprintf(sockname, sizeof(sockname), "AF_INET6 %s:%d",
+                g_snprintf(sockname, sizeof(sockname), "AF_INET6 %s port %d",
                            inet_ntop(sock_addr_in6->sin6_family,
                                      &sock_addr_in6->sin6_addr, addr, sizeof(addr)),
                            ntohs(sock_addr_in6->sin6_port));


### PR DESCRIPTION
IPv6 addresses can have colons in their names, so the final colon can be confusing.

http uses [ip]:port, but this is just a log, we can be more user friendly.