### PR TITLE
Allow PAM file selection in configure, improve autodetection, add SUSE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,6 +74,10 @@ AC_ARG_ENABLE(pamuserpass, AS_HELP_STRING([--enable-pamuserpass],
               [Build pam userpass support (default: no)]),
               [], [enable_pamuserpass=no])
 AM_CONDITIONAL(SESMAN_PAMUSERPASS, [test x$enable_pamuserpass = xyes])
+AC_ARG_ENABLE(pam-config, AS_HELP_STRING([--enable-pam-config=CONF],
+              [Select PAM config to install: debian, redhat, suse, unix
+               (default: autodetect)]))
+
 AC_ARG_ENABLE(xrdpdebug, AS_HELP_STRING([--enable-xrdpdebug],
               [Build debug (default: no)]),
               [], [enable_xrdpdebug=no])
@@ -156,7 +160,19 @@ then
         [AC_MSG_ERROR([please install libpam0g-dev or pam-devel])])
     fi
   fi
+  if test "x$enable_pam_config" = "x"; then
+    PAM_RULES="auto"
+  else
+    pam_config_file="$srcdir/instfiles/pam.d/xrdp-sesman.$enable_pam_config"
+    if test -f "$pam_config_file"; then
+      PAM_RULES="$enable_pam_config"
+    else
+      AC_MSG_ERROR([PAM file "$pam_config_file" is not available])
+    fi
+  fi
 fi
+
+AC_SUBST(PAM_RULES)
 
 if test "x$enable_ipv6only" = "xyes"
 then

--- a/instfiles/pam.d/Makefile.am
+++ b/instfiles/pam.d/Makefile.am
@@ -1,7 +1,10 @@
-EXTRA_DIST = \
-  xrdp-sesman.common \
-  xrdp-sesman.other \
-  xrdp-sesman.password-auth
+PAM_FILES = \
+  xrdp-sesman.debian \
+  xrdp-sesman.redhat \
+  xrdp-sesman.suse \
+  xrdp-sesman.unix
+
+EXTRA_DIST = $(PAM_FILES) mkpamrules
 
 CLEANFILES = xrdp-sesman
 
@@ -24,14 +27,5 @@ pamddir = $(sysconfdir)/pam.d
 pamd_DATA = \
   $(PAMFILE)
 
-xrdp-sesman:
-	if test -e /etc/pam.d/password-auth; then \
-	  pamrules=xrdp-sesman.password-auth; \
-	else \
-	  if test -e /etc/pam.d/common-auth; then \
-	    pamrules=xrdp-sesman.common; \
-	  else \
-	    pamrules=xrdp-sesman.other; \
-	  fi; \
-	fi; \
-	$(LN_S) $(srcdir)/$$pamrules $@
+xrdp-sesman: mkpamrules
+	$(srcdir)/mkpamrules $(PAM_RULES) $(srcdir) $@

--- a/instfiles/pam.d/mkpamrules
+++ b/instfiles/pam.d/mkpamrules
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# Find suitable PAM config file
+
+rules="$1"
+srcdir="$2"
+outfile="$3"
+
+service="xrdp-sesman"
+pamdir="/etc/pam.d"
+
+guess_rules ()
+{
+  if test -s "$pamdir/password-auth"; then
+    rules="redhat"
+    return
+  fi
+
+  if test -s "$pamdir/common-account"; then
+    if grep "^@include" "$pamdir/passwd" >/dev/null 2>&1; then
+      rules="debian"
+    else
+      rules="suse"
+    fi
+    return
+  fi
+
+  rules="unix"
+  return
+}
+
+if test "$rules" = "auto"; then
+  guess_rules
+fi
+
+if test -s "$srcdir/$service.$rules"; then
+  ln -nsf "$srcdir/$service.$rules" "$outfile"
+else
+  echo "Cannot find $srcdir/$service.$rules"
+  exit 1
+fi

--- a/instfiles/pam.d/xrdp-sesman.debian
+++ b/instfiles/pam.d/xrdp-sesman.debian
@@ -2,3 +2,4 @@
 @include common-auth
 @include common-account
 @include common-session
+@include common-password

--- a/instfiles/pam.d/xrdp-sesman.other
+++ b/instfiles/pam.d/xrdp-sesman.other
@@ -1,5 +1,0 @@
-#%PAM-1.0
-auth       include     system-auth
-account    include     system-auth
-password   include     system-auth
-session    include     system-auth

--- a/instfiles/pam.d/xrdp-sesman.password-auth
+++ b/instfiles/pam.d/xrdp-sesman.password-auth
@@ -1,4 +1,0 @@
-#%PAM-1.0
-auth       include      password-auth
-account    include      password-auth
-session    include      password-auth

--- a/instfiles/pam.d/xrdp-sesman.redhat
+++ b/instfiles/pam.d/xrdp-sesman.redhat
@@ -1,0 +1,5 @@
+#%PAM-1.0
+auth        include     password-auth
+account     include     password-auth
+session     include     password-auth
+password    include     password-auth

--- a/instfiles/pam.d/xrdp-sesman.suse
+++ b/instfiles/pam.d/xrdp-sesman.suse
@@ -1,0 +1,5 @@
+#%PAM-1.0
+auth        include     common-auth
+account     include     common-account
+session     include     common-session
+password    include     common-password

--- a/instfiles/pam.d/xrdp-sesman.unix
+++ b/instfiles/pam.d/xrdp-sesman.unix
@@ -1,0 +1,5 @@
+#%PAM-1.0
+auth        include     system-auth
+account     include     system-auth
+password    include     system-auth
+session     include     system-auth


### PR DESCRIPTION
Use easy to understand names for config files (debian, redhat, suse,
unix). Move all autodetection to a separate script.