### PR TITLE
UDS connection only accessible by root

### DIFF
--- a/xrdp/xrdp_listen.c
+++ b/xrdp/xrdp_listen.c
@@ -371,6 +371,10 @@ xrdp_listen_main_loop(struct xrdp_listen *self)
 
     /* Create socket */
     error = trans_listen_address(self->listen_trans, port, address);
+    if (port[0] == '/')
+    {
+        g_chmod_hex(port, 0x0666);
+    }
 
     if (error == 0)
     {


### PR DESCRIPTION
_(If the "port" specified in /etc/xrdp/xrdp.ini is an absolute path then a
Unix Domain Socket (UDS) is created instead of a TCP port. I want to use
this feature to implement authentication over SSH, issue #773.)_

If you run xrdp with a Unix Domain Socket (UDS) for the port specified in
/etc/xrdp/xrdp.ini then only root can connect to it.

Test case:

1. Edit /etc/xrdp/xrdp.ini to set "port=/var/run/xrdp-local.socket".

2. Restart xrdp.

3. Run the following, as a non-root user.

  socat TCP-LISTEN:12345 UNIX-CONNECT:/var/run/xrdp-local.socket &
  rdesktop localhost:12345

Expected behaviour: rdesktop starts up and displays the logon dialog.
Observed behaviour: rdesktop exits with "ERROR: Connection closed" and
socat exits with "Permission denied".  (But it suceeds if root runs
socat.)

UDS files are created by trans_listen_address() and given permissions
0660, so only root can connect to it.  In this case, for the RDP client
connection, it it fine for any user to connect so it should be given
permissions 0666.

Note that this is only relevant when the port in /etc/xrdp/xrdp.ini has
been set to create a UDS instead of a TCP socket.  When a TCP port is
created any user (including remote users, unless the loopback interface
is used) can connect so this is not less secure.