### PR TITLE
Include config_ac.h from *.c files, not from headers

### DIFF
--- a/common/arch.h
+++ b/common/arch.h
@@ -19,10 +19,6 @@
 #if !defined(ARCH_H)
 #define ARCH_H
 
-#if defined(HAVE_CONFIG_H)
-#include "config_ac.h"
-#endif
-
 #include <stdlib.h>
 
 #if defined(HAVE_STDINT_H)

--- a/common/fifo.c
+++ b/common/fifo.c
@@ -18,6 +18,10 @@
  * FIFO implementation to store pointer to data struct
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "fifo.h"
 #include "os_calls.h"
 

--- a/common/file.c
+++ b/common/file.c
@@ -18,6 +18,10 @@
  * read a config file
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "arch.h"
 #include "os_calls.h"
 #include "list.h"

--- a/common/list.c
+++ b/common/list.c
@@ -18,6 +18,10 @@
  * simple list
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "arch.h"
 #include "os_calls.h"
 #include "list.h"

--- a/common/list16.c
+++ b/common/list16.c
@@ -18,6 +18,10 @@
  * simple list
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "arch.h"
 #include "os_calls.h"
 #include "list16.h"

--- a/common/log.c
+++ b/common/log.c
@@ -16,6 +16,10 @@
  * limitations under the License.
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>

--- a/common/pixman-region.c
+++ b/common/pixman-region.c
@@ -63,6 +63,10 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #define PIXREGION_NIL(reg) ((reg)->data && !(reg)->data->numRects)
 /* not a region */
 #define PIXREGION_NAR(reg)      ((reg)->data == pixman_broken_data)

--- a/common/ssl_calls.c
+++ b/common/ssl_calls.c
@@ -19,6 +19,10 @@
  * ssl calls
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include <stdlib.h> /* needed for openssl headers */
 #include <openssl/ssl.h>
 #include <openssl/err.h>

--- a/common/thread_calls.c
+++ b/common/thread_calls.c
@@ -18,6 +18,10 @@
  * thread calls
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #if defined(_WIN32)
 #include <windows.h>
 #elif defined(__APPLE__)

--- a/common/trans.c
+++ b/common/trans.c
@@ -18,6 +18,10 @@
  * generic transport
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "os_calls.h"
 #include "trans.h"
 #include "arch.h"

--- a/genkeymap/genkeymap.c
+++ b/genkeymap/genkeymap.c
@@ -32,6 +32,10 @@
  en-uk UK English 0x809
 */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/keygen/keygen.c
+++ b/keygen/keygen.c
@@ -25,6 +25,10 @@
 
 */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "os_calls.h"
 #include "ssl_calls.h"
 #include "arch.h"

--- a/libxrdp/libxrdp.c
+++ b/libxrdp/libxrdp.c
@@ -18,6 +18,10 @@
  * this is the interface to libxrdp
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "libxrdp.h"
 #include "xrdp_orders_rail.h"
 

--- a/libxrdp/libxrdp.h
+++ b/libxrdp/libxrdp.h
@@ -21,9 +21,6 @@
 #if !defined(LIBXRDP_H)
 #define LIBXRDP_H
 
-#if defined(HAVE_CONFIG_H)
-#include "config_ac.h"
-#endif
 #include "arch.h"
 #include "parse.h"
 #include "trans.h"

--- a/libxrdp/xrdp_bitmap32_compress.c
+++ b/libxrdp/xrdp_bitmap32_compress.c
@@ -24,6 +24,10 @@ RDP 6.0 Bitmap Compression
 http://msdn.microsoft.com/en-us/library/cc241877.aspx
 */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "libxrdp.h"
 
 #define FLAGS_RLE     0x10

--- a/libxrdp/xrdp_bitmap_compress.c
+++ b/libxrdp/xrdp_bitmap_compress.c
@@ -20,6 +20,10 @@
  * This does not do 32 bpp compression, nscodec, rfx, etc
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "libxrdp.h"
 
 #define BC_MAX_BYTES (16 * 1024)

--- a/libxrdp/xrdp_caps.c
+++ b/libxrdp/xrdp_caps.c
@@ -19,6 +19,10 @@
  * RDP Capability Sets
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "libxrdp.h"
 
 /*****************************************************************************/

--- a/libxrdp/xrdp_channel.c
+++ b/libxrdp/xrdp_channel.c
@@ -18,6 +18,10 @@
  * channel layer
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "libxrdp.h"
 
 /* todo, move these to constants.h */

--- a/libxrdp/xrdp_fastpath.c
+++ b/libxrdp/xrdp_fastpath.c
@@ -17,6 +17,10 @@
  * limitations under the License.
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "libxrdp.h"
 
 /*****************************************************************************/

