### PR TITLE
travis: Unbreak travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ max_x86_deps: &max_x86_deps
   - *common_deps
   - g++-multilib
   - gcc-multilib
+  - libgl1-mesa-dev:i386
   - libglu1-mesa-dev:i386
   - libjpeg-dev:i386
   - libmp3lame-dev:i386


### PR DESCRIPTION
since Ubuntu Precise (12.04) is retired September 2017. Now build test
is run on Ubuntu Trusty (14.04). A trivial fix for requisite packages
needed.