### PR TITLE
Channels improvements

### DIFF
--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -65,7 +65,7 @@ struct xrdp_client_info
   int rdp_compression;
   int rdp_autologin;
   int crypt_level; /* 1, 2, 3 = low, medium, high */
-  int channel_code; /* 0 = no channels 1 = channels */
+  int channels_allowed; /* 0 = no channels 1 = channels */
   int sound_code; /* 1 = leave sound at server */
   int is_mce;
   int rdp5_performanceflags;

--- a/libxrdp/libxrdp.c
+++ b/libxrdp/libxrdp.c
@@ -1242,7 +1242,7 @@ libxrdp_send_to_channel(struct xrdp_session *session, int channel_id,
 
     if (xrdp_channel_send(chan, s, channel_id, total_data_len, flags) != 0)
     {
-        g_writeln("Debug - data NOT sent to channel");
+        g_writeln("libxrdp_send_to_channel: error, server channel data NOT sent to client channel");
         free_stream(s);
         return 1;
     }

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -105,8 +105,8 @@ xrdp_rdp_read_config(struct xrdp_client_info *client_info)
         }
         else if (g_strcasecmp(item, "allow_channels") == 0)
         {
-            client_info->channel_code = g_text2bool(value);
-            if (client_info->channel_code == 0)
+            client_info->channels_allowed = g_text2bool(value);
+            if (client_info->channels_allowed == 0)
             {
                 log_message(LOG_LEVEL_DEBUG,"Info - All channels are disabled");
             }

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -1862,6 +1862,12 @@ xrdp_sec_process_mcs_data_channels(struct xrdp_sec *self, struct stream *s)
             return 1;
         }
         in_uint8a(s, channel_item->name, 8);
+        if (g_strlen(channel_item->name) == 0)
+        {
+            g_writeln("xrdp_sec_process_mcs_data_channels: got an empty channel name, ignoring it");
+            g_free(channel_item);
+            continue;
+        }
         in_uint32_le(s, channel_item->flags);
         channel_item->chanid = MCS_GLOBAL_CHANNEL + (index + 1);
         list_add_item(self->mcs_layer->channel_list, (tintptr) channel_item);

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -1829,12 +1829,12 @@ xrdp_sec_process_mcs_data_channels(struct xrdp_sec *self, struct stream *s)
     client_info = &(self->rdp_layer->client_info);
 
 
-    DEBUG(("processing channels, channel_code is %d", client_info->channel_code));
+    DEBUG(("processing channels, channels_allowed is %d", client_info->channels_allowed));
 
     /* this is an option set in xrdp.ini */
-    if (client_info->channel_code != 1) /* are channels on? */
+    if (client_info->channels_allowed != 1) /* are channels on? */
     {
-        g_writeln("Processing channel data from client - The channel is off");
+        g_writeln("xrdp_sec_process_mcs_data_channels: all channels are disabled by configuration");
         return 0;
     }
 

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -1864,7 +1864,7 @@ xrdp_sec_process_mcs_data_channels(struct xrdp_sec *self, struct stream *s)
         in_uint8a(s, channel_item->name, 8);
         if (g_strlen(channel_item->name) == 0)
         {
-            g_writeln("xrdp_sec_process_mcs_data_channels: got an empty channel name, ignoring it");
+            log_message(LOG_LEVEL_WARNING, "xrdp_sec_process_mcs_data_channels: got an empty channel name, ignoring it");
             g_free(channel_item);
             continue;
         }

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -740,8 +740,11 @@ xrdp_mm_trans_process_channel_data(struct xrdp_mm *self, struct trans *trans)
 
     if (rv == 0)
     {
-        rv = libxrdp_send_to_channel(self->wm->session, chan_id, s->p, size, total_size,
-                                     chan_flags);
+        if (is_channel_allowed(self->wm, chan_id))
+        {
+            rv = libxrdp_send_to_channel(self->wm->session, chan_id, s->p, size, total_size,
+                                         chan_flags);
+        }
     }
 
     return rv;


### PR DESCRIPTION
* Check for empty channel names, they are unusable. Jump Desktop client send empty channel names for disabled channels. That made xrdp think we got more channels then really negotiated via  Client MCS Channel Join Request PDUs. That fix makes Jump Desktop client work with xrdp (should resolve #594)

* Respect xrdp.ini channel blocking settings. The restriction was only applied on client to server channel data.  block PDUs coming from chansrv if channel is not allowed. This change can help with Parallels Client, which doesn't support our rdpsnd channel (#608). One can now block rdpsnd channel in xrdp.ini so Parallels Client will not drop the connection.

