### PR TITLE
pulse fixes after socket directory change

### DIFF
--- a/sesman/chansrv/pulse/module-xrdp-sink.c
+++ b/sesman/chansrv/pulse/module-xrdp-sink.c
@@ -68,7 +68,7 @@ typedef bool pa_bool_t;
 #endif
 
 #include "module-xrdp-sink-symdef.h"
-#include "../common/file_loc.h"
+#include "../../../common/file_loc.h"
 
 PA_MODULE_AUTHOR("Jay Sorg");
 PA_MODULE_DESCRIPTION("xrdp sink");

--- a/sesman/chansrv/pulse/module-xrdp-sink.c
+++ b/sesman/chansrv/pulse/module-xrdp-sink.c
@@ -308,7 +308,7 @@ static int data_send(struct userdata *u, pa_memchunk *chunk) {
         memset(&s, 0, sizeof(s));
         s.sun_family = AF_UNIX;
         bytes = sizeof(s.sun_path) - 1;
-        snprintf(s.sun_path, bytes, CHANSRV_PORT_STR, u->display_num);
+        snprintf(s.sun_path, bytes, CHANSRV_PORT_OUT_STR, u->display_num);
         pa_log_debug("trying to connect to %s", s.sun_path);
         if (connect(fd, (struct sockaddr *)&s,
                     sizeof(struct sockaddr_un)) != 0) {

--- a/sesman/chansrv/pulse/module-xrdp-source.c
+++ b/sesman/chansrv/pulse/module-xrdp-source.c
@@ -186,7 +186,7 @@ static int data_get(struct userdata *u, pa_memchunk *chunk) {
         memset(&s, 0, sizeof(s));
         s.sun_family = AF_UNIX;
         bytes = sizeof(s.sun_path) - 1;
-        snprintf(s.sun_path, bytes, CHANSRV_PORT_STR, u->display_num);
+        snprintf(s.sun_path, bytes, CHANSRV_PORT_IN_STR, u->display_num);
         pa_log_debug("Trying to connect to %s", s.sun_path);
 
         if (connect(fd, (struct sockaddr *) &s, sizeof(struct sockaddr_un)) != 0) {

--- a/sesman/chansrv/pulse/module-xrdp-source.c
+++ b/sesman/chansrv/pulse/module-xrdp-source.c
@@ -55,7 +55,7 @@ typedef bool pa_bool_t;
 #endif
 
 #include "module-xrdp-source-symdef.h"
-#include "../common/file_loc.h"
+#include "../../../common/file_loc.h"
 
 PA_MODULE_AUTHOR("Laxmikant Rashinkar");
 PA_MODULE_DESCRIPTION("xrdp source");


### PR DESCRIPTION
Pulse module doesn't build after recent socket directory change.  This is not a complete fix. One more thing needs to be done. `XRDP_SOCKET_PATH`  needs to be passed pulse module.