### PR TITLE
Check for openssl binary in configure, don't fail if not found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -140,6 +140,10 @@ AC_SUBST(DLOPEN_LIBS)
 PKG_CHECK_MODULES([OPENSSL], [openssl >= 0], [],
   [AC_MSG_ERROR([please install libssl-dev or openssl-devel])])
 
+# look for openssl binary
+OPENSSL_BIN=`$PKG_CONFIG --variable=exec_prefix openssl`/bin
+AC_PATH_PROGS([OPENSSL], [openssl], [:], [$OPENSSL_BIN:$PATH])
+
 # checking for pam variation
 # Linux-PAM is used in Linux systems
 # OpenPAM is used by FreeBSD, NetBSD, DragonFly BSD and OS X

--- a/keygen/Makefile.am
+++ b/keygen/Makefile.am
@@ -23,7 +23,7 @@ install-data-hook:
 	  ./xrdp-keygen xrdp $(DESTDIR)$(xrdpsysconfdir)/rsakeys.ini; \
 	fi && \
 	if [ ! -f $(DESTDIR)$(xrdpsysconfdir)/cert.pem ]; then \
-	  openssl req -x509 -newkey rsa:2048 -sha256 -nodes \
+	  $(OPENSSL) req -x509 -newkey rsa:2048 -sha256 -nodes \
 	    -keyout $(DESTDIR)$(xrdpsysconfdir)/key.pem -out \
 	    $(DESTDIR)$(xrdpsysconfdir)/cert.pem -days 365 \
 	    -subj /C=US/ST=CA/L=Sunnyvale/O=xrdp/CN=www.xrdp.org \


### PR DESCRIPTION
Prefer openssl binary from the same location as the openssl library.

Make it possible to suppress certificate generation during install by
passing OPENSSL=: to make.