### PR TITLE
neutrinordp: don't enable remote_app if the INFO_RAIL flag is not set

### DIFF
--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -155,6 +155,7 @@ struct xrdp_client_info
 
   int no_orders_supported;
   int use_cache_glyph_v2;
+  int rail_enable;
 };
 
 #endif

--- a/common/xrdp_constants.h
+++ b/common/xrdp_constants.h
@@ -370,6 +370,7 @@
 #define RDP_COMPRESSION                0x0080
 #define RDP_LOGON_BLOB                 0x0100
 #define RDP_LOGON_LEAVE_AUDIO          0x2000
+#define RDP_LOGON_RAIL                 0x8000
 
 /* Compression Flags (MS-RDPBCGR 3.1.8.2.1) */
 /* TODO: to be renamed, not used anywhere */

--- a/libxrdp/xrdp_caps.c
+++ b/libxrdp/xrdp_caps.c
@@ -964,20 +964,23 @@ xrdp_caps_send_demand_active(struct xrdp_rdp *self)
     out_uint16_le(s, flags);
     out_uint8s(s, 82);
 
-    /* Remote Programs Capability Set */
-    caps_count++;
-    out_uint16_le(s, 0x0017); /* CAPSETTYPE_RAIL */
-    out_uint16_le(s, 8);
-    out_uint32_le(s, 3); /* TS_RAIL_LEVEL_SUPPORTED
-                          TS_RAIL_LEVEL_DOCKED_LANGBAR_SUPPORTED */
+    if (self->client_info.rail_enable) /* MS-RDPERP 3.3.5.1.4 */
+    {
+        /* Remote Programs Capability Set */
+        caps_count++;
+        out_uint16_le(s, 0x0017); /* CAPSETTYPE_RAIL */
+        out_uint16_le(s, 8);
+        out_uint32_le(s, 3); /* TS_RAIL_LEVEL_SUPPORTED
+                              TS_RAIL_LEVEL_DOCKED_LANGBAR_SUPPORTED */
 
-    /* Window List Capability Set */
-    caps_count++;
-    out_uint16_le(s, 0x0018); /* CAPSETTYPE_WINDOW */
-    out_uint16_le(s, 11);
-    out_uint32_le(s, 2); /* TS_WINDOW_LEVEL_SUPPORTED_EX */
-    out_uint8(s, 3); /* NumIconCaches */
-    out_uint16_le(s, 12); /* NumIconCacheEntries */
+        /* Window List Capability Set */
+        caps_count++;
+        out_uint16_le(s, 0x0018); /* CAPSETTYPE_WINDOW */
+        out_uint16_le(s, 11);
+        out_uint32_le(s, 2); /* TS_WINDOW_LEVEL_SUPPORTED_EX */
+        out_uint8(s, 3); /* NumIconCaches */
+        out_uint16_le(s, 12); /* NumIconCacheEntries */
+    }
 
     /* 6 - bitmap cache v3 codecid */
     caps_count++;

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -701,6 +701,12 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
         DEBUG(("flag RDP_LOGON_LEAVE_AUDIO found"));
     }
 
+    if (flags & RDP_LOGON_RAIL)
+    {
+        self->rdp_layer->client_info.rail_enable = 1;
+        DEBUG(("flag RDP_LOGON_RAIL found"));
+    }
+
     if ((flags & RDP_LOGON_AUTO) && (!self->rdp_layer->client_info.is_mce))
         /* todo, for now not allowing autologon and mce both */
     {

--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -1527,7 +1527,7 @@ lfreerdp_pre_connect(freerdp *instance)
     instance->settings->password = g_strdup(mod->password);
     instance->settings->domain = g_strdup(mod->domain);
 
-    if (mod->client_info.rail_support_level > 0)
+    if (mod->client_info.rail_enable && (mod->client_info.rail_support_level > 0))
     {
         LLOGLN(0, ("Railsupport !!!!!!!!!!!!!!!!!!"));
         instance->settings->remote_app = 1;


### PR DESCRIPTION
I'm trying to connect xrdp with Microsoft Remote Desktop for Mac 8(8.0.30030),
Nothing displayed after logged in with neutrinordp-any.This is the output:
```
lfreerdp_context_new: 0x1fae370
loaded module 'libxrdpneutrinordp.so' ok, interface size 408984, version 3
lfreerdp_pre_connect:
The colormap is all NULL
Railsupport !!!!!!!!!!!!!!!!!!
host 10.10.xx.xx port 3389
connected to 10.10.xx.xx:3389
null server certificate
lxrdp_connect: freerdp_connect returned 1
...
```
I think remote_app should not been enable if INFO_RAIL is not set.
MS-RDPERP 3.3.5.1.3 and 3.3.5.1.4