### PR TITLE
common: increase tls_ciphers size to 1024 bytes

### DIFF
--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -148,7 +148,7 @@ struct xrdp_client_info
   int max_unacknowledged_frame_count;
 
   long ssl_protocols;
-  char tls_ciphers[64];
+  char tls_ciphers[1024];
 
   int client_os_major;
   int client_os_minor;

--- a/docs/man/xrdp.ini.5.in
+++ b/docs/man/xrdp.ini.5.in
@@ -168,7 +168,7 @@ Specify send/recv buffer sizes in bytes.  The default value depends on operating
 
 .TP
 \fBtls_ciphers\fP=\fIcipher_suite\fP
-Specifies TLS cipher suite in 63 characters or less.  The format of this parameter is
+Specifies TLS cipher suite in 1023 characters or less.  The format of this parameter is
 equivalent to which \fBopenssl\fP(1) ciphers subcommand accepts.
 
 (ex. $ openssl ciphers 'HIGH:!ADH:!SHA1')

--- a/xrdp/xrdp.ini
+++ b/xrdp/xrdp.ini
@@ -28,7 +28,7 @@ key_file=
 ; set SSL protocols
 ; can be comma separated list of 'SSLv3', 'TLSv1', 'TLSv1.1', 'TLSv1.2'
 ssl_protocols=TLSv1, TLSv1.1, TLSv1.2
-; set TLS cipher suites (up to 63 characters)
+; set TLS cipher suites (up to 1023 characters)
 #tls_ciphers=HIGH
 
 ; Section name to use for automatic login if the client sends username


### PR DESCRIPTION
Fixes #544 