### PR TITLE
xrdp-sesadmin: fix error when there are no sessions

### DIFF
--- a/sesman/libscp/libscp_v1s_mng.c
+++ b/sesman/libscp/libscp_v1s_mng.c
@@ -188,11 +188,18 @@ scp_v1s_mng_list_sessions(struct SCP_CONNECTION *c, struct SCP_SESSION *s,
     struct SCP_DISCONNECTED_SESSION *cds;
 
     /* calculating the number of packets to send */
-    pktcnt = sescnt / SCP_SERVER_MAX_LIST_SIZE;
-
-    if ((sescnt % SCP_SERVER_MAX_LIST_SIZE) != 0)
+    if (sescnt == 0)
     {
-        pktcnt++;
+      pktcnt = 1;
+    }
+    else
+    {
+      pktcnt = sescnt / SCP_SERVER_MAX_LIST_SIZE;
+
+      if ((sescnt % SCP_SERVER_MAX_LIST_SIZE) != 0)
+      {
+          pktcnt++;
+      }
     }
 
     for (idx = 0; idx < pktcnt; idx++)

--- a/sesman/scp_v1_mng.c
+++ b/sesman/scp_v1_mng.c
@@ -84,19 +84,13 @@ scp_v1_mng_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
                 /* list disconnected sessions */
                 slist = session_get_byuser(NULL, &scount, SESMAN_SESSION_STATUS_ALL);
                 LOG_DBG("sessions on TS: %d (slist: %x)", scount, slist);
-
                 if (0 == slist)
                 {
-                    //          e=scp_v1s_connection_error(c, "Internal error");
                     log_message(LOG_LEVEL_INFO, "No sessions on Terminal Server");
-                    end = 0;
-                }
-                else
-                {
-                    e = scp_v1s_mng_list_sessions(c, s, scount, slist);
-                    g_free(slist);
                 }
 
+                e = scp_v1s_mng_list_sessions(c, s, scount, slist);
+                g_free(slist);
                 break;
             default:
                 /* we check the other errors */


### PR DESCRIPTION
Test case:  On a system running xrdp with no sessions running run:

  xrdp-sesadmin -u=<user> -p=<password> -c=list

Expected result: "No sessions." (ignoring debug output)
Observed result: "Error getting session list."

In the SCP_SERVER_STATE_MNG_LISTREQ case in scp_v1_mng_process() if
there are no sessions it ends the scp session, which causes an error in
the client.  In commit 0017081d the client was changed to report errors,
giving the result above.

Fix by calling scp_v1s_mng_list_sessions() from scp_v1_mng_process()
even when there are no sessions, and if so sending a packet with a count
of zero so that the client gets what it expects.