### PR TITLE
xrdp-sesman: fix help text to match the manual and the actual behavior

### DIFF
--- a/sesman/tools/sesadmin.c
+++ b/sesman/tools/sesadmin.c
@@ -183,8 +183,8 @@ void cmndHelp()
     fprintf(stderr, "-i=<port>    : sesman port (default 3350)\n");
     fprintf(stderr, "-c=<command> : command to execute on the server [MANDATORY]\n");
     fprintf(stderr, "               it can be one of those:\n");
-    fprintf(stderr, "               LIST\n");
-    fprintf(stderr, "               KILL:<sid>\n");
+    fprintf(stderr, "               list\n");
+    fprintf(stderr, "               kill:<sid>\n");
 }
 
 void cmndList(struct SCP_CONNECTION *c)


### PR DESCRIPTION
This is for 0.9.1. The patch is minimal on purpose to minimize risks.

---

The help text mentions "LIST" and "KILL" commands, but the manual says
"list" and "kill", and the command line parser expects the later.