### PR TITLE
Only check for systemd on Linux, no need to warn users of other OSes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,12 @@ AM_CONDITIONAL(NETBSD, [test "x$netbsd" = xyes])
 
 AC_ARG_WITH([systemdsystemunitdir],
         AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files]),
-        [], [with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])
+        [], [
+if test "x$linux" = xyes; then
+  with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)
+fi
+])
+
 if test "x$with_systemdsystemunitdir" != xno; then
         AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])
 fi


### PR DESCRIPTION
That's the text that pkg-config and configure output to stderr:
```
Package systemd was not found in the pkg-config search path.
Perhaps you should add the directory containing `systemd.pc'
to the PKG_CONFIG_PATH environment variable
No package 'systemd' found
```
That's not useful on FreeBSD or Mac OS. It is still possible to specify
`--with-systemdsystemunitdir=DIR` manually on any OS.