### PR TITLE
pulse: define default socket directory in Makefile

### DIFF
--- a/sesman/chansrv/pulse/Makefile
+++ b/sesman/chansrv/pulse/Makefile
@@ -2,8 +2,11 @@
 # build xrdp pulseaudio modules
 #
 
+# change this to your pulseaudio source directory
 PULSE_DIR = /home/lk/pulseaudio-1.1
-CFLAGS    = -Wall -O2 -I$(PULSE_DIR) -I$(PULSE_DIR)/src -DHAVE_CONFIG_H -fPIC
+# change this if you're using non-default socket directory
+SOCK_DIR  = /tmp/.xrdp
+CFLAGS    = -Wall -O2 -I$(PULSE_DIR) -I$(PULSE_DIR)/src -DHAVE_CONFIG_H -fPIC -DXRDP_SOCKET_PATH=\"$(SOCK_DIR)\"
 
 all: module-xrdp-sink.so module-xrdp-source.so
 


### PR DESCRIPTION
The build should be integrated to xrdp and socket directory should be inherited from xrdp but let's apply workaround for the present.

This helps users such as #723.