--- a/libxrdp/xrdp_iso.c
+++ b/libxrdp/xrdp_iso.c
@@ -19,6 +19,10 @@
  * iso layer
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "libxrdp.h"
 #include "log.h"
 

--- a/libxrdp/xrdp_jpeg_compress.c
+++ b/libxrdp/xrdp_jpeg_compress.c
@@ -18,6 +18,10 @@
  * jpeg compressor
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "libxrdp.h"
 
 #if defined(XRDP_TJPEG)

--- a/libxrdp/xrdp_mcs.c
+++ b/libxrdp/xrdp_mcs.c
@@ -18,6 +18,10 @@
  * mcs layer
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "libxrdp.h"
 #include "log.h"
 

--- a/libxrdp/xrdp_mppc_enc.c
+++ b/libxrdp/xrdp_mppc_enc.c
@@ -18,6 +18,10 @@
  * limitations under the License.
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "libxrdp.h"
 
 #define MPPC_ENC_DEBUG 0

--- a/libxrdp/xrdp_orders.c
+++ b/libxrdp/xrdp_orders.c
@@ -18,6 +18,10 @@
  * orders
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "libxrdp.h"
 
 #if defined(XRDP_NEUTRINORDP)

--- a/libxrdp/xrdp_orders_rail.c
+++ b/libxrdp/xrdp_orders_rail.c
@@ -16,6 +16,10 @@
  * limitations under the License.
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "libxrdp.h"
 #include "xrdp_rail.h"
 

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -18,6 +18,10 @@
  * rdp layer
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include <openssl/ssl.h>
 #include "libxrdp.h"
 #include "log.h"

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -18,6 +18,10 @@
  * secure layer
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "libxrdp.h"
 #include "log.h"
 

--- a/libxrdp/xrdp_surface.c
+++ b/libxrdp/xrdp_surface.c
@@ -17,6 +17,10 @@
  * limitations under the License.
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "libxrdp.h"
 #include "freerdp/codec/rfx.h"
 

--- a/mc/mc.c
+++ b/mc/mc.c
@@ -18,6 +18,10 @@
  * media center
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "mc.h"
 
 /*****************************************************************************/

--- a/neutrinordp/xrdp-color.c
+++ b/neutrinordp/xrdp-color.c
@@ -17,6 +17,10 @@
  * limitations under the License.
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "xrdp-neutrinordp.h"
 
 char *APP_CC

--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -17,6 +17,10 @@
  * limitations under the License.
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "xrdp-neutrinordp.h"
 #include "xrdp-color.h"
 #include "xrdp_rail.h"

--- a/sesman/access.c
+++ b/sesman/access.c
@@ -24,6 +24,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "sesman.h"
 
 extern struct config_sesman *g_cfg; /* in sesman.c */

--- a/sesman/chansrv/chansrv.c
+++ b/sesman/chansrv/chansrv.c
@@ -17,6 +17,10 @@
  * limitations under the License.
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "arch.h"
 #include "os_calls.h"
 #include "thread_calls.h"

--- a/sesman/chansrv/chansrv_common.c
+++ b/sesman/chansrv/chansrv_common.c
@@ -16,6 +16,10 @@
  * limitations under the License.
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "chansrv_common.h"
 
 /**

--- a/sesman/chansrv/chansrv_fuse.c
+++ b/sesman/chansrv/chansrv_fuse.c
@@ -43,6 +43,10 @@
 char g_fuse_root_path[256] = "";
 char g_fuse_clipboard_path[256] = ""; /* for clipboard use */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #ifndef XRDP_FUSE
 
 /******************************************************************************

--- a/sesman/chansrv/clipboard.c
+++ b/sesman/chansrv/clipboard.c
@@ -159,6 +159,10 @@ x-special/gnome-copied-files
 
 */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include <X11/Xlib.h>
 #include <X11/Xatom.h>
 #include <X11/extensions/Xfixes.h>

--- a/sesman/chansrv/clipboard_file.c
+++ b/sesman/chansrv/clipboard_file.c
@@ -22,6 +22,10 @@
  * CLIPRDR_FILEDESCRIPTOR
  * http://msdn.microsoft.com/en-us/library/ff362447%28prot.20%29.aspx */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include <sys/time.h>
 #include <X11/Xlib.h>
 #include <X11/Xatom.h>

--- a/sesman/chansrv/devredir.c
+++ b/sesman/chansrv/devredir.c
@@ -34,6 +34,10 @@
  *      o mark local funcs with static
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>

