### PR TITLE
Do not treat `!` as a comment out symbol

### DIFF
--- a/common/file.c
+++ b/common/file.c
@@ -138,7 +138,7 @@ file_read_ini_line(struct stream *s, char *text, int text_bytes)
     while (c != 10 && c != 13)
     {
         /* these mean skip the rest of the line */
-        if (c == '#' || c == '!' || c == ';')
+        if (c == '#' || c == ';')
         {
             skip_to_end = 1;
         }

--- a/common/ssl_calls.c
+++ b/common/ssl_calls.c
@@ -595,6 +595,7 @@ ssl_tls_accept(struct ssl_tls *self, long ssl_protocols,
 
     if (g_strlen(tls_ciphers) > 1)
     {
+        log_message(LOG_LEVEL_TRACE, "ssl_tls_accept: tls_ciphers=%s", tls_ciphers);
         if (SSL_CTX_set_cipher_list(self->ctx, tls_ciphers) == 0)
         {
             g_writeln("ssl_tls_accept: invalid cipher options");


### PR DESCRIPTION
The simplest fix for #1033.