### PR TITLE
Fix Parallels Client on Mac

### DIFF
--- a/xrdp/xrdp_bitmap.c
+++ b/xrdp/xrdp_bitmap.c
@@ -149,9 +149,9 @@ xrdp_bitmap_create_with_data(int width, int height,
                              struct xrdp_wm *wm)
 {
     struct xrdp_bitmap *self = (struct xrdp_bitmap *)NULL;
+    int Bpp;
 #if defined(NEED_ALIGN)
     tintptr data_as_int;
-    int Bpp;
 #endif
 
     self = (struct xrdp_bitmap *)g_malloc(sizeof(struct xrdp_bitmap), 1);
@@ -160,6 +160,22 @@ xrdp_bitmap_create_with_data(int width, int height,
     self->height = height;
     self->bpp = bpp;
     self->wm = wm;
+
+    Bpp = 4;
+    switch (bpp)
+    {
+        case 8:
+            Bpp = 1;
+            break;
+        case 15:
+            Bpp = 2;
+            break;
+        case 16:
+            Bpp = 2;
+            break;
+    }
+    self->line_size = width * Bpp;
+
 #if defined(NEED_ALIGN)
     data_as_int = (tintptr) data;
     if (((bpp >= 24) && (data_as_int & 3)) ||
@@ -167,19 +183,6 @@ xrdp_bitmap_create_with_data(int width, int height,
     {
         /* got to copy data here, it's not aligned
            other calls in this file assume alignment */
-        Bpp = 4;
-        switch (bpp)
-        {
-            case 8:
-                Bpp = 1;
-                break;
-            case 15:
-                Bpp = 2;
-                break;
-            case 16:
-                Bpp = 2;
-                break;
-        }
         self->data = (char *)g_malloc(width * height * Bpp, 0);
         g_memcpy(self->data, data, width * height * Bpp);
         return self;


### PR DESCRIPTION
This is for 0.9.1. This code was in the original noorders branch (d3d2bdc001f951d7b456256bca756d79a4556d6f) but wasn't submitted (yet).

---

self->line_size should be calculated in xrdp_bitmap_create_with_data()

The code was in the original noorders branch but got lost. Without this
fix, the image is garbled.

The client should be configured with compression disabled, or it will
disconnect. That's a known problem.