### PR TITLE
[refactor] change unclear variable name 

### DIFF
--- a/sesman/config.c
+++ b/sesman/config.c
@@ -472,29 +472,29 @@ config_read_session_variables(int file, struct config_sesman *cs,
     list_clear(param_v);
     list_clear(param_n);
 
-    cs->session_variables1 = list_create();
-    cs->session_variables1->auto_free = 1;
-    cs->session_variables2 = list_create();
-    cs->session_variables2->auto_free = 1;
+    cs->env_names = list_create();
+    cs->env_names->auto_free = 1;
+    cs->env_values = list_create();
+    cs->env_values->auto_free = 1;
 
     file_read_section(file, SESMAN_CFG_SESSION_VARIABLES, param_n, param_v);
 
     for (i = 0; i < param_n->count; i++)
     {
-        list_add_item(cs->session_variables1,
+        list_add_item(cs->env_names,
                       (tintptr) g_strdup((char *) list_get_item(param_n, i)));
-        list_add_item(cs->session_variables2,
+        list_add_item(cs->env_values,
                       (tintptr) g_strdup((char *) list_get_item(param_v, i)));
     }
 
     /* printing session variables */
     g_writeln("%s parameters:", SESMAN_CFG_SESSION_VARIABLES);
 
-    for (i = 0; i < cs->session_variables1->count; i++)
+    for (i = 0; i < cs->env_names->count; i++)
     {
         g_writeln("  Parameter %02d                   %s=%s", i,
-               (char *) list_get_item(cs->session_variables1, i),
-               (char *) list_get_item(cs->session_variables2, i));
+               (char *) list_get_item(cs->env_names, i),
+               (char *) list_get_item(cs->env_values, i));
     }
 
     return 0;
@@ -506,7 +506,7 @@ config_free(struct config_sesman *cs)
     list_delete(cs->rdp_params);
     list_delete(cs->vnc_params);
     list_delete(cs->xorg_params);
-    list_delete(cs->session_variables1);
-    list_delete(cs->session_variables2);
+    list_delete(cs->env_names);
+    list_delete(cs->env_values);
     g_free(cs);
 }

--- a/sesman/config.h
+++ b/sesman/config.h
@@ -240,8 +240,16 @@ struct config_sesman
    */
   struct config_sessions sess;
 
-  struct list* session_variables1;
-  struct list* session_variables2;
+  /**
+   * @var env_names
+   * @brief environment variable name list
+   */
+  struct list* env_names;
+   /**
+   * @var env_values
+   * @brief environment variable value list
+   */
+  struct list* env_values;
 };
 
 /**

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -360,7 +360,7 @@ session_start_chansrv(char *username, int display)
     chansrv_pid = g_fork();
     if (chansrv_pid == 0)
     {
-        chansrv_params = list_create(); 
+        chansrv_params = list_create();
         chansrv_params->auto_free = 1;
 
         /* building parameters */

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -371,8 +371,8 @@ session_start_chansrv(char *username, int display)
         list_add_item(chansrv_params, 0); /* mandatory */
 
         env_set_user(username, 0, display,
-                     g_cfg->session_variables1,
-                     g_cfg->session_variables2);
+                     g_cfg->env_names,
+                     g_cfg->env_values);
 
         /* executing chansrv */
         g_execvp(exe_path, (char **) (chansrv_params->items));
@@ -513,8 +513,8 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
             env_set_user(s->username,
                          0,
                          display,
-                         g_cfg->session_variables1,
-                         g_cfg->session_variables2);
+                         g_cfg->env_names,
+                         g_cfg->env_values);
             if (x_server_running(display))
             {
                 auth_set_env(data);
@@ -604,16 +604,16 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
                     env_set_user(s->username,
                                  &passwd_file,
                                  display,
-                                 g_cfg->session_variables1,
-                                 g_cfg->session_variables2);
+                                 g_cfg->env_names,
+                                 g_cfg->env_values);
                 }
                 else
                 {
                     env_set_user(s->username,
                                  0,
                                  display,
-                                 g_cfg->session_variables1,
-                                 g_cfg->session_variables2);
+                                 g_cfg->env_names,
+                                 g_cfg->env_values);
                 }
 
 
@@ -857,8 +857,8 @@ session_reconnect_fork(int display, char *username)
         env_set_user(username,
                      0,
                      display,
-                     g_cfg->session_variables1,
-                     g_cfg->session_variables2);
+                     g_cfg->env_names,
+                     g_cfg->env_values);
         g_snprintf(text, 255, "%s/%s", XRDP_CFG_PATH, "reconnectwm.sh");
 
         if (g_file_exist(text))


### PR DESCRIPTION
The new names are used in prototype declaration of this function.

```C
int
env_set_user(const char *username, char **passwd_file, int display,
const struct list *env_names, const struct list *env_values);
```