### PR TITLE
Dont spit on the console (sesman)

### DIFF
--- a/sesman/config.c
+++ b/sesman/config.c
@@ -171,15 +171,6 @@ config_read_globals(int file, struct config_sesman *cf, struct list *param_n,
         g_strncpy(cf->default_wm, "startwm.sh", 11);
     }
 
-    /* showing read config */
-    g_printf("sesman config:\r\n");
-    g_printf("\tListenAddress:            %s\r\n", cf->listen_address);
-    g_printf("\tListenPort:               %s\r\n", cf->listen_port);
-    g_printf("\tEnableUserWindowManager:  %i\r\n", cf->enable_user_wm);
-    g_printf("\tUserWindowManager:        %s\r\n", cf->user_wm);
-    g_printf("\tDefaultWindowManager:     %s\r\n", cf->default_wm);
-    g_printf("\tAuthFilePath:             %s\r\n", ((cf->auth_file_path) ? (cf->auth_file_path) : ("disabled")));
-
     return 0;
 }
 
@@ -239,30 +230,6 @@ config_read_security(int file, struct config_security *sc,
         {
             sc->ts_always_group_check = g_text2bool((char *)list_get_item(param_v, i));
         }
-    }
-
-    /* printing security config */
-    g_printf("security configuration:\r\n");
-    g_printf("\tAllowRootLogin:       %i\r\n", sc->allow_root);
-    g_printf("\tMaxLoginRetry:        %i\r\n", sc->login_retry);
-    g_printf("\tAlwaysGroupCheck:     %i\r\n", sc->ts_always_group_check);
-
-    if (sc->ts_users_enable)
-    {
-        g_printf("\tTSUsersGroup:         %i\r\n", sc->ts_users);
-    }
-    else
-    {
-        g_printf("\tNo TSUsersGroup defined\r\n");
-    }
-
-    if (sc->ts_admins_enable)
-    {
-        g_printf("\tTSAdminsGroup:        %i\r\n", sc->ts_admins);
-    }
-    else
-    {
-        g_printf("\tNo TSAdminsGroup defined\r\n");
     }
 
     return 0;
@@ -352,15 +319,6 @@ config_read_sessions(int file, struct config_sessions *se, struct list *param_n,
         }
     }
 
-    /* printing session config */
-    g_printf("session configuration:\r\n");
-    g_printf("\tMaxSessions:                 %i\r\n", se->max_sessions);
-    g_printf("\tX11DisplayOffset:            %i\r\n", se->x11_display_offset);
-    g_printf("\tKillDisconnected:            %i\r\n", se->kill_disconnected);
-    g_printf("\tIdleTimeLimit:               %i\r\n", se->max_idle_time);
-    g_printf("\tDisconnectedTimeLimit:       %i\r\n", se->max_disc_time);
-    g_printf("\tPolicy:       %i\r\n", se->policy);
-
     return 0;
 }
 
@@ -382,14 +340,6 @@ config_read_rdp_params(int file, struct config_sesman *cs, struct list *param_n,
     for (i = 0; i < param_n->count; i++)
     {
         list_add_item(cs->rdp_params, (long)g_strdup((char *)list_get_item(param_v, i)));
-    }
-
-    /* printing X11rdp parameters */
-    g_printf("X11rdp parameters:\r\n");
-
-    for (i = 0; i < cs->rdp_params->count; i++)
-    {
-        g_printf("\tParameter %02d                   %s\r\n", i, (char *)list_get_item(cs->rdp_params, i));
     }
 
     return 0;
@@ -416,15 +366,6 @@ config_read_xorg_params(int file, struct config_sesman *cs,
                       (long) g_strdup((char *) list_get_item(param_v, i)));
     }
 
-    /* printing Xorg parameters */
-    g_printf("Xorg parameters:\r\n");
-
-    for (i = 0; i < cs->xorg_params->count; i++)
-    {
-        g_printf("\tParameter %02d                   %s\r\n",
-                 i, (char *) list_get_item(cs->xorg_params, i));
-    }
-
     return 0;
 }
 
@@ -446,14 +387,6 @@ config_read_vnc_params(int file, struct config_sesman *cs, struct list *param_n,
     for (i = 0; i < param_n->count; i++)
     {
         list_add_item(cs->vnc_params, (long)g_strdup((char *)list_get_item(param_v, i)));
-    }
-
-    /* printing Xvnc parameters */
-    g_printf("Xvnc parameters:\r\n");
-
-    for (i = 0; i < cs->vnc_params->count; i++)
-    {
-        g_printf("\tParameter %02d                   %s\r\n", i, (char *)list_get_item(cs->vnc_params, i));
     }
 
     return 0;
@@ -484,17 +417,114 @@ config_read_session_variables(int file, struct config_sesman *cs,
                       (tintptr) g_strdup((char *) list_get_item(param_v, i)));
     }
 
