### PR TITLE
Created PID folder before starting the daemon

### DIFF
--- a/instfiles/xrdp-sesman.service
+++ b/instfiles/xrdp-sesman.service
@@ -10,6 +10,7 @@ Type=forking
 PIDFile=/var/run/xrdp-sesman.pid
 EnvironmentFile=-/etc/sysconfig/xrdp
 EnvironmentFile=-/etc/default/xrdp
+ExecStartPre=/bin/mkdir -p /var/run/xrdp
 ExecStart=/usr/sbin/xrdp-sesman $SESMAN_OPTIONS
 ExecStop=/usr/sbin/xrdp-sesman $SESMAN_OPTIONS --kill
 


### PR DESCRIPTION
This is needed for Debian at least.