### PR TITLE
FreeBSD: separate rc script into xrdp and xrdp-sesman

### DIFF
--- a/instfiles/Makefile.am
+++ b/instfiles/Makefile.am
@@ -97,5 +97,6 @@ endif
 if FREEBSD
 # must be tab below
 install-data-hook:
-	sed -i '' 's|%%PREFIX%%|$(prefix)|g' $(DESTDIR)$(sysconfdir)/rc.d/xrdp
+	sed -i '' 's|%%PREFIX%%|$(prefix)|g' $(DESTDIR)$(sysconfdir)/rc.d/xrdp \
+                                         $(DESTDIR)$(sysconfdir)/rc.d/xrdp-sesman
 endif

--- a/instfiles/rc.d/Makefile.am
+++ b/instfiles/rc.d/Makefile.am
@@ -1,2 +1,2 @@
 startscriptdir = $(sysconfdir)/rc.d
-dist_startscript_SCRIPTS = xrdp
+dist_startscript_SCRIPTS = xrdp xrdp-sesman

--- a/instfiles/rc.d/xrdp-sesman
+++ b/instfiles/rc.d/xrdp-sesman
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 1992-2018 The FreeBSD Project. All rights reserved.
+# Copyright (c) 1992-2015 The FreeBSD Project. All rights reserved.
 # Copyright (c) 2015-2018 Koichiro Iwao <meta@FreeBSD.org>
 #
 # Redistribution and use in source and binary forms, with or without
@@ -26,57 +26,19 @@
 #
 # $FreeBSD$
 #
-# REQUIRE: DAEMON
-# PROVIDE: xrdp
+# REQUIRE: LOGIN
+# PROVIDE: xrdp_sesman
 #
-# Add the following line to /etc/rc.conf to enable xrdp:
-#
-#  xrdp_enable="YES"
-#  xrdp_sesman_enable="YES"
 
 . /etc/rc.subr
 
-name="xrdp"
-rcvar="xrdp_enable"
+name="xrdp_sesman"
+rcvar="xrdp_sesman_enable"
 
 load_rc_config "$name"
-: ${xrdp_enable="NO"}
+: ${xrdp_sesman_enable="NO"}
 
-extra_commands="status allstart allstop allrestart"
-command="%%PREFIX%%/sbin/xrdp"
-
-allstart_cmd="xrdp_allstart"
-allstop_cmd="xrdp_allstop"
-allrestart_cmd="xrdp_allrestart"
-
-xrdp_allstart()
-{
-     run_rc_command "start"
-
-    if checkyesno "xrdp_sesman_enable" && \
-        ! %%PREFIX%%/etc/rc.d/xrdp-sesman forcestatus 1>/dev/null 2>&1; then
-        %%PREFIX%%/etc/rc.d/xrdp-sesman start || return 1
-    fi
-}
-
-xrdp_allstop()
-{
-    if checkyesno "xrdp_sesman_enable" && \
-        %%PREFIX%%/etc/rc.d/xrdp-sesman forcestatus 1>/dev/null 2>&1; then
-        %%PREFIX%%/etc/rc.d/xrdp-sesman stop || return 1
-    fi
-
-    run_rc_command "stop"
-}
-
-xrdp_allrestart()
-{
-    if checkyesno "xrdp_sesman_enable" && \
-        %%PREFIX%%/etc/rc.d/xrdp-sesman forcestatus 1>/dev/null 2>&1; then
-        %%PREFIX%%/etc/rc.d/xrdp-sesman restart || return 1
-    fi
-
-    run_rc_command "restart"
-}
+extra_commands="status"
+command="%%PREFIX%%/sbin/xrdp-sesman"
 
 run_rc_command "$1"


### PR DESCRIPTION
to improve fscd(8)[1] compatibility. fscd(8) monitors daemons and
restarts after daemons crashed. We usually want to start, stop, and
restart xrdp and xrdp-sesman separately because restarting xrdp-sesman
means losing existing sessions. This change will enable fscd(8) not to
restart xrdp-sesman together when only xrdp daemon crashes.

Now rc.d/xrdp mainly has following commands:

* start      - starts xrdp
* stop       - stops xrdp
* restart    - stops xrdp, then starts it again
* allstart   - starts both xrdp and xrdp-sesman
* allstop    - stops both
* allrestart - stops both, then start them again
* status     - returns status of xrdp

rc.d/xrdp-sesman doesn't have all- prefixed commands.

[1] https://www.freshports.org/sysutils/fsc/