### PR TITLE
fix potential fd leak

### DIFF
--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -265,7 +265,7 @@ xrdp_load_keyboard_layout(struct xrdp_client_info *client_info)
 
     fd = g_file_open(keyboard_cfg_file);
 
-    if (fd > 0)
+    if (fd >= 0)
     {
         int section_found = -1;
         char section_rdp_layouts[256] = { 0 };

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -1310,7 +1310,7 @@ xrdp_mm_get_sesman_port(char *port, int port_bytes)
     g_snprintf(cfg_file, 255, "%s/sesman.ini", XRDP_CFG_PATH);
     fd = g_file_open(cfg_file);
 
-    if (fd > 0)
+    if (fd >= 0)
     {
         names = list_create();
         names->auto_free = 1;
@@ -1343,10 +1343,8 @@ xrdp_mm_get_sesman_port(char *port, int port_bytes)
 
         list_delete(names);
         list_delete(values);
-    }
-
-    if (fd != -1)
         g_file_close(fd);
+    }
 
     return 0;
 }

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -405,7 +405,7 @@ xrdp_wm_load_static_colors_plus(struct xrdp_wm *self, char *autorun_name)
     g_snprintf(cfg_file, 255, "%s/xrdp.ini", XRDP_CFG_PATH);
     fd = g_file_open(cfg_file);
 
-    if (fd > 0)
+    if (fd >= 0)
     {
         names = list_create();
         names->auto_free = 1;


### PR DESCRIPTION
In most cases, checking fd > 0 is not valid. open(2) returns -1 on
error, 0 on stdin, 1 on stdout, 2 on stderr, >2 . The border should be
between -1 and 0. Additionally, between 2 and 3.

Pointed out by: #919