-    /* printing session variables */
-    g_writeln("%s parameters:", SESMAN_CFG_SESSION_VARIABLES);
+    return 0;
+}
 
-    for (i = 0; i < cs->env_names->count; i++)
+void
+config_dump(struct config_sesman *config)
+{
+    int i;
+    struct config_sessions *se;
+    struct config_security *sc;
+    se = &(config->sess);
+    sc = &(config->sec);
+
+    /* Global sesman configuration */
+    g_writeln("Global configuration:");
+    g_writeln("    ListenAddress:            %s", config->listen_address);
+    g_writeln("    ListenPort:               %s", config->listen_port);
+    g_writeln("    EnableUserWindowManager:  %d", config->enable_user_wm);
+    g_writeln("    UserWindowManager:        %s", config->user_wm);
+    g_writeln("    DefaultWindowManager:     %s", config->default_wm);
+    g_writeln("    AuthFilePath:             %s",
+             ((config->auth_file_path) ? (config->auth_file_path) : ("disabled")));
+
+    /* Session configuration */
+    g_writeln("Session configuration:");
+    g_writeln("    MaxSessions:              %d", se->max_sessions);
+    g_writeln("    X11DisplayOffset:         %d", se->x11_display_offset);
+    g_writeln("    KillDisconnected:         %d", se->kill_disconnected);
+    g_writeln("    IdleTimeLimit:            %d", se->max_idle_time);
+    g_writeln("    DisconnectedTimeLimit:    %d", se->max_disc_time);
+    g_writeln("    Policy:                   %d", se->policy);
+
+    /* Security configuration */
+    g_writeln("Security configuration:");
+    g_writeln("    AllowRootLogin:           %d", sc->allow_root);
+    g_writeln("    MaxLoginRetry:            %d", sc->login_retry);
+    g_writeln("    AlwaysGroupCheck:         %d", sc->ts_always_group_check);
+
+    g_printf( "    TSUsersGroup:             ");
+    if (sc->ts_users_enable)
     {
-        g_writeln("  Parameter %02d                   %s=%s", i,
-               (char *) list_get_item(cs->env_names, i),
-               (char *) list_get_item(cs->env_values, i));
+        g_printf("%d", sc->ts_users);
+    }
+    else
+    {
+        g_printf("(not defined)");
+    }
+    g_writeln("%s", "");
+
+    g_printf( "    TSAdminsGroup:            ");
+    if (sc->ts_admins_enable)
+    {
+        g_printf("%d", sc->ts_admins);
+    }
+    else
+    {
+        g_printf("(not defined)");
+    }
+    g_writeln("%s", "");
+
+
+    /* Xorg */
+    if (config->xorg_params->count)
+    {
+        g_writeln("Xorg parameters:");
     }
 
-    return 0;
+    for (i = 0; i < config->xorg_params->count; i++)
+    {
+        g_writeln("    Parameter %02d              %s",
+                 i, (char *) list_get_item(config->xorg_params, i));
+    }
+
+    /* Xvnc */
+    if (config->vnc_params->count)
+    {
+        g_writeln("Xvnc parameters:");
+    }
+
+    for (i = 0; i < config->vnc_params->count; i++)
+    {
+        g_writeln("    Parameter %02d              %s",
+                 i, (char *)list_get_item(config->vnc_params, i));
+    }
+
+    /* X11rdp */
+    if (config->rdp_params->count)
+    {
+        g_writeln("X11rdp parameters:");
+    }
+
+    for (i = 0; i < config->rdp_params->count; i++)
+    {
+        g_writeln("    Parameter %02d              %s",
+                 i, (char *)list_get_item(config->rdp_params, i));
+    }
+
+    /* SessionVariables */
+    if (config->env_names->count)
+    {
+        g_writeln("%s parameters:", SESMAN_CFG_SESSION_VARIABLES);
+    }
+
+    for (i = 0; i < config->env_names->count; i++)
+    {
+        g_writeln("    Parameter %02d              %s=%s",
+                  i, (char *) list_get_item(config->env_names, i),
+                     (char *) list_get_item(config->env_values, i));
+    }
 }
 
 void

--- a/sesman/config.c
+++ b/sesman/config.c
@@ -83,9 +83,6 @@ config_read(struct config_sesman *cfg)
     config_read_rdp_params(fd, cfg, param_n, param_v);
     config_read_xorg_params(fd, cfg, param_n, param_v);
 
