### PR TITLE
Show OpenSSL version to --version

### DIFF
--- a/common/ssl_calls.c
+++ b/common/ssl_calls.c
@@ -33,6 +33,7 @@
 #include <openssl/bn.h>
 #include <openssl/rsa.h>
 #include <openssl/dh.h>
+#include <openssl/crypto.h>
 
 #include "os_calls.h"
 #include "arch.h"
@@ -78,7 +79,7 @@ DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g)
         return 0;
     }
 
-    if (p != NULL) 
+    if (p != NULL)
     {
         BN_free(dh->p);
         dh->p = p;
@@ -1062,5 +1063,17 @@ ssl_get_protocols_from_string(const char *str, long *ssl_protocols)
     }
     *ssl_protocols = protocols;
     return rv;
+}
+
+/*****************************************************************************/
+const char
+*get_openssl_version()
+{
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    return SSLeay_version(SSLEAY_VERSION);
+#else
+    return OpenSSL_version(OPENSSL_VERSION);
+#endif
+
 }
 

--- a/common/ssl_calls.h
+++ b/common/ssl_calls.h
@@ -114,5 +114,7 @@ const char *
 ssl_get_cipher_name(const struct ssl_st *ssl);
 int
 ssl_get_protocols_from_string(const char *str, long *ssl_protocols);
+const char *
+get_openssl_version();
 
 #endif

--- a/xrdp/xrdp.c
+++ b/xrdp/xrdp.c
@@ -46,6 +46,31 @@ static long g_sync_param2 = 0;
 static long (*g_sync_func)(long param1, long param2);
 
 /*****************************************************************************/
+void
+print_version(void)
+{
+    g_writeln("xrdp %s", PACKAGE_VERSION);
+    g_writeln("  A Remote Desktop Protocol Server.");
+    g_writeln("  Copyright (C) 2004-2018 Jay Sorg, "
+                "Neutrino Labs, and all contributors.");
+    g_writeln("  See https://github.com/neutrinolabs/xrdp for more information.");
+    g_writeln("%s", "");
+    g_writeln("  Compiled with %s", get_openssl_version());
+}
+
+/*****************************************************************************/
+void
+print_help(void)
+{
+    g_writeln("Usage: xrdp [options]");
+    g_writeln("   -h, --help       show help");
+    g_writeln("   -n, --nodaemon   don't fork into background");
+    g_writeln("   -k, --kill       shut down xrdp");
+    g_writeln("   -p, --port       tcp listen port");
+    g_writeln("   -f, --fork       fork on new connection");
+}
+
+/*****************************************************************************/
 /* This function is used to run a function from the main thread.
    Sync_func is the function pointer that will run from main thread
    The function can have two long in parameters and must return long */
@@ -393,9 +418,12 @@ main(int argc, char **argv)
 
     if (xrdp_process_params(argc, argv, startup_params) != 0)
     {
-        g_writeln("Unknown Parameter");
-        g_writeln("xrdp -h for help");
+        print_version();
         g_writeln("%s", "");
+        print_help();
+        g_writeln("%s", "");
+
+        g_writeln("Unknown option");
         g_deinit();
         g_exit(1);
     }
@@ -405,30 +433,17 @@ main(int argc, char **argv)
 
     if (startup_params->help)
     {
+        print_version();
         g_writeln("%s", "");
-        g_writeln("xrdp: A Remote Desktop Protocol server.");
-        g_writeln("Copyright (C) Jay Sorg 2004-2014");
-        g_writeln("See http://www.xrdp.org for more information.");
-        g_writeln("%s", "");
-        g_writeln("Usage: xrdp [options]");
-        g_writeln("   -h, --help       show help");
-        g_writeln("   -n, --nodaemon   don't fork into background");
-        g_writeln("   -k, --kill       shut down xrdp");
-        g_writeln("   -p, --port       tcp listen port");
-        g_writeln("   -f, --fork       fork on new connection");
-        g_writeln("%s", "");
+        print_help();
+
         g_deinit();
         g_exit(0);
     }
 
     if (startup_params->version)
     {
-        g_writeln("%s", "");
-        g_writeln("xrdp: A Remote Desktop Protocol server.");
-        g_writeln("Copyright (C) Jay Sorg 2004-2014");
-        g_writeln("See http://www.xrdp.org for more information.");
-        g_writeln("Version %s", PACKAGE_VERSION);
-        g_writeln("%s", "");
+        print_version();
         g_deinit();
         g_exit(0);
     }

--- a/xrdp/xrdp.c
+++ b/xrdp/xrdp.c
@@ -242,6 +242,14 @@ g_process_waiting_function(void)
 }
 
 /*****************************************************************************/
