### PR TITLE
One way clipboard feature

### DIFF
--- a/sesman/chansrv/Makefile.am
+++ b/sesman/chansrv/Makefile.am
@@ -9,7 +9,9 @@ AM_CPPFLAGS = \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
   -DXRDP_SHARE_PATH=\"${datadir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \
-  -I$(top_srcdir)/common
+  -I$(top_srcdir)/common \
+  -I$(top_srcdir)/sesman \
+  -I$(top_srcdir)/sesman/libscp
 
 CHANSRV_EXTRA_LIBS =
 
@@ -63,7 +65,8 @@ xrdp_chansrv_SOURCES = \
   sound.c \
   sound.h \
   xcommon.c \
-  xcommon.h
+  xcommon.h \
+  config.c
 
 xrdp_chansrv_LDFLAGS = \
   $(X_LIBS)

--- a/sesman/chansrv/config.c
+++ b/sesman/chansrv/config.c
@@ -1,0 +1,1 @@
+#include "../config.c"

--- a/sesman/config.c
+++ b/sesman/config.c
@@ -200,6 +200,7 @@ config_read_security(int file, struct config_security *sc,
     sc->login_retry = 3;
     sc->ts_users_enable = 0;
     sc->ts_admins_enable = 0;
+    sc->restrict_clipboard = 0;
 
     file_read_section(file, SESMAN_CFG_SECURITY, param_n, param_v);
 
@@ -235,9 +236,14 @@ config_read_security(int file, struct config_security *sc,
             }
         }
         if (0 == g_strcasecmp(buf, SESMAN_CFG_SEC_ALWAYSGROUPCHECK))
-        {
-            sc->ts_always_group_check = g_text2bool((char *)list_get_item(param_v, i));
-        }
+		{
+			sc->ts_always_group_check = g_text2bool((char *)list_get_item(param_v, i));
+		}
+        if (0 == g_strcasecmp(buf, SESMAN_CFG_RESTRICT_CLIPBOARD))
+		{
+			sc->restrict_clipboard = g_text2bool((char *)list_get_item(param_v, i));
+		}
+
     }
 
     /* printing security config */
@@ -245,6 +251,7 @@ config_read_security(int file, struct config_security *sc,
     g_printf("\tAllowRootLogin:       %i\r\n", sc->allow_root);
     g_printf("\tMaxLoginRetry:        %i\r\n", sc->login_retry);
     g_printf("\tAlwaysGroupCheck:     %i\r\n", sc->ts_always_group_check);
+    g_printf("\tRestrictClipboard:    %i\r\n", sc->restrict_clipboard);
 
     if (sc->ts_users_enable)
     {

--- a/sesman/config.h
+++ b/sesman/config.h
@@ -59,6 +59,7 @@
 #define SESMAN_CFG_SEC_USR_GROUP     "TerminalServerUsers"
 #define SESMAN_CFG_SEC_ADM_GROUP     "TerminalServerAdmins"
 #define SESMAN_CFG_SEC_ALWAYSGROUPCHECK "AlwaysGroupCheck"
+#define SESMAN_CFG_RESTRICT_CLIPBOARD "RestrictClipboard"
 
 #define SESMAN_CFG_SESSIONS          "Sessions"
 #define SESMAN_CFG_SESS_MAX          "MaxSessions"
@@ -125,6 +126,14 @@ struct config_security
    * @brief if the Groups are not found deny access
    */
   int ts_always_group_check;
+  /**
+   * @var restrict_clipboard
+   * @brief if the one-direction clipboard policy should be enforced. Only allow client -> serve, not vice versa.
+   */
+  int restrict_clipboard;
+
+
+
 };
 
 /**

--- a/sesman/sesman.ini
+++ b/sesman/sesman.ini
@@ -13,6 +13,7 @@ TerminalServerAdmins=tsadmins
 ; When AlwaysGroupCheck=false access will be permitted
 ; if the group TerminalServerUsers is not defined.
 AlwaysGroupCheck=false
+RestrictClipboard=false
 
 [Sessions]
 ;; X11DisplayOffset - x11 display number offset


### PR DESCRIPTION
This is a one-way clipboard basic implementation.
Discards clipboard selection event so they are not propagated to the client.

Feature needed for companies having to restrict the user ability to take data out from the server.