### PR TITLE
instfiles: Add pam.d config for arch linux.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -96,7 +96,7 @@ AC_ARG_ENABLE(pamuserpass, AS_HELP_STRING([--enable-pamuserpass],
               [], [enable_pamuserpass=no])
 AM_CONDITIONAL(SESMAN_PAMUSERPASS, [test x$enable_pamuserpass = xyes])
 AC_ARG_ENABLE(pam-config, AS_HELP_STRING([--enable-pam-config=CONF],
-              [Select PAM config to install: arch, debian, redhat, suse, freebsd, unix
+              [Select PAM config to install: arch, debian, redhat, suse, freebsd, macos, unix
                (default: autodetect)]))
 
 AC_ARG_ENABLE(xrdpdebug, AS_HELP_STRING([--enable-xrdpdebug],

--- a/configure.ac
+++ b/configure.ac
@@ -96,7 +96,7 @@ AC_ARG_ENABLE(pamuserpass, AS_HELP_STRING([--enable-pamuserpass],
               [], [enable_pamuserpass=no])
 AM_CONDITIONAL(SESMAN_PAMUSERPASS, [test x$enable_pamuserpass = xyes])
 AC_ARG_ENABLE(pam-config, AS_HELP_STRING([--enable-pam-config=CONF],
-              [Select PAM config to install: debian, redhat, suse, freebsd, unix
+              [Select PAM config to install: arch, debian, redhat, suse, freebsd, unix
                (default: autodetect)]))
 
 AC_ARG_ENABLE(xrdpdebug, AS_HELP_STRING([--enable-xrdpdebug],

--- a/instfiles/pam.d/Makefile.am
+++ b/instfiles/pam.d/Makefile.am
@@ -4,7 +4,8 @@ PAM_FILES = \
   xrdp-sesman.suse \
   xrdp-sesman.freebsd \
   xrdp-sesman.macos \
-  xrdp-sesman.unix
+  xrdp-sesman.unix \
+  xrdp-sesman.arch
 
 EXTRA_DIST = $(PAM_FILES) mkpamrules
 

--- a/instfiles/pam.d/mkpamrules
+++ b/instfiles/pam.d/mkpamrules
@@ -35,6 +35,11 @@ guess_rules ()
     return
   fi
 
+  if test -s "$pamdir/system-remote-login"; then
+    rules="arch"
+    return
+  fi
+
   rules="unix"
   return
 }

--- a/instfiles/pam.d/xrdp-sesman.arch
+++ b/instfiles/pam.d/xrdp-sesman.arch
@@ -1,0 +1,5 @@
+#%PAM-1.0
+auth        include     system-remote-login
+account     include     system-remote-login
+password    include     system-remote-login
+session     include     system-remote-login


### PR DESCRIPTION
system-auth didn't work for gnome under arch linux. 

According to https://wiki.archlinux.org/index.php/PAM#PAM_base-stack system-remote-login seemed to be the right choice. Works for gnome at least.