### PR TITLE
Remove unnecessary reference from sesman/config.c

### DIFF
--- a/sesman/config.c
+++ b/sesman/config.c
@@ -34,8 +34,6 @@
 #include "sesman.h"
 #include "log.h"
 
-extern struct config_sesman *g_cfg; /* in sesman.c */
-
 
 
 /******************************************************************************/


### PR DESCRIPTION
Really small potential tidy-up I just spotted.

Following commit 81703c426f8498022c28a231df7d88ca28bfa842, there are
no longer any references to g_cfg from within sesman/config.c, and so the
`extern` reference can be removed, reducing the coupling between these two files.