### PR TITLE
Fix crash of xrdp-chansrv process, issue #1202.

### DIFF
--- a/sesman/chansrv/chansrv_fuse.c
+++ b/sesman/chansrv/chansrv_fuse.c
@@ -1228,9 +1228,16 @@ xfuse_create_file_in_xrdp_fs(tui32 device_id, int pinode, const char *name,
 {
     XRDP_INODE *xinode;
     XRDP_INODE *xinodep;
+    time_t cur_time;
 
     if ((name == NULL) || (strlen(name) == 0))
         return NULL;
+
+    /* Do we have an inode table yet? */
+    if (xfuse_init_xrdp_fs())
+    {
+        return NULL;
+    }
 
     xinode = g_new0(XRDP_INODE, 1);
     if (xinode == NULL)
@@ -1238,6 +1245,8 @@ xfuse_create_file_in_xrdp_fs(tui32 device_id, int pinode, const char *name,
         log_error("system out of memory");
         return NULL;
     }
+
+    cur_time = time(0);
 
     xinode->parent_inode = pinode;
     xinode->inode = g_xrdp_fs.next_node++;

--- a/sesman/chansrv/chansrv_fuse.c
+++ b/sesman/chansrv/chansrv_fuse.c
@@ -1253,9 +1253,9 @@ xfuse_create_file_in_xrdp_fs(tui32 device_id, int pinode, const char *name,
     xinode->nlink = 1;
     xinode->uid = getuid();
     xinode->gid = getgid();
-    xinode->atime = time(0);
-    xinode->mtime = time(0);
-    xinode->ctime = time(0);
+    xinode->atime = cur_time;
+    xinode->mtime = cur_time;
+    xinode->ctime = cur_time;
     xinode->device_id = device_id;
     xinode->is_synced = 1;
     strcpy(xinode->name, name);


### PR DESCRIPTION
In xfuse_create_file_in_xrdp_fs insure that xfuse_fs is properly initialized.