### PR TITLE
xrdp: Use configured values instead of hardcoded ones in login_wnd inputs.

### DIFF
--- a/xrdp/xrdp.ini.in
+++ b/xrdp/xrdp.ini.in
@@ -96,7 +96,7 @@ ls_logo_y_pos=50
 
 ; for positioning labels such as username, password etc
 ls_label_x_pos=30
-ls_label_width=60
+ls_label_width=65
 
 ; for positioning text and combo boxes next to above labels
 ls_input_x_pos=110

--- a/xrdp/xrdp_login_wnd.c
+++ b/xrdp/xrdp_login_wnd.c
@@ -386,7 +386,7 @@ xrdp_wm_show_edits(struct xrdp_wm *self, struct xrdp_bitmap *combo)
             else if (g_strncmp(ASK, value, ASK_LEN) == 0)
             {
                 /* label */
-                b = xrdp_bitmap_create(95, DEFAULT_EDIT_H, self->screen->bpp,
+                b = xrdp_bitmap_create(globals->ls_label_width, DEFAULT_EDIT_H, self->screen->bpp,
                                        WND_TYPE_LABEL, self);
                 list_insert_item(self->login_window->child_list, insert_index,
                                  (long)b);
@@ -401,7 +401,7 @@ xrdp_wm_show_edits(struct xrdp_wm *self, struct xrdp_bitmap *combo)
                 set_string(&b->caption1, name);
 
                 /* edit */
-                b = xrdp_bitmap_create(DEFAULT_EDIT_W, DEFAULT_EDIT_H, self->screen->bpp,
+                b = xrdp_bitmap_create(globals->ls_input_width, DEFAULT_EDIT_H, self->screen->bpp,
                                        WND_TYPE_EDIT, self);
                 list_insert_item(self->login_window->child_list, insert_index,
                                  (long)b);
@@ -859,7 +859,7 @@ load_xrdp_config(struct xrdp_config *config, int bpp)
     globals->ls_logo_x_pos = 63;
     globals->ls_logo_y_pos = 50;
     globals->ls_label_x_pos = 30;
-    globals->ls_label_width = 60;
+    globals->ls_label_width = 65;
     globals->ls_input_x_pos = 110;
     globals->ls_input_width = 210;
     globals->ls_input_y_pos = 150;

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -496,9 +496,7 @@ struct xrdp_bitmap
 #define DEFAULT_ELEMENT_TOP   35
 #define DEFAULT_BUTTON_W      60
 #define DEFAULT_BUTTON_H      23
-#define DEFAULT_COMBO_W       210
 #define DEFAULT_COMBO_H       21
-#define DEFAULT_EDIT_W        210
 #define DEFAULT_EDIT_H        21
 #define DEFAULT_WND_LOGIN_W   425
 #define DEFAULT_WND_LOGIN_H   475


### PR DESCRIPTION
Configured ls_label_width and ls_input_width currently only apply to the combo label and dropdown. Other labels and inputs (username, password, port, ...) use hardcoded defaults.

Also had to change the default label width; for the previous value of 60, "username" ends up just a few pixels too wide.