### PR TITLE
Make libpainter a subpackage of xrdp

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,6 +23,7 @@ RFXCODECDIR =
 endif
 
 SUBDIRS = \
+  libpainter \
   common \
   vnc \
   rdp \

--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ AC_C_CONST
 AC_PROG_LIBTOOL
 PKG_PROG_PKG_CONFIG
 
-AC_CONFIG_SUBDIRS([librfxcodec])
+AC_CONFIG_SUBDIRS([libpainter librfxcodec])
 
 # Use silent rules by default if supported by Automake
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])


### PR DESCRIPTION
This is a part of the noorders task for 0.9.1. With this change, libpainter will be configured and compiled automatically as part of the build.