### PR TITLE
Revert "devredir: fix xinode leak"

### DIFF
--- a/sesman/chansrv/devredir.c
+++ b/sesman/chansrv/devredir.c
@@ -986,8 +986,6 @@ dev_redir_proc_query_dir_response(IRP *irp,
         /* add this entry to xrdp file system */
         fuse_data = devredir_fuse_data_peek(irp);
         xfuse_devredir_cb_enum_dir(fuse_data->data_ptr, xinode);
-
-        g_free(xinode);
     }
 
     dev_redir_send_drive_dir_request(irp, DeviceId, 0, NULL);


### PR DESCRIPTION
Sorry about that. I should have been careful.   After reverting this commit, drive redirection works again. This should be shipped to v0.9.6.

----
This reverts commit 5daa09171e1e6e65a1a3ab969775fdf8affffc37.

Causes "double free":

```
[1271363627]: DEV_REDIR  dev_redir_proc_device_iocompletion: 738 : entered: IoStatus=0x0 CompletionId=1
[1271363627]: DEV_REDIR  dev_redir_proc_device_iocompletion: 839 : got CID_DIRECTORY_CONTROL
[1271363627]: DEV_REDIR  dev_redir_proc_query_dir_response: 933 : processing FILE_DIRECTORY_INFORMATION structs
[1271363627]: DEV_REDIR  dev_redir_proc_query_dir_response: 968 : FileName:          .
[1271363627]: DEV_REDIR  devredir_fuse_data_peek: 1335 : returning 0x7f2a9c013410
*** Error in `/usr/sbin/xrdp-chansrv': double free or corruption (out): 0x00007f2a9c13a330 ***
```