+/**
+ *
+ * @brief  Command line argument parser
+ * @param  number of command line arguments
+ * @param  pointer array of commandline arguments
+ * @return 0 on success, n on nth argument is unknown
+ *
+ */
 int
 xrdp_process_params(int argc, char **argv,
                     struct xrdp_startup_params *startup_params)
@@ -315,9 +323,9 @@ xrdp_process_params(int argc, char **argv,
             startup_params->fork = 1;
             g_writeln("--fork parameter found, ini override");
         }
-        else
+        else /* unknown option */
         {
-            return 1;
+            return index;
         }
 
         index++;
@@ -402,6 +410,7 @@ main(int argc, char **argv)
     int no_daemon;
     char text[256];
     char pid_file[256];
+    int errored_argc;
 
     g_init("xrdp");
     ssl_init();
@@ -416,14 +425,15 @@ main(int argc, char **argv)
     startup_params = (struct xrdp_startup_params *)
                      g_malloc(sizeof(struct xrdp_startup_params), 1);
 
-    if (xrdp_process_params(argc, argv, startup_params) != 0)
+    errored_argc = xrdp_process_params(argc, argv, startup_params);
+    if (errored_argc > 0)
     {
         print_version();
         g_writeln("%s", "");
         print_help();
         g_writeln("%s", "");
 
-        g_writeln("Unknown option");
+        g_writeln("Unknown option: %s", argv[errored_argc]);
         g_deinit();
         g_exit(1);
     }

--- a/xrdp/xrdp.c
+++ b/xrdp/xrdp.c
@@ -397,7 +397,7 @@ main(int argc, char **argv)
         g_writeln("xrdp -h for help");
         g_writeln("%s", "");
         g_deinit();
-        g_exit(0);
+        g_exit(1);
     }
 
     g_snprintf(pid_file, 255, "%s/xrdp.pid", XRDP_PID_PATH);

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -49,6 +49,10 @@ tbus
 g_get_sync_event(void);
 void
 g_process_waiting_function(void);
+void
+print_version(void);
+void
+print_help(void);
 
 /* xrdp_cache.c */
 struct xrdp_cache*


### PR DESCRIPTION
If multiple versions of OpenSSL installed to the system, it is helpful to know which OpenSSL xrdp uses in case OpenSSL have vulnerability. Also, some cleanups and improvements.

* add OpenSSL version to --version
* use GitHub URL rather than xrdp.org, it should be more helpful
* exit with error code when unknown CLI option given
* show which CLI option is unknown to xrdp

# --version
## before
```
$ xrdp --version

xrdp: A Remote Desktop Protocol server.
Copyright (C) Jay Sorg 2004-2014
See http://www.xrdp.org for more information.
Version 0.9.5

``` 
## after
```
$ xrdp --version
xrdp 0.9.6
  A Remote Desktop Protocol Server.
  Copyright (C) 2004-2018 Jay Sorg, Neutrino Labs, and all contributors.
  See https://github.com/neutrinolabs/xrdp for more information.

  Compiled with OpenSSL 1.0.2o  27 Mar 2018
```
# --help
## before
```
$ xrdp --help

xrdp: A Remote Desktop Protocol server.
Copyright (C) Jay Sorg 2004-2014
See http://www.xrdp.org for more information.

Usage: xrdp [options]
   -h, --help       show help
   -n, --nodaemon   don't fork into background
   -k, --kill       shut down xrdp
   -p, --port       tcp listen port
   -f, --fork       fork on new connection

```
## after
```
$ xrdp --help
xrdp 0.9.6
  A Remote Desktop Protocol Server.
  Copyright (C) 2004-2018 Jay Sorg, Neutrino Labs, and all contributors.
  See https://github.com/neutrinolabs/xrdp for more information.

  Compiled with OpenSSL 1.0.2o  27 Mar 2018

Usage: xrdp [options]
   -h, --help       show help
   -n, --nodaemon   don't fork into background
   -k, --kill       shut down xrdp
   -p, --port       tcp listen port
   -f, --fork       fork on new connection
```

# --unknown-option
## before
```
$ xrdp --nodaemon --unknown-option; echo $?
Unknown Parameter
xrdp -h for help

0
```
## after 
```
$ xrdp --nodaemon --unknown-option; echo $?
xrdp 0.9.6
  A Remote Desktop Protocol Server.
  Copyright (C) 2004-2018 Jay Sorg, Neutrino Labs, and all contributors.
  See https://github.com/neutrinolabs/xrdp for more information.

  Compiled with OpenSSL 1.0.2o  27 Mar 2018

Usage: xrdp [options]
   -h, --help       show help
   -n, --nodaemon   don't fork into background
   -k, --kill       shut down xrdp
   -p, --port       tcp listen port
   -f, --fork       fork on new connection

Unknown option: --unknown-option
1
```