### PR TITLE
Make xrdp.ini to be dynamic for each operating system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ sesman/tools/xrdp-sesrun
 sesman/tools/xrdp-sestest
 sesman/tools/xrdp-xcon
 sesman/xrdp-sesman
+sesman/sesman.ini
 *.so
 stamp-h1
 xrdp/xrdp

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ sesman/xrdp-sesman
 *.so
 stamp-h1
 xrdp/xrdp
+xrdp/xrdp.ini

--- a/sesman/Makefile.am
+++ b/sesman/Makefile.am
@@ -75,6 +75,17 @@ xrdp_sesman_LDADD = \
 
 sesmansysconfdir=$(sysconfdir)/xrdp
 
+SUBST_VARS = sed \
+   -e 's|@sesmansysconfdir[@]|$(sesmansysconfdir)|g'
+
+subst_verbose = $(subst_verbose_@AM_V@)
+subst_verbose_ = $(subst_verbose_@AM_DEFAULT_V@)
+subst_verbose_0 = @echo "  SUBST    $@";
+
+SUFFIXES = .in
+.in:
+	$(subst_verbose)$(SUBST_VARS) $< > $@
+
 dist_sesmansysconf_DATA = \
   sesman.ini
 

--- a/sesman/sesman.ini.in
+++ b/sesman/sesman.ini.in
@@ -99,4 +99,4 @@ param=96
 FuseMountName=thinclient_drives
 
 [SessionVariables]
-PULSE_SCRIPT=/etc/xrdp/pulse/default.pa
+PULSE_SCRIPT=@sesmansysconfdir@/pulse/default.pa

--- a/xrdp/Makefile.am
+++ b/xrdp/Makefile.am
@@ -67,6 +67,23 @@ xrdp_LDADD = \
 
 xrdpsysconfdir=$(sysconfdir)/xrdp
 
+if MACOS
+lib_extension = dylib
+else
+lib_extension = so
+endif
+
+SUBST_VARS = sed \
+   -e 's|@lib_extension[@]|$(lib_extension)|g'
+
+subst_verbose = $(subst_verbose_@AM_V@)
+subst_verbose_ = $(subst_verbose_@AM_DEFAULT_V@)
+subst_verbose_0 = @echo "  SUBST    $@";
+
+SUFFIXES = .in
+.in:
+	$(subst_verbose)$(SUBST_VARS) $< > $@
+
 dist_xrdpsysconf_DATA = \
   xrdp.ini \
   xrdp_keyboard.ini

--- a/xrdp/xrdp.ini.in
+++ b/xrdp/xrdp.ini.in
@@ -155,7 +155,7 @@ tcutils=true
 ; in sesman.ini. See and configure also sesman.ini.
 [Xorg]
 name=Xorg
-lib=libxup.so
+lib=libxup.@lib_extension@
 username=ask
 password=ask
 ip=127.0.0.1
@@ -164,7 +164,7 @@ code=20
 
 [X11rdp]
 name=X11rdp
-lib=libxup.so
+lib=libxup.@lib_extension@
 username=ask
 password=ask
 ip=127.0.0.1
@@ -174,7 +174,7 @@ code=10
 
 [Xvnc]
 name=Xvnc
-lib=libvnc.so
+lib=libvnc.@lib_extension@
 username=ask
 password=ask
 ip=127.0.0.1
@@ -184,7 +184,7 @@ port=-1
 
 [console]
 name=console
-lib=libvnc.so
+lib=libvnc.@lib_extension@
 ip=127.0.0.1
 port=5900
 username=na
@@ -193,7 +193,7 @@ password=ask
 
 [vnc-any]
 name=vnc-any
-lib=libvnc.so
+lib=libvnc.@lib_extension@
 ip=ask
 port=ask5900
 username=na
@@ -205,7 +205,7 @@ password=ask
 
 [sesman-any]
 name=sesman-any
-lib=libvnc.so
+lib=libvnc.@lib_extension@
 ip=ask
 port=-1
 username=ask
@@ -214,7 +214,7 @@ password=ask
 
 [neutrinordp-any]
 name=neutrinordp-any
-lib=libxrdpneutrinordp.so
+lib=libxrdpneutrinordp.@lib_extension@
 ip=ask
 port=ask3389
 username=ask


### PR DESCRIPTION
Mac OS needs libraries to be `.dylib` instead of `.so`. By using the same logic available in _docs/man/Makefile.am_ this commit makes the _xrdp/xrdp.ini_ file to depend on the operating system and replace the libraries extensions where necessary