### PR TITLE
Use constant strings for input arguments in keygen, kill dead code

### DIFF
--- a/common/ssl_calls.c
+++ b/common/ssl_calls.c
@@ -344,8 +344,8 @@ ssl_reverse_it(char *p, int len)
 
 /*****************************************************************************/
 int APP_CC
-ssl_mod_exp(char *out, int out_len, char *in, int in_len,
-            char *mod, int mod_len, char *exp, int exp_len)
+ssl_mod_exp(char *out, int out_len, const char *in, int in_len,
+            const char *mod, int mod_len, const char *exp, int exp_len)
 {
     BN_CTX *ctx;
     BIGNUM *lmod;
@@ -406,7 +406,7 @@ ssl_mod_exp(char *out, int out_len, char *in, int in_len,
    generates a new rsa key
    exp is passed in and mod and pri are passed out */
 int APP_CC
-ssl_gen_key_xrdp1(int key_size_in_bits, char *exp, int exp_len,
+ssl_gen_key_xrdp1(int key_size_in_bits, const char *exp, int exp_len,
                   char *mod, int mod_len, char *pri, int pri_len)
 {
     BIGNUM *my_e;

--- a/common/ssl_calls.h
+++ b/common/ssl_calls.h
@@ -75,10 +75,10 @@ ssl_hmac_transform(void *hmac, const char *data, int len);
 void APP_CC
 ssl_hmac_complete(void *hmac, char *data, int len);
 int APP_CC
-ssl_mod_exp(char* out, int out_len, char* in, int in_len,
-            char* mod, int mod_len, char* exp, int exp_len);
+ssl_mod_exp(char *out, int out_len, const char *in, int in_len,
+            const char *mod, int mod_len, const char *exp, int exp_len);
 int APP_CC
-ssl_gen_key_xrdp1(int key_size_in_bits, char* exp, int exp_len,
+ssl_gen_key_xrdp1(int key_size_in_bits, const char* exp, int exp_len,
                   char* mod, int mod_len, char* pri, int pri_len);
 
 /* ssl_tls */

--- a/configure.ac
+++ b/configure.ac
@@ -145,7 +145,7 @@ AC_CHECK_FUNC(dlopen, [],
 AC_SUBST(DLOPEN_LIBS)
 
 # checking for openssl
-PKG_CHECK_MODULES([OPENSSL], [openssl >= 0], [],
+PKG_CHECK_MODULES([OPENSSL], [openssl >= 0.9.8], [],
   [AC_MSG_ERROR([please install libssl-dev or openssl-devel])])
 
 # look for openssl binary

--- a/keygen/keygen.c
+++ b/keygen/keygen.c
@@ -206,7 +206,7 @@ out_params(void)
 /*****************************************************************************/
 /* this is the special key signing algorithm */
 static int APP_CC
-sign_key(char *e_data, int e_len, char *n_data, int n_len,
+sign_key(const char *e_data, int e_len, const char *n_data, int n_len,
          char *sign_data, int sign_len)
 {
     char *key;
@@ -282,7 +282,7 @@ sign_key(char *e_data, int e_len, char *n_data, int n_len,
 
 /*****************************************************************************/
 static int APP_CC
-write_out_line(int fd, const char *name, char *data, int len)
+write_out_line(int fd, const char *name, const char *data, int len)
 {
     int max;
     int error;
@@ -334,8 +334,8 @@ write_out_line(int fd, const char *name, char *data, int len)
 
 /*****************************************************************************/
 static int APP_CC
-save_all(char *e_data, int e_len, char *n_data, int n_len,
-         char *d_data, int d_len, char *sign_data, int sign_len,
+save_all(const char *e_data, int e_len, const char *n_data, int n_len,
+         const char *d_data, int d_len, const char *sign_data, int sign_len,
          const char *path_and_file_name)
 {
     int fd;


### PR DESCRIPTION
It's hard to read code where input string arguments use type `char *`, especially if it's cryptographic code. Functions should not modify its input arguments. The compiler can produce better code if it knows the constraints.

Remove code for compatibility with OpenSSL prior to 0.9.8. It's hard to find old versions of OpenSSL. Everybody who cares about security should be using OpenSSL 1.0.2 or newer. But let's allow for older OpenSSL for systems that backport security fixes.