-    /* read logging config */
-    // config_read_logging(fd, &(cfg->log), param_n, param_v);
-
     /* read security config */
     config_read_security(fd, &(cfg->sec), param_n, param_v);
 

--- a/sesman/config.c
+++ b/sesman/config.c
@@ -78,7 +78,7 @@ config_read(struct config_sesman *cfg)
     /* read global config */
     config_read_globals(fd, cfg, param_n, param_v);
 
-    /* read Xvnc/X11rdp/XOrg parameter list */
+    /* read Xvnc/X11rdp/Xorg parameter list */
     config_read_vnc_params(fd, cfg, param_n, param_v);
     config_read_rdp_params(fd, cfg, param_n, param_v);
     config_read_xorg_params(fd, cfg, param_n, param_v);
@@ -416,8 +416,8 @@ config_read_xorg_params(int file, struct config_sesman *cs,
                       (long) g_strdup((char *) list_get_item(param_v, i)));
     }
 
-    /* printing XOrg parameters */
-    g_printf("XOrg parameters:\r\n");
+    /* printing Xorg parameters */
+    g_printf("Xorg parameters:\r\n");
 
     for (i = 0; i < cs->xorg_params->count; i++)
     {

--- a/sesman/config.h
+++ b/sesman/config.h
@@ -278,20 +278,6 @@ config_read_globals(int file, struct config_sesman* cf,
 
 /**
  *
- * @brief Reads sesman [logging] configuration section
- * @param file configuration file descriptor
- * @param lc pointer to a log_config struct
- * @param param_n parameter name list
- * @param param_v parameter value list
- * @return 0 on success, 1 on failure
- *
- */
-int
-config_read_logging(int file, struct log_config* lc, struct list* param_n,
-                    struct list* param_v);
-
-/**
- *
  * @brief Reads sesman [Security] configuration section
  * @param file configuration file descriptor
  * @param sc pointer to a config_security struct

--- a/sesman/config.h
+++ b/sesman/config.h
@@ -349,6 +349,14 @@ config_read_vnc_params(int file, struct config_sesman* cs, struct list* param_n,
 int
 config_read_session_variables(int file, struct config_sesman *cs,
                               struct list *param_n, struct list *param_v);
+/**
+ *
+ * @brief Dumps configuration
+ * @param pointer to a config_sesman struct
+ *
+ */
+void
+config_dump(struct config_sesman *config);
 
 void
 config_free(struct config_sesman *cs);

--- a/sesman/config.h
+++ b/sesman/config.h
@@ -320,7 +320,7 @@ config_read_rdp_params(int file, struct config_sesman* cs, struct list* param_n,
 
 /**
  *
- * @brief Reads sesman [XOrg] configuration section
+ * @brief Reads sesman [Xorg] configuration section
  * @param file configuration file descriptor
  * @param cs pointer to a config_sesman struct
  * @param param_n parameter name list

--- a/sesman/sesman.c
+++ b/sesman/sesman.c
@@ -209,8 +209,7 @@ main(int argc, char **argv)
 
     if (1 == argc)
     {
-        /* no options on command line. normal startup */
-        g_printf("starting sesman...\n");
+        /* start in daemon mode if no cli options */
         daemon = 1;
     }
     else if ((2 == argc) && ((0 == g_strcasecmp(argv[1], "--nodaemon")) ||
@@ -310,6 +309,12 @@ main(int argc, char **argv)
         g_printf("error reading config: %s\nquitting.\n", g_get_strerror());
         g_deinit();
         g_exit(1);
+    }
+
+    /* not to spit on the console, show config summary only when running in foreground */
+    if (!daemon)
+    {
+        config_dump(g_cfg);
     }
 
     g_snprintf(cfg_file, 255, "%s/sesman.ini", XRDP_CFG_PATH);

--- a/sesman/sesman.c
+++ b/sesman/sesman.c
@@ -342,8 +342,17 @@ main(int argc, char **argv)
         g_exit(1);
     }
 
+    if (daemon)
+    {
+        /* not to spit on the console, shut up stdout/stderr before anything's logged */
+        g_file_close(0);
+        g_file_close(1);
+        g_file_close(2);
+    }
+
     /* libscp initialization */
     scp_init();
+
 
     if (daemon)
     {
@@ -362,10 +371,6 @@ main(int argc, char **argv)
             g_deinit();
             g_exit(0);
         }
-
-        g_file_close(0);
-        g_file_close(1);
-        g_file_close(2);
 
         if (g_file_open("/dev/null") < 0)
         {


### PR DESCRIPTION
# synopsis

As the Debian patch[1] expresses, spitting messages on the console when a process starts in background is a bad idea.

* don't print sesman config summary and any other messages
* create config_dump() function rather than dumping config while config reading
* config_dump() when xrdp-sesman runs in foreground
* remove prototype declaration which no longer exists 
* adjust indent of sesman configuration summary

Logging configuration summary is still dumped on the console. I'll remove it later.

[1] https://salsa.debian.org/debian-remote-team/xrdp/blob/2751ad4d62b1f63dbc2e4b8fa1580fa54b0f5460/debian/patches/shutup-daemon.diff

# before 
```
# xrdp-sesman 
starting sesman...
sesman config:
        ListenAddress:            127.0.0.1
        ListenPort:               3350
        EnableUserWindowManager:  1
        UserWindowManager:        startwm.sh
        DefaultWindowManager:     startwm.sh
        AuthFilePath:             disabled
Xvnc parameters:
        Parameter 00                   Xvnc
        Parameter 01                   -bs
        Parameter 02                   -nolisten
        Parameter 03                   tcp
        Parameter 04                   -localhost
        Parameter 05                   -dpi
        Parameter 06                   96
X11rdp parameters:
XOrg parameters:
        Parameter 00                   Xorg
        Parameter 01                   -config
        Parameter 02                   xrdp/xorg.conf
        Parameter 03                   -noreset
        Parameter 04                   -nolisten
        Parameter 05                   tcp
security configuration:
        AllowRootLogin:       1
        MaxLoginRetry:        4
        AlwaysGroupCheck:     0
        No TSUsersGroup defined
        No TSAdminsGroup defined
session configuration:
        MaxSessions:                 50
        X11DisplayOffset:            10
        KillDisconnected:            0
        IdleTimeLimit:               0
        DisconnectedTimeLimit:       0
        Policy:       0
SessionVariables parameters:
  Parameter 00                   PULSE_SCRIPT=/usr/local/etc/xrdp/pulse/default.pa
logging configuration:
        LogFile:       /var/log/xrdp-sesman.log
        LogLevel:      4
        EnableSyslog:  1
        SyslogLevel:   4
[20180604-23:34:17] [DEBUG] libscp initialized
[20180604-23:34:17] [DEBUG] Testing if xrdp-sesman can listen on 127.0.0.1 port 3350.
[20180604-23:34:17] [DEBUG] Closed socket 5 (AF_INET6 ::1 port 3350)
```

## after
```
# xrdp-sesman -ns
starting sesman in foreground...
Global configuration:
    ListenAddress:            127.0.0.1
    ListenPort:               3350
    EnableUserWindowManager:  1
    UserWindowManager:        startwm.sh
    DefaultWindowManager:     startwm.sh
    AuthFilePath:             disabled
Session configuration:
    MaxSessions:              50
    X11DisplayOffset:         10
    KillDisconnected:         0
    IdleTimeLimit:            0
    DisconnectedTimeLimit:    0
    Policy:                   0
Security configuration:
    AllowRootLogin:           1
    MaxLoginRetry:            4
    AlwaysGroupCheck:         0
    TSUsersGroup:             (not defined)
    TSAdminsGroup:            (not defined)
Xorg parameters:
    Parameter 00              Xorg
    Parameter 01              -config
    Parameter 02              xrdp/xorg.conf
    Parameter 03              -noreset
    Parameter 04              -nolisten
    Parameter 05              tcp
Xvnc parameters:
    Parameter 00              Xvnc
    Parameter 01              -bs
    Parameter 02              -nolisten
    Parameter 03              tcp
    Parameter 04              -localhost
    Parameter 05              -dpi
    Parameter 06              96
SessionVariables parameters:
    Parameter 00              PULSE_SCRIPT=/usr/local/etc/xrdp/pulse/default.pa
Logging configuration:
        LogFile:       /var/log/xrdp-sesman.log
        LogLevel:      4
        EnableSyslog:  1
        SyslogLevel:   4
[20180604-23:36:11] [DEBUG] libscp initialized
[20180604-23:36:11] [INFO ] starting xrdp-sesman with pid 32766
[20180604-23:36:11] [INFO ] listening to port 3350 on 127.0.0.1
```

```
# xrdp-sesman : in background (daemon mode)
logging configuration:
        LogFile:       /var/log/xrdp-sesman.log
        LogLevel:      4
        EnableSyslog:  1
        SyslogLevel:   4
```