### PR TITLE
Accept full path for DefaultWindowManager

### DIFF
--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -17,7 +17,8 @@ SUBST_VARS = sed \
    -e 's|@bindir[@]|$(bindir)|g' \
    -e 's|@localstatedir[@]|$(localstatedir)|g' \
    -e 's|@sysconfdir[@]|$(sysconfdir)|g' \
-   -e 's|@socketdir[@]|$(socketdir)|g'
+   -e 's|@socketdir[@]|$(socketdir)|g' \
+   -e 's|@xrdpconfdir[@]|$(sysconfdir)/xrdp|g'
 
 subst_verbose = $(subst_verbose_@AM_V@)
 subst_verbose_ = $(subst_verbose_@AM_DEFAULT_V@)

--- a/docs/man/sesman.ini.5.in
+++ b/docs/man/sesman.ini.5.in
@@ -62,14 +62,23 @@ specified by \fBUserWindowManager\fR if it exists.
 
 .TP
 \fBUserWindowManager\fR=\fIfilename\fR
-Name of the startup script relative to the user's home directory. If
+Path of the startup script relative to the user's home directory. If
 present and enabled by \fBEnableUserWindowManager\fR, that script is
 executed instead of \fBDefaultWindowManager\fR.
 
 .TP
 \fBDefaultWindowManager\fR=\fIfilename\fR
-Full path to the default startup script used by xrdp-sesman to start a
-session if the user script is disabled or missing.
+Full path or relative path of the default startup script used by xrdp-sesman
+to start a session.  If the path is not a full path, it will be resolved as
+relative path to \fI@xrdpconfdir@\fR. If not specified, defaults to
+\fI@xrdpconfdir@/startwm.sh\fR.
+
+.TP
+\fBReconnectScript\fR=\fIfilename\fR
+Full path or relative path if the script which executed when users reconnects
+to the existing session. If the path is not a full path, it will be resolved as
+relative path to \fI@xrdpconfdir@\fR. If not specified, defaults to
+\fI@xrdpconfdir@/reconnectwm.sh\fR.
 
 .SH "LOGGING"
 Following parameters can be used in the \fB[Logging]\fR section.

--- a/sesman/config.c
+++ b/sesman/config.c
@@ -117,6 +117,7 @@ config_read_globals(int file, struct config_sesman *cf, struct list *param_n,
     cf->user_wm[0] = '\0';
     cf->default_wm = 0;
     cf->auth_file_path = 0;
+    cf->reconnect_sh = 0;
 
     file_read_section(file, SESMAN_CFG_GLOBALS, param_n, param_v);
 
@@ -147,6 +148,10 @@ config_read_globals(int file, struct config_sesman *cf, struct list *param_n,
         else if (0 == g_strcasecmp(buf, SESMAN_CFG_AUTH_FILE_PATH))
         {
             cf->auth_file_path = g_strdup((char *)list_get_item(param_v, i));
+        }
+        else if (g_strcasecmp(buf, SESMAN_CFG_RECONNECT_SH) == 0)
+        {
+            cf->reconnect_sh = g_strdup((char *)list_get_item(param_v, i));
         }
     }
 
@@ -185,6 +190,25 @@ config_read_globals(int file, struct config_sesman *cf, struct list *param_n,
         g_cfg->default_wm = g_strdup(buf);
         g_free(buf);
     }
+
+    if (cf->reconnect_sh == 0)
+    {
+        cf->reconnect_sh = g_strdup("reconnectwm.sh");
+    }
+    else if (g_strlen(cf->reconnect_sh) == 0)
+    {
+        g_free(cf->reconnect_sh);
+        cf->reconnect_sh = g_strdup("reconnectwm.sh");
+    }
+    if (cf->reconnect_sh[0] != '/')
+    {
+        buf = (char *)g_malloc(1024, 0);
+        g_sprintf(buf, "%s/%s", XRDP_CFG_PATH, g_cfg->reconnect_sh);
+        g_free(g_cfg->reconnect_sh);
+        g_cfg->reconnect_sh = g_strdup(buf);
+        g_free(buf);
+    }
+
 
     return 0;
 }
