### PR TITLE
configure: set default value for enable_strict_locations

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -328,7 +328,8 @@ AC_SUBST([moduledir], '${libdir}/xrdp')
 AC_ARG_ENABLE([strict-locations],
   [AS_HELP_STRING([--enable-strict-locations],
                   [Use standard Autoconf install directories unless overridden
-                   (default: use /etc and /var)])])
+                   (default: use /etc and /var)])],
+                  [], [enable_strict_locations=no])
 
 if test "x$enable_strict_locations" != "xyes"; then
   sysconfdir="/etc";


### PR DESCRIPTION
This change prints yes or no to configure summary introduced in #1118.

```
$ ./configure --prefix=/usr/local
xrdp will be compiled with:

  mp3lame         no
  opus            no
  fdkaac          no
  jpeg            no
  turbo jpeg      no
  rfxcodec        yes
  painter         yes
  pixman          no
  fuse            no
  ipv6            no
  vsock           no
  pam             yes
  kerberos        no
  debug           no

  strict_locations        no
  prefix                  /usr/local
  exec_prefix             ${prefix}
  libdir                  ${exec_prefix}/lib
  bindir                  ${exec_prefix}/bin
  sysconfdir              /etc
```

```
$ ./configure --prefix=/usr/local --enable-strict-locations

xrdp will be compiled with:

  mp3lame         no
  opus            no
  fdkaac          no
  jpeg            no
  turbo jpeg      no
  rfxcodec        yes
  painter         yes
  pixman          no
  fuse            no
  ipv6            no
  vsock           no
  pam             yes
  kerberos        no
  debug           no

  strict_locations        yes
  prefix                  /usr/local
  exec_prefix             ${prefix}
  libdir                  ${exec_prefix}/lib
  bindir                  ${exec_prefix}/bin
  sysconfdir              ${prefix}/etc
```
