### PR TITLE
Constify color depth and capability set

### DIFF
--- a/common/xrdp_constants.h
+++ b/common/xrdp_constants.h
@@ -101,6 +101,13 @@
 #define CONNECTION_TYPE_LAN            0x06
 #define CONNECTION_TYPE_AUTODETECT     0x07
 
+/* Client Core Data: colorDepth, postBeta2ColorDepth (MS-RDPBCGR 2.2.1.3.2) */
+#define RNS_UD_COLOR_4BPP              0xCA00
+#define RNS_UD_COLOR_8BPP              0xCA01
+#define RNS_UD_COLOR_16BPP_555         0xCA02
+#define RNS_UD_COLOR_16BPP_565         0xCA03
+#define RNS_UD_COLOR_24BPP             0xCA04
+
 /* Slow-Path Input Event: messageType (MS-RDPBCGR 2.2.8.1.1.3.1.1) */
 /* TODO: to be renamed */
 #define RDP_INPUT_SYNCHRONIZE          0

--- a/common/xrdp_constants.h
+++ b/common/xrdp_constants.h
@@ -417,53 +417,53 @@
 
 /* Capability Set: capabilitySetType (MS-RDPBCGR 2.2.1.13.1.1.1) */
 /* TODO: to be renamed */
-#define RDP_CAPSET_GENERAL             1
+#define RDP_CAPSET_GENERAL             0x0001
 #define RDP_CAPLEN_GENERAL             0x18
 
-#define RDP_CAPSET_BITMAP              2
+#define RDP_CAPSET_BITMAP              0x0002
 #define RDP_CAPLEN_BITMAP              0x1C
 
-#define RDP_CAPSET_ORDER               3
+#define RDP_CAPSET_ORDER               0x0003
 #define RDP_CAPLEN_ORDER               0x58
 #define ORDER_CAP_NEGOTIATE            2
 #define ORDER_CAP_NOSUPPORT            4
 
-#define RDP_CAPSET_BMPCACHE            4
+#define RDP_CAPSET_BMPCACHE            0x0004
 #define RDP_CAPLEN_BMPCACHE            0x28
 
-#define RDP_CAPSET_CONTROL             5
+#define RDP_CAPSET_CONTROL             0x0005
 #define RDP_CAPLEN_CONTROL             0x0C
 
-#define RDP_CAPSET_ACTIVATE            7
+#define RDP_CAPSET_ACTIVATE            0x0007
 #define RDP_CAPLEN_ACTIVATE            0x0C
 
-#define RDP_CAPSET_POINTER             8
+#define RDP_CAPSET_POINTER             0x0008
 #define RDP_CAPLEN_POINTER             0x0a
 #define RDP_CAPLEN_POINTER_MONO        0x08
 
-#define RDP_CAPSET_SHARE               9
+#define RDP_CAPSET_SHARE               0x0009
 #define RDP_CAPLEN_SHARE               0x08
 
-#define RDP_CAPSET_COLCACHE            10
+#define RDP_CAPSET_COLCACHE            0x000A
 #define RDP_CAPLEN_COLCACHE            0x08
 
-#define RDP_CAPSET_INPUT               13
+#define RDP_CAPSET_INPUT               0x000D
 #define RDP_CAPLEN_INPUT               0x58
 
-#define RDP_CAPSET_FONT                14
+#define RDP_CAPSET_FONT                0x000E
 #define RDP_CAPLEN_FONT                0x04
 
-#define RDP_CAPSET_BRUSHCACHE          15
+#define RDP_CAPSET_BRUSHCACHE          0x000F
 #define RDP_CAPLEN_BRUSHCACHE          0x08
 
-#define RDP_CAPSET_BITMAP_OFFSCREEN    18
+#define RDP_CAPSET_BITMAP_OFFSCREEN    0x0012
 #define RDP_CAPLEN_BITMAP_OFFSCREEN    0x08
 
-#define RDP_CAPSET_BMPCACHE2           19
+#define RDP_CAPSET_BMPCACHE2           0x0013
 #define RDP_CAPLEN_BMPCACHE2           0x28
 #define BMPCACHE2_FLAG_PERSIST         ((long)1<<31)
 
-#define RDP_CAPSET_VIRCHAN             20
+#define RDP_CAPSET_VIRCHAN             0x0014
 #define RDP_CAPLEN_VIRCHAN             0x08
 
 #define RDP_CAPSET_MULTIFRAGMENT       0x001A
@@ -472,16 +472,16 @@
 #define RDP_CAPSET_FRAME_ACKNOWLEDGE   0x001E
 #define RDP_CAPLEN_FRAME_ACKNOWLEDGE   0x08
 
