### PR TITLE
aarch64 doesn't require pointers to be aligned

### DIFF
--- a/common/arch.h
+++ b/common/arch.h
@@ -84,7 +84,7 @@ typedef int bool_t;
 #define NEED_ALIGN
 #elif defined(__x86__) || defined(__x86_64__) || \
       defined(__AMD64__) || defined(_M_IX86) || defined (_M_AMD64) || \
-      defined(__i386__)
+      defined(__i386__) || defined(__aarch64__)
 #define NO_NEED_ALIGN
 #else
 #warning unknown arch


### PR DESCRIPTION
Without this patch, a warning is printed for every file: https://kojipkgs.fedoraproject.org/packages/xrdp/0.9.1/2.fc26/data/logs/aarch64/build.log