### PR TITLE
Make socket directory configurable

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -16,7 +16,8 @@ AM_CPPFLAGS = \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
   -DXRDP_SHARE_PATH=\"${datadir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \
-  -DXRDP_LOG_PATH=\"${localstatedir}/log\"
+  -DXRDP_LOG_PATH=\"${localstatedir}/log\" \
+  -DXRDP_SOCKET_PATH=\"${socketdir}\"
 
 if XRDP_DEBUG
 AM_CPPFLAGS += -DXRDP_DEBUG

--- a/common/file_loc.h
+++ b/common/file_loc.h
@@ -21,48 +21,11 @@
 #if !defined(FILE_LOC_H)
 #define FILE_LOC_H
 
-#if !defined(XRDP_CFG_PATH)
-#define XRDP_CFG_PATH "/etc/xrdp"
-#endif
-
-#if !defined(XRDP_PID_PATH)
-#define XRDP_PID_PATH "/var/run"
-#endif
-
-#if !defined(XRDP_SBIN_PATH)
-#define XRDP_SBIN_PATH "/usr/local/sbin"
-#endif
-
-#if !defined(XRDP_SHARE_PATH)
-#define XRDP_SHARE_PATH "/usr/local/share/xrdp"
-#endif
-
-#if !defined(XRDP_MODULE_PATH)
-#define XRDP_MODULE_PATH "/usr/local/lib/xrdp"
-#endif
-
-#if !defined(XRDP_LOG_PATH)
-#define XRDP_LOG_PATH "/var/log"
-#endif
-
-#if !defined(XRDP_CHANSRV_STR)
-#define XRDP_CHANSRV_STR "/tmp/.xrdp/xrdp_chansrv_socket_%d"
-#endif
-
-#if !defined(CHANSRV_PORT_OUT_STR)
-#define CHANSRV_PORT_OUT_STR "/tmp/.xrdp/xrdp_chansrv_audio_out_socket_%d"
-#endif
-
-#if !defined(CHANSRV_PORT_IN_STR)
-#define CHANSRV_PORT_IN_STR "/tmp/.xrdp/xrdp_chansrv_audio_in_socket_%d"
-#endif
-
-#if !defined(CHANSRV_API_STR)
-#define CHANSRV_API_STR "/tmp/.xrdp/xrdpapi_%d"
-#endif
-
-#if !defined(XRDP_X11RDP_STR)
-#define XRDP_X11RDP_STR "/tmp/.xrdp/xrdp_display_%d"
-#endif
+#define XRDP_CHANSRV_STR      XRDP_SOCKET_PATH "/xrdp_chansrv_socket_%d"
+#define CHANSRV_PORT_OUT_STR  XRDP_SOCKET_PATH "/xrdp_chansrv_audio_out_socket_%d"
+#define CHANSRV_PORT_IN_STR   XRDP_SOCKET_PATH "/xrdp_chansrv_audio_in_socket_%d"
+#define CHANSRV_API_STR       XRDP_SOCKET_PATH "/xrdpapi_%d"
+#define XRDP_X11RDP_STR       XRDP_SOCKET_PATH "/xrdp_display_%d"
+#define XRDP_DISCONNECT_STR   XRDP_SOCKET_PATH "/xrdp_disconnect_display_%d"
 
 #endif

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -111,18 +111,19 @@ g_rm_temp_dir(void)
 int
 g_mk_temp_dir(const char *app_name)
 {
-    if (!g_directory_exist("/tmp/.xrdp"))
+    if (!g_directory_exist(XRDP_SOCKET_PATH))
     {
-        if (!g_create_dir("/tmp/.xrdp"))
+        if (!g_create_dir(XRDP_SOCKET_PATH))
         {
             /* if failed, still check if it got created by someone else */
-            if (!g_directory_exist("/tmp/.xrdp"))
+            if (!g_directory_exist(XRDP_SOCKET_PATH))
             {
-                printf("g_mk_temp_dir: g_create_dir failed\n");
+                printf("g_mk_temp_dir: g_create_dir(%s) failed\n",
+                       XRDP_SOCKET_PATH);
                 return 1;
             }
         }
-        g_chmod_hex("/tmp/.xrdp", 0x1777);
+        g_chmod_hex(XRDP_SOCKET_PATH, 0x1777);
     }
     return 0;
 }

--- a/configure.ac
+++ b/configure.ac
@@ -47,6 +47,12 @@ AM_CONDITIONAL(FREEBSD, [test "x$freebsd" = xyes])
 AM_CONDITIONAL(OPENBSD, [test "x$openbsd" = xyes])
 AM_CONDITIONAL(NETBSD, [test "x$netbsd" = xyes])
 
