### PR TITLE
Fix WTSVirtualChannelWrite() returncode

### DIFF
--- a/tcutils/utils.cpp
+++ b/tcutils/utils.cpp
@@ -37,7 +37,7 @@ int Utils::getMountList(void *wtsChannel, QList<QListWidgetItem *> *itemList)
 
     /* send command */
     rv = WTSVirtualChannelWrite(wtsChannel, s.data, bytesToSend, &bytesWritten);
-    if (rv)
+    if (!rv)
     {
         QMessageBox::information(NULL, "Get device list", "\nError sending "
                                  "command to client");
@@ -126,7 +126,7 @@ int Utils::unmountDevice(void *wtsChannel, QString device, QStatusBar *statusBar
 
     /* send command */
     rv = WTSVirtualChannelWrite(wtsChannel, s.data, bytesToSend, &bytesWritten);
-    if (rv)
+    if (!rv)
     {
         QMessageBox::information(NULL, "Unmount device", "\nError sending "
                                  "command to client");

--- a/xrdpapi/xrdpapi.c
+++ b/xrdpapi/xrdpapi.c
@@ -227,18 +227,18 @@ WTSVirtualChannelWrite(void *hChannelHandle, const char *Buffer,
     if (wts == 0)
     {
         LLOGLN(10, ("WTSVirtualChannelWrite: wts is NULL"));
-        return -1;
+        return 0;
     }
 
     if (wts->status != 1)
     {
         LLOGLN(10, ("WTSVirtualChannelWrite: wts->status != 1"));
-        return -1;
+        return 0;
     }
 
     if (!can_send(wts->fd, 0))
     {
-        return 0;    /* can't write now, ok to try again */
+        return 1;    /* can't write now, ok to try again */
     }
 
     rv = 0;
@@ -251,7 +251,7 @@ WTSVirtualChannelWrite(void *hChannelHandle, const char *Buffer,
     else
     {
         LLOGLN(0, ("WTSVirtualChannelWrite: header write failed"));
-        return -1;
+        return 0;
     }
 
     LLOGLN(10, ("WTSVirtualChannelWrite: mysend() returned %d", rv));
@@ -260,19 +260,19 @@ WTSVirtualChannelWrite(void *hChannelHandle, const char *Buffer,
     {
         /* success, but zero bytes may have been written */
         *pBytesWritten = rv;
-        return 0;
+        return 1;
     }
 
 #if 0 /* coverity: this is dead code */
     /* error, but is it ok to try again? */
     if ((rv == EWOULDBLOCK) || (rv == EAGAIN) || (rv == EINPROGRESS))
     {
-        return 0;    /* failed to send, but should try again */
+        return 1;    /* failed to send, but should try again */
     }
 #endif
 
     /* fatal error */
-    return -1;
+    return 0;
 }
 
 /*****************************************************************************/

--- a/xrdpvr/xrdpvr.c
+++ b/xrdpvr/xrdpvr.c
@@ -915,7 +915,7 @@ xrdpvr_write_to_client(void *channel, STREAM *s)
         rv = WTSVirtualChannelWrite(channel, &s->data[index], bytes_to_send,
                                     &bytes_written);
 
-        if (rv < 0)
+        if (rv == 0)
         {
             return -1;
         }
@@ -923,7 +923,7 @@ xrdpvr_write_to_client(void *channel, STREAM *s)
         index += bytes_written;
         bytes_to_send -= bytes_written;
 
-        if ((rv == 0) && (bytes_to_send == 0))
+        if ((rv != 0) && (bytes_to_send == 0))
         {
             return 0;
         }


### PR DESCRIPTION
The function WTSVirtualChannelWrite() in xrdpapi.c returns 0 on success
and -1 on error.  It should return 1 on success and 0 on error, because:

1. It is the behaviour described in Microsoft's [API documentation](https://msdn.microsoft.com/en-us/library/aa383855(v=vs.85).aspx).
2. It is the behaviour expected by xrdpapi/[simple.c](https://github.com/neutrinolabs/xrdp/blob/devel/xrdpapi/simple.c#L124).
3. It is consistent with xrdpapi's behaviour for other functions
   including [WTSVirtualChannelRead()](https://github.com/neutrinolabs/xrdp/blob/devel/xrdpapi/xrdpapi.c#L280).