### PR TITLE
xrdp: check term event for more responsive shutdown

### DIFF
--- a/common/trans.c
+++ b/common/trans.c
@@ -712,12 +712,20 @@ trans_connect(struct trans *self, const char *server, const char *port,
                 now = g_time3();
                 if (now - start_time < timeout)
                 {
-                    g_sleep(timeout / 5);
+                    g_sleep(100);
                 }
                 else
                 {
                     self->status = TRANS_STATUS_DOWN;
                     return 1;
+                }
+                if (self->is_term != NULL)
+                {
+                    if (self->is_term())
+                    {
+                        self->status = TRANS_STATUS_DOWN;
+                        return 1;
+                    }
                 }
             }
         }
@@ -748,12 +756,20 @@ trans_connect(struct trans *self, const char *server, const char *port,
                 now = g_time3();
                 if (now - start_time < timeout)
                 {
-                    g_sleep(timeout / 5);
+                    g_sleep(100);
                 }
                 else
                 {
                     self->status = TRANS_STATUS_DOWN;
                     return 1;
+                }
+                if (self->is_term != NULL)
+                {
+                    if (self->is_term())
+                    {
+                        self->status = TRANS_STATUS_DOWN;
+                        return 1;
+                    }
                 }
             }
         }

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -1440,7 +1440,10 @@ xrdp_mm_connect_chansrv(struct xrdp_mm *self, const char *ip, const char *port)
             self->chan_trans_up = 1;
             break;
         }
-
+        if (g_is_term())
+        {
+            break;
+        }
         g_sleep(1000);
         log_message(LOG_LEVEL_ERROR,"xrdp_mm_connect_chansrv: connect failed "
                   "trying again...");
@@ -2275,7 +2278,10 @@ xrdp_mm_connect(struct xrdp_mm *self)
                 ok = 1;
                 break;
             }
-
+            if (g_is_term())
+            {
+                break;
+            }
             g_sleep(1000);
             g_writeln("xrdp_mm_connect: connect failed "
                       "trying again...");


### PR DESCRIPTION
Annoying when xrdp does not kill with friendly kill command.  This is better method until we have a connection complete callback in trans.