### PR TITLE
FreeBSD: rework setsid code

### DIFF
--- a/sesman/session.c
+++ b/sesman/session.c
@@ -484,22 +484,40 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
          *  $OpenBSD: session.c,v 1.252 2010/03/07 11:57:13 dtucker Exp $
          *  with some ideas about BSD process grouping to xrdp
          */
+        pid_t bsdsespid = g_fork();
 
-        /**
-         * Create a new session and process group since the 4.4BSD
-         * setlogin() affects the entire process group
-         */
-        if (g_setsid() < 0)
+        if (bsdsespid == -1)
         {
-            log_message(LOG_LEVEL_ERROR,
-                        "setsid failed - pid %d", g_getpid());
+        }
+        else if (bsdsespid == 0) /* BSD session leader */
+        {
+            /**
+             * Create a new session and process group since the 4.4BSD
+             * setlogin() affects the entire process group
+             */
+            if (g_setsid() < 0)
+            {
+                log_message(LOG_LEVEL_ERROR,
+                            "setsid failed - pid %d", g_getpid());
+            }
+
+            if (g_setlogin(s->username) < 0)
+            {
+                log_message(LOG_LEVEL_ERROR,
+                            "setlogin failed for user %s - pid %d", s->username,
+                            g_getpid());
+            }
         }
 
-        if (g_setlogin(s->username) < 0)
+        g_waitpid(bsdsespid);
+
+        if (bsdsespid > 0)
         {
-            log_message(LOG_LEVEL_ERROR,
-                        "setlogin failed for user %s - pid %d", s->username,
-                        g_getpid());
+            g_exit(0);
+            /*
+             * intermediate sesman should exit here after WM exits.
+             * do not execure the following codes.
+             */
         }
 #endif
         window_manager_pid = g_fork(); /* parent becomes X,


### PR DESCRIPTION
Pull request #650 is not valid to avoid run session twice.
It certainly stops running session twice but causes #1016.

In FreeBSD, sesman process will run like this. The intermediate
sesman is needed to detect session termination correctly.
```
xrdp-sesman (daemon)
    |
    +- xrdp-sesman (FreeBSD specific intermediate sesman)
        |
        +- xrdp-sesman (bsd sesion leader & each session)
             |
             +- Xorg
             +- startwm.sh
             +- xrdp-chansrv
```

To stop runninng session twice correctly, just exit before the
intermediate sesman executes Xorg, WM and chansrv.