### PR TITLE
Make listen check before daemon fork

### DIFF
--- a/sesman/sesman.c
+++ b/sesman/sesman.c
@@ -343,18 +343,17 @@ main(int argc, char **argv)
     if (daemon)
     {
         /* start of daemonizing code */
-        g_pid = g_fork();
-
-        if (0 != g_pid)
+        if (sesman_listen_test(g_cfg) != 0)
         {
-            if (sesman_listen_test(g_cfg) != 0)
-	    {
 
-                log_message(LOG_LEVEL_ERROR, "Failed to start xrdp-sesman daemon, "
-                                             "possibly address already in use.");
-                g_deinit();
-                g_exit(1);
-            }
+            log_message(LOG_LEVEL_ERROR, "Failed to start xrdp-sesman daemon, "
+                                         "possibly address already in use.");
+            g_deinit();
+            g_exit(1);
+        }
+
+        if (0 != g_fork())
+        {
             g_deinit();
             g_exit(0);
         }


### PR DESCRIPTION
There seems to be a race condition related to sesman_listen_test() when  xrdp-sesman is run in daemon mode.

Because sesman_listen_test() is called after the daemon fork() call, there is a chance that it will be called in the parent at the same time as the child trying to listen. The following log was produced on a RHEL 7.4 system when this happens:-

```
xrdp-sesman[11958]: (11958)(139665042258048)[DEBUG] libscp initialized
xrdp-sesman[11961]: (11961)(139665042258048)[INFO ] starting xrdp-sesman with pid 11961
xrdp-sesman[11958]: (11958)(139665042258048)[DEBUG] Testing if xrdp-sesman can listen on 127.0.0.1 port 3350.
xrdp-sesman[11961]: (11961)(139665042258048)[INFO ] listening to port 3350 on 127.0.0.1
xrdp-sesman[11958]: (11958)(139665042258048)[ERROR] Failed to start xrdp-sesman daemon, possibly address already in use.
systemd[1]: xrdp-sesman.service: control process exited, code=exited status=1
xrdp-sesman[11961]: (11961)(139665042258048)[INFO ] shutting down sesman 1
xrdp-sesman[11961]: (11961)(139665042258048)[DEBUG] Closed socket 9 (AF_INET 127.0.0.1:3350)
```

With the attached patch, the two processes did not interfere with each other, and this log was produced:-

```
xrdp-sesman[11991]: (11991)(140064586561664)[DEBUG] libscp initialized
xrdp-sesman[11991]: (11991)(140064586561664)[DEBUG] Testing if xrdp-sesman can listen on 127.0.0.1 port 3350.
xrdp-sesman[11994]: (11994)(140064586561664)[INFO ] starting xrdp-sesman with pid 11994
xrdp-sesman[11991]: (11991)(140064586561664)[DEBUG] Closed socket 7 (AF_INET 127.0.0.1:3350)
xrdp-sesman[11994]: (11994)(140064586561664)[INFO ] listening to port 3350 on 127.0.0.1
systemd[1]: Started xrdp session manager.
```