-#define RDP_CAPSET_SURFCMDS            0x1C
+#define RDP_CAPSET_SURFCMDS            0x001C
 #define RDP_CAPLEN_SURFCMDS            0x0C
 
-#define RDP_CAPSET_BMPCODECS           0x1D
+#define RDP_CAPSET_BMPCODECS           0x001D
 #define RDP_CAPLEN_BMPCODECS           0x1C
 
-#define RDP_CAPSET_COMPDESK            0x19
+#define RDP_CAPSET_COMPDESK            0x0019
 #define RDP_CAPLEN_COMPDESK            0x06
 
-#define RDP_CAPSET_LPOINTER            0x1B
+#define RDP_CAPSET_LPOINTER            0x001B
 #define RDP_CAPLEN_LPOINTER            0x06
 
 /* TS_SECURITY_HEADER: flags (MS-RDPBCGR 2.2.8.1.1.2.1) */

--- a/common/xrdp_constants.h
+++ b/common/xrdp_constants.h
@@ -447,6 +447,8 @@
 #define RDP_CAPSET_COLCACHE            0x000A
 #define RDP_CAPLEN_COLCACHE            0x08
 
+#define RDP_CAPSET_SOUND               0x000C
+
 #define RDP_CAPSET_INPUT               0x000D
 #define RDP_CAPLEN_INPUT               0x58
 
@@ -455,6 +457,9 @@
 
 #define RDP_CAPSET_BRUSHCACHE          0x000F
 #define RDP_CAPLEN_BRUSHCACHE          0x08
+
+#define RDP_CAPSET_GLYPHCACHE          0x0010
+#define RDP_CAPSET_OFFSCREENCACHE      0x0011
 
 #define RDP_CAPSET_BITMAP_OFFSCREEN    0x0012
 #define RDP_CAPLEN_BITMAP_OFFSCREEN    0x08
@@ -466,8 +471,19 @@
 #define RDP_CAPSET_VIRCHAN             0x0014
 #define RDP_CAPLEN_VIRCHAN             0x08
 
+#define RDP_CAPSET_DRAWNINEGRIDCACHE   0x0015
+#define RDP_CAPSET_DRAWGDIPLUS         0x0016
+#define RDP_CAPSET_RAIL                0x0017
+#define RDP_CAPSET_WINDOW              0x0018
+
+#define RDP_CAPSET_COMPDESK            0x0019
+#define RDP_CAPLEN_COMPDESK            0x06
+
 #define RDP_CAPSET_MULTIFRAGMENT       0x001A
 #define RDP_CAPLEN_MULTIFRAGMENT       0x08
+
+#define RDP_CAPSET_LPOINTER            0x001B
+#define RDP_CAPLEN_LPOINTER            0x06
 
 #define RDP_CAPSET_FRAME_ACKNOWLEDGE   0x001E
 #define RDP_CAPLEN_FRAME_ACKNOWLEDGE   0x08
@@ -478,11 +494,7 @@
 #define RDP_CAPSET_BMPCODECS           0x001D
 #define RDP_CAPLEN_BMPCODECS           0x1C
 
-#define RDP_CAPSET_COMPDESK            0x0019
-#define RDP_CAPLEN_COMPDESK            0x06
 
-#define RDP_CAPSET_LPOINTER            0x001B
-#define RDP_CAPLEN_LPOINTER            0x06
 
 /* TS_SECURITY_HEADER: flags (MS-RDPBCGR 2.2.8.1.1.2.1) */
 /* TODO: to be renamed */

