### PR TITLE
fix issue #1112: set SSL object's read_ahead flag to be 0

### DIFF
--- a/common/ssl_calls.c
+++ b/common/ssl_calls.c
@@ -734,7 +734,7 @@ ssl_tls_accept(struct ssl_tls *self, long ssl_protocols,
         }
     }
 
-    SSL_CTX_set_read_ahead(self->ctx, 1);
+    SSL_CTX_set_read_ahead(self->ctx, 0);
 
     if (SSL_CTX_use_RSAPrivateKey_file(self->ctx, self->key, SSL_FILETYPE_PEM)
             <= 0)


### PR DESCRIPTION
If the SSL object's read_ahead flag is set, it is possible for no more bytes to be readable from the underlying BIO (because OpenSSL has already read them) and for SSL_pending() to return 0, even though readable application data bytes are available (because the data is in unprocessed buffered records).
In this case, ssl_tls_can_recv() return 0 and xrdp will not read the data.
https://www.openssl.org/docs/man1.1.0/ssl/SSL_pending.html
