### PR TITLE
Fix systemd sessions

### DIFF
--- a/sesman/session.c
+++ b/sesman/session.c
@@ -360,7 +360,7 @@ session_start_chansrv(char *username, int display)
     chansrv_pid = g_fork();
     if (chansrv_pid == 0)
     {
-        chansrv_params = list_create(); 
+        chansrv_params = list_create();
         chansrv_params->auto_free = 1;
 
         /* building parameters */
@@ -457,7 +457,7 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
         return 0;
     }
 
-    auth_start_session(data, display);
+
     pid = g_fork(); /* parent is fork from tcp accept,
                        child forks X and wm, then becomes scp */
 
@@ -466,6 +466,7 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
     }
     else if (pid == 0)
     {
+        auth_start_session(data, display);
         g_delete_wait_obj(g_term_event);
         g_tcp_close(g_sck);
         g_tcp_close(c->in_sck);


### PR DESCRIPTION
Move the session creation inside of the child fork.  This will allow sesman to only have the child as a part of the user's session scope and the parent remain part of the services scope.

This was tested with:

1. Signon new session - xrdp-sesman parent in xrdp-sesman.service scope and xrdp-sesman child in the user's session scope.
1. Log off session - xrdp-sesman parent remains in xrdp-sesman.service scope and child xrdp-sesman is terminated along with the user's session.
1. Disconnect session - xrdp-sesman parent remains in xrdp-sesman.service scope and child xrdp-sesman remains inside of the user's scope.  
1. Reconnect session  - xrdp-sesman parent remains in xrdp-sesman.service scope and child xrdp-sesman remains inside of the user's scope.  Old session is re-attached.

This should fix issue #778.

Signed-off-by: Ian Geiser <geiseri@geekcentral.pub>