### PR TITLE
Fix calling XChangeProperty in clipboard provide

### DIFF
--- a/sesman/chansrv/clipboard.c
+++ b/sesman/chansrv/clipboard.c
@@ -966,7 +966,7 @@ clipboard_provide_selection(XSelectionRequestEvent *req, Atom type, int format,
     if (bytes < g_incr_max_req_size)
     {
         XChangeProperty(g_display, req->requestor, req->property,
-                        type, format, PropModeReplace, (tui8 *)data, bytes);
+                        type, format, PropModeReplace, (tui8 *)data, length);
         g_memset(&xev, 0, sizeof(xev));
         xev.xselection.type = SelectionNotify;
         xev.xselection.send_event = True;


### PR DESCRIPTION
[XChangeProperty](https://tronche.com/gui/x/xlib/window-information/XChangeProperty.html)'s last parameter is number of elements, not number of bytes.
Because of this bug, Paste did not work in any java applications.
Java checks all formats first and because bytes are always bigger than length, it reads further and once it finds a 0 value, check fails with java.lang.NullPointerException
As I checked other calls of XChangeProperty in clipboard.c are fine.