### PR TITLE
Fix a warning in jpeg compression code with --enable-jpeg

### DIFF
--- a/libxrdp/xrdp_jpeg_compress.c
+++ b/libxrdp/xrdp_jpeg_compress.c
@@ -365,11 +365,14 @@ jpeg_compress(char *in_data, int width, int height,
                 *(dst8++) = red;
             }
 
-            for (i = 0; i < e; i++)
+            if (width > 0)
             {
-                *(dst8++) = blue;
-                *(dst8++) = green;
-                *(dst8++) = red;
+                for (i = 0; i < e; i++)
+                {
+                    *(dst8++) = blue;
+                    *(dst8++) = green;
+                    *(dst8++) = red;
+                }
             }
         }
     }


### PR DESCRIPTION
Let's keep our standards high. We don't need any warnings. This is for 0.9.1, please.

---

If the image width is not divisible by 4, the image is padded to the next
multiple of 4. The additional pixels are filled with the colors of the
last pixel in the row.

The last pixel colors may not be initialized if the width is 0. In this
case, the would be no padding, but the compiler doesn't know that.

Add a check that the width is more that 0 before filling the padding.