### PR TITLE
Warning fixes

### DIFF
--- a/common/trans.h
+++ b/common/trans.h
@@ -128,7 +128,5 @@ int APP_CC
 trans_shutdown_tls_mode(struct trans *self);
 int APP_CC
 trans_tcp_force_read_s(struct trans *self, struct stream *in_s, int size);
-int APP_CC
-trans_force_write_s(struct trans *self, struct stream *out_s);
 
 #endif

--- a/sesman/chansrv/devredir.c
+++ b/sesman/chansrv/devredir.c
@@ -699,9 +699,8 @@ void devredir_proc_client_devlist_announce_req(struct stream *s)
 
                 /* for smart cards, device data len always 0 */
 
-                log_debug("device_type=SMARTCARD device_id=0x%x dosname=%s "
-                          "device_data_len=%d",
-                          g_device_id, preferred_dos_name, device_data_len);
+                log_debug("device_type=SMARTCARD device_id=0x%x dosname=%s",
+                          g_device_id, preferred_dos_name);
 
                 devredir_send_server_device_announce_resp(g_device_id);
                 scard_device_announce(g_device_id);

--- a/sesman/chansrv/devredir.c
+++ b/sesman/chansrv/devredir.c
@@ -46,6 +46,7 @@
 #include "parse.h"
 #include "os_calls.h"
 #include "log.h"
+#include "chansrv.h"
 #include "chansrv_fuse.h"
 #include "devredir.h"
 #include "smartcard.h"

--- a/sesman/chansrv/devredir.h
+++ b/sesman/chansrv/devredir.h
@@ -112,8 +112,6 @@ dev_redir_file_write(void *fusep, tui32 DeviceId, tui32 FileId,
 int APP_CC
 devredir_rmdir_or_file(void *fusep, tui32 device_id, const char *path, int mode);
 
-int send_channel_data(int chan_id, char *data, int size);
-
 /*
  * RDPDR_HEADER definitions
  */

--- a/sesman/libscp/libscp_v1c.c
+++ b/sesman/libscp/libscp_v1c.c
@@ -136,13 +136,6 @@ scp_v1c_resend_credentials(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
     return _scp_v1c_check_response(c, s);
 }
 
-/* 021 */
-enum SCP_CLIENT_STATES_E
-scp_v1c_pwd_change(struct SCP_CONNECTION *c, char *newpass);
-/* 022 */
-enum SCP_CLIENT_STATES_E
-scp_v1c_pwd_change_cancel(struct SCP_CONNECTION *c);
-
 /* 041 */
 enum SCP_CLIENT_STATES_E
 scp_v1c_get_session_list(struct SCP_CONNECTION *c, int *scount,

--- a/sesman/libscp/libscp_v1c_mng.h
+++ b/sesman/libscp/libscp_v1c_mng.h
@@ -52,8 +52,4 @@ enum SCP_CLIENT_STATES_E
 scp_v1c_mng_get_session_list(struct SCP_CONNECTION* c, int* scount,
                          struct SCP_DISCONNECTED_SESSION** s);
 
-/* 044 */
-enum SCP_CLIENT_STATES_E
-scp_v1c_select_session_cancel(struct SCP_CONNECTION* c);
-
 #endif


### PR DESCRIPTION
This is a result of compiling xrdp with most warnings enabled and suppressing non-interesting warnings. This PR addressed duplicate and misplaced function declarations. It also fixes logging data that is not guaranteed to be initialized.