### PR TITLE
log: add log level TRACE

### DIFF
--- a/common/log.c
+++ b/common/log.c
@@ -94,6 +94,7 @@ internal_log_xrdp2syslog(const enum logLevels lvl)
         case LOG_LEVEL_INFO:
             return LOG_INFO;
         case LOG_LEVEL_DEBUG:
+        case LOG_LEVEL_TRACE:
             return LOG_DEBUG;
         default:
             g_writeln("Undefined log level - programming error");
@@ -127,6 +128,9 @@ internal_log_lvl2str(const enum logLevels lvl, char *str)
             break;
         case LOG_LEVEL_DEBUG:
             snprintf(str, 9, "%s", "[DEBUG] ");
+            break;
+        case LOG_LEVEL_TRACE:
+            snprintf(str, 9, "%s", "[TRACE] ");
             break;
         default:
             snprintf(str, 9, "%s", "PRG ERR!");
@@ -253,6 +257,11 @@ internal_log_text2level(const char *buf)
              0 == g_strcasecmp(buf, "debug"))
     {
         return LOG_LEVEL_DEBUG;
+    }
+    else if (0 == g_strcasecmp(buf, "5") ||
+             0 == g_strcasecmp(buf, "trace"))
+    {
+        return LOG_LEVEL_TRACE;
     }
 
     g_writeln("Your configured log level is corrupt - we use debug log level");

--- a/common/log.h
+++ b/common/log.h
@@ -33,7 +33,8 @@ enum logLevels
     LOG_LEVEL_ERROR,
     LOG_LEVEL_WARNING,
     LOG_LEVEL_INFO,
-    LOG_LEVEL_DEBUG
+    LOG_LEVEL_DEBUG,
+    LOG_LEVEL_TRACE
 };
 
 /* startup return values */


### PR DESCRIPTION
TRACE means more verbose than DEBUG. syslog doesn't have more verbose
level than DEBUG, map TRACE to DEBUG for syslog.