### PR TITLE
xrdp: get port from configfile in access_control()

### DIFF
--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -1471,11 +1471,13 @@ access_control(char *username, char *password, char *srv)
     unsigned long size;
     int index;
     int socket = g_tcp_socket();
+    char port[8];
 
     if (socket != -1)
     {
+        xrdp_mm_get_sesman_port(port, sizeof(port));
         /* we use a blocking socket here */
-        reply = g_tcp_connect(socket, srv, "3350");
+        reply = g_tcp_connect(socket, srv, port);
 
         if (reply == 0)
         {


### PR DESCRIPTION
This fixes #894

access_control() does not read the port from the configuration file and it uses a hardcoded port instead.
So,  in case we use another port which is not the default one(3350), we are going to fail while connecting.
