### PR TITLE
chansrv: dvc, check channel exists on get/remove api struct

### DIFF
--- a/sesman/chansrv/chansrv.c
+++ b/sesman/chansrv/chansrv.c
@@ -1666,7 +1666,8 @@ struct_from_dvc_chan_id(tui32 dvc_chan_id)
 
     for (i = 0; i < MAX_DVC_CHANNELS; i++)
     {
-        if (g_dvc_channels[i]->dvc_chan_id >= 0 &&
+        if (g_dvc_channels[i] != NULL &&
+            g_dvc_channels[i]->dvc_chan_id >= 0 &&
             (tui32) g_dvc_channels[i]->dvc_chan_id == dvc_chan_id)
         {
             return g_dvc_channels[i];
@@ -1683,7 +1684,8 @@ remove_struct_with_chan_id(tui32 dvc_chan_id)
 
     for (i = 0; i < MAX_DVC_CHANNELS; i++)
     {
-        if (g_dvc_channels[i]->dvc_chan_id >= 0 &&
+        if (g_dvc_channels[i] != NULL &&
+            g_dvc_channels[i]->dvc_chan_id >= 0 &&
             (tui32) g_dvc_channels[i]->dvc_chan_id == dvc_chan_id)
         {
             g_dvc_channels[i] = NULL;


### PR DESCRIPTION
This issue fixes a case when xrdpapi (WTS calls) is used in an unexpected way, there is a case which can lead chansrv to get an api struct which is already removed, then chansrv can crash with segfault.