### PR TITLE
Add GNU/kFreeBSD support

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -87,8 +87,8 @@ extern char **environ;
 #endif
 
 /* sys/ucred.h needs to be included to use struct xucred
- * in FreeBSD and OS X. No need for other BSDs  */
-#if defined(__FreeBSD__) || defined(__APPLE__)
+ * in FreeBSD and OS X. No need for other BSDs except GNU/kFreeBSD */
+#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__FreeBSD_kernel__)
 #include <sys/ucred.h>
 #endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,9 @@ case $host_os in
 	*linux*)
 		linux=yes
 		;;
+	*kfreebsd*)
+		linux=yes # only used in instfiles/ so that’s ok for us for now
+		;;
 	*freebsd*)
 		freebsd=yes
 		;;

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -503,7 +503,7 @@ session_start_fork(tbus data, tui8 type, struct SCP_SESSION *s)
         g_sprintf(geometry, "%dx%d", s->width, s->height);
         g_sprintf(depth, "%d", s->bpp);
         g_sprintf(screen, ":%d", display);
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
         /*
          * FreeBSD bug
          * ports/157282: effective login name is not set by xrdp-sesman


### PR DESCRIPTION
This depends on https://github.com/neutrinolabs/xorgxrdp/pull/65 and https://github.com/neutrinolabs/librfxcodec/pull/14 however.

I’ve tested this with Debian (compile test only).