### PR TITLE
Use "void" for empty argument list in declarations

### DIFF
--- a/common/arch.h
+++ b/common/arch.h
@@ -140,7 +140,7 @@ typedef signed long long tsi64;
 #ifdef __cplusplus
 extern "C" {
 #endif
-   tintptr mod_init();
+   tintptr mod_init(void);
    int mod_exit(tintptr);
 #ifdef __cplusplus
 }

--- a/common/ssl_calls.c
+++ b/common/ssl_calls.c
@@ -42,7 +42,7 @@
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 static inline HMAC_CTX *
-HMAC_CTX_new()
+HMAC_CTX_new(void)
 {
     HMAC_CTX *hmac_ctx = g_new(HMAC_CTX, 1);
     HMAC_CTX_init(hmac_ctx);

--- a/sesman/chansrv/chansrv.c
+++ b/sesman/chansrv/chansrv.c
@@ -1637,7 +1637,7 @@ main(int argc, char **argv)
  * @return unused slot index on success, -1 on failure
  ******************************************************************************/
 int APP_CC
-find_empty_slot_in_dvc_channels()
+find_empty_slot_in_dvc_channels(void)
 {
     int i;
 

--- a/sesman/chansrv/chansrv.h
+++ b/sesman/chansrv/chansrv.h
@@ -61,7 +61,7 @@ int APP_CC send_channel_data(int chan_id, char *data, int size);
 int APP_CC send_rail_drawing_orders(char* data, int size);
 int APP_CC main_cleanup(void);
 int APP_CC add_timeout(int msoffset, void (*callback)(void* data), void* data);
-int APP_CC find_empty_slot_in_dvc_channels();
+int APP_CC find_empty_slot_in_dvc_channels(void);
 struct xrdp_api_data * APP_CC struct_from_dvc_chan_id(tui32 dvc_chan_id);
 int remove_struct_with_chan_id(tui32 dvc_chan_id);
 

--- a/sesman/chansrv/chansrv_fuse.c
+++ b/sesman/chansrv/chansrv_fuse.c
@@ -848,7 +848,7 @@ static int xfuse_init_lib(struct fuse_args *args)
  *
  *****************************************************************************/
 
-static int xfuse_init_xrdp_fs()
+static int xfuse_init_xrdp_fs(void)
 {
     struct xrdp_inode *xino;
 
@@ -949,7 +949,7 @@ static int xfuse_init_xrdp_fs()
  * @return 0 on success, -1 on failure
  *****************************************************************************/
 
-static int xfuse_deinit_xrdp_fs()
+static int xfuse_deinit_xrdp_fs(void)
 {
     return 0;
 }
@@ -1043,7 +1043,7 @@ static void xfuse_create_file(fuse_req_t req, fuse_ino_t parent,
 }
 #endif
 
-static void xfuse_dump_fs()
+static void xfuse_dump_fs(void)
 {
     fuse_ino_t i;
     struct xrdp_inode *xinode;
@@ -1387,7 +1387,7 @@ static int xfuse_recursive_delete_dir_with_xinode(XRDP_INODE *xinode)
     return 0;
 }
 
-static void xfuse_update_xrdpfs_size()
+static void xfuse_update_xrdpfs_size(void)
 {
     void *vp;
     int diff;

--- a/sesman/chansrv/chansrv_fuse.h
+++ b/sesman/chansrv/chansrv_fuse.h
@@ -45,8 +45,8 @@ struct xrdp_inode
 };
 typedef struct xrdp_inode XRDP_INODE; // LK_TODO use this instead of using struct xrdp_inode
 
-int xfuse_init();
-int xfuse_deinit();
+int xfuse_init(void);
+int xfuse_deinit(void);
 int xfuse_check_wait_objs(void);
 int xfuse_get_wait_objs(tbus *objs, int *count, int *timeout);
 int xfuse_create_share(tui32 share_id, char *dirname);

--- a/sesman/chansrv/devredir.h
+++ b/sesman/chansrv/devredir.h
@@ -40,9 +40,9 @@ int APP_CC dev_redir_data_in(struct stream* s, int chan_id, int chan_flags,
 int APP_CC dev_redir_get_wait_objs(tbus* objs, int* count, int* timeout);
 int APP_CC dev_redir_check_wait_objs(void);
 
-void dev_redir_send_server_core_cap_req();
-void dev_redir_send_server_clientID_confirm();
-void dev_redir_send_server_user_logged_on();
+void dev_redir_send_server_core_cap_req(void);
+void dev_redir_send_server_clientID_confirm(void);
+void dev_redir_send_server_user_logged_on(void);
 void devredir_send_server_device_announce_resp(tui32 device_id);
 
 void dev_redir_send_drive_dir_request(IRP *irp, tui32 device_id,

--- a/sesman/chansrv/irp.c
+++ b/sesman/chansrv/irp.c
@@ -69,7 +69,7 @@ IRP *g_irp_head = NULL;
  * @return new IRP or NULL on error
  *****************************************************************************/
 
-IRP * devredir_irp_new()
+IRP * devredir_irp_new(void)
 {
     IRP *irp;
     IRP *irp_last;
@@ -239,7 +239,7 @@ IRP * devredir_irp_find_by_fileid(tui32 FileId)
  * Return last IRP in linked list
  *****************************************************************************/
 
-IRP * devredir_irp_get_last()
+IRP * devredir_irp_get_last(void)
 {
     IRP *irp = g_irp_head;
 
@@ -255,7 +255,7 @@ IRP * devredir_irp_get_last()
     return irp;
 }
 
-void devredir_irp_dump()
+void devredir_irp_dump(void)
 {
     IRP *irp = g_irp_head;
 

--- a/sesman/chansrv/rail.c
+++ b/sesman/chansrv/rail.c
@@ -356,7 +356,7 @@ rail_deinit(void)
 }
 
 int APP_CC
-rail_startup()
+rail_startup(void)
 {
     int dummy;
     int ver_maj;

--- a/sesman/chansrv/sound.c
+++ b/sesman/chansrv/sound.c
@@ -212,8 +212,8 @@ static int APP_CC sound_input_start_recording(void);
 static int APP_CC sound_input_stop_recording(void);
 static int APP_CC sound_process_input_data(struct stream *s, int bytes);
 static int DEFAULT_CC sound_sndsrvr_source_data_in(struct trans *trans);
-static int APP_CC sound_start_source_listener();
-static int APP_CC sound_start_sink_listener();
+static int APP_CC sound_start_source_listener(void);
+static int APP_CC sound_start_sink_listener(void);
 
 /*****************************************************************************/
 static int APP_CC
@@ -1513,7 +1513,7 @@ sound_sndsrvr_source_data_in(struct trans *trans)
  * Start a listener for microphone redirection connections
  *****************************************************************************/
 static int APP_CC
-sound_start_source_listener()
+sound_start_source_listener(void)
 {
     char port[1024];
 
@@ -1530,7 +1530,7 @@ sound_start_source_listener()
  * Start a listener for speaker redirection connections
  *****************************************************************************/
 static int APP_CC
-sound_start_sink_listener()
+sound_start_sink_listener(void)
 {
     char port[1024];
 

--- a/sesman/libscp/libscp_init.c
+++ b/sesman/libscp/libscp_init.c
@@ -30,7 +30,7 @@
 
 /* server API */
 int DEFAULT_CC
-scp_init()
+scp_init(void)
 {
     /*
       if (0 == log)

--- a/sesman/libscp/libscp_init.h
+++ b/sesman/libscp/libscp_init.h
@@ -41,6 +41,6 @@
  *
  */
 int DEFAULT_CC
-scp_init();
+scp_init(void);
 
 #endif

--- a/sesman/libscp/libscp_session.c
+++ b/sesman/libscp/libscp_session.c
@@ -34,7 +34,7 @@
 
 /*******************************************************************/
 struct SCP_SESSION *
-scp_session_create()
+scp_session_create(void)
 {
     struct SCP_SESSION *s;
 

--- a/sesman/libscp/libscp_session.h
+++ b/sesman/libscp/libscp_session.h
@@ -38,7 +38,7 @@
  *
  */
 struct SCP_SESSION*
-scp_session_create();
+scp_session_create(void);
 
 int
 scp_session_set_type(struct SCP_SESSION* s, tui8 type);

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -997,7 +997,7 @@ session_kill(int pid)
 
 /******************************************************************************/
 void DEFAULT_CC
-session_sigkill_all()
+session_sigkill_all(void)
 {
     struct session_chain *tmp;
 

--- a/sesman/session.h
+++ b/sesman/session.h
@@ -127,7 +127,7 @@ session_kill(int pid);
  *
  */
 void DEFAULT_CC
-session_sigkill_all();
+session_sigkill_all(void);
 
 /**
  *

--- a/sesman/tools/sesadmin.c
+++ b/sesman/tools/sesadmin.c
@@ -37,7 +37,7 @@ struct log_config logging;
 
 void cmndList(struct SCP_CONNECTION *c);
 void cmndKill(struct SCP_CONNECTION *c, struct SCP_SESSION *s);
-void cmndHelp();
+void cmndHelp(void);
 
 int inputSession(struct SCP_SESSION *s);
 unsigned int menuSelect(unsigned int choices);
@@ -173,7 +173,7 @@ int main(int argc, char **argv)
     return 0;
 }
 
-void cmndHelp()
+void cmndHelp(void)
 {
     fprintf(stderr, "sesadmin - a console sesman administration tool\n");
     fprintf(stderr, "syntax: sesadmin [] COMMAND [OPTIONS]\n\n");

--- a/xorg/tests/xdemo/xdemo.c
+++ b/xorg/tests/xdemo/xdemo.c
@@ -823,7 +823,7 @@ int drawBMP(char *filename, int scroll_type)
     return 0;
 }
 
-int process_bmp_event()
+int process_bmp_event(void)
 {
     XEvent ev;
     long   event_mask;

--- a/xrdpapi/simple.c
+++ b/xrdpapi/simple.c
@@ -37,8 +37,8 @@
 #include <errno.h>
 
 /* forward declarations */
-int run_echo_test();
-int run_tsmf_test();
+int run_echo_test(void);
+int run_tsmf_test(void);
 
 int
 main(int argc, char **argv)
@@ -76,7 +76,7 @@ main(int argc, char **argv)
  * @return 0 on success, -1 on failure
  */
 int
-run_echo_test()
+run_echo_test(void)
 {
     char    out_buf[8192];
     char    in_buf[1700];
@@ -162,7 +162,7 @@ run_echo_test()
 }
 
 int
-run_tsmf_test()
+run_tsmf_test(void)
 {
     void *channel;
 


### PR DESCRIPTION
In C, an empty argument list in a declaration means that the function
can accept any arguments. Use "void" instead, it means "no arguments".

C++ treats void and empty list as "no arguments".