### PR TITLE
Propel xorgxrdp as default backend, give xorgxrdp the first place

### DIFF
--- a/xrdp/xrdp.ini
+++ b/xrdp/xrdp.ini
@@ -148,6 +148,15 @@ tcutils=true
 ; Session types
 ;
 
+[Xorg]
+name=Xorg
+lib=libxup.so
+username=ask
+password=ask
+ip=127.0.0.1
+port=-1
+code=20
+
 [X11rdp]
 name=X11rdp
 lib=libxup.so
@@ -157,15 +166,6 @@ ip=127.0.0.1
 port=-1
 xserverbpp=24
 code=10
-
-[Xorg]
-name=Xorg
-lib=libxup.so
-username=ask
-password=ask
-ip=127.0.0.1
-port=-1
-code=20
 
 [Xvnc]
 name=Xvnc


### PR DESCRIPTION
If we recommend xorgxrdp as preferred backend, we should set xorgxrdp as default.

This is a part of "Merge Debian local patches project".