### PR TITLE
sesman: install empty reconnectwm.sh as a template

### DIFF
--- a/sesman/Makefile.am
+++ b/sesman/Makefile.am
@@ -78,7 +78,8 @@ dist_sesmansysconf_DATA = \
   sesman.ini
 
 dist_sesmansysconf_SCRIPTS = \
-  startwm.sh
+  startwm.sh \
+  reconnectwm.sh
 
 SUBDIRS = \
   libscp \

--- a/sesman/reconnectwm.sh
+++ b/sesman/reconnectwm.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+# Write procedures here you want to execute on reconnect


### PR DESCRIPTION
as it was undocumented and few people know reconnectwm.sh is executed on
client reconnect. The behaviour of startwm.sh / reconnectwm.sh  should
be documented. This is a first step of documenting them.