### PR TITLE
Several fixes for xrdp-sesadmin, including bad free() on error

### DIFF
--- a/sesman/tools/sesadmin.c
+++ b/sesman/tools/sesadmin.c
@@ -187,6 +187,20 @@ void cmndHelp(void)
     fprintf(stderr, "               kill:<sid>\n");
 }
 
+static void
+print_session(const struct SCP_DISCONNECTED_SESSION *s)
+{
+    printf("Session ID: %d\n", s->SID);
+    printf("\tSession type: %d\n", s->type);
+    printf("\tScreen size: %dx%d, color depth %d\n",
+           s->width, s->height, s->bpp);
+    printf("\tIdle time: %d day(s) %d hour(s) %d minute(s)\n",
+           s->idle_days, s->idle_hours, s->idle_minutes);
+    printf("\tConnected: %04d/%02d/%02d %02d:%02d\n",
+           s->conn_year, s->conn_month, s->conn_day, s->conn_hour,
+           s->conn_minute);
+}
+
 void cmndList(struct SCP_CONNECTION *c)
 {
     struct SCP_DISCONNECTED_SESSION *dsl;
@@ -206,13 +220,7 @@ void cmndList(struct SCP_CONNECTION *c)
     {
         for (idx = 0; idx < scnt; idx++)
         {
-            struct SCP_DISCONNECTED_SESSION *s = &dsl[idx];
-
-            printf("%d\t%d\t%dx%dx%d\t%d-%d-%d\t%04d/%02d/%02d@%02d:%02d\n",
-                   s->SID, s->type, s->width, s->height, s->bpp,
-                   s->idle_days, s->idle_hours, s->idle_minutes,
-                   s->conn_year, s->conn_month, s->conn_day, s->conn_hour,
-                   s->conn_minute);
+            print_session(&dsl[idx]);
         }
     }
     else

--- a/sesman/tools/sesadmin.c
+++ b/sesman/tools/sesadmin.c
@@ -206,10 +206,13 @@ void cmndList(struct SCP_CONNECTION *c)
     {
         for (idx = 0; idx < scnt; idx++)
         {
-            printf("%d\t%d\t%dx%dx%d\t%d-%d-%d\t%04d/%02d/%02d@%02d:%02d\n", \
-                   (dsl[idx]).SID, (dsl[idx]).type, (dsl[idx]).width, (dsl[idx]).height, (dsl[idx]).bpp, \
-                   (dsl[idx]).idle_days, (dsl[idx]).idle_hours, (dsl[idx]).idle_minutes, \
-                   (dsl[idx]).conn_year, (dsl[idx]).conn_month, (dsl[idx]).conn_day, (dsl[idx]).conn_hour, (dsl[idx]).conn_minute);
+            struct SCP_DISCONNECTED_SESSION *s = &dsl[idx];
+
+            printf("%d\t%d\t%dx%dx%d\t%d-%d-%d\t%04d/%02d/%02d@%02d:%02d\n",
+                   s->SID, s->type, s->width, s->height, s->bpp,
+                   s->idle_days, s->idle_hours, s->idle_minutes,
+                   s->conn_year, s->conn_month, s->conn_day, s->conn_hour,
+                   s->conn_minute);
         }
     }
     else

--- a/sesman/tools/sesadmin.c
+++ b/sesman/tools/sesadmin.c
@@ -196,7 +196,13 @@ void cmndList(struct SCP_CONNECTION *c)
 
     e = scp_v1c_mng_get_session_list(c, &scnt, &dsl);
 
-    if ((SCP_CLIENT_STATE_LIST_OK == e) && (scnt > 0))
+    if (e != SCP_CLIENT_STATE_LIST_OK)
+    {
+        printf("Error getting session list.\n");
+        return;
+    }
+
+    if (scnt > 0)
     {
         for (idx = 0; idx < scnt; idx++)
         {
@@ -211,10 +217,7 @@ void cmndList(struct SCP_CONNECTION *c)
         printf("No sessions.\n");
     }
 
-    if (0 != dsl)
-    {
-        g_free(dsl);
-    }
+    g_free(dsl);
 }
 
 void cmndKill(struct SCP_CONNECTION *c, struct SCP_SESSION *s)


### PR DESCRIPTION
Example of improved output:
```
Session ID: 24952
	Session type: 2
	Screen size: 640x480, color depth 24
	Idle time: 0 day(s) 0 hour(s) 0 minute(s)
	Connected: 2017/01/26 00:11
Session ID: 23848
	Session type: 3
	Screen size: 1280x800, color depth 24
	Idle time: 0 day(s) 0 hour(s) 0 minute(s)
	Connected: 2017/01/26 00:07
Session ID: 13199
	Session type: 1
	Screen size: 1280x800, color depth 24
	Idle time: 0 day(s) 0 hour(s) 0 minute(s)
	Connected: 2017/01/25 23:02
```