--- a/libxrdp/xrdp_caps.c
+++ b/libxrdp/xrdp_caps.c
@@ -610,89 +610,89 @@ xrdp_caps_process_confirm_active(struct xrdp_rdp *self, struct stream *s)
         len -= 4;
         switch (type)
         {
-            case RDP_CAPSET_GENERAL: /* 1 */
+            case RDP_CAPSET_GENERAL: /* 0x01 */
                 DEBUG(("RDP_CAPSET_GENERAL"));
                 xrdp_caps_process_general(self, s, len);
                 break;
-            case RDP_CAPSET_BITMAP: /* 2 */
+            case RDP_CAPSET_BITMAP: /* 0x02 */
                 DEBUG(("RDP_CAPSET_BITMAP"));
                 break;
-            case RDP_CAPSET_ORDER: /* 3 */
+            case RDP_CAPSET_ORDER: /* 0x03 */
                 DEBUG(("RDP_CAPSET_ORDER"));
                 xrdp_caps_process_order(self, s, len);
                 break;
-            case RDP_CAPSET_BMPCACHE: /* 4 */
+            case RDP_CAPSET_BMPCACHE: /* 0x04 */
                 DEBUG(("RDP_CAPSET_BMPCACHE"));
                 xrdp_caps_process_bmpcache(self, s, len);
                 break;
-            case RDP_CAPSET_CONTROL: /* 5 */
+            case RDP_CAPSET_CONTROL: /* 0x05 */
                 DEBUG(("RDP_CAPSET_CONTROL"));
                 break;
             case 6:
                 xrdp_caps_process_cache_v3_codec_id(self, s, len);
                 break;
-            case RDP_CAPSET_ACTIVATE: /* 7 */
+            case RDP_CAPSET_ACTIVATE: /* 0x07 */
                 DEBUG(("RDP_CAPSET_ACTIVATE"));
                 break;
-            case RDP_CAPSET_POINTER: /* 8 */
+            case RDP_CAPSET_POINTER: /* 0x08 */
                 DEBUG(("RDP_CAPSET_POINTER"));
                 xrdp_caps_process_pointer(self, s, len);
                 break;
-            case RDP_CAPSET_SHARE: /* 9 */
+            case RDP_CAPSET_SHARE: /* 0x09 */
                 DEBUG(("RDP_CAPSET_SHARE"));
                 break;
-            case RDP_CAPSET_COLCACHE: /* 10 */
+            case RDP_CAPSET_COLCACHE: /* 0x0A */
                 DEBUG(("RDP_CAPSET_COLCACHE"));
                 break;
-            case 12: /* 12 */
-                DEBUG(("--12"));
+            case RDP_CAPSET_SOUND: /* 0x0C */
+                DEBUG(("--0x0C"));
                 break;
-            case 13: /* 13 */
+            case RDP_CAPSET_INPUT: /* 0x0D */
                 xrdp_caps_process_input(self, s, len);
                 break;
-            case 14: /* 14 */
-                DEBUG(("--14"));
+            case RDP_CAPSET_FONT: /* 0x0E */
+                DEBUG(("--0x0D"));
                 break;
-            case RDP_CAPSET_BRUSHCACHE: /* 15 */
+            case RDP_CAPSET_BRUSHCACHE: /* 0x0F */
                 xrdp_caps_process_brushcache(self, s, len);
                 break;
-            case 16: /* 16 */
-                DEBUG(("--16"));
+            case RDP_CAPSET_GLYPHCACHE: /* 0x11 */
+                DEBUG(("--0x11"));
                 break;
-            case 17: /* 17 */
+            case RDP_CAPSET_OFFSCREENCACHE: /* 0x12 */
                 DEBUG(("CAPSET_TYPE_OFFSCREEN_CACHE"));
                 xrdp_caps_process_offscreen_bmpcache(self, s, len);
                 break;
-            case RDP_CAPSET_BMPCACHE2: /* 19 */
+            case RDP_CAPSET_BMPCACHE2: /* 0x13 */
                 DEBUG(("RDP_CAPSET_BMPCACHE2"));
                 xrdp_caps_process_bmpcache2(self, s, len);
                 break;
-            case 20: /* 20 */
-                DEBUG(("--20"));
+            case RDP_CAPSET_VIRCHAN: /* 0x14 */
+                DEBUG(("--0x14"));
                 break;
-            case 21: /* 21 */
-                DEBUG(("--21"));
+            case RDP_CAPSET_DRAWNINEGRIDCACHE: /* 0x15 */
+                DEBUG(("--0x15"));
                 break;
-            case 22: /* 22 */
-                DEBUG(("--22"));
+            case RDP_CAPSET_DRAWGDIPLUS: /* 0x16 */
+                DEBUG(("--0x16"));
                 break;
-            case 0x0017: /* 23 CAPSETTYPE_RAIL */
+            case RDP_CAPSET_RAIL: /* 0x17 CAPSETTYPE_RAIL */
                 xrdp_caps_process_rail(self, s, len);
                 break;
-            case 0x0018: /* 24 CAPSETTYPE_WINDOW */
+            case RDP_CAPSET_WINDOW: /* 24 CAPSETTYPE_WINDOW */
                 xrdp_caps_process_window(self, s, len);
                 break;
-            case 0x001A: /* 26 CAPSETTYPE_MULTIFRAGMENTUPDATE */
+            case RDP_CAPSET_MULTIFRAGMENT: /* 26 CAPSETTYPE_MULTIFRAGMENTUPDATE */
                 xrdp_caps_process_multifragmentupdate(self, s, len);
                 break;
-            case RDP_CAPSET_BMPCODECS: /* 0x1d(29) */
+            case RDP_CAPSET_SURFCMDS: /* 0x1C CAPSETTYPE_SURFACE_COMMANDS */
+                xrdp_caps_process_surface_cmds(self, s, len);
+                break;
+            case RDP_CAPSET_BMPCODECS: /* 0x1D */
                 xrdp_caps_process_codecs(self, s, len);
                 break;
-            case 0x001E: /* CAPSSETTYPE_FRAME_ACKNOWLEDGE */
+            case RDP_CAPSET_FRAME_ACKNOWLEDGE: /* 0x1E CAPSSETTYPE_FRAME_ACKNOWLEDGE */
                 xrdp_caps_process_frame_ack(self, s, len);
-                break;
-            case RDP_CAPSET_SURFCMDS: /* CAPSETTYPE_SURFACE_COMMANDS */
-                xrdp_caps_process_surface_cmds(self, s, len);
                 break;
             default:
                 g_writeln("unknown in xrdp_caps_process_confirm_active %d", type);

--- a/libxrdp/xrdp_caps.c
+++ b/libxrdp/xrdp_caps.c
@@ -610,88 +610,88 @@ xrdp_caps_process_confirm_active(struct xrdp_rdp *self, struct stream *s)
         len -= 4;
         switch (type)
         {
-            case RDP_CAPSET_GENERAL: /* 0x01 */
+            case RDP_CAPSET_GENERAL:
                 DEBUG(("RDP_CAPSET_GENERAL"));
                 xrdp_caps_process_general(self, s, len);
                 break;
-            case RDP_CAPSET_BITMAP: /* 0x02 */
+            case RDP_CAPSET_BITMAP:
                 DEBUG(("RDP_CAPSET_BITMAP"));
                 break;
-            case RDP_CAPSET_ORDER: /* 0x03 */
+            case RDP_CAPSET_ORDER:
                 DEBUG(("RDP_CAPSET_ORDER"));
                 xrdp_caps_process_order(self, s, len);
                 break;
-            case RDP_CAPSET_BMPCACHE: /* 0x04 */
+            case RDP_CAPSET_BMPCACHE:
                 DEBUG(("RDP_CAPSET_BMPCACHE"));
                 xrdp_caps_process_bmpcache(self, s, len);
                 break;
-            case RDP_CAPSET_CONTROL: /* 0x05 */
+            case RDP_CAPSET_CONTROL:
                 DEBUG(("RDP_CAPSET_CONTROL"));
                 break;
             case 6:
                 xrdp_caps_process_cache_v3_codec_id(self, s, len);
                 break;
-            case RDP_CAPSET_ACTIVATE: /* 0x07 */
+            case RDP_CAPSET_ACTIVATE:
                 DEBUG(("RDP_CAPSET_ACTIVATE"));
                 break;
-            case RDP_CAPSET_POINTER: /* 0x08 */
+            case RDP_CAPSET_POINTER:
                 DEBUG(("RDP_CAPSET_POINTER"));
                 xrdp_caps_process_pointer(self, s, len);
                 break;
-            case RDP_CAPSET_SHARE: /* 0x09 */
+            case RDP_CAPSET_SHARE:
                 DEBUG(("RDP_CAPSET_SHARE"));
                 break;
-            case RDP_CAPSET_COLCACHE: /* 0x0A */
+            case RDP_CAPSET_COLCACHE:
                 DEBUG(("RDP_CAPSET_COLCACHE"));
                 break;
-            case RDP_CAPSET_SOUND: /* 0x0C */
+            case RDP_CAPSET_SOUND:
                 DEBUG(("--0x0C"));
                 break;
-            case RDP_CAPSET_INPUT: /* 0x0D */
+            case RDP_CAPSET_INPUT:
                 xrdp_caps_process_input(self, s, len);
                 break;
-            case RDP_CAPSET_FONT: /* 0x0E */
+            case RDP_CAPSET_FONT:
                 DEBUG(("--0x0D"));
                 break;
-            case RDP_CAPSET_BRUSHCACHE: /* 0x0F */
+            case RDP_CAPSET_BRUSHCACHE:
                 xrdp_caps_process_brushcache(self, s, len);
                 break;
-            case RDP_CAPSET_GLYPHCACHE: /* 0x11 */
+            case RDP_CAPSET_GLYPHCACHE:
                 DEBUG(("--0x11"));
                 break;
-            case RDP_CAPSET_OFFSCREENCACHE: /* 0x12 */
+            case RDP_CAPSET_OFFSCREENCACHE:
                 DEBUG(("CAPSET_TYPE_OFFSCREEN_CACHE"));
                 xrdp_caps_process_offscreen_bmpcache(self, s, len);
                 break;
-            case RDP_CAPSET_BMPCACHE2: /* 0x13 */
+            case RDP_CAPSET_BMPCACHE2:
                 DEBUG(("RDP_CAPSET_BMPCACHE2"));
                 xrdp_caps_process_bmpcache2(self, s, len);
                 break;
-            case RDP_CAPSET_VIRCHAN: /* 0x14 */
+            case RDP_CAPSET_VIRCHAN:
                 DEBUG(("--0x14"));
                 break;
-            case RDP_CAPSET_DRAWNINEGRIDCACHE: /* 0x15 */
+            case RDP_CAPSET_DRAWNINEGRIDCACHE:
                 DEBUG(("--0x15"));
                 break;
-            case RDP_CAPSET_DRAWGDIPLUS: /* 0x16 */
+            case RDP_CAPSET_DRAWGDIPLUS:
                 DEBUG(("--0x16"));
                 break;
-            case RDP_CAPSET_RAIL: /* 0x17 CAPSETTYPE_RAIL */
+            case RDP_CAPSET_RAIL:
                 xrdp_caps_process_rail(self, s, len);
                 break;
-            case RDP_CAPSET_WINDOW: /* 24 CAPSETTYPE_WINDOW */
+            case RDP_CAPSET_WINDOW:
                 xrdp_caps_process_window(self, s, len);
                 break;
-            case RDP_CAPSET_MULTIFRAGMENT: /* 26 CAPSETTYPE_MULTIFRAGMENTUPDATE */
+            case RDP_CAPSET_MULTIFRAGMENT:
                 xrdp_caps_process_multifragmentupdate(self, s, len);
                 break;
-            case RDP_CAPSET_SURFCMDS: /* 0x1C CAPSETTYPE_SURFACE_COMMANDS */
+            case RDP_CAPSET_SURFCMDS:
                 xrdp_caps_process_surface_cmds(self, s, len);
                 break;
-            case RDP_CAPSET_BMPCODECS: /* 0x1D */
+            case RDP_CAPSET_BMPCODECS:
                 xrdp_caps_process_codecs(self, s, len);
                 break;
-            case RDP_CAPSET_FRAME_ACKNOWLEDGE: /* 0x1E CAPSSETTYPE_FRAME_ACKNOWLEDGE */
+            case RDP_CAPSET_FRAME_ACKNOWLEDGE:
                 xrdp_caps_process_frame_ack(self, s, len);
                 break;
             default:

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -1608,10 +1608,10 @@ xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec* self, struct stream* s)
     g_writeln("colorDepth 0x%4.4x (0xca00 4bpp 0xca01 8bpp)", colorDepth);
     switch (colorDepth)
     {
-        case 0xca00: /* RNS_UD_COLOR_4BPP */
+        case RNS_UD_COLOR_4BPP:
             self->rdp_layer->client_info.bpp = 4;
             break;
-        case 0xca01: /* RNS_UD_COLOR_8BPP */
+        case RNS_UD_COLOR_8BPP:
             self->rdp_layer->client_info.bpp = 8;
             break;
     }
@@ -1630,19 +1630,19 @@ xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec* self, struct stream* s)
 
     switch (postBeta2ColorDepth)
     {
-        case 0xca00: /* RNS_UD_COLOR_4BPP */
+        case RNS_UD_COLOR_4BPP:
             self->rdp_layer->client_info.bpp = 4;
             break;
-        case 0xca01: /* RNS_UD_COLOR_8BPP */
+        case RNS_UD_COLOR_8BPP :
             self->rdp_layer->client_info.bpp = 8;
             break;
-        case 0xca02: /* RNS_UD_COLOR_16BPP_555 */
+        case RNS_UD_COLOR_16BPP_555:
             self->rdp_layer->client_info.bpp = 15;
             break;
-        case 0xca03: /* RNS_UD_COLOR_16BPP_565 */
+        case RNS_UD_COLOR_16BPP_565:
             self->rdp_layer->client_info.bpp = 16;
             break;
-        case 0xca04: /* RNS_UD_COLOR_24BPP */
+        case RNS_UD_COLOR_24BPP:
             self->rdp_layer->client_info.bpp = 24;
             break;
     }


### PR DESCRIPTION
Define capset constants in hex as MS-RDPBCGR does. Easier to compare with MS documents.