### PR TITLE
Make librfxcodec a subpackage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,6 +16,12 @@ else
 XRDPVRDIR =
 endif
 
+if XRDP_RFXCODEC
+RFXCODECDIR = librfxcodec
+else
+RFXCODECDIR =
+endif
+
 SUBDIRS = \
   common \
   vnc \
@@ -24,6 +30,7 @@ SUBDIRS = \
   mc \
   $(NEUTRINORDPDIR) \
   libxrdp \
+  $(RFXCODECDIR) \
   xrdp \
   sesman \
   keygen \

--- a/configure.ac
+++ b/configure.ac
@@ -10,6 +10,8 @@ AC_C_CONST
 AC_PROG_LIBTOOL
 PKG_PROG_PKG_CONFIG
 
+AC_CONFIG_SUBDIRS([librfxcodec])
+
 # Use silent rules by default if supported by Automake
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 

--- a/xrdp/Makefile.am
+++ b/xrdp/Makefile.am
@@ -19,7 +19,7 @@ endif
 if XRDP_RFXCODEC
 AM_CPPFLAGS += -DXRDP_RFXCODEC
 AM_CPPFLAGS += -I$(top_srcdir)/librfxcodec/include
-XRDP_EXTRA_LIBS += $(top_srcdir)/librfxcodec/src/.libs/librfxencode.a
+XRDP_EXTRA_LIBS += $(top_builddir)/librfxcodec/src/.libs/librfxencode.a
 endif
 
 if XRDP_PIXMAN


### PR DESCRIPTION
Since libpainter is going to become a subpackage, we can make librfxcodec
a subpackage as well.

With this change, librfxcodec is configured, built and linked to xrdp
automatically if enabled by "--enable-rfxcodec"

librfxcodec is packaged by "make dist" regardless of "--enable-rfxcodec"

librfxcodec/confgure is run unconditionally, it's needed for "make dist"
to work. But librfxcodec is only compiled if enabled.