### PR TITLE
fix crash neutrinordp missing home env

### DIFF
--- a/instfiles/xrdp.service.in
+++ b/instfiles/xrdp.service.in
@@ -6,6 +6,7 @@ After=network.target xrdp-sesman.service
 
 [Service]
 Type=forking
+User=root
 PIDFile=@localstatedir@/run/xrdp.pid
 EnvironmentFile=-@sysconfdir@/sysconfig/xrdp
 EnvironmentFile=-@sysconfdir@/default/xrdp


### PR DESCRIPTION
https://github.com/neutrinolabs/xrdp/issues/719

One possible way to fix the crash is to add User=xxx in xrdp.service-file

Other fix would be in neutrinordp to set a fallsback path if no home env exists.