### PR TITLE
Add --enable-strict-locations option, describe default in its help text

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,7 @@
 ACLOCAL_AMFLAGS = -I m4
-AM_DISTCHECK_CONFIGURE_FLAGS = --without-systemdsystemunitdir
+AM_DISTCHECK_CONFIGURE_FLAGS = \
+  --without-systemdsystemunitdir \
+  --enable-strict-locations
 
 EXTRA_DIST = \
   COPYING \

--- a/configure.ac
+++ b/configure.ac
@@ -292,9 +292,14 @@ CFLAGS="$save_CFLAGS"
 
 AC_SUBST([moduledir], '${libdir}/xrdp')
 
-if test "x${prefix}" = "xNONE" ; then
-sysconfdir="/etc";
-localstatedir="/var";
+AC_ARG_ENABLE([strict-locations],
+  [AS_HELP_STRING([--enable-strict-locations],
+                  [Use standard Autoconf install directories unless overridden
+                   (default: use /etc and /var)])])
+
+if test "x$enable_strict_locations" != "xyes"; then
+  sysconfdir="/etc";
+  localstatedir="/var";
 fi
 
 PKG_INSTALLDIR


### PR DESCRIPTION
Rather than guess user's intention based on whether --prefix was
specified, use an explicit option to enable strict GNU Coding Standards
for installation directories.

The default is to use /etc and /var rather than corresponding directories
under prefix.

Use --enable-strict-locations in "make distcheck", it expects all
installed files to be under prefix.