### PR TITLE
x11rdp: respect disconnect timeout set by XRDP_SESMAN_MAX_DISC_TIME

### DIFF
--- a/xorg/X11R7.6/rdp/rdpup.c
+++ b/xorg/X11R7.6/rdp/rdpup.c
@@ -1337,7 +1337,6 @@ rdpup_init(void)
         if (i != 0)
         {
             g_do_kill_disconnected = 1;
-            g_disconnect_timeout_s = 0;
         }
     }
 


### PR DESCRIPTION
The old code overwrites disconnect timeout to 60 sec when
XRDP_SESMAN_KILL_DISCONNECT is set to truthy value.