### PR TITLE
keygen: add CA extensions to self-signed certificates

### DIFF
--- a/keygen/openssl.conf
+++ b/keygen/openssl.conf
@@ -1,41 +1,36 @@
 [req]
 distinguished_name = req_distinguished_name
-x509_extensions = v3_ca	# The extentions to add to the self signed cert
+# The extensions to add to the self signed cert
+x509_extensions = v3_ca
 
 [req_distinguished_name]
 
-[ v3_ca ]
-
-# Extensions for a typical CA
-
-
-# PKIX recommendation.
-
-subjectKeyIdentifier=hash
-
-authorityKeyIdentifier=keyid:always,issuer
+[v3_ca]
+# Extensions for a typical CA - PKIX recommendation.
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always, issuer
 
 # This is what PKIX recommends but some broken software chokes on critical
 # extensions.
-#basicConstraints = critical,CA:true
+#basicConstraints = critical, CA:true
 # So we do this instead.
 basicConstraints = CA:true
 
 # Key usage: this is typical for a CA certificate. However since it will
 # prevent it being used as an test self-signed certificate it is best
 # left out by default.
-# keyUsage = cRLSign, keyCertSign
+#keyUsage = cRLSign, keyCertSign
 
 # Some might want this also
-# nsCertType = sslCA, emailCA
+#nsCertType = sslCA, emailCA
 
 # Include email address in subject alt name: another PKIX recommendation
-# subjectAltName=email:copy
+#subjectAltName = email:copy
 # Copy issuer details
-# issuerAltName=issuer:copy
+#issuerAltName = issuer:copy
 
-# DER hex encoding of an extension: beware experts only!
-# obj=DER:02:03
+# DER hex encoding of an extension: experts only!
+#obj = DER:02:03
 # Where 'obj' is a standard or added object
 # You can even override a supported extension:
-# basicConstraints= critical, DER:30:03:01:01:FF
+#basicConstraints = critical, DER:30:03:01:01:FF

--- a/keygen/openssl.conf
+++ b/keygen/openssl.conf
@@ -1,4 +1,41 @@
 [req]
 distinguished_name = req_distinguished_name
+x509_extensions = v3_ca	# The extentions to add to the self signed cert
 
 [req_distinguished_name]
+
+[ v3_ca ]
+
+# Extensions for a typical CA
+
+
+# PKIX recommendation.
+
+subjectKeyIdentifier=hash
+
+authorityKeyIdentifier=keyid:always,issuer
+
+# This is what PKIX recommends but some broken software chokes on critical
+# extensions.
+#basicConstraints = critical,CA:true
+# So we do this instead.
+basicConstraints = CA:true
+
+# Key usage: this is typical for a CA certificate. However since it will
+# prevent it being used as an test self-signed certificate it is best
+# left out by default.
+# keyUsage = cRLSign, keyCertSign
+
+# Some might want this also
+# nsCertType = sslCA, emailCA
+
+# Include email address in subject alt name: another PKIX recommendation
+# subjectAltName=email:copy
+# Copy issuer details
+# issuerAltName=issuer:copy
+
+# DER hex encoding of an extension: beware experts only!
+# obj=DER:02:03
+# Where 'obj' is a standard or added object
+# You can even override a supported extension:
+# basicConstraints= critical, DER:30:03:01:01:FF


### PR DESCRIPTION
Self-signed certificates lacks the required CA extensions.
MS RDP client for iOS cannot connect because of it. the app is crashing right after TLS handshake.
I think it worked before we added our openssl.conf file.