--- a/sesman/chansrv/drdynvc.c
+++ b/sesman/chansrv/drdynvc.c
@@ -16,6 +16,10 @@
  * limitations under the License.
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "drdynvc.h"
 
 extern int g_drdynvc_chan_id; /* in chansrv.c */

--- a/sesman/chansrv/fifo.c
+++ b/sesman/chansrv/fifo.c
@@ -19,6 +19,10 @@
  /* FIFO implementation to store a pointer to a user struct */
 
 /* module based logging */
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #define MODULE_NAME "FIFO      "
 #define LOCAL_DEBUG
 

--- a/sesman/chansrv/irp.c
+++ b/sesman/chansrv/irp.c
@@ -21,6 +21,10 @@
  * manage I/O for redirected file system and devices
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "parse.h"
 #include "os_calls.h"
 #include "irp.h"

--- a/sesman/chansrv/rail.c
+++ b/sesman/chansrv/rail.c
@@ -26,6 +26,10 @@
    http://msdn.microsoft.com/en-us/library/cc242568(v=prot.20).aspx
 */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include <X11/Xlib.h>
 #include <X11/Xatom.h>
 #include <X11/extensions/Xrandr.h>

--- a/sesman/chansrv/smartcard.c
+++ b/sesman/chansrv/smartcard.c
@@ -22,6 +22,10 @@
  * smartcard redirection support
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include <string.h>
 #include "os_calls.h"
 #include "smartcard.h"

--- a/sesman/chansrv/smartcard_pcsc.c
+++ b/sesman/chansrv/smartcard_pcsc.c
@@ -23,6 +23,10 @@
  * pcsc lib and daemon write struct on unix domain socket for communication
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #define JAY_TODO_CONTEXT    0
 #define JAY_TODO_WIDE       1
 

--- a/sesman/chansrv/sound.c
+++ b/sesman/chansrv/sound.c
@@ -16,6 +16,10 @@
  * limitations under the License.
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/socket.h>

--- a/sesman/chansrv/xcommon.c
+++ b/sesman/chansrv/xcommon.c
@@ -16,6 +16,10 @@
  * limitations under the License.
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include <X11/Xlib.h>
 #include "arch.h"
 #include "parse.h"

--- a/sesman/config.c
+++ b/sesman/config.c
@@ -24,6 +24,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "arch.h"
 #include "list.h"
 #include "file.h"

--- a/sesman/env.c
+++ b/sesman/env.c
@@ -24,6 +24,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include <grp.h>
 
 #include "list.h"

--- a/sesman/libscp/libscp.h
+++ b/sesman/libscp/libscp.h
@@ -27,10 +27,6 @@
 #ifndef LIBSCP_H
 #define LIBSCP_H
 
-#if defined(HAVE_CONFIG_H)
-#include "config_ac.h"
-#endif
-
 #include "libscp_types.h"
 #include "libscp_commands.h"
 

--- a/sesman/libscp/libscp_connection.c
+++ b/sesman/libscp/libscp_connection.c
@@ -24,6 +24,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "libscp_connection.h"
 
 //extern struct log_config* s_log;

--- a/sesman/libscp/libscp_init.c
+++ b/sesman/libscp/libscp_init.c
@@ -24,6 +24,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "libscp_init.h"
 
 //struct log_config* s_log;

--- a/sesman/libscp/libscp_lock.c
+++ b/sesman/libscp/libscp_lock.c
@@ -19,6 +19,10 @@
  * linux only
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "libscp_lock.h"
 #include "thread_calls.h"
 

--- a/sesman/libscp/libscp_session.c
+++ b/sesman/libscp/libscp_session.c
@@ -24,6 +24,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "libscp_session.h"
 
 #include <sys/types.h>

--- a/sesman/libscp/libscp_tcp.c
+++ b/sesman/libscp/libscp_tcp.c
@@ -24,6 +24,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "libscp_tcp.h"
 
 extern struct log_config *s_log;

--- a/sesman/libscp/libscp_v0.c
+++ b/sesman/libscp/libscp_v0.c
@@ -24,6 +24,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "libscp_v0.h"
 
 #include "os_calls.h"

--- a/sesman/libscp/libscp_v1c.c
+++ b/sesman/libscp/libscp_v1c.c
@@ -24,6 +24,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "libscp_v1c.h"
 
 #include <stdlib.h>

--- a/sesman/libscp/libscp_v1c_mng.c
+++ b/sesman/libscp/libscp_v1c_mng.c
@@ -24,6 +24,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "libscp_v1c_mng.h"
 
 #include <stdlib.h>

