### PR TITLE
sesman: search pam files also in ${sysconfdir}/pam.d

### DIFF
--- a/sesman/Makefile.am
+++ b/sesman/Makefile.am
@@ -2,6 +2,7 @@ EXTRA_DIST = \
   Doxyfile
 
 AM_CPPFLAGS = \
+  -DXRDP_SYSCONF_PATH=\"${sysconfdir}\" \
   -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
   -DXRDP_SHARE_PATH=\"${datadir}/xrdp\" \

--- a/sesman/verify_user_pam.c
+++ b/sesman/verify_user_pam.c
@@ -91,7 +91,8 @@ get_service_name(char *service_name)
 {
     service_name[0] = 0;
 
-    if (g_file_exist("/etc/pam.d/xrdp-sesman"))
+    if (g_file_exist("/etc/pam.d/xrdp-sesman") ||
+        g_file_exist(XRDP_SYSCONF_PATH "/pam.d/xrdp-sesman"))
     {
         g_strncpy(service_name, "xrdp-sesman", 255);
     }


### PR DESCRIPTION
as some operating system such as FreeBSD searches not only `/etc/pam.d`
but also `/usr/local/etc/pam.d` [1].

[1] https://www.freebsd.org/cgi/man.cgi?query=pam.d&sektion=5