### PR TITLE
sound: g_bbuf_size should be determined after codec is determined

### DIFF
--- a/sesman/chansrv/sound.c
+++ b/sesman/chansrv/sound.c
@@ -400,19 +400,16 @@ sound_process_output_format(int aindex, int wFormatTag, int nChannels,
             LOG(0, ("wFormatTag, fdk aac"));
             g_client_does_fdk_aac = 1;
             g_client_fdk_aac_index = aindex;
-            g_bbuf_size = 4096;
             break;
         case WAVE_FORMAT_MPEGLAYER3:
             LOG(0, ("wFormatTag, mp3"));
             g_client_does_mp3lame = 1;
             g_client_mp3lame_index = aindex;
-            g_bbuf_size = 11520;
             break;
         case WAVE_FORMAT_OPUS:
             LOG(0, ("wFormatTag, opus"));
             g_client_does_opus = 1;
             g_client_opus_index = aindex;
-            g_bbuf_size = 11520;
             break;
     }
 
@@ -840,14 +837,17 @@ sound_wave_compress(char *data, int data_bytes, int *format_index)
 {
     if (g_client_does_fdk_aac)
     {
+        g_bbuf_size = 4096;
         return sound_wave_compress_fdk_aac(data, data_bytes, format_index);
     }
     else if (g_client_does_opus)
     {
+        g_bbuf_size = 11520;
         return sound_wave_compress_opus(data, data_bytes, format_index);
     }
     else if (g_client_does_mp3lame)
     {
+        g_bbuf_size = 11520;
         return sound_wave_compress_mp3lame(data, data_bytes, format_index);
     }
     return data_bytes;


### PR DESCRIPTION
Fixes #910, if both client and server support more than one codecs,
g_bbuf_size might be set to wrong value.

There might be a better fix but this certainly fixes the issue.