--- a/sesman/libscp/libscp_v1s.c
+++ b/sesman/libscp/libscp_v1s.c
@@ -24,6 +24,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #ifndef LIBSCP_V1S_C
 #define LIBSCP_V1S_C
 

--- a/sesman/libscp/libscp_v1s_mng.c
+++ b/sesman/libscp/libscp_v1s_mng.c
@@ -24,6 +24,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #ifndef LIBSCP_V1S_MNG_C
 #define LIBSCP_V1S_MNG_C
 

--- a/sesman/libscp/libscp_vX.c
+++ b/sesman/libscp/libscp_vX.c
@@ -24,6 +24,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "libscp_vX.h"
 
 /* server API */

--- a/sesman/scp.c
+++ b/sesman/scp.c
@@ -27,6 +27,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "sesman.h"
 
 extern struct config_sesman *g_cfg; /* in sesman.c */

--- a/sesman/scp_v0.c
+++ b/sesman/scp_v0.c
@@ -24,6 +24,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "sesman.h"
 
 extern struct config_sesman *g_cfg; /* in sesman.c */

--- a/sesman/scp_v1.c
+++ b/sesman/scp_v1.c
@@ -24,6 +24,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "sesman.h"
 
 //#include "libscp_types.h"

--- a/sesman/scp_v1_mng.c
+++ b/sesman/scp_v1_mng.c
@@ -24,6 +24,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "sesman.h"
 
 #include "libscp.h"

--- a/sesman/sesman.c
+++ b/sesman/sesman.c
@@ -24,6 +24,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "sesman.h"
 
 int g_sck;

--- a/sesman/sesman.h
+++ b/sesman/sesman.h
@@ -27,9 +27,6 @@
 #ifndef SESMAN_H
 #define SESMAN_H
 
-#if defined(HAVE_CONFIG_H)
-#include "config_ac.h"
-#endif
 #include "arch.h"
 #include "parse.h"
 #include "os_calls.h"

--- a/sesman/sig.c
+++ b/sesman/sig.c
@@ -24,6 +24,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include <signal.h>
 
 #include "sesman.h"

--- a/sesman/tools/config.c
+++ b/sesman/tools/config.c
@@ -1,1 +1,5 @@
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "../config.c"

--- a/sesman/tools/dis.c
+++ b/sesman/tools/dis.c
@@ -16,6 +16,10 @@
  * limitations under the License.
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/sesman/tools/sesadmin.c
+++ b/sesman/tools/sesadmin.c
@@ -17,6 +17,10 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "arch.h"
 #include "tcp.h"
 #include "libscp.h"

--- a/sesman/tools/sesrun.c
+++ b/sesman/tools/sesrun.c
@@ -24,6 +24,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "sesman.h"
 #include "tcp.h"
 

--- a/sesman/tools/sestest.c
+++ b/sesman/tools/sestest.c
@@ -17,6 +17,10 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "arch.h"
 #include "tcp.h"
 #include "libscp.h"

--- a/sesman/tools/tcp.c
+++ b/sesman/tools/tcp.c
@@ -24,6 +24,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "sesman.h"
 
 #include <netinet/in.h>

--- a/sesman/tools/xcon.c
+++ b/sesman/tools/xcon.c
@@ -16,6 +16,10 @@
  * limitations under the License.
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/sesman/verify_user.c
+++ b/sesman/verify_user.c
@@ -24,6 +24,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "sesman.h"
 
 #include <stdio.h>

--- a/sesman/verify_user_bsd.c
+++ b/sesman/verify_user_bsd.c
@@ -24,6 +24,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "sesman.h"
 
 #define _XOPEN_SOURCE

--- a/sesman/verify_user_kerberos.c
+++ b/sesman/verify_user_kerberos.c
@@ -24,6 +24,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "arch.h"
 #include "os_calls.h"
 

--- a/sesman/verify_user_pam.c
+++ b/sesman/verify_user_pam.c
@@ -24,6 +24,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "arch.h"
 #include "os_calls.h"
 

--- a/sesman/verify_user_pam_userpass.c
+++ b/sesman/verify_user_pam_userpass.c
@@ -24,6 +24,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "arch.h"
 #include "os_calls.h"
 

--- a/sesman/xauth.c
+++ b/sesman/xauth.c
@@ -23,6 +23,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include <stdio.h>
 #include "log.h"
 #include "os_calls.h"

--- a/vnc/vnc.c
+++ b/vnc/vnc.c
@@ -18,6 +18,10 @@
  * libvnc
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "vnc.h"
 #include "log.h"
 #include "trans.h"

--- a/xrdp/funcs.c
+++ b/xrdp/funcs.c
@@ -18,6 +18,10 @@
  * simple functions
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "xrdp.h"
 
 /*****************************************************************************/

