### PR TITLE
Adjustments to XRDP_SOCKET_PATH make process

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -109,17 +109,17 @@ g_rm_temp_dir(void)
 
 /*****************************************************************************/
 int
-g_mk_temp_dir(const char *app_name)
+g_mk_socket_path(const char *app_name)
 {
     if (!g_directory_exist(XRDP_SOCKET_PATH))
     {
-        if (!g_create_dir(XRDP_SOCKET_PATH))
+        if (!g_create_path(XRDP_SOCKET_PATH))
         {
             /* if failed, still check if it got created by someone else */
             if (!g_directory_exist(XRDP_SOCKET_PATH))
             {
                 log_message(LOG_LEVEL_ERROR,
-                            "g_mk_temp_dir: g_create_dir(%s) failed",
+                            "g_mk_socket_path: g_create_path(%s) failed",
                             XRDP_SOCKET_PATH);
                 return 1;
             }
@@ -153,7 +153,7 @@ g_init(const char *app_name)
         setlocale(LC_CTYPE, "en_US.UTF-8");
     }
 
-    g_mk_temp_dir(app_name);
+    g_mk_socket_path(app_name);
 }
 
 /*****************************************************************************/
@@ -2954,7 +2954,7 @@ g_execvp(const char *p1, char *args[])
 
     g_rm_temp_dir();
     rv = execvp(p1, args);
-    g_mk_temp_dir(0);
+    g_mk_socket_path(0);
     return rv;
 #endif
 }
@@ -2971,7 +2971,7 @@ g_execlp3(const char *a1, const char *a2, const char *a3)
 
     g_rm_temp_dir();
     rv = execlp(a1, a2, a3, (void *)0);
-    g_mk_temp_dir(0);
+    g_mk_socket_path(0);
     return rv;
 #endif
 }
@@ -3067,7 +3067,7 @@ g_fork(void)
 
     if (rv == 0) /* child */
     {
-        g_mk_temp_dir(0);
+        g_mk_socket_path(0);
     }
 
     return rv;

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -38,7 +38,7 @@
 #define g_close_wait_obj g_delete_wait_obj
 
 int      g_rm_temp_dir(void);
-int      g_mk_temp_dir(const char* app_name);
+int      g_mk_socket_path(const char* app_name);
 void     g_init(const char* app_name);
 void     g_deinit(void);
 void*    g_malloc(int size, int zero);

--- a/sesman/env.c
+++ b/sesman/env.c
@@ -69,7 +69,7 @@ env_check_password_file(const char *filename, const char *passwd)
     g_strncpy(encryptedPasswd, passwd, 8);
     g_memset(key, 0, sizeof(key));
     g_mirror_memcpy(key, g_fixedkey, 8);
-    des = ssl_des3_encrypt_info_create(key, 0); 
+    des = ssl_des3_encrypt_info_create(key, 0);
     ssl_des3_encrypt(des, 8, encryptedPasswd, encryptedPasswd);
     ssl_des3_info_delete(des);
     fd = g_file_open_ex(filename, 0, 1, 1, 1);
@@ -124,7 +124,7 @@ env_set_user(const char *username, char **passwd_file, int display,
             error = g_setuid(uid);
         }
 
-        g_mk_temp_dir(0);
+        g_mk_socket_path(0);
 
         if (error == 0)
         {

--- a/sesman/sesman.c
+++ b/sesman/sesman.c
@@ -418,7 +418,7 @@ main(int argc, char **argv)
                 "starting xrdp-sesman with pid %d", g_pid);
 
     /* make sure the socket directory exists */
-    g_mk_temp_dir("xrdp-sesman");
+    g_mk_socket_path("xrdp-sesman");
 
     /* make sure the /tmp/.X11-unix directory exists */
     if (!g_directory_exist("/tmp/.X11-unix"))


### PR DESCRIPTION
This does 2 things.  The first is use ```g_create_path``` instead of ```g_create_dir``` to ensure the entire path is present when creating the socket path.  The second is to rename ```g_mk_temp_dir``` to something more meaningful.  It is now called ```g_mk_socket_path```.

