### PR TITLE
Fix compilation on MacOS

### DIFF
--- a/libxrdp/Makefile.am
+++ b/libxrdp/Makefile.am
@@ -8,6 +8,8 @@ AM_CPPFLAGS = \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \
   -I$(top_srcdir)/common
 
+AM_CFLAGS = $(OPENSSL_CFLAGS)
+
 AM_LDFLAGS =
 
 LIBXRDP_EXTRA_LIBS =


### PR DESCRIPTION
xrdp_rdp.c includes openssl/ssl.h now, make sure the OpenSSL include path
is used.

---

That's a compile issue, let's merge it before 0.9.2.