### PR TITLE
Add libpainter submodule, update librfxcodec URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = librfxcodec
 	url = https://github.com/neutrinolabs/librfxcodec.git
 
+[submodule "libpainter"]
+	path = libpainter
+	url = https://github.com/neutrinolabs/libpainter.git
+	branch = devel

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "librfxcodec"]
 	path = librfxcodec
-	url = git://github.com/neutrinolabs/librfxcodec
+	url = https://github.com/neutrinolabs/librfxcodec.git
 


### PR DESCRIPTION
This PR prepares the stage for the noorders branch. Moving back and forth through a commit that adds a submodule is quite painful, so let's get it merged so that further changes can be tested easily.

I used the latest commit of libpainter. It includes a fix for "make distcheck".

I also changes the git protocol used for librfxcodec from git to https. The git protocol is a bad choice in my opinion. See this writeup for example: https://gist.github.com/grawity/4392747

GitHub doesn't even advertise the git protocol. It recommends https. https://help.github.com/articles/which-remote-url-should-i-use/

This PR is for version 0.9.1, since we want noorders to be part of 0.9.1.