### PR TITLE
xfuse_create_share() called before xfuse_init()

### DIFF
--- a/sesman/chansrv/chansrv_fuse.c
+++ b/sesman/chansrv/chansrv_fuse.c
@@ -611,6 +611,12 @@ int xfuse_create_share(tui32 device_id, const char *dirname)
     if (dirname == NULL || strlen(dirname) == 0)
         return -1;
 
+    /* Do we have an inode table yet? */
+    if (xfuse_init_xrdp_fs())
+    {
+        return -1;
+    }
+
     xinode = g_new0(struct xrdp_inode, 1);
     if (xinode == NULL)
     {
@@ -857,6 +863,12 @@ static int xfuse_init_lib(struct fuse_args *args)
 static int xfuse_init_xrdp_fs(void)
 {
     struct xrdp_inode *xino;
+
+    /* Already called? */
+    if (g_xrdp_fs.inode_table != NULL)
+    {
+        return 0;
+    }
 
     g_xrdp_fs.inode_table = g_new0(struct xrdp_inode *, 4096);
     if (g_xrdp_fs.inode_table == NULL)


### PR DESCRIPTION
Running xrdp 0.9.2 on CentOS/RHEL 7.3, we occasionally see coredumps of chansrv, always when logging in.

Investigation of these coredumps shows a SEGV in `xfuse_create_share()`, where the new xinode is inserted into the inode_table. At this point, `g_xrdp_fs` is uninitialized so it seems that `xfuse_init()` has not yet been called.

```
(gdb) print g_xrdp_fs
$1 = {inode_table = 0x0, max_entries = 0, num_entries = 1, next_node = 1}
```

This patch caters for this situation by creating the inode table if required during `xfuse_create_share()`

My local testing shows chansrv to be more robust with this patch. Is there maybe a preferable way to handle this situation, like calling `xfuse_init()` from elsewhere?