### PR TITLE
Distribute all files except git and github specific data

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,8 +1,25 @@
 ACLOCAL_AMFLAGS = -I m4
 AM_DISTCHECK_CONFIGURE_FLAGS = --without-systemdsystemunitdir
 
-EXTRA_DIST = bootstrap COPYING coding_style.md design.txt faq-compile.txt \
-  faq-general.txt file-loc.txt install.txt m4 readme.txt
+EXTRA_DIST = \
+  COPYING \
+  astyle_config.as \
+  bootstrap \
+  coding_style.md \
+  description-pak \
+  design.txt \
+  faq-compile.txt \
+  faq-general.txt \
+  file-loc.txt \
+  fontdump \
+  install.txt \
+  m4 \
+  postinstall-pak \
+  readme.txt \
+  tcutils \
+  tests \
+  vrplayer \
+  xorg
 
 if XRDP_NEUTRINORDP
 NEUTRINORDPDIR = neutrinordp

--- a/genkeymap/Makefile.am
+++ b/genkeymap/Makefile.am
@@ -1,3 +1,7 @@
+EXTRA_DIST = \
+  dump-keymaps.sh \
+  readme.txt
+
 AM_CFLAGS = $(X_CFLAGS)
 
 bin_PROGRAMS = \

--- a/instfiles/Makefile.am
+++ b/instfiles/Makefile.am
@@ -1,4 +1,5 @@
 EXTRA_DIST = \
+   keymap-names.txt \
    xrdp.sh \
    xrdp-sesman.service \
    xrdp.service

--- a/libxrdp/Makefile.am
+++ b/libxrdp/Makefile.am
@@ -1,3 +1,6 @@
+EXTRA_DIST = \
+  xrdp_surface.c
+
 AM_CPPFLAGS = \
   -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \

--- a/neutrinordp/Makefile.am
+++ b/neutrinordp/Makefile.am
@@ -17,6 +17,7 @@ module_LTLIBRARIES = \
 
 libxrdpneutrinordp_la_SOURCES = \
   xrdp-color.c \
+  xrdp-color.h \
   xrdp-neutrinordp.c \
   xrdp-neutrinordp.h
 

--- a/sesman/Makefile.am
+++ b/sesman/Makefile.am
@@ -1,3 +1,6 @@
+EXTRA_DIST = \
+  Doxyfile
+
 AM_CPPFLAGS = \
   -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \

--- a/sesman/chansrv/Makefile.am
+++ b/sesman/chansrv/Makefile.am
@@ -1,3 +1,9 @@
+EXTRA_DIST = \
+  clipboard-notes.txt \
+  pcsc \
+  pulse \
+  wave-format-server.txt
+
 AM_CPPFLAGS = \
   -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \

--- a/xrdp/Makefile.am
+++ b/xrdp/Makefile.am
@@ -1,3 +1,8 @@
+EXTRA_DIST = \
+  czech.txt \
+  rdp-scan-codes.txt \
+  xrdpwin.c
+
 AM_CPPFLAGS = \
   -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \

--- a/xrdpapi/Makefile.am
+++ b/xrdpapi/Makefile.am
@@ -1,3 +1,8 @@
+EXTRA_DIST = \
+  simple.c \
+  vrplayer.c \
+  vrplayer.mk
+
 module_LTLIBRARIES = \
   libxrdpapi.la
 

--- a/xrdpvr/Makefile.am
+++ b/xrdpvr/Makefile.am
@@ -3,4 +3,5 @@ module_LTLIBRARIES = \
 
 libxrdpvr_la_SOURCES = \
   xrdpvr.c \
-  xrdpvr.h
+  xrdpvr.h \
+  xrdpvr_internal.h


### PR DESCRIPTION
Another patch that needs to be in 0.9.1. I don't know in the 0.9.1 release will be made using `make dist`. If yes, it would be missing a lot of files that were included in older releases. Even the sources of X11rdp would not be included.

I believe that it would be better to err on the side of distributing files. If some files are truly useless, we should remove them from git first.