### PR TITLE
Deprecate x11rdp and simplify session types

### DIFF
--- a/sesman/sesman.ini.in
+++ b/sesman/sesman.ini.in
@@ -90,13 +90,6 @@ param=tcp
 param=-logfile
 param=.xorgxrdp.%s.log
 
-[X11rdp]
-param=X11rdp
-param=-bs
-param=-nolisten
-param=tcp
-param=-uds
-
 [Xvnc]
 param=Xvnc
 param=-bs

--- a/xrdp/xrdp.ini.in
+++ b/xrdp/xrdp.ini.in
@@ -172,15 +172,6 @@ port=-1
 #xserverbpp=24
 #delay_ms=2000
 
-[console]
-name=console
-lib=libvnc.@lib_extension@
-ip=127.0.0.1
-port=5900
-username=na
-password=ask
-#delay_ms=2000
-
 [vnc-any]
 name=vnc-any
 lib=libvnc.@lib_extension@

--- a/xrdp/xrdp.ini.in
+++ b/xrdp/xrdp.ini.in
@@ -162,16 +162,6 @@ ip=127.0.0.1
 port=-1
 code=20
 
-[X11rdp]
-name=X11rdp
-lib=libxup.@lib_extension@
-username=ask
-password=ask
-ip=127.0.0.1
-port=-1
-xserverbpp=24
-code=10
-
 [Xvnc]
 name=Xvnc
 lib=libvnc.@lib_extension@

--- a/xrdp/xrdp.ini.in
+++ b/xrdp/xrdp.ini.in
@@ -193,15 +193,6 @@ password=ask
 #pamsessionmng=127.0.0.1
 #delay_ms=2000
 
-[sesman-any]
-name=sesman-any
-lib=libvnc.@lib_extension@
-ip=ask
-port=-1
-username=ask
-password=ask
-#delay_ms=2000
-
 [neutrinordp-any]
 name=neutrinordp-any
 lib=libxrdpneutrinordp.@lib_extension@


### PR DESCRIPTION
Too many session type choices make users confused. I think 

* Xorg
* Xvnc
* vnc-any
* rdp-any

are enough.