--- a/xrdp/lang.c
+++ b/xrdp/lang.c
@@ -19,6 +19,10 @@
  * maximum unicode 19996(0x4e00)
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "xrdp.h"
 #include "log.h"
 

--- a/xrdp/xrdp.c
+++ b/xrdp/xrdp.c
@@ -18,6 +18,10 @@
  * main program
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "xrdp.h"
 #include "log.h"
 

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -19,9 +19,6 @@
  */
 
 /* include other h files */
-#if defined(HAVE_CONFIG_H)
-#include "config_ac.h"
-#endif
 #include "arch.h"
 #include "parse.h"
 #include "trans.h"

--- a/xrdp/xrdp_bitmap.c
+++ b/xrdp/xrdp_bitmap.c
@@ -21,6 +21,10 @@
  * maybe it should be called xrdp_drawable
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "xrdp.h"
 #include "log.h"
 #include "crc16.h"

--- a/xrdp/xrdp_cache.c
+++ b/xrdp/xrdp_cache.c
@@ -18,6 +18,10 @@
  * cache
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "xrdp.h"
 #include "log.h"
 #include "crc16.h"

--- a/xrdp/xrdp_encoder.c
+++ b/xrdp/xrdp_encoder.c
@@ -18,6 +18,10 @@
  * Encoder
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "xrdp_encoder.h"
 #include "xrdp.h"
 #include "thread_calls.h"

--- a/xrdp/xrdp_font.c
+++ b/xrdp/xrdp_font.c
@@ -36,6 +36,10 @@
     Glyph Data var, see FONT_DATASIZE macro
 */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "xrdp.h"
 #include "log.h"
 

--- a/xrdp/xrdp_listen.c
+++ b/xrdp/xrdp_listen.c
@@ -18,6 +18,10 @@
  * listen for incoming connection
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "xrdp.h"
 #include "log.h"
 

--- a/xrdp/xrdp_login_wnd.c
+++ b/xrdp/xrdp_login_wnd.c
@@ -18,6 +18,10 @@
  * main login window and login help window
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "xrdp.h"
 #include "log.h"
 

--- a/xrdp/xrdp_painter.c
+++ b/xrdp/xrdp_painter.c
@@ -18,6 +18,10 @@
  * painter, gc
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "xrdp.h"
 
 #if defined(XRDP_PAINTER)

--- a/xrdp/xrdp_process.c
+++ b/xrdp/xrdp_process.c
@@ -18,6 +18,10 @@
  * main rdp process
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "xrdp.h"
 
 static int g_session_id = 0;

--- a/xrdp/xrdp_region.c
+++ b/xrdp/xrdp_region.c
@@ -18,6 +18,10 @@
  * region
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "xrdp.h"
 
 #if defined(XRDP_PIXMAN)

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -18,6 +18,10 @@
  * simple window manager
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include <stdarg.h>
 #include <stdio.h>
 #include "xrdp.h"

--- a/xrdp/xrdpwin.c
+++ b/xrdp/xrdpwin.c
@@ -18,6 +18,10 @@
  * main program
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #if defined(_WIN32)
 #include <windows.h>
 #endif

--- a/xrdpapi/simple.c
+++ b/xrdpapi/simple.c
@@ -25,6 +25,10 @@
  *     gcc simple.c -o simple -L./.libs -lxrdpapi
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #ifdef __WIN32__
 #include <mstsapi.h>
 #endif

--- a/xrdpapi/vrplayer.c
+++ b/xrdpapi/vrplayer.c
@@ -26,6 +26,10 @@
  * run vrplayer:        vrplayer <media file>
  *****************************************************************************/
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #ifdef __WIN32__
 #include <mstsapi.h>
 #endif

--- a/xrdpapi/xrdpapi.c
+++ b/xrdpapi/xrdpapi.c
@@ -17,6 +17,10 @@
  * limitations under the License.
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #define LOG_LEVEL 1
 #define LLOG(_level, _args) \
     do { if (_level < LOG_LEVEL) { ErrorF _args ; } } while (0)

--- a/xrdpvr/xrdpvr.c
+++ b/xrdpvr/xrdpvr.c
@@ -21,6 +21,10 @@
  *
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "xrdpvr.h"
 #include "xrdpvr_internal.h"
 

--- a/xup/xup.c
+++ b/xup/xup.c
@@ -18,6 +18,10 @@
  * libxup main file
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "xup.h"
 #include "log.h"
 #include "trans.h"


### PR DESCRIPTION
Directories without Makefile.am are exempt from the change, which includes X11rdp. They have their own build systems.

Resolves #647.