### PR TITLE
When Xfixes.h is checked, the user should have libX11 already

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -256,7 +256,7 @@ CFLAGS="$CFLAGS $X_CFLAGS"
 
 # checking for Xfixes
 AC_CHECK_HEADER([X11/extensions/Xfixes.h], [],
-  [AC_MSG_ERROR([please install libx11-dev and libxfixes-dev or libXfixes-devel])],
+  [AC_MSG_ERROR([please install libxfixes-dev or libXfixes-devel])],
   [#include <X11/Xlib.h>])
 
 # checking for Xrandr


### PR DESCRIPTION
No need to confuse the user by asking to install libX11 headers.