### PR TITLE
make audio sockets path configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,6 @@ sesman/tools/xrdp-sesrun
 sesman/tools/xrdp-sestest
 sesman/tools/xrdp-xcon
 sesman/xrdp-sesman
+*.so
 stamp-h1
 xrdp/xrdp

--- a/common/xrdp_sockets.h
+++ b/common/xrdp_sockets.h
@@ -21,11 +21,20 @@
 #if !defined(XRDP_SOCKETS_H)
 #define XRDP_SOCKETS_H
 
-#define XRDP_CHANSRV_STR      XRDP_SOCKET_PATH "/xrdp_chansrv_socket_%d"
-#define CHANSRV_PORT_OUT_STR  XRDP_SOCKET_PATH "/xrdp_chansrv_audio_out_socket_%d"
-#define CHANSRV_PORT_IN_STR   XRDP_SOCKET_PATH "/xrdp_chansrv_audio_in_socket_%d"
-#define CHANSRV_API_STR       XRDP_SOCKET_PATH "/xrdpapi_%d"
-#define XRDP_X11RDP_STR       XRDP_SOCKET_PATH "/xrdp_display_%d"
-#define XRDP_DISCONNECT_STR   XRDP_SOCKET_PATH "/xrdp_disconnect_display_%d"
+/* basename of socket files */
+#define XRDP_CHANSRV_BASE_STR      "xrdp_chansrv_socket_%d"
+#define CHANSRV_PORT_OUT_BASE_STR  "xrdp_chansrv_audio_out_socket_%d"
+#define CHANSRV_PORT_IN_BASE_STR   "xrdp_chansrv_audio_in_socket_%d"
+#define CHANSRV_API_BASE_STR       "xrdpapi_%d"
+#define XRDP_X11RDP_BASE_STR       "xrdp_display_%d"
+#define XRDP_DISCONNECT_BASE_STR   "xrdp_disconnect_display_%d"
+
+/* fullpath of sockets */
+#define XRDP_CHANSRV_STR      XRDP_SOCKET_PATH "/" XRDP_CHANSRV_BASE_STR
+#define CHANSRV_PORT_OUT_STR  XRDP_SOCKET_PATH "/" CHANSRV_PORT_OUT_BASE_STR
+#define CHANSRV_PORT_IN_STR   XRDP_SOCKET_PATH "/" CHANSRV_PORT_IN_BASE_STR
+#define CHANSRV_API_STR       XRDP_SOCKET_PATH "/" CHANSRV_API_BASE_STR
+#define XRDP_X11RDP_STR       XRDP_SOCKET_PATH "/" XRDP_X11RDP_BASE_STR
+#define XRDP_DISCONNECT_STR   XRDP_SOCKET_PATH "/" XRDP_DISCONNECT_BASE_STR
 
 #endif

--- a/sesman/chansrv/pulse/Makefile
+++ b/sesman/chansrv/pulse/Makefile
@@ -3,10 +3,8 @@
 #
 
 # change this to your pulseaudio source directory
-PULSE_DIR = /home/lk/pulseaudio-1.1
-# change this if you're using non-default socket directory
-SOCK_DIR  = /tmp/.xrdp
-CFLAGS    = -Wall -O2 -I$(PULSE_DIR) -I$(PULSE_DIR)/src -DHAVE_CONFIG_H -fPIC -DXRDP_SOCKET_PATH=\"$(SOCK_DIR)\"
+PULSE_DIR = /tmp/pulseaudio-10.0
+CFLAGS    = -Wall -O2 -I$(PULSE_DIR) -I$(PULSE_DIR)/src -DHAVE_CONFIG_H -fPIC
 
 all: module-xrdp-sink.so module-xrdp-source.so
 

--- a/sesman/chansrv/pulse/module-xrdp-sink.c
+++ b/sesman/chansrv/pulse/module-xrdp-sink.c
@@ -292,6 +292,7 @@ static int lsend(int fd, char *data, int bytes) {
 
 static int data_send(struct userdata *u, pa_memchunk *chunk) {
     char *data;
+    char *socket_dir;
     int bytes;
     int sent;
     int fd;
@@ -308,7 +309,13 @@ static int data_send(struct userdata *u, pa_memchunk *chunk) {
         memset(&s, 0, sizeof(s));
         s.sun_family = AF_UNIX;
         bytes = sizeof(s.sun_path) - 1;
-        snprintf(s.sun_path, bytes, CHANSRV_PORT_OUT_STR, u->display_num);
+        socket_dir = getenv("XRDP_SOCKET_PATH");
+        if (socket_dir == NULL || socket_dir[0] == '\0')
+        {
+            socket_dir = "/tmp/.xrdp";
+        }
+        snprintf(s.sun_path, bytes, "%s/" CHANSRV_PORT_OUT_BASE_STR,
+                 socket_dir, u->display_num);
         pa_log_debug("trying to connect to %s", s.sun_path);
         if (connect(fd, (struct sockaddr *)&s,
                     sizeof(struct sockaddr_un)) != 0) {

--- a/sesman/chansrv/pulse/module-xrdp-source.c
+++ b/sesman/chansrv/pulse/module-xrdp-source.c
@@ -177,6 +177,7 @@ static int data_get(struct userdata *u, pa_memchunk *chunk) {
     int read_bytes;
     struct sockaddr_un s;
     char *data;
+    char *socket_dir;
     char buf[11];
     unsigned char ubuf[10];
 
@@ -186,7 +187,13 @@ static int data_get(struct userdata *u, pa_memchunk *chunk) {
         memset(&s, 0, sizeof(s));
         s.sun_family = AF_UNIX;
         bytes = sizeof(s.sun_path) - 1;
-        snprintf(s.sun_path, bytes, CHANSRV_PORT_IN_STR, u->display_num);
+        socket_dir = getenv("XRDP_SOCKET_PATH");
+        if (socket_dir == NULL || socket_dir[0] == '\0')
+        {
+            socket_dir = "/tmp/.xrdp";
+        }
+        snprintf(s.sun_path, bytes, "%s/" CHANSRV_PORT_IN_BASE_STR,
+                 socket_dir, u->display_num);
         pa_log_debug("Trying to connect to %s", s.sun_path);
 
         if (connect(fd, (struct sockaddr *) &s, sizeof(struct sockaddr_un)) != 0) {

--- a/sesman/env.c
+++ b/sesman/env.c
@@ -140,6 +140,8 @@ env_set_user(const char *username, char **passwd_file, int display,
             g_sprintf(text, ":%d.0", display);
             g_setenv("DISPLAY", text, 1);
             g_setenv("XRDP_SESSION", "1", 1);
+            /* XRDP_SOCKET_PATH should be set even here, chansrv uses this */
+            g_setenv("XRDP_SOCKET_PATH", XRDP_SOCKET_PATH, 1);
             if ((env_names != 0) && (env_values != 0) &&
                 (env_names->count == env_values->count))
             {


### PR DESCRIPTION
* pass xrdp socket path to user session (chansrv) via environment variable
* respect XRDP_SOCKET_PATH environment variable 
* other minor changes

I confirmed this properly works with non-default socket directory. Compiled `--with-socket-dir=/tmp/.xrdp2` option. If this is OK to merge, let's ship this to v0.9 branch too.