### PR TITLE
Suppress versioning for modules, tell libtool they are modules

### DIFF
--- a/mc/Makefile.am
+++ b/mc/Makefile.am
@@ -18,3 +18,5 @@ libmc_la_SOURCES = \
 
 libmc_la_LIBADD = \
   $(top_builddir)/common/libcommon.la
+
+libmc_la_LDFLAGS = -avoid-version -module

--- a/neutrinordp/Makefile.am
+++ b/neutrinordp/Makefile.am
@@ -22,3 +22,5 @@ libxrdpneutrinordp_la_SOURCES = \
 libxrdpneutrinordp_la_LIBADD = \
   $(top_builddir)/common/libcommon.la \
   $(FREERDP_LIBS)
+
+libxrdpneutrinordp_la_LDFLAGS = -avoid-version -module

--- a/rdp/Makefile.am
+++ b/rdp/Makefile.am
@@ -26,3 +26,5 @@ librdp_la_SOURCES = \
 
 librdp_la_LIBADD = \
   $(top_builddir)/common/libcommon.la
+
+librdp_la_LDFLAGS = -avoid-version -module

--- a/vnc/Makefile.am
+++ b/vnc/Makefile.am
@@ -18,3 +18,5 @@ libvnc_la_SOURCES = \
 
 libvnc_la_LIBADD = \
   $(top_builddir)/common/libcommon.la
+
+libvnc_la_LDFLAGS = -avoid-version -module

--- a/xup/Makefile.am
+++ b/xup/Makefile.am
@@ -18,3 +18,5 @@ libxup_la_SOURCES = \
 
 libxup_la_LIBADD = \
   $(top_builddir)/common/libcommon.la
+
+libxup_la_LDFLAGS = -avoid-version -module


### PR DESCRIPTION
Versioning is for libraries. Modules are not libraries; no code is linked
against them.

Libtool makes sure the modules can be opened by dlopen(). That is already
true for ELF format, but other file formats may need special processing.