### PR TITLE
sesman: LOGNAME should be set to username

### DIFF
--- a/sesman/env.c
+++ b/sesman/env.c
@@ -132,6 +132,7 @@ env_set_user(const char *username, char **passwd_file, int display,
             g_setenv("SHELL", pw_shell, 1);
             g_setenv("PATH", "/sbin:/bin:/usr/bin:/usr/local/bin", 1);
             g_setenv("USER", username, 1);
+            g_setenv("LOGNAME", username, 1);
             g_sprintf(text, "%d", uid);
             g_setenv("UID", text, 1);
             g_setenv("HOME", pw_dir, 1);


### PR DESCRIPTION
which is used to store login name. The login name shall be the string
that would be returned by the getlogin() function [1]. Some applications
only refers LOGNAME environment variable and don't fallback to other
variables such as USER.

Fixes #725.  Reported by @seidler2547.

[1] The Single UNIX Specification, Issue 7