### PR TITLE
Update version to 0.9.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 # Process this file with autoconf to produce a configure script
 
 AC_PREREQ(2.65)
-AC_INIT([xrdp], [0.9.0], [xrdp-devel@googlegroups.com])
+AC_INIT([xrdp], [0.9.1], [xrdp-devel@googlegroups.com])
 AC_CONFIG_HEADERS(config_ac.h:config_ac-h.in)
 AM_INIT_AUTOMAKE([1.7.2 foreign])
 AC_CONFIG_MACRO_DIR([m4])

--- a/docs/man/sesman.ini.5
+++ b/docs/man/sesman.ini.5
@@ -1,5 +1,5 @@
 .\"
-.TH "sesman.ini" "5" "0.9.0" "xrdp team" ""
+.TH "sesman.ini" "5" "0.9.1" "xrdp team" ""
 .SH "NAME"
 \fBsesman.ini\fR \- Configuration file for \fBxrdp-sesman\fR(8)
 

--- a/docs/man/xrdp-chansrv.8
+++ b/docs/man/xrdp-chansrv.8
@@ -1,4 +1,4 @@
-.TH "xrdp\-chansrv" "8" "0.9.0" "xrdp team" ""
+.TH "xrdp\-chansrv" "8" "0.9.1" "xrdp team" ""
 .SH "NAME"
 \fBxrdp\-chansrv\fR \- \fBxrdp\fR channel server
 

--- a/docs/man/xrdp-dis.1
+++ b/docs/man/xrdp-dis.1
@@ -1,4 +1,4 @@
-.TH "xrdp-dis" "1" "0.9.0" "xrdp team"
+.TH "xrdp-dis" "1" "0.9.1" "xrdp team"
 .SH NAME
 xrdp\-dis \- xrdp disconnect utility
 

--- a/docs/man/xrdp-genkeymap.8
+++ b/docs/man/xrdp-genkeymap.8
@@ -1,4 +1,4 @@
-.TH "xrdp\-genkeymap" "8" "0.9.0" "xrdp team" ""
+.TH "xrdp\-genkeymap" "8" "0.9.1" "xrdp team" ""
 .de URL
 . \\$2 \(laURL: \\$1 \(ra\\$3
 ..

--- a/docs/man/xrdp-keygen.8
+++ b/docs/man/xrdp-keygen.8
@@ -3,7 +3,7 @@
 .\" Copyright © 2007, 2008 Vincent Bernat <bernat@debian.org>
 .\" License: GPL-2+
 .\"-
-.TH xrdp\-keygen 8 "0.9.0" "xrdp team"
+.TH xrdp\-keygen 8 "0.9.1" "xrdp team"
 .SH NAME
 xrdp\-keygen \- xrdp RSA key generation utility
 

--- a/docs/man/xrdp-sesadmin.8
+++ b/docs/man/xrdp-sesadmin.8
@@ -1,4 +1,4 @@
-.TH "xrdp-sesadmin" "8" "0.7.0" "xrdp team"
+.TH "xrdp-sesadmin" "8" "0.9.1" "xrdp team"
 .SH NAME
 xrdp\-sesadmin \- console XRDP sessions administration tool
 

--- a/docs/man/xrdp-sesman.8
+++ b/docs/man/xrdp-sesman.8
@@ -1,4 +1,4 @@
-.TH "xrdp\-sesman" "8" "0.9.0" "xrdp team" ""
+.TH "xrdp\-sesman" "8" "0.9.1" "xrdp team" ""
 .SH "NAME"
 xrdp\-sesman \- \fBxrdp\fR(8) session manager
 

--- a/docs/man/xrdp-sesrun.8
+++ b/docs/man/xrdp-sesrun.8
@@ -1,4 +1,4 @@
-.TH "xrdp\-sesrun" "8" "0.9.0" "xrdp team" ""
+.TH "xrdp\-sesrun" "8" "0.9.1" "xrdp team" ""
 .SH "NAME"
 xrdp\-sesrun \- \fBsesman\fR(8) session launcher
 

--- a/docs/man/xrdp-sessvc.8
+++ b/docs/man/xrdp-sessvc.8
@@ -1,4 +1,4 @@
-.TH "xrdp\-sessvc" "8" "0.9.0" "xrdp team" ""
+.TH "xrdp\-sessvc" "8" "0.9.1" "xrdp team" ""
 .SH "NAME"
 xrdp\-sessvc \- \fBxrdp\fR session supervisor
 

--- a/docs/man/xrdp-xcon.8
+++ b/docs/man/xrdp-xcon.8
@@ -1,4 +1,4 @@
-.TH "xrdp-xcon" "8" "0.9.0" "xrdp team"
+.TH "xrdp-xcon" "8" "0.9.1" "xrdp team"
 .SH NAME
 xrdp\-xcon \- X11 event loop debugging helper for XRDP
 

--- a/docs/man/xrdp.8
+++ b/docs/man/xrdp.8
@@ -1,4 +1,4 @@
-.TH "xrdp" "8" "0.9.0" "xrdp team" ""
+.TH "xrdp" "8" "0.9.1" "xrdp team" ""
 .SH "NAME"
 \fBxrdp\fR \- a Remote Desktop Protocol (RDP) server
 

--- a/docs/man/xrdp.ini.5
+++ b/docs/man/xrdp.ini.5
@@ -1,4 +1,4 @@
-.TH "xrdp.ini" "5" "0.9.0" "xrdp team" ""
+.TH "xrdp.ini" "5" "0.9.1" "xrdp team" ""
 .SH "NAME"
 \fBxrdp.ini\fR \- Configuration file for \fBxrdp\fR(8)
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 
-xrdp 0.9.0
+xrdp 0.9.1
 
 Credits
   This project is very much dependent on NeutrinoRDP, FreeRDP, rdesktop, and

--- a/xorg/X11R7.6/rdp/rdp.h
+++ b/xorg/X11R7.6/rdp/rdp.h
@@ -90,7 +90,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #  endif
 #endif
 
-#define X11RDPVER "0.9.0"
+#define X11RDPVER "0.9.1"
 
 #define PixelDPI 100
 #define PixelToMM(_size) (((_size) * 254 + (PixelDPI) * 5) / ((PixelDPI) * 10))


### PR DESCRIPTION
This is for 0.9.1, obviously, to be applied immediately before the release. We have many places where the version is used, let's take care of every occurrence. Please note that xrdp-sesadmin.8 uses 0.7.0 now, not 0.9.0.