@@ -451,6 +475,7 @@ config_dump(struct config_sesman *config)
     g_writeln("    EnableUserWindowManager:  %d", config->enable_user_wm);
     g_writeln("    UserWindowManager:        %s", config->user_wm);
     g_writeln("    DefaultWindowManager:     %s", config->default_wm);
+    g_writeln("    ReconnectScript:          %s", config->reconnect_sh);
     g_writeln("    AuthFilePath:             %s",
              ((config->auth_file_path) ? (config->auth_file_path) : ("disabled")));
 
@@ -546,6 +571,7 @@ void
 config_free(struct config_sesman *cs)
 {
     g_free(cs->default_wm);
+    g_free(cs->reconnect_sh);
     g_free(cs->auth_file_path);
     list_delete(cs->rdp_params);
     list_delete(cs->vnc_params);

--- a/sesman/config.c
+++ b/sesman/config.c
@@ -105,6 +105,7 @@ config_read_globals(int file, struct config_sesman *cf, struct list *param_n,
                     struct list *param_v)
 {
     int i;
+    int length;
     char *buf;
 
     list_clear(param_v);
@@ -180,11 +181,11 @@ config_read_globals(int file, struct config_sesman *cf, struct list *param_n,
         g_free(cf->default_wm);
         cf->default_wm = g_strdup("startwm.sh");
     }
-
-    /* if default_wm doesn't begin with '/', it's a relative path from XRDP_CFG_PATH */
+    /* if default_wm doesn't begin with '/', it's a relative path to XRDP_CFG_PATH */
     if (cf->default_wm[0] != '/')
     {
-        buf = (char *)g_malloc(1024, 0);
+        length = sizeof(XRDP_CFG_PATH) + g_strlen(g_cfg->default_wm) + 1; /* '/' */
+        buf = (char *)g_malloc(length, 0);
         g_sprintf(buf, "%s/%s", XRDP_CFG_PATH, g_cfg->default_wm);
         g_free(g_cfg->default_wm);
         g_cfg->default_wm = g_strdup(buf);
@@ -200,15 +201,16 @@ config_read_globals(int file, struct config_sesman *cf, struct list *param_n,
         g_free(cf->reconnect_sh);
         cf->reconnect_sh = g_strdup("reconnectwm.sh");
     }
+    /* if reconnect_sh doesn't begin with '/', it's a relative path to XRDP_CFG_PATH */
     if (cf->reconnect_sh[0] != '/')
     {
-        buf = (char *)g_malloc(1024, 0);
+        length = sizeof(XRDP_CFG_PATH) + g_strlen(g_cfg->reconnect_sh) + 1; /* '/' */
+        buf = (char *)g_malloc(length, 0);
         g_sprintf(buf, "%s/%s", XRDP_CFG_PATH, g_cfg->reconnect_sh);
         g_free(g_cfg->reconnect_sh);
         g_cfg->reconnect_sh = g_strdup(buf);
         g_free(buf);
     }
-
 
     return 0;
 }

--- a/sesman/config.c
+++ b/sesman/config.c
@@ -184,6 +184,7 @@ config_read_globals(int file, struct config_sesman *cf, struct list *param_n,
     /* if default_wm doesn't begin with '/', it's a relative path to XRDP_CFG_PATH */
     if (cf->default_wm[0] != '/')
     {
+        /* sizeof operator returns string length including null terminator  */
         length = sizeof(XRDP_CFG_PATH) + g_strlen(g_cfg->default_wm) + 1; /* '/' */
         buf = (char *)g_malloc(length, 0);
         g_sprintf(buf, "%s/%s", XRDP_CFG_PATH, g_cfg->default_wm);
@@ -204,6 +205,7 @@ config_read_globals(int file, struct config_sesman *cf, struct list *param_n,
     /* if reconnect_sh doesn't begin with '/', it's a relative path to XRDP_CFG_PATH */
     if (cf->reconnect_sh[0] != '/')
     {
+        /* sizeof operator returns string length including null terminator  */
         length = sizeof(XRDP_CFG_PATH) + g_strlen(g_cfg->reconnect_sh) + 1; /* '/' */
         buf = (char *)g_malloc(length, 0);
         g_sprintf(buf, "%s/%s", XRDP_CFG_PATH, g_cfg->reconnect_sh);

--- a/sesman/config.h
+++ b/sesman/config.h
@@ -39,6 +39,7 @@
 #define SESMAN_CFG_USERWM            "UserWindowManager"
 #define SESMAN_CFG_MAX_SESSION       "MaxSessions"
 #define SESMAN_CFG_AUTH_FILE_PATH    "AuthFilePath"
+#define SESMAN_CFG_RECONNECT_SH      "ReconnectScript"
 
 #define SESMAN_CFG_RDP_PARAMS        "X11rdp"
 #define SESMAN_CFG_XORG_PARAMS       "Xorg"
@@ -204,6 +205,11 @@ struct config_sesman
    * @brief Default window manager
    */
   char user_wm[32];
+  /**
+   * @var reconnect_sh
+   * @brief Script executed when reconnected
+   */
+  char *reconnect_sh;
   /**
    * @var auth_file_path
    * @brief Auth file path

--- a/sesman/config.h
+++ b/sesman/config.h
@@ -198,7 +198,7 @@ struct config_sesman
    * @var default_wm
    * @brief Default window manager
    */
-  char default_wm[32];
+  char *default_wm;
   /**
    * @var user_wm
    * @brief Default window manager

--- a/sesman/sesman.ini.in
+++ b/sesman/sesman.ini.in
@@ -4,6 +4,7 @@ ListenPort=3350
 EnableUserWindowManager=true
 UserWindowManager=startwm.sh
 DefaultWindowManager=startwm.sh
+ReconnectScript=reconnectwm.sh
 
 [Security]
 AllowRootLogin=true

--- a/sesman/sesman.ini.in
+++ b/sesman/sesman.ini.in
@@ -1,9 +1,14 @@
+;; See `man 5 sesman.ini` for details
+
 [Globals]
 ListenAddress=127.0.0.1
 ListenPort=3350
 EnableUserWindowManager=true
+; Give in relative path to user's home directory
 UserWindowManager=startwm.sh
+; Give in full path or relative path to @sesmansysconfdir@
 DefaultWindowManager=startwm.sh
+; Give in full path or relative path to @sesmansysconfdir@
 ReconnectScript=reconnectwm.sh
 
 [Security]

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -584,7 +584,7 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
                             "%s", g_get_errno(), g_get_strerror());
                 log_message(LOG_LEVEL_DEBUG, "execlp3 parameter list:");
                 log_message(LOG_LEVEL_DEBUG, "        argv[0] = %s",
-                            text);
+                            g_cfg->default_wm);
                 log_message(LOG_LEVEL_DEBUG, "        argv[1] = %s",
                             g_cfg->default_wm);
 

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -575,8 +575,7 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
                 }
                 /* if we're here something happened to g_execlp3
                    so we try running the default window manager */
-                g_sprintf(text, "%s/%s", XRDP_CFG_PATH, g_cfg->default_wm);
-                g_execlp3(text, g_cfg->default_wm, 0);
+                g_execlp3(g_cfg->default_wm, g_cfg->default_wm, 0);
 
                 log_message(LOG_LEVEL_ALWAYS, "error starting default "
                              "wm for user %s - pid %d", s->username, g_getpid());

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -862,7 +862,6 @@ static int
 session_reconnect_fork(int display, char *username, long data)
 {
     int pid;
-    char text[256];
 
     pid = g_fork();
 
@@ -877,11 +876,10 @@ session_reconnect_fork(int display, char *username, long data)
                      g_cfg->env_names,
                      g_cfg->env_values);
         auth_set_env(data);
-        g_snprintf(text, 255, "%s/%s", XRDP_CFG_PATH, "reconnectwm.sh");
 
-        if (g_file_exist(text))
+        if (g_file_exist(g_cfg->reconnect_sh))
         {
-            g_execlp3(text, g_cfg->default_wm, 0);
+            g_execlp3(g_cfg->reconnect_sh, g_cfg->reconnect_sh, 0);
         }
 
         g_exit(0);


### PR DESCRIPTION
Also, 
* make path of reconnectwm.sh configurable
* improve documents 

Solves #1143. Inspired by Fedora's patch[1].
[1] https://src.fedoraproject.org/cgit/rpms/xrdp.git/commit/xrdp-0.9.6-scripts-libexec.patch?id=02f845c1b8cea781313cf3e9efcd6d7d50341824