### PR TITLE
Ensure socket directory present

### DIFF
--- a/common/trans.c
+++ b/common/trans.c
@@ -808,7 +808,6 @@ trans_listen_address(struct trans *self, char *port, const char *address)
     }
     else if (self->mode == TRANS_MODE_UNIX) /* unix socket */
     {
-        g_create_path(port);
 
         g_free(self->listen_filename);
         self->listen_filename = 0;

--- a/common/trans.c
+++ b/common/trans.c
@@ -808,7 +808,6 @@ trans_listen_address(struct trans *self, char *port, const char *address)
     }
     else if (self->mode == TRANS_MODE_UNIX) /* unix socket */
     {
-
         g_free(self->listen_filename);
         self->listen_filename = 0;
         g_file_delete(port);

--- a/common/trans.c
+++ b/common/trans.c
@@ -808,6 +808,8 @@ trans_listen_address(struct trans *self, char *port, const char *address)
     }
     else if (self->mode == TRANS_MODE_UNIX) /* unix socket */
     {
+        g_create_path(port);
+
         g_free(self->listen_filename);
         self->listen_filename = 0;
         g_file_delete(port);

--- a/sesman/sesman.c
+++ b/sesman/sesman.c
@@ -417,6 +417,17 @@ main(int argc, char **argv)
     log_message(LOG_LEVEL_INFO,
                 "starting xrdp-sesman with pid %d", g_pid);
 
+    /* make sure socket (XRDP_SOCKET_PATH) directory exists */
+    if (!g_directory_exist(XRDP_SOCKET_PATH))
+    {
+        if (!g_create_path(XRDP_SOCKET_PATH "/"))
+        {
+            log_message(LOG_LEVEL_ERROR,
+                "sesman.c: error creating dir "XRDP_SOCKET_PATH);
+        }
+        g_chmod_hex(XRDP_SOCKET_PATH, 0x1777);
+    }
+
     /* make sure the /tmp/.X11-unix directory exist */
     if (!g_directory_exist("/tmp/.X11-unix"))
     {


### PR DESCRIPTION
In cases where the socket directory is in tmpfs it cannot always be certain to exist.  Debian has a hack around this by running a shell script to generate the needed directory structure when the socket dir is not ```/tmp/.xrdp```.  This does the equivalent at startup of sessman.  This should fix issue #801.