### PR TITLE
Enable painter and librfxcodec by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -110,10 +110,6 @@ AC_ARG_ENABLE(xrdpvr, AS_HELP_STRING([--enable-xrdpvr],
               [Build xrdpvr module (default: no)]),
               [], [enable_xrdpvr=no])
 AM_CONDITIONAL(XRDP_XRDPVR, [test x$enable_xrdpvr = xyes])
-AC_ARG_ENABLE(rfxcodec, AS_HELP_STRING([--enable-rfxcodec],
-              [Build using librfxcodec (default: no)]),
-              [], [enable_rfxcodec=no])
-AM_CONDITIONAL(XRDP_RFXCODEC, [test x$enable_rfxcodec = xyes])
 AC_ARG_ENABLE(opus, AS_HELP_STRING([--enable-opus],
               [Build opus(audio codec) (default: no)]),
               [], [enable_opus=no])
@@ -126,11 +122,16 @@ AC_ARG_ENABLE(pixman, AS_HELP_STRING([--enable-pixman],
               [Use pixman library (default: no)]),
               [], [enable_pixman=no])
 AM_CONDITIONAL(XRDP_PIXMAN, [test x$enable_pixman = xyes])
+
+AC_ARG_ENABLE(painter, AS_HELP_STRING([--disable-painter],
+              [Use included painter library (default: yes)]),
+              [], [enable_painter=yes])
 AM_CONDITIONAL(XRDP_PAINTER, [test x$enable_painter = xyes])
-AC_ARG_ENABLE(painter, AS_HELP_STRING([--enable-painter],
-              [Use painter library (default: no)]),
-              [], [enable_painter=no])
-AM_CONDITIONAL(XRDP_PAINTER, [test x$enable_painter = xyes])
+
+AC_ARG_ENABLE(rfxcodec, AS_HELP_STRING([--disable-rfxcodec],
+              [Use included librfxcodec library (default: yes)]),
+              [], [enable_rfxcodec=yes])
+AM_CONDITIONAL(XRDP_RFXCODEC, [test x$enable_rfxcodec = xyes])
 
 # Don't fail without working nasm if rfxcodec is not enabled
 if test "x$enable_rfxcodec" != xyes; then


### PR DESCRIPTION
Change help messages to clarify that both libraries are included. Move
messages next to each other. Remove duplicate XRDP_PAINTER conditional.