### PR TITLE
Compile libpainter only if enabled, fix path to libpainter.a

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,6 +33,12 @@ else
 XRDPVRDIR =
 endif
 
+if XRDP_PAINTER
+PAINTERDIR = libpainter
+else
+PAINTERDIR =
+endif
+
 if XRDP_RFXCODEC
 RFXCODECDIR = librfxcodec
 else
@@ -40,7 +46,6 @@ RFXCODECDIR =
 endif
 
 SUBDIRS = \
-  libpainter \
   common \
   vnc \
   rdp \
@@ -48,6 +53,7 @@ SUBDIRS = \
   mc \
   $(NEUTRINORDPDIR) \
   libxrdp \
+  $(PAINTERDIR) \
   $(RFXCODECDIR) \
   xrdp \
   sesman \

--- a/xrdp/Makefile.am
+++ b/xrdp/Makefile.am
@@ -36,7 +36,7 @@ endif
 if XRDP_PAINTER
 AM_CPPFLAGS += -DXRDP_PAINTER
 AM_CPPFLAGS += -I$(top_srcdir)/libpainter/include
-XRDP_EXTRA_LIBS += $(top_srcdir)/libpainter/src/.libs/libpainter.a
+XRDP_EXTRA_LIBS += $(top_builddir)/libpainter/src/.libs/libpainter.a
 endif
 
 sbin_PROGRAMS = \


### PR DESCRIPTION
This is for 0.9.1 - fixes on top of the last noorders patches.
