### PR TITLE
workaround for corrupted display with W2K8

### DIFF
--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -1468,7 +1468,9 @@ lfreerdp_pre_connect(freerdp *instance)
 
     instance->settings->glyph_cache = true;
     /* GLYPH_SUPPORT_FULL and GLYPH_SUPPORT_PARTIAL seem to be the same */
-    instance->settings->glyphSupportLevel = GLYPH_SUPPORT_FULL;
+    /* disabled as workaround for corrupted display like black bars left of cmd with W2K8 */
+    /* instance->settings->glyphSupportLevel = GLYPH_SUPPORT_FULL; */
+    instance->settings->glyphSupportLevel = GLYPH_SUPPORT_NONE;
 
     instance->settings->order_support[NEG_DSTBLT_INDEX] = 1; /* 0x00 */
     instance->settings->order_support[NEG_PATBLT_INDEX] = 1;
@@ -1497,7 +1499,10 @@ lfreerdp_pre_connect(freerdp *instance)
     instance->settings->order_support[NEG_FAST_GLYPH_INDEX] = 0; /* 0x18 */
     instance->settings->order_support[NEG_ELLIPSE_SC_INDEX] = 0;
     instance->settings->order_support[NEG_ELLIPSE_CB_INDEX] = 0;
-    instance->settings->order_support[NEG_GLYPH_INDEX_INDEX] = 1;
+    /* disabled as workaround for corrupted display like black bars left of cmd with W2K8 */
+    /* instance->settings->order_support[NEG_GLYPH_INDEX_INDEX] = 1; */
+    instance->settings->order_support[NEG_GLYPH_INDEX_INDEX] = 0;
+    
     instance->settings->order_support[NEG_GLYPH_WEXTTEXTOUT_INDEX] = 0;
     instance->settings->order_support[NEG_GLYPH_WLONGTEXTOUT_INDEX] = 0;
     instance->settings->order_support[NEG_GLYPH_WLONGEXTTEXTOUT_INDEX] = 0;


### PR DESCRIPTION
workaround for corrupted display like black bars left of cmd with W2K8
as requested here: https://github.com/neutrinolabs/xrdp/issues/860

But maybe someone can do proper fixes.

BTW:
I reported this looong timea go ;)

here:
http://xrdp-devel.766250.n3.nabble.com/Xrdp-devel-NeutrinoRDP-black-lines-with-ping-in-a-remote-console-screenshot-td4025274.html

or here:
https://github.com/neutrinolabs/NeutrinoRDP/issues/1


BTW2: still open bugs:

- ~~misuse of hidelogwindow instead of correct own hideloginwindow~~

- ~~xrdp systemd setting User=root and fix neutrinordp https://github.com/neutrinolabs/NeutrinoRDP/blob/devel/libfreerdp-utils/file.c#L81
(question is if it can cause any harm if home is set to / if it can't get from env)~~

- new cursor + Windows 10