+AC_ARG_WITH([socketdir],
+  [AS_HELP_STRING([--with-socketdir=DIR],
+                  [Use directory for UNIX sockets (default: /tmp/.xrdp)])],
+                  [], [with_socketdir="/tmp/.xrdp"])
+AC_SUBST([socketdir], [$with_socketdir])
+
 AC_ARG_WITH([systemdsystemunitdir],
         AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files]),
         [], [

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -17,7 +17,8 @@ SUBST_VARS = sed \
    -e 's|@PACKAGE_VERSION[@]|$(PACKAGE_VERSION)|g' \
    -e 's|@bindir[@]|$(bindir)|g' \
    -e 's|@localstatedir[@]|$(localstatedir)|g' \
-   -e 's|@sysconfdir[@]|$(sysconfdir)|g'
+   -e 's|@sysconfdir[@]|$(sysconfdir)|g' \
+   -e 's|@socketdir[@]|$(socketdir)|g'
 
 subst_verbose = $(subst_verbose_@AM_V@)
 subst_verbose_ = $(subst_verbose_@AM_DEFAULT_V@)

--- a/docs/man/xrdp-chansrv.8.in
+++ b/docs/man/xrdp-chansrv.8.in
@@ -30,10 +30,10 @@ Dynamic Virtual Channel
 
 .SH FILES
 .TP
-.I /tmp/.xrdp/xrdp_chansrv_socket_*
+.I @socketdir@/xrdp_chansrv_socket_*
 UNIX socket used by external programs to implement channels.
 .TP
-.I /tmp/.xrdp/xrdp_api_*
+.I @socketdir@/xrdp_api_*
 UNIX socket used by \fBxrdp\-chansrv\fP to communicate with \fBxrdp\-sesman\fP.
 .TP
 .I $XDG_DATA_HOME/xrdp/xrdp-chansrv.log

--- a/docs/man/xrdp-dis.1.in
+++ b/docs/man/xrdp-dis.1.in
@@ -16,7 +16,7 @@ to get the default host and display number.
 
 .SH FILES
 .TP
-.I /tmp/.xrdp/xrdp_disconnect_display_*
+.I @socketdir@/xrdp_disconnect_display_*
 UNIX socket used to communicate with the \fBxrdp\fP(8) session manager.
 
 .SH KNOWN ISSUES

--- a/sesman/Makefile.am
+++ b/sesman/Makefile.am
@@ -6,6 +6,7 @@ AM_CPPFLAGS = \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
   -DXRDP_SHARE_PATH=\"${datadir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \
+  -DXRDP_SOCKET_PATH=\"${socketdir}\" \
   -I$(top_srcdir)/common \
   -I$(top_srcdir)/sesman/libscp
 

--- a/sesman/chansrv/Makefile.am
+++ b/sesman/chansrv/Makefile.am
@@ -9,6 +9,7 @@ AM_CPPFLAGS = \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
   -DXRDP_SHARE_PATH=\"${datadir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \
+  -DXRDP_SOCKET_PATH=\"${socketdir}\" \
   -I$(top_srcdir)/common
 
 if XRDP_DEBUG

--- a/sesman/chansrv/pulse/module-xrdp-sink.c
+++ b/sesman/chansrv/pulse/module-xrdp-sink.c
@@ -68,6 +68,7 @@ typedef bool pa_bool_t;
 #endif
 
 #include "module-xrdp-sink-symdef.h"
+#include "../common/file_loc.h"
 
 PA_MODULE_AUTHOR("Jay Sorg");
 PA_MODULE_DESCRIPTION("xrdp sink");
@@ -84,7 +85,6 @@ PA_MODULE_USAGE(
 #define DEFAULT_SINK_NAME "xrdp-sink"
 #define BLOCK_USEC 30000
 //#define BLOCK_USEC (PA_USEC_PER_SEC * 2)
-#define CHANSRV_PORT_STR "/tmp/.xrdp/xrdp_chansrv_audio_out_socket_%d"
 
 struct userdata {
     pa_core *core;

--- a/sesman/chansrv/pulse/module-xrdp-source.c
+++ b/sesman/chansrv/pulse/module-xrdp-source.c
@@ -55,6 +55,7 @@ typedef bool pa_bool_t;
 #endif
 
 #include "module-xrdp-source-symdef.h"
+#include "../common/file_loc.h"
 
 PA_MODULE_AUTHOR("Laxmikant Rashinkar");
 PA_MODULE_DESCRIPTION("xrdp source");
@@ -72,7 +73,6 @@ PA_MODULE_USAGE(
 #define DEFAULT_SOURCE_NAME "xrdp-source"
 #define DEFAULT_LATENCY_TIME 10
 #define MAX_LATENCY_USEC 1000
-#define CHANSRV_PORT_STR "/tmp/.xrdp/xrdp_chansrv_audio_in_socket_%d"
 
 struct userdata {
     pa_core *core;

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -668,6 +668,7 @@ session_start_fork(tbus data, tui8 type, struct SCP_SESSION *s)
                 g_setenv("XRDP_SESMAN_MAX_DISC_TIME", text, 1);
                 g_snprintf(text, 255, "%d", g_cfg->sess.kill_disconnected);
                 g_setenv("XRDP_SESMAN_KILL_DISCONNECTED", text, 1);
+                g_setenv("XRDP_SOCKET_PATH", XRDP_SOCKET_PATH, 1);
 
                 /* prepare the Xauthority stuff */
                 if (g_getenv("XAUTHORITY") != NULL)

--- a/sesman/sessvc/sessvc.c
+++ b/sesman/sessvc/sessvc.c
@@ -49,30 +49,6 @@ nil_signal_handler(int sig)
 }
 
 /******************************************************************************/
-/* chansrv can exit at any time without cleaning up, it's an xlib app */
-int
-chansrv_cleanup(int pid)
-{
-    char text[256];
-
-    g_snprintf(text, 255, "/tmp/.xrdp/xrdp_chansrv_%8.8x_main_term", pid);
-
-    if (g_file_exist(text))
-    {
-        g_file_delete(text);
-    }
-
-    g_snprintf(text, 255, "/tmp/.xrdp/xrdp_chansrv_%8.8x_thread_done", pid);
-
-    if (g_file_exist(text))
-    {
-        g_file_delete(text);
-    }
-
-    return 0;
-}
-
-/******************************************************************************/
 int
 main(int argc, char **argv)
 {
@@ -148,7 +124,6 @@ main(int argc, char **argv)
         g_sleep(1);
     }
 
-    chansrv_cleanup(chansrv_pid);
     /* kill X server */
     g_writeln("xrdp-sessvc: stopping X server");
     g_sigterm(x_pid);

--- a/sesman/tools/Makefile.am
+++ b/sesman/tools/Makefile.am
@@ -3,6 +3,7 @@ AM_CPPFLAGS = \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
   -DXRDP_SHARE_PATH=\"${datadir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \
+  -DXRDP_SOCKET_PATH=\"${socketdir}\" \
   -I$(top_srcdir)/common \
   -I$(top_srcdir)/sesman/libscp \
   -I$(top_srcdir)/sesman

--- a/sesman/tools/dis.c
+++ b/sesman/tools/dis.c
@@ -27,6 +27,8 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 
+#include "file_loc.h"
+
 int main(int argc, char **argv)
 {
     int sck;
@@ -54,7 +56,7 @@ int main(int argc, char **argv)
     dis = strtol(display + 1, &p, 10);
     memset(&sa, 0, sizeof(sa));
     sa.sun_family = AF_UNIX;
-    sprintf(sa.sun_path, "/tmp/.xrdp/xrdp_disconnect_display_%d", dis);
+    sprintf(sa.sun_path, XRDP_DISCONNECT_STR, dis);
 
     if (access(sa.sun_path, F_OK) != 0)
     {

--- a/xorg/X11R7.6/rdp/rdp.h
+++ b/xorg/X11R7.6/rdp/rdp.h
@@ -348,6 +348,8 @@ int
 g_directory_exist(const char* dirname);
 int
 g_chmod_hex(const char* filename, int flags);
+const char *
+g_socket_dir(void);
 void
 hexdump(unsigned char *p, unsigned int len);
 void

--- a/xorg/X11R7.6/rdp/rdpmain.c
+++ b/xorg/X11R7.6/rdp/rdpmain.c
@@ -769,7 +769,8 @@ ddxGiveUp(void)
     {
         sprintf(unixSocketName, "/tmp/.X11-unix/X%s", display);
         unlink(unixSocketName);
-        sprintf(unixSocketName, "/tmp/.xrdp/xrdp_disconnect_display_%s", display);
+        sprintf(unixSocketName, "%s/xrdp_disconnect_display_%s",
+                g_socket_dir(), display);
         unlink(unixSocketName);
 
         if (g_uds_data[0] != 0)
@@ -823,7 +824,7 @@ ddxUseMsg(void)
     ErrorF("X11rdp specific options\n");
     ErrorF("-geometry WxH          set framebuffer width & height\n");
     ErrorF("-depth D               set framebuffer depth\n");
-    ErrorF("-uds                   create and listen on /tmp/.xrdp/xrdp_display_x\n");
+    ErrorF("-uds                   create and listen on xrdp_display_x\n");
     ErrorF("\n");
     exit(1);
 }

--- a/xorg/X11R7.6/rdp/rdpmisc.c
+++ b/xorg/X11R7.6/rdp/rdpmisc.c
@@ -517,6 +517,22 @@ g_chmod_hex(const char *filename, int flags)
     return chmod(filename, fl);
 }
 
+/*****************************************************************************/
+/* returns directory where UNIX sockets are located */
+const char *
+g_socket_dir(void)
+{
+    const char *socket_dir;
+
+    socket_dir = getenv("XRDP_SOCKET_PATH");
+    if (socket_dir == NULL || socket_dir[0] == '\0')
+    {
+        socket_dir = "/tmp/.xrdp";
+    }
+
+    return socket_dir;
+}
+
 /* produce a hex dump */
 void
 hexdump(unsigned char *p, unsigned int len)

--- a/xorg/X11R7.6/rdp/rdpup.c
+++ b/xorg/X11R7.6/rdp/rdpup.c
@@ -1233,16 +1233,19 @@ rdpup_init(void)
     char text[256];
     char *ptext;
     int i;
+    const char *socket_dir;
 
-    if (!g_directory_exist("/tmp/.xrdp"))
+    socket_dir = g_socket_dir();
+
+    if (!g_directory_exist(socket_dir))
     {
-        if (!g_create_dir("/tmp/.xrdp"))
+        if (!g_create_dir(socket_dir))
         {
-            LLOGLN(0, ("rdpup_init: g_create_dir failed"));
+            LLOGLN(0, ("rdpup_init: g_create_dir(%s) failed", socket_dir));
             return 0;
         }
 
-        g_chmod_hex("/tmp/.xrdp", 0x1777);
+        g_chmod_hex(socket_dir, 0x1777);
     }
 
     i = atoi(display);
@@ -1266,7 +1269,7 @@ rdpup_init(void)
 
     if (g_use_uds)
     {
-        g_sprintf(g_uds_data, "/tmp/.xrdp/xrdp_display_%s", display);
+        g_sprintf(g_uds_data, "%s/xrdp_display_%s", socket_dir, display);
 
         if (g_listen_sck == 0)
         {
@@ -1304,7 +1307,7 @@ rdpup_init(void)
 
     if (g_dis_listen_sck != 0)
     {
-        g_sprintf(text, "/tmp/.xrdp/xrdp_disconnect_display_%s", display);
+        g_sprintf(text, "%s/xrdp_disconnect_display_%s", socket_dir, display);
 
         if (g_tcp_local_bind(g_dis_listen_sck, text) == 0)
         {

--- a/xrdp/Makefile.am
+++ b/xrdp/Makefile.am
@@ -9,6 +9,7 @@ AM_CPPFLAGS = \
   -DXRDP_SHARE_PATH=\"${datadir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \
   -DXRDP_MODULE_PATH=\"${moduledir}\" \
+  -DXRDP_SOCKET_PATH=\"${socketdir}\" \
   -I$(top_builddir) \
   -I$(top_srcdir)/common \
   -I$(top_srcdir)/libxrdp

--- a/xrdpapi/Makefile.am
+++ b/xrdpapi/Makefile.am
@@ -3,6 +3,10 @@ EXTRA_DIST = \
   vrplayer.c \
   vrplayer.mk
 
+AM_CPPFLAGS = \
+  -DXRDP_SOCKET_PATH=\"${socketdir}\" \
+  -I$(top_srcdir)/common
+
 module_LTLIBRARIES = \
   libxrdpapi.la
 

--- a/xrdpapi/xrdpapi.c
+++ b/xrdpapi/xrdpapi.c
@@ -39,6 +39,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 
+#include "file_loc.h"
 #include "xrdpapi.h"
 
 struct wts_obj
@@ -148,7 +149,7 @@ WTSVirtualChannelOpenEx(unsigned int SessionId, const char *pVirtualName,
     memset(&s, 0, sizeof(struct sockaddr_un));
     s.sun_family = AF_UNIX;
     bytes = sizeof(s.sun_path);
-    snprintf(s.sun_path, bytes - 1, "/tmp/.xrdp/xrdpapi_%d", wts->display_num);
+    snprintf(s.sun_path, bytes - 1, CHANSRV_API_STR, wts->display_num);
     s.sun_path[bytes - 1] = 0;
     bytes = sizeof(struct sockaddr_un);
 


### PR DESCRIPTION
The default remains `/tmp/.xrdp` for compatibility with older versions of X1rdp and xorgxrdp.

The socket directory is configured by passing `--with-socketdir=DIR` to `configure`.

xrdp-sesman passes the socket directory to the backends as XRDP_SOCKET_PATH environment variable. X11rdp uses it.

`file_loc.h` has been striped of the defines that should not have a default value.

Remove cleanup code in xrdp-sessvc, it is obsolete. xrdp-chansrv should be able to clean up after itself.