### PR TITLE
Corrected endianness detection on ppc64el.

### DIFF
--- a/common/arch.h
+++ b/common/arch.h
@@ -63,8 +63,10 @@ typedef int bool_t;
 #endif
 
 #if !(defined(L_ENDIAN) || defined(B_ENDIAN))
-#if defined(__sparc__) || defined(__PPC__) || defined(__ppc__) || \
-    defined(__hppa__)
+#if defined(__sparc__) || \
+    defined(__hppa__) || \
+    (defined(__PPC__) && defined(__BIG_ENDIAN__)) || \
+    (defined(__ppc__) && defined(__BIG_ENDIAN__))
 #define B_ENDIAN
 #else
 #define L_ENDIAN
@@ -75,8 +77,10 @@ typedef int bool_t;
 /* check if we need to align data */
 #if !(defined(NEED_ALIGN) || defined(NO_NEED_ALIGN))
 #if defined(__sparc__) || defined(__alpha__) || defined(__hppa__) || \
-    defined(__AIX__) || defined(__PPC__) || defined(__mips__) || \
-    defined(__ia64__) || defined(__ppc__) || defined(__arm__)
+    defined(__AIX__) || defined(__mips__) || \
+    defined(__ia64__) || defined(__arm__) || \
+    (defined(__PPC__) && defined(__BIG_ENDIAN__)) || \
+    (defined(__ppc__) && defined(__BIG_ENDIAN__))
 #define NEED_ALIGN
 #elif defined(__x86__) || defined(__x86_64__) || \
       defined(__AMD64__) || defined(_M_IX86) || defined (_M_AMD64) || \


### PR DESCRIPTION
In common/arch.h, the endianness detection considers all powerpc
architectures as big endian. Since that is not true for ppc64el, I
added a verification that checks other preprocessor macros, only for
ppc cases.

Signed-off-by: Fernando Seiti Furusato <ferseiti@gmail.com>