### PR TITLE
TLS: new method to specify SSL/TLS version

### DIFF
--- a/common/ssl_calls.c
+++ b/common/ssl_calls.c
@@ -534,7 +534,7 @@ ssl_tls_print_error(const char *func, SSL *connection, int value)
 
 /*****************************************************************************/
 int APP_CC
-ssl_tls_accept(struct ssl_tls *self, int disableSSLv3,
+ssl_tls_accept(struct ssl_tls *self, long ssl_protocols,
                const char *tls_ciphers)
 {
     int connection_status;
@@ -543,13 +543,14 @@ ssl_tls_accept(struct ssl_tls *self, int disableSSLv3,
     /**
      * SSL_OP_NO_SSLv2
      * SSLv3 is used by, eg. Microsoft RDC for Mac OS X.
-     * No SSLv3 if disableSSLv3=yes so only tls used
      */
     options |= SSL_OP_NO_SSLv2;
-    if (disableSSLv3)
-    {
-        options |= SSL_OP_NO_SSLv3;
-    }
+
+    /**
+     * Disable SSL protocols not listed in ssl_protocols.
+     */
+    options |= ssl_protocols;
+
 
 #if defined(SSL_OP_NO_COMPRESSION)
     /**

--- a/common/ssl_calls.h
+++ b/common/ssl_calls.h
@@ -96,7 +96,7 @@ struct ssl_tls
 struct ssl_tls *APP_CC
 ssl_tls_create(struct trans *trans, const char *key, const char *cert);
 int APP_CC
-ssl_tls_accept(struct ssl_tls *self, int disableSSLv3,
+ssl_tls_accept(struct ssl_tls *self, long ssl_protocols,
                const char *tls_ciphers);
 int APP_CC
 ssl_tls_disconnect(struct ssl_tls *self);

--- a/common/trans.c
+++ b/common/trans.c
@@ -882,7 +882,7 @@ trans_get_out_s(struct trans *self, int size)
 /* returns error */
 int APP_CC
 trans_set_tls_mode(struct trans *self, const char *key, const char *cert,
-                   int disableSSLv3, const char *tls_ciphers)
+                   long ssl_protocols, const char *tls_ciphers)
 {
     self->tls = ssl_tls_create(self, key, cert);
     if (self->tls == NULL)
@@ -891,7 +891,7 @@ trans_set_tls_mode(struct trans *self, const char *key, const char *cert,
         return 1;
     }
 
-    if (ssl_tls_accept(self->tls, disableSSLv3, tls_ciphers) != 0)
+    if (ssl_tls_accept(self->tls, ssl_protocols, tls_ciphers) != 0)
     {
         g_writeln("trans_set_tls_mode: ssl_tls_accept failed");
         return 1;

--- a/common/trans.h
+++ b/common/trans.h
@@ -125,7 +125,7 @@ struct stream* APP_CC
 trans_get_out_s(struct trans* self, int size);
 int APP_CC
 trans_set_tls_mode(struct trans *self, const char *key, const char *cert,
-                   int disableSSLv3, const char *tls_ciphers);
+                   long ssl_protocols, const char *tls_ciphers);
 int APP_CC
 trans_shutdown_tls_mode(struct trans *self);
 int APP_CC

--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -143,7 +143,7 @@ struct xrdp_client_info
   int use_frame_acks;
   int max_unacknowledged_frame_count;
 
-  int disableSSLv3; /* 0 = no, 1 = yes */
+  long ssl_protocols;
   char tls_ciphers[64];
 
   int client_os_major;

--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -135,6 +135,10 @@ struct xrdp_client_info
   char variant[16];
   char options[256];
 
+  /* !!!!!!!!!!!!!!!!!!!!!!!!!! */
+  /* NO CHANGES ABOVE THIS LINE */
+  /* !!!!!!!!!!!!!!!!!!!!!!!!!! */
+
   /* codec */
   int h264_codec_id;
   int h264_prop_len;

--- a/docs/man/xrdp.ini.5.in
+++ b/docs/man/xrdp.ini.5.in
@@ -168,8 +168,8 @@ Specify send/recv buffer sizes in bytes.  The default value depends on operating
 
 .TP
 \fBtls_ciphers\fP=\fIcipher_suite\fP
-Specifies TLS cipher suite.  The format of this parameter is equivalent to which
-\fBopenssl\fP(1) ciphers subcommand accepts.
+Specifies TLS cipher suite in 63 characters or less.  The format of this parameter is
+equivalent to which \fBopenssl\fP(1) ciphers subcommand accepts.
 
 (ex. $ openssl ciphers 'HIGH:!ADH:!SHA1')
 

--- a/docs/man/xrdp.ini.5.in
+++ b/docs/man/xrdp.ini.5.in
@@ -145,7 +145,7 @@ Negotiate these security methods with clients.
 
 .TP
 \fBssl_protocols\fP=\fI[SSLv3] [TLSv1] [TLSv1.1] [TLSv1.2]\fP
-Enables the specified SSL/TLS protocols. Each value should be separated by space.
+Enables the specified SSL/TLS protocols. Each value should be separated by comma.
 SSLv2 is always disabled. At least one protocol should be given to accept TLS connections.
 This parameter is effective only if \fBsecurity_layer\fP is set to \fBtls\fP or \fBnegotiate\fP.
 

--- a/docs/man/xrdp.ini.5.in
+++ b/docs/man/xrdp.ini.5.in
@@ -96,12 +96,6 @@ Processing Standard 140-1 validated encryption methods.
 .RE
 
 .TP
-\fBdisableSSLv3\fP=\fI[true|false]\fP
-If set to \fB1\fP, \fBtrue\fP or \fByes\fP, \fBxrdp\fP will not accept SSLv3 connections.
-If not specified, defaults to \fBfalse\fP.
-This parameter is effective only if \fBsecurity_layer\fP is set to \fBtls\fP or \fBnegotiate\fP.
-
-.TP
 \fBfork\fP=\fI[true|false]\fP
 If set to \fB1\fR, \fBtrue\fR or \fByes\fR for each incoming connection \fBxrdp\fR(8) forks a sub-process instead of using threads.
 
@@ -148,6 +142,12 @@ of Standard RDP Security is controlled by \fBcrypt_level\fP.
 .B negotiate
 Negotiate these security methods with clients.
 .RE
+
+.TP
+\fBssl_protocols\fP=\fI[SSLv3] [TLSv1] [TLSv1.1] [TLSv1.2]\fP
+Enables the specified SSL/TLS protocols. Each value should be separated by space.
+SSLv2 is always disabled. At least one protocol should be given to accept TLS connections.
+This parameter is effective only if \fBsecurity_layer\fP is set to \fBtls\fP or \fBnegotiate\fP.
 
 .TP
 \fBtcp_keepalive\fP=\fI[true|false]\fP

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -170,7 +170,7 @@ xrdp_rdp_read_config(struct xrdp_client_info *client_info)
             tmp = g_new(char, tmp_length);
             g_snprintf(tmp, tmp_length, "%s%s%s", " ", value, " ");
 
-	    /* disable all protocols first, enable later */
+            /* disable all protocols first, enable later */
             client_info->ssl_protocols =
                 SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2;
 
@@ -193,6 +193,14 @@ xrdp_rdp_read_config(struct xrdp_client_info *client_info)
             {
                 log_message(LOG_LEVEL_DEBUG, "SSLv3 enabled");
                 client_info->ssl_protocols &= ~SSL_OP_NO_SSLv3;
+            }
+
+            if (client_info->ssl_protocols ==
+                (SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2))
+            {
+                log_message(LOG_LEVEL_WARNING, "No SSL/TLS protocols enabled. "
+                            "At least one protocol should be enabled to accept "
+                            "TLS connections.");
             }
         }
         else if (g_strcasecmp(item, "tls_ciphers") == 0)

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -42,11 +42,11 @@ xrdp_rdp_read_config(struct xrdp_client_info *client_info)
     int index = 0;
     struct list *items = (struct list *)NULL;
     struct list *values = (struct list *)NULL;
-    char *item = (char *)NULL;
-    char *value = (char *)NULL;
+    char *item = NULL;
+    char *value = NULL;
     char cfg_file[256];
-    char *p = (char *)NULL;
-    char *tmp = (char *)NULL;
+    char *p = NULL;
+    char *tmp = NULL;
     int tmp_length = 0;
 
     /* initialize (zero out) local variables: */

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -2254,7 +2254,7 @@ xrdp_sec_incoming(struct xrdp_sec *self)
         if (trans_set_tls_mode(self->mcs_layer->iso_layer->trans,
                 self->rdp_layer->client_info.key_file,
                 self->rdp_layer->client_info.certificate,
-                self->rdp_layer->client_info.disableSSLv3,
+                self->rdp_layer->client_info.ssl_protocols,
                 self->rdp_layer->client_info.tls_ciphers) != 0)
         {
             g_writeln("xrdp_sec_incoming: trans_set_tls_mode failed");

--- a/xrdp/xrdp.ini
+++ b/xrdp/xrdp.ini
@@ -25,8 +25,9 @@ crypt_level=high
 ; openssl req -x509 -newkey rsa:2048 -nodes -keyout key.pem -out cert.pem -days 365
 certificate=
 key_file=
-; specify whether SSLv3 should be disabled
-#disableSSLv3=true
+; set SSL protocols
+; can be space separated list of 'SSLv3', 'TLSv1', 'TLSv1.1', 'TLSv1.2'
+ssl_protocols=TLSv1 TLSv1.1 TLSv1.2
 ; set TLS cipher suites
 #tls_ciphers=HIGH
 

--- a/xrdp/xrdp.ini
+++ b/xrdp/xrdp.ini
@@ -26,8 +26,8 @@ crypt_level=high
 certificate=
 key_file=
 ; set SSL protocols
-; can be space separated list of 'SSLv3', 'TLSv1', 'TLSv1.1', 'TLSv1.2'
-ssl_protocols=TLSv1 TLSv1.1 TLSv1.2
+; can be comma separated list of 'SSLv3', 'TLSv1', 'TLSv1.1', 'TLSv1.2'
+ssl_protocols=TLSv1, TLSv1.1, TLSv1.2
 ; set TLS cipher suites (up to 63 characters)
 #tls_ciphers=HIGH
 

--- a/xrdp/xrdp.ini
+++ b/xrdp/xrdp.ini
@@ -28,7 +28,7 @@ key_file=
 ; set SSL protocols
 ; can be space separated list of 'SSLv3', 'TLSv1', 'TLSv1.1', 'TLSv1.2'
 ssl_protocols=TLSv1 TLSv1.1 TLSv1.2
-; set TLS cipher suites
+; set TLS cipher suites (up to 63 characters)
 #tls_ciphers=HIGH
 
 ; Section name to use for automatic login if the client sends username


### PR DESCRIPTION
SSL/TLS protocols only listed in ssl_protocols should be used.
The name "ssl_protocols" comes from nginx.

Resolves #428.

Document hasn't been updated yet. 