### PR TITLE
Added PAM support for Mac OS

### DIFF
--- a/instfiles/Makefile.am
+++ b/instfiles/Makefile.am
@@ -78,6 +78,10 @@ SUBDIRS += \
   pulse
 endif
 
+if MACOS
+SUBDIRS += pam.d
+endif
+
 #
 # install-data-hook for each platform
 # TODO: subst these directories as well as service files

--- a/instfiles/pam.d/Makefile.am
+++ b/instfiles/pam.d/Makefile.am
@@ -3,6 +3,7 @@ PAM_FILES = \
   xrdp-sesman.redhat \
   xrdp-sesman.suse \
   xrdp-sesman.freebsd \
+  xrdp-sesman.macos \
   xrdp-sesman.unix
 
 EXTRA_DIST = $(PAM_FILES) mkpamrules

--- a/instfiles/pam.d/mkpamrules
+++ b/instfiles/pam.d/mkpamrules
@@ -30,6 +30,11 @@ guess_rules ()
     return
   fi
 
+  if test -s "$pamdir/authorization"; then
+    rules="macos"
+    return
+  fi
+
   rules="unix"
   return
 }

--- a/instfiles/pam.d/xrdp-sesman.macos
+++ b/instfiles/pam.d/xrdp-sesman.macos
@@ -1,0 +1,12 @@
+# xrdp-sesman: auth account password session
+# based on Apple's sshd PAM configuration
+auth       optional       pam_krb5.so use_kcminit
+auth       optional       pam_ntlm.so try_first_pass
+auth       optional       pam_mount.so try_first_pass
+auth       required       pam_opendirectory.so try_first_pass
+account    required       pam_nologin.so
+account    required       pam_sacl.so sacl_service=ssh
+account    required       pam_opendirectory.so
+password   required       pam_opendirectory.so
+session    required       pam_launchd.so
+session    optional       pam_mount.so


### PR DESCRIPTION
Mac OS supports PAM, so it makes sense to add support for it, at least I can login after this commit (there are more issues down the line, but this commit fixes that).

Some notes:
* I'm not sure at all if the file */etc/pam.d/authorization* is unique to Mac OS, but it seems to be standard for it (is available in both machines I use)
* The PAM configuration file I uploaded (*xrdp-sesman.macos*) is basically the same as Mac OS' default SSH's PAM configuration, I don't know how to fine tune it but it makes sense you need the same permissions as SSH