### PR TITLE
Add atexit() handler to unmount the filesystem on fatal X error

### DIFF
--- a/sesman/chansrv/chansrv.c
+++ b/sesman/chansrv/chansrv.c
@@ -1279,6 +1279,16 @@ segfault_signal_handler(int sig)
 }
 
 /*****************************************************************************/
+static void
+x_server_fatal_handler(void)
+{
+    LOGM((LOG_LEVEL_INFO, "xserver_fatal_handler: entered......."));
+    /* At this point the X server has gone away. Dont make any X calls. */
+    xfuse_deinit();
+    exit(0);
+}
+
+/*****************************************************************************/
 static int
 get_display_num_from_display(char *display_text)
 {
@@ -1575,6 +1585,9 @@ main(int argc, char **argv)
     g_signal_pipe(nil_signal_handler); /* SIGPIPE */
     g_signal_child_stop(child_signal_handler); /* SIGCHLD */
     g_signal_segfault(segfault_signal_handler);
+
+    /* Cater for the X server exiting unexpectedly */
+    xcommon_set_x_server_fatal_handler(x_server_fatal_handler);
 
     LOGM((LOG_LEVEL_INFO, "main: DISPLAY env var set to %s", display_text));
 

--- a/sesman/chansrv/xcommon.h
+++ b/sesman/chansrv/xcommon.h
@@ -26,6 +26,8 @@
 #define FORMAT_TO_BYTES(_format) \
     (_format) == 32 ? sizeof(long) : (_format) / 8
 
+typedef void (*x_server_fatal_cb_type)(void);
+
 int
 xcommon_get_local_time(void);
 int
@@ -34,5 +36,7 @@ int
 xcommon_get_wait_objs(tbus* objs, int* count, int* timeout);
 int
 xcommon_check_wait_objs(void);
+void
+xcommon_set_x_server_fatal_handler(x_server_fatal_cb_type handler);
 
 #endif


### PR DESCRIPTION
A couple of our guys log out of their remote sessions every night, rather than simply disconnecting and reconnecting.

I'd had reports that when this is done, the chansrv process can exit without unmounting the FUSE filesystem. When the user logs in again, the FUSE system cannot be mounted over the old one so the user loses remote drives and copy-paste.

Since this is fairly common, I attached a debugger to chansrv and set a breakpoint on _exit. Here's what I got (CentOS 7.4):-

```
#0  0x00007f7a1d8df4f0 in _exit () from /lib64/libc.so.6
#1  0x00007f7a1d858a2b in __run_exit_handlers () from /lib64/libc.so.6
#2  0x00007f7a1d858ab5 in exit () from /lib64/libc.so.6
#3  0x00007f7a1de65ee5 in _XDefaultIOError () from /lib64/libX11.so.6
#4  0x00007f7a1de6611e in _XIOError () from /lib64/libX11.so.6
#5  0x00007f7a1de63acd in _XEventsQueued () from /lib64/libX11.so.6
#6  0x00007f7a1de555dd in XPending () from /lib64/libX11.so.6
#7  0x00005563dd22927a in xcommon_check_wait_objs ()
#8  0x00005563dd2130bd in channel_thread_loop ()
#9  0x00007f7a1ee4ee25 in start_thread () from /lib64/libpthread.so.0
#10 0x00007f7a1d91834d in clone () from /lib64/libc.so.6
```

So this is clearly a fatal X error.

I've had a poke-around and there was a handler which could have been used to pick up on this which was removed by @jsorg71  in commit e11dce79dc8708cd86a8917c16c16c9bf4beb45b back in 2009 when the code was much simpler!

Since the original X Error handler was removed for what were good reasons at the time, I've gone for another approach and used the standard C library atexit() call to add a handler to unmount the filesystem at exit if for some reason it's still mounted.

The approach works in my testing, but I'm not completely happy with it because of the commit referred to above. Maybe a better approach might be to re-instate the standard X11 error handler and see what happens now that nearly a decade has passed.