### PR TITLE
Make changes to generate dylibs in mac again

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,12 +40,16 @@ case $host_os in
 	*openbsd*)
 		openbsd=yes
 		;;
+	*darwin*)
+		macos=yes
+		;;
 esac
 
 AM_CONDITIONAL(LINUX, [test "x$linux" = xyes])
 AM_CONDITIONAL(FREEBSD, [test "x$freebsd" = xyes])
 AM_CONDITIONAL(OPENBSD, [test "x$openbsd" = xyes])
 AM_CONDITIONAL(NETBSD, [test "x$netbsd" = xyes])
+AM_CONDITIONAL(MACOS, [test "x$macos" = xyes])
 
 AC_ARG_WITH([socketdir],
   [AS_HELP_STRING([--with-socketdir=DIR],

--- a/mc/Makefile.am
+++ b/mc/Makefile.am
@@ -19,4 +19,6 @@ libmc_la_SOURCES = \
 libmc_la_LIBADD = \
   $(top_builddir)/common/libcommon.la
 
+if !MACOS
 libmc_la_LDFLAGS = -avoid-version -module
+endif

--- a/vnc/Makefile.am
+++ b/vnc/Makefile.am
@@ -19,4 +19,6 @@ libvnc_la_SOURCES = \
 libvnc_la_LIBADD = \
   $(top_builddir)/common/libcommon.la
 
+if !MACOS
 libvnc_la_LDFLAGS = -avoid-version -module
+endif

--- a/xup/Makefile.am
+++ b/xup/Makefile.am
@@ -19,4 +19,6 @@ libxup_la_SOURCES = \
 libxup_la_LIBADD = \
   $(top_builddir)/common/libcommon.la
 
+if !MACOS
 libxup_la_LDFLAGS = -avoid-version -module
+endif


### PR DESCRIPTION
The *-module* prevents Mac OS' toolchain from creating *.dylib* files, for xrdp to work on Mac OS these files are needed. This will fix issue #790 