### PR TITLE
Set autorun to empty, improve autorun documentation

### DIFF
--- a/docs/man/xrdp.ini.5
+++ b/docs/man/xrdp.ini.5
@@ -29,9 +29,13 @@ Specify xrdp listening address. If not specified, defaults to 0.0.0.0 (all inter
 
 .TP
 \fBautorun\fP=\fIsession_name\fP
-Automatically run the connection specified by \fIsession_name\fP, which must match a section as described below.
-By default a drop-down list with all available connections is shown.
-A connection can also be chosen by the connecting client by setting the \fBLOGIN DOMAIN\fP to a valid \fIsession name\fP.
+Section name for automatic login. If set and the client supplies valid
+username and password, the user will be logged in automatically using the
+connection specified by \fIsession_name\fP.
+
+If \fIsession_name\fP is empty, the \fBLOGIN DOMAIN\fR from the client
+with be used to select the section. If no domain name is supplied, the
+first suitable section will be used for automatic login.
 
 .TP
 \fBbitmap_cache\fR=\fI[true|false]\fR

--- a/xrdp/xrdp.ini
+++ b/xrdp/xrdp.ini
@@ -31,8 +31,10 @@ key_file=
 #tls_ciphers=HIGH
 
 ; Section name to use for automatic login if the client sends username
-; and password
-autorun=X11rdp
+; and password. If empty, the domain name sent by the client is used.
+; If empty and no domain name is given, the first suitable section in
+; this file will be used.
+autorun=
 
 allow_channels=true
 allow_multimon=true


### PR DESCRIPTION
Setting autorun to empty keeps X11rdp as the default backend for
autologin (since it's the first section), but it also enables the backend
selection by the domain name.

Describe the autorun interaction with the domain name both in the config
file and in the manual.