### PR TITLE
configure: fix confusing help text about painter and librfxcodec

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -130,12 +130,12 @@ AC_ARG_ENABLE(pixman, AS_HELP_STRING([--enable-pixman],
 AM_CONDITIONAL(XRDP_PIXMAN, [test x$enable_pixman = xyes])
 
 AC_ARG_ENABLE(painter, AS_HELP_STRING([--disable-painter],
-              [Use included painter library (default: yes)]),
+              [Do not use included painter library (default: no)]),
               [], [enable_painter=yes])
 AM_CONDITIONAL(XRDP_PAINTER, [test x$enable_painter = xyes])
 
 AC_ARG_ENABLE(rfxcodec, AS_HELP_STRING([--disable-rfxcodec],
-              [Use included librfxcodec library (default: yes)]),
+              [Do not use included librfxcodec library (default: no)]),
               [], [enable_rfxcodec=yes])
 AM_CONDITIONAL(XRDP_RFXCODEC, [test x$enable_rfxcodec = xyes])
 


### PR DESCRIPTION
painter and librfxcodec are enabled by default. --disable-* options
disables them.

Before:
  --disable-painter       Use included painter library (default: yes)
  --disable-rfxcodec      Use included librfxcodec library (default: yes)

After:
  --disable-painter       Do not use included painter library (default: no)
  --disable-rfxcodec      Do not use included librfxcodec library (default:
                          no)

----
CC: @proski 