### PR TITLE
Log user-friendly message when certificate/privkey is inaccessible

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -2234,6 +2234,18 @@ g_file_exist(const char *filename)
 }
 
 /*****************************************************************************/
+/* returns boolean, non zero if the file is readable */
+int
+g_file_readable(const char *filename)
+{
+#if defined(_WIN32)
+    return 0; /* TODO: what should be done here? */
+#else
+    return access(filename, R_OK) == 0;
+#endif
+}
+
+/*****************************************************************************/
 /* returns boolean, non zero if the directory exists */
 int
 g_directory_exist(const char *dirname)

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -2239,7 +2239,7 @@ int
 g_file_readable(const char *filename)
 {
 #if defined(_WIN32)
-    return 0; /* TODO: what should be done here? */
+    return _waccess(filename, 04) == 0;
 #else
     return access(filename, R_OK) == 0;
 #endif

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -109,6 +109,7 @@ int      g_mkdir(const char* dirname);
 char*    g_get_current_dir(char* dirname, int maxlen);
 int      g_set_current_dir(const char *dirname);
 int      g_file_exist(const char* filename);
+int      g_file_readable(const char *filename);
 int      g_directory_exist(const char* dirname);
 int      g_create_dir(const char* dirname);
 int      g_create_path(const char* path);

--- a/libxrdp/xrdp_iso.c
+++ b/libxrdp/xrdp_iso.c
@@ -78,12 +78,12 @@ xrdp_iso_negotiate_security(struct xrdp_iso *self)
         case PROTOCOL_SSL:
             if (self->requestedProtocol & PROTOCOL_SSL)
             {
-
-                if(!g_file_exist(client_info->certificate) ||
-                   !g_file_exist(client_info->key_file))
+                if (!g_file_readable(client_info->certificate) ||
+                    !g_file_readable(client_info->key_file))
                 {
-                    /* certificate file doesn't exist */
-                    LLOGLN(0, ("xrdp_iso_negotiate_security: TLS certificate not found on server"));
+                    /* certificate or privkey is not readable */
+                    log_message(LOG_LEVEL_DEBUG, "No readable certificates or "
+                                "private keys, cannot accept TLS connections");
                     self->failureCode = SSL_CERT_NOT_ON_SERVER;
                     rv = 1; /* error */
                 }
@@ -102,8 +102,8 @@ xrdp_iso_negotiate_security(struct xrdp_iso *self)
         case PROTOCOL_HYBRID_EX:
         default:
             if ((self->requestedProtocol & PROTOCOL_SSL) &&
-                g_file_exist(client_info->certificate) &&
-                g_file_exist(client_info->key_file))
+                g_file_readable(client_info->certificate) &&
+                g_file_readable(client_info->key_file))
             {
                 /* that's a patch since we don't support CredSSP for now */
                 self->selectedProtocol = PROTOCOL_SSL;

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -269,6 +269,12 @@ xrdp_rdp_read_config(struct xrdp_client_info *client_info)
                 /* use user defined certificate */
                 g_strncpy(client_info->certificate, value, 1023);
             }
+
+	    if (!g_file_readable(client_info->certificate))
+            {
+                log_message(LOG_LEVEL_ERROR, "Cannot open certificate file %s: %s",
+                            client_info->certificate, g_get_strerror());
+            }
         }
         else if (g_strcasecmp(item, "key_file") == 0)
         {
@@ -292,6 +298,12 @@ xrdp_rdp_read_config(struct xrdp_client_info *client_info)
             {
                 /* use user defined key_file */
                 g_strncpy(client_info->key_file, value, 1023);
+            }
+
+	    if (!g_file_readable(client_info->key_file))
+            {
+                log_message(LOG_LEVEL_ERROR, "Cannot open private key file %s: %s",
+                            client_info->key_file, g_get_strerror());
             }
         }
 

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -272,7 +272,7 @@ xrdp_rdp_read_config(struct xrdp_client_info *client_info)
 
 	    if (!g_file_readable(client_info->certificate))
             {
-                log_message(LOG_LEVEL_ERROR, "Cannot open certificate file %s: %s",
+                log_message(LOG_LEVEL_ERROR, "Cannot read certificate file %s: %s",
                             client_info->certificate, g_get_strerror());
             }
         }
@@ -302,7 +302,7 @@ xrdp_rdp_read_config(struct xrdp_client_info *client_info)
 
 	    if (!g_file_readable(client_info->key_file))
             {
-                log_message(LOG_LEVEL_ERROR, "Cannot open private key file %s: %s",
+                log_message(LOG_LEVEL_ERROR, "Cannot read private key file %s: %s",
                             client_info->key_file, g_get_strerror());
             }
         }


### PR DESCRIPTION
We shouldn't assume that xrdp daemon is running under root privilege.
In many cases, root privilege is not really needed for xrdp daemon.
xrdp may fail to load certificate/privkey due to lack of permissions
when running under user privilege. Checking existence of files is not
enough and xrdp should output user-friendly log in such case.

Reported by Debian user in bug 856436 [1].

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=856436