### PR TITLE
Exit with error message if pkg-config is not found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,11 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_CC
 AC_C_CONST
 AC_PROG_LIBTOOL
+
 PKG_PROG_PKG_CONFIG
+if test "x$PKG_CONFIG" = "x"; then
+  AC_MSG_ERROR([please install pkg-config])
+fi
 
 AC_CONFIG_SUBDIRS([libpainter librfxcodec])
 


### PR DESCRIPTION
PKG_PROG_PKG_CONFIG does not exit if it fails to find pkg-config.

Continuing without pkg-config leads to misleading error messages when
checks for packages fail.