### PR TITLE
exit with failure status if port already in use

### DIFF
--- a/xrdp/xrdp.c
+++ b/xrdp/xrdp.c
@@ -657,4 +657,6 @@ main(int argc, char **argv)
     {
         g_exit(1);
     }
+
+    return 0;
 }

--- a/xrdp/xrdp.c
+++ b/xrdp/xrdp.c
@@ -363,6 +363,7 @@ xrdp_sanity_check(void)
 int
 main(int argc, char **argv)
 {
+    int exit_status = 0;
     int test;
     char cfg_file[256];
     enum logReturns error;
@@ -620,7 +621,7 @@ main(int argc, char **argv)
     }
 
     g_listen->startup_params = startup_params;
-    xrdp_listen_main_loop(g_listen);
+    exit_status = xrdp_listen_main_loop(g_listen);
     xrdp_listen_delete(g_listen);
     tc_mutex_delete(g_sync_mutex);
     tc_mutex_delete(g_sync1_mutex);
@@ -637,5 +638,13 @@ main(int argc, char **argv)
     g_free(startup_params);
     log_end();
     g_deinit();
-    return 0;
+
+    if (exit_status == 0)
+    {
+        g_exit(0);
+    }
+    else
+    {
+        g_exit(1);
+    }
 }

--- a/xrdp/xrdp.c
+++ b/xrdp/xrdp.c
@@ -550,7 +550,17 @@ main(int argc, char **argv)
 
         if (0 != pid)
         {
-            g_writeln("process %d started ok", pid);
+            /* if can't listen, exit with failure status */
+            if (xrdp_listen_test() != 0)
+            {
+                log_message(LOG_LEVEL_ERROR, "Failed to start xrdp daemon, "
+                                             "possibly address already in use.");
+                g_deinit();
+                /* must exit with failure status,
+                   or systemd cannot detect xrdp daemon couldn't start properly */
+                g_exit(1);
+            }
+            g_writeln("daemon process %d started ok", pid);
             /* exit, this is the main process */
             g_deinit();
             g_exit(0);

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -163,6 +163,8 @@ void
 xrdp_listen_delete(struct xrdp_listen* self);
 int
 xrdp_listen_main_loop(struct xrdp_listen* self);
+int
+xrdp_listen_test(void);
 
 /* xrdp_region.c */
 struct xrdp_region*

--- a/xrdp/xrdp_listen.c
+++ b/xrdp/xrdp_listen.c
@@ -331,7 +331,8 @@ xrdp_listen_conn_in(struct trans *self, struct trans *new_self)
 }
 
 /*****************************************************************************/
-/* wait for incoming connections */
+/* wait for incoming connections
+   passes through trans_listen_address return value */
 int
 xrdp_listen_main_loop(struct xrdp_listen *self)
 {
@@ -547,5 +548,5 @@ xrdp_listen_main_loop(struct xrdp_listen *self)
     }
 
     self->status = -1;
-    return 0;
+    return error;
 }


### PR DESCRIPTION
Pointed out by @cocoon in #644.

xrdp and xrdp-sesman should exit with failure status if 3389/tcp or 3350/tcp port is already in use.
Before this fix, as described in #644, `systemd start xrdp` does not show any errors when daemon failed to start due to port already in use.  xrdp and xrdp-sesman executed in foreground should exit with failure status as well.

Tested on FreeBSD 11-STABLE and CentOS 7.  I describe test procedure on CentOS 7.
Use X11RDP-RH-Matic to build xrdp.


First of all, install xrdp from my branch.
```
$ GH_ACCOUNT=metalefty GH_BRANCH=error-used-port ./X11RDP-RH-Matic.sh --nox11rdp
```

Make 3389/tcp in use by another process.
```
$ nc -l 3389 &
$ netstat -an | egrep "3389|3350"
tcp        0      0 0.0.0.0:3389            0.0.0.0:*               LISTEN
tcp6       0      0 :::3389                 :::*                    LISTEN
```

xrdp in foreground mode exits with return status 1.
```
$  sudo xrdp -ns ; echo $?
[20170517-07:58:18] [ERROR] g_tcp_bind(11, 3389) failed bind IPv6 (errno=98) and IPv4 (errno=22).
[20170517-07:58:18] [ERROR] xrdp_listen_main_loop: listen error, possible port already in use
[20170517-07:58:18] [DEBUG] Closed socket 11 (AF_INET6 :: port 0)
[20170517-07:58:18] [CORE ] shutting down log subsystem...
1
```

xrdp in daemon mode exits with return status 1 as well.
```
$ sudo xrdp ; echo $?
[20170517-08:01:07] [DEBUG] Testing if xrdp can listen on 0.0.0.0 port 3389.
[20170517-08:01:07] [ERROR] g_tcp_bind(7, 3389) failed bind IPv6 (errno=98) and IPv4 (errno=22).
[20170517-08:01:07] [DEBUG] Closed socket 7 (AF_INET6 :: port 0)
[20170517-08:01:07] [ERROR] Failed to start xrdp daemon, possibly address already in use.
1
```

Starting xrdp daemon by systemd shows 
```
$ sudo systemctl start xrdp
Job for xrdp.service canceled.
$ LANG=C systemctl status xrdp.service -l
* xrdp.service - xrdp daemon
   Loaded: loaded (/usr/lib/systemd/system/xrdp.service; disabled; vendor preset: disabled)
   Active: failed (Result: exit-code) since Wed 2017-05-17 08:56:31 UTC; 2s ago
     Docs: man:xrdp(8)
           man:xrdp.ini(5)
  Process: 565 ExecStart=/usr/sbin/xrdp $XRDP_OPTIONS (code=exited, status=1/FAILURE)
 Main PID: 537 (code=exited, status=0/SUCCESS)
```

Before this fix, `systemctl status` shows like this when 3389/tcp is already in use.
```
$ LANG=C systemctl status xrdp.service -l
* xrdp.service - xrdp daemon
   Loaded: loaded (/usr/lib/systemd/system/xrdp.service; disabled; vendor preset: disabled)
   Active: inactive (dead)
     Docs: man:xrdp(8)
           man:xrdp.ini(5)
```


sesman can be tested with this procedure in case 3350/tcp is already in use.
```
$ killall nc 
$ nc -l 3350 &
$ sudo xrdp-sesman
$ sudo xrdp-sesman -ns
$ sudo systemctl start xrdp
$ sudo systemctl start xrdp-sesman
```