### PR TITLE
Regression fix: session matching uses wrong bpp for Xorg

### DIFF
--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -229,14 +229,19 @@ xrdp_mm_send_login(struct xrdp_mm *self)
     out_uint16_be(s, self->wm->screen->width);
     out_uint16_be(s, self->wm->screen->height);
 
-    if (xserverbpp > 0)
+    /* select and send X server bpp */
+    if (xserverbpp == 0)
     {
-        out_uint16_be(s, xserverbpp);
+        if (self->code == 20)
+        {
+            xserverbpp = 24; /* xorgxrdp is always at 24 bpp */
+        }
+        else
+        {
+            xserverbpp = self->wm->screen->bpp; /* use client's bpp */
+        }
     }
-    else
-    {
-        out_uint16_be(s, self->wm->screen->bpp);
-    }
+    out_uint16_be(s, xserverbpp);
 
     /* send domain */
     if(self->wm->client_info->domain[0]!='_')


### PR DESCRIPTION
Even seemingly harmless configuration changes can have unexpected consequences. This is a regression caused by my recent change in `xrdp.ini`, please fix it before 0.9.1.

---

The removal of "xserverbpp=24" from the Xorg entry lead to a regression.
Clients with a different bpp would not reconnect to an xorgxrdp session
if the client's bpp is different, even though xorgxrdp is always using 24
bpp.

Imply "xserverbpp=24" for "code=20" in xrdp.ini.