### PR TITLE
instfiles: don't include generated *.services files to distribution

### DIFF
--- a/instfiles/Makefile.am
+++ b/instfiles/Makefile.am
@@ -60,7 +60,7 @@ SUBDIRS += \
   pulse
 dist_startscript_SCRIPTS = xrdp.sh
 if HAVE_SYSTEMD
-dist_systemdsystemunit_DATA = \
+systemdsystemunit_DATA = \
   xrdp-sesman.service \
   xrdp.service
 else


### PR DESCRIPTION
Solves #848.
Pointed out by: Fuminobu TAKEYAMA (@ftake)
