### PR TITLE
Fix Xvnc backend disconnects when some data copied to clipboard

### DIFF
--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -3239,9 +3239,14 @@ server_send_to_channel(struct xrdp_mod *mod, int channel_id,
     {
         if (wm->mm->usechansrv)
         {
-            return 1;
+            /*
+             * Xvnc backend reaches here
+             * should not return 1 as this case is not an error
+             */
+            return 0;
         }
 
+        /* vnc proxy mode reaches here */
         return libxrdp_send_to_channel(wm->session, channel_id, data, data_len,
                                        total_data_len, flags);
     }


### PR DESCRIPTION
Should fix #755.

----
I tested these 4 scenario works fine (no disconnection, copy & paste works).

Now clipboard is working fine with Windows 7 mstsc, MS Remote Desktop for Mac 8.0.40 (Build 27310) however not working with FreeRDP due to FreeRDP/FreeRDP#3309.

1. Xvnc backend + clipboard sharing **enabled** client side
2. Xvnc backend + clipboard sharing **disabled** client side
3. vnc-proxy + clipboard sharing **enabled** client side
4. vnc-proxy + clipboard sharing **disabled** client side