### PR TITLE
Add resizeable backend VNC support

### DIFF
--- a/docs/man/sesman.ini.5.in
+++ b/docs/man/sesman.ini.5.in
@@ -148,12 +148,12 @@ This works only with xorgxrdp session. Moreover, xorgxrdp must be v0.2.9 or late
 
 .TP
 \fBPolicy\fR=\fI[Default|UBD|UBI|UBC|UBDI|UBDC]\fR
-Session allocation policy. By default, a new session is created
-for the combination <User,BitPerPixel> when using Xrdp, and
-for the combination <User,BitPerPixel,DisplaySize> when using Xvnc.
-This behavior can be changed by setting session policy to:
+Session allocation policy. Used to decide when to allocate a
+new session. Set to one of the following values:
 .br
 
+.br
+\fBDefault\fR - session per <User,BitPerPixel>
 .br
 \fBUBD\fR - session per <User,BitPerPixel,DisplaySize>
 .br
@@ -168,7 +168,8 @@ This behavior can be changed by setting session policy to:
 
 .br
 Note that the \fBUser\fR and \fBBitPerPixel\fR criteria cannot be turned
-off. For Xvnc connections, \fBDisplaySize\fR is always enabled as well.
+off. \fBDisplaySize\fR refers to the initial geometry of a connection,
+as actual display sizes can change dynamically.
 .br
 
 .SH "SECURITY"

--- a/docs/man/xrdp.ini.5.in
+++ b/docs/man/xrdp.ini.5.in
@@ -303,6 +303,14 @@ depth of the client. Only Xvnc and X11rdp use that setting. Xorg runs at
 \fI24\fR bpp.
 
 .TP
+\fBdisabled_encodings_mask\fR=\fI<number>\fR
+Set this bitmask to a non-zero value to prevent \fBxrdp\fR(8) requesting
+some features from the Xvnc server. You should only need to set this
+to  a non-zero value to work around bugs in your Xvnc server. The bit
+values supported for a particular release of \fBxrdp\fR(8) are documented in
+\fBxrdp.ini\fR.
+
+.TP
 \fBcode\fR=\fI<number>\fR|\fI0\fR
 Specifies the session type. The default, \fI0\fR, is Xvnc, \fI10\fR is
 X11rdp, and \fI20\fR is Xorg with xorgxrdp modules.

--- a/libxrdp/libxrdp.c
+++ b/libxrdp/libxrdp.c
@@ -1044,29 +1044,36 @@ libxrdp_orders_send_font(struct xrdp_session *session,
 }
 
 /*****************************************************************************/
+/* Note : if this is called on a multimon setup, the client is resized
+ * to a single monitor */
 int EXPORT_CC
 libxrdp_reset(struct xrdp_session *session,
               int width, int height, int bpp)
 {
     if (session->client_info != 0)
     {
+        struct xrdp_client_info *client_info = session->client_info;
+
         /* older client can't resize */
-        if (session->client_info->build <= 419)
+        if (client_info->build <= 419)
         {
             return 0;
         }
 
-        /* if same, don't need to do anything */
-        if (session->client_info->width == width &&
-                session->client_info->height == height &&
-                session->client_info->bpp == bpp)
+        /* if same (and only one monitor on client) don't need to do anything */
+        if (client_info->width == width &&
+            client_info->height == height &&
+            client_info->bpp == bpp &&
+            (client_info->monitorCount == 0 || client_info->multimon == 0))
         {
             return 0;
         }
 
-        session->client_info->width = width;
-        session->client_info->height = height;
-        session->client_info->bpp = bpp;
+        client_info->width = width;
+        client_info->height = height;
+        client_info->bpp = bpp;
+        client_info->monitorCount = 0;
+        client_info->multimon = 0;
     }
     else
     {

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -105,9 +105,6 @@ session_get_bydata(const char *name, int width, int height, int bpp, int type,
     {
         case SCP_SESSION_TYPE_XVNC: /* 0 */
             type = SESMAN_SESSION_TYPE_XVNC; /* 2 */
-            /* Xvnc cannot resize */
-            policy = (enum SESMAN_CFG_SESS_POLICY)
-                     (policy | SESMAN_CFG_SESS_POLICY_D);
             break;
         case SCP_SESSION_TYPE_XRDP: /* 1 */
             type = SESMAN_SESSION_TYPE_XRDP; /* 1 */

--- a/sesman/tools/sesrun.c
+++ b/sesman/tools/sesrun.c
@@ -31,6 +31,10 @@
 #include "sesman.h"
 #include "tcp.h"
 
+#if !defined(PACKAGE_VERSION)
+#define PACKAGE_VERSION "???"
+#endif
+
 struct config_sesman g_cfg; /* config.h */
 
 /******************************************************************************/
@@ -61,9 +65,9 @@ main(int argc, char **argv)
 
     if (argc == 1)
     {
-        g_printf("xrdp session starter v0.1\n");
+        g_printf("xrdp session starter v" PACKAGE_VERSION "\n");
         g_printf("\nusage:\n");
-        g_printf("sesrun <server> <username> <password> <width> <height> <bpp> <session_cod>\n");
+        g_printf("sesrun <server> <username> <password> <width> <height> <bpp> <session_code>\n");
         g_printf("session code 0 for Xvnc, 10 for X11RDP, 20 for Xorg\n");
     }
     else if (argc == 8)

--- a/vnc/vnc.h
+++ b/vnc/vnc.h
@@ -26,98 +26,129 @@
 
 #define CURRENT_MOD_VER 4
 
+/* Screen used for ExtendedDesktopSize / Set DesktopSize */
+struct vnc_screen
+{
+    int id;
+    int x;
+    int y;
+    int width;
+    int height;
+    int flags;
+};
+
+struct vnc_screen_layout
+{
+    int total_width;
+    int total_height;
+    unsigned int count;
+    /* For comparison, screens are sorted in increasing order of ID */
+    struct vnc_screen *s;
+};
+
+/**
+ * Keep track of resize status at start of connection
+ */
+enum vnc_resize_status
+{
+    VRS_WAITING_FOR_FIRST_UPDATE,
+    VRS_WAITING_FOR_RESIZE_CONFIRM,
+    VRS_DONE
+};
+
 struct vnc
 {
-  int size; /* size of this struct */
-  int version; /* internal version */
-  /* client functions */
-  int (*mod_start)(struct vnc* v, int w, int h, int bpp);
-  int (*mod_connect)(struct vnc* v);
-  int (*mod_event)(struct vnc* v, int msg, long param1, long param2,
-                   long param3, long param4);
-  int (*mod_signal)(struct vnc* v);
-  int (*mod_end)(struct vnc* v);
-  int (*mod_set_param)(struct vnc *v, const char *name, const char *value);
-  int (*mod_session_change)(struct vnc* v, int, int);
-  int (*mod_get_wait_objs)(struct vnc* v, tbus* read_objs, int* rcount,
-                           tbus* write_objs, int* wcount, int* timeout);
-  int (*mod_check_wait_objs)(struct vnc* v);
-  int (*mod_frame_ack)(struct vnc* v, int flags, int frame_id);
-  int (*mod_suppress_output)(struct vnc* v, int suppress,
-                             int left, int top, int right, int bottom);
-  tintptr mod_dumby[100 - 11]; /* align, 100 minus the number of mod
+    int size; /* size of this struct */
+    int version; /* internal version */
+    /* client functions */
+    int (*mod_start)(struct vnc *v, int w, int h, int bpp);
+    int (*mod_connect)(struct vnc *v);
+    int (*mod_event)(struct vnc *v, int msg, long param1, long param2,
+                     long param3, long param4);
+    int (*mod_signal)(struct vnc *v);
+    int (*mod_end)(struct vnc *v);
+    int (*mod_set_param)(struct vnc *v, const char *name, const char *value);
+    int (*mod_session_change)(struct vnc *v, int, int);
+    int (*mod_get_wait_objs)(struct vnc *v, tbus *read_objs, int *rcount,
+                             tbus *write_objs, int *wcount, int *timeout);
+    int (*mod_check_wait_objs)(struct vnc *v);
+    int (*mod_frame_ack)(struct vnc *v, int flags, int frame_id);
+    int (*mod_suppress_output)(struct vnc *v, int suppress,
+                               int left, int top, int right, int bottom);
+    tintptr mod_dumby[100 - 11]; /* align, 100 minus the number of mod
                                   functions above */
-  /* server functions */
-  int (*server_begin_update)(struct vnc* v);
-  int (*server_end_update)(struct vnc* v);
-  int (*server_fill_rect)(struct vnc* v, int x, int y, int cx, int cy);
-  int (*server_screen_blt)(struct vnc* v, int x, int y, int cx, int cy,
-                           int srcx, int srcy);
-  int (*server_paint_rect)(struct vnc* v, int x, int y, int cx, int cy,
-                           char* data, int width, int height, int srcx, int srcy);
-  int (*server_set_cursor)(struct vnc* v, int x, int y, char* data, char* mask);
-  int (*server_palette)(struct vnc* v, int* palette);
-  int (*server_msg)(struct vnc* v, const char *msg, int code);
-  int (*server_is_term)(struct vnc* v);
-  int (*server_set_clip)(struct vnc* v, int x, int y, int cx, int cy);
-  int (*server_reset_clip)(struct vnc* v);
-  int (*server_set_fgcolor)(struct vnc* v, int fgcolor);
-  int (*server_set_bgcolor)(struct vnc* v, int bgcolor);
-  int (*server_set_opcode)(struct vnc* v, int opcode);
-  int (*server_set_mixmode)(struct vnc* v, int mixmode);
-  int (*server_set_brush)(struct vnc* v, int x_origin, int y_origin,
-                          int style, char* pattern);
-  int (*server_set_pen)(struct vnc* v, int style,
-                        int width);
-  int (*server_draw_line)(struct vnc* v, int x1, int y1, int x2, int y2);
-  int (*server_add_char)(struct vnc* v, int font, int character,
-                         int offset, int baseline,
-                         int width, int height, char* data);
-  int (*server_draw_text)(struct vnc* v, int font,
-                          int flags, int mixmode, int clip_left, int clip_top,
-                          int clip_right, int clip_bottom,
-                          int box_left, int box_top,
-                          int box_right, int box_bottom,
-                          int x, int y, char* data, int data_len);
-  int (*server_reset)(struct vnc* v, int width, int height, int bpp);
-  int (*server_query_channel)(struct vnc* v, int index,
-                              char* channel_name,
-                              int* channel_flags);
-  int (*server_get_channel_id)(struct vnc* v, const char *name);
-  int (*server_send_to_channel)(struct vnc* v, int channel_id,
-                                char* data, int data_len,
-                                int total_data_len, int flags);
-  int (*server_bell_trigger)(struct vnc* v);
-  tintptr server_dumby[100 - 25]; /* align, 100 minus the number of server
+    /* server functions */
+    int (*server_begin_update)(struct vnc *v);
+    int (*server_end_update)(struct vnc *v);
+    int (*server_fill_rect)(struct vnc *v, int x, int y, int cx, int cy);
+    int (*server_screen_blt)(struct vnc *v, int x, int y, int cx, int cy,
+                             int srcx, int srcy);
+    int (*server_paint_rect)(struct vnc *v, int x, int y, int cx, int cy,
+                             char *data, int width, int height, int srcx, int srcy);
+    int (*server_set_cursor)(struct vnc *v, int x, int y, char *data, char *mask);
+    int (*server_palette)(struct vnc *v, int *palette);
+    int (*server_msg)(struct vnc *v, const char *msg, int code);
+    int (*server_is_term)(struct vnc *v);
+    int (*server_set_clip)(struct vnc *v, int x, int y, int cx, int cy);
+    int (*server_reset_clip)(struct vnc *v);
+    int (*server_set_fgcolor)(struct vnc *v, int fgcolor);
+    int (*server_set_bgcolor)(struct vnc *v, int bgcolor);
+    int (*server_set_opcode)(struct vnc *v, int opcode);
+    int (*server_set_mixmode)(struct vnc *v, int mixmode);
+    int (*server_set_brush)(struct vnc *v, int x_origin, int y_origin,
+                            int style, char *pattern);
+    int (*server_set_pen)(struct vnc *v, int style,
+                          int width);
+    int (*server_draw_line)(struct vnc *v, int x1, int y1, int x2, int y2);
+    int (*server_add_char)(struct vnc *v, int font, int character,
+                           int offset, int baseline,
+                           int width, int height, char *data);
+    int (*server_draw_text)(struct vnc *v, int font,
+                            int flags, int mixmode, int clip_left, int clip_top,
+                            int clip_right, int clip_bottom,
+                            int box_left, int box_top,
+                            int box_right, int box_bottom,
+                            int x, int y, char *data, int data_len);
+    int (*server_reset)(struct vnc *v, int width, int height, int bpp);
+    int (*server_query_channel)(struct vnc *v, int index,
+                                char *channel_name,
+                                int *channel_flags);
+    int (*server_get_channel_id)(struct vnc *v, const char *name);
+    int (*server_send_to_channel)(struct vnc *v, int channel_id,
+                                  char *data, int data_len,
+                                  int total_data_len, int flags);
+    int (*server_bell_trigger)(struct vnc *v);
+    tintptr server_dumby[100 - 25]; /* align, 100 minus the number of server
                                      functions above */
-  /* common */
-  tintptr handle; /* pointer to self as long */
-  tintptr wm;
-  tintptr painter;
-  tintptr si;
-  /* mod data */
-  int server_width;
-  int server_height;
-  int server_bpp;
-  int mod_width;
-  int mod_height;
-  int mod_bpp;
-  char mod_name[256];
-  int mod_mouse_state;
-  int palette[256];
-  int vnc_desktop;
-  char username[256];
-  char password[256];
-  char ip[256];
-  char port[256];
-  int sck_closed;
-  int shift_state; /* 0 up, 1 down */
-  int keylayout;
-  int clip_chanid;
-  struct stream *clip_data_s;
-  int delay_ms;
-  struct trans *trans;
-  int got_guid;
-  tui8 guid[16];
-  int suppress_output;
+    /* common */
+    tintptr handle; /* pointer to self as long */
+    tintptr wm;
+    tintptr painter;
+    tintptr si;
+    /* mod data */
+    int server_width;
+    int server_height;
+    int server_bpp;
+    char mod_name[256];
+    int mod_mouse_state;
+    int palette[256];
+    int vnc_desktop;
+    char username[256];
+    char password[256];
+    char ip[256];
+    char port[256];
+    int sck_closed;
+    int shift_state; /* 0 up, 1 down */
+    int keylayout;
+    int clip_chanid;
+    struct stream *clip_data_s;
+    int delay_ms;
+    struct trans *trans;
+    int got_guid;
+    tui8 guid[16];
+    int suppress_output;
+    unsigned int enabled_encodings_mask;
+    /* Resizeable support */
+    struct vnc_screen_layout client_layout;
+    enum vnc_resize_status initial_resize_status;
 };

--- a/xrdp/xrdp.ini.in
+++ b/xrdp/xrdp.ini.in
@@ -196,6 +196,10 @@ ip=127.0.0.1
 port=-1
 #xserverbpp=24
 #delay_ms=2000
+; Disable requested encodings to support buggy VNC servers
+; (1 = ExtendedDesktopSize)
+#disabled_encodings_mask=0
+
 
 [vnc-any]
 name=vnc-any

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -3261,6 +3261,9 @@ server_draw_text(struct xrdp_mod *mod, int font,
 }
 
 /*****************************************************************************/
+
+/* Note : if this is called on a multimon setup, the client is resized
+ * to a single monitor */
 int
 server_reset(struct xrdp_mod *mod, int width, int height, int bpp)
 {
@@ -3279,10 +3282,11 @@ server_reset(struct xrdp_mod *mod, int width, int height, int bpp)
         return 0;
     }
 
-    /* if same, don't need to do anything */
+    /* if same (and only one monitor on client) don't need to do anything */
     if (wm->client_info->width == width &&
-            wm->client_info->height == height &&
-            wm->client_info->bpp == bpp)
+        wm->client_info->height == height &&
+        wm->client_info->bpp == bpp &&
+        (wm->client_info->monitorCount == 0 || wm->client_info->multimon == 0))
     {
         return 0;
     }


### PR DESCRIPTION
This has been discussed in the past - see #259 and #287.

The VNC backend still seems to be with us, and still seems to have a few useful use cases.  At our place, developers working at home are are using Citrix to connect in to a Windows farm and from there are using XRDP to connect to the Linux workstations. Some of them have reported noticeably better performance using Xvnc rather than Xorg in this configuration.

This PR supports the VNC resizing and multi-screen features used by tigervnc.  I've tested both resizing and multi-screen on CentOS 7.5 (tigervnc 1.8). and resizing on xubuntu 18.04 (tigervnc 1.7).  I can't currently test multi-monitor on xubuntu due to a lack of kit.

I've made the feature optional to avoid breaking workflows used by existing users. So by default there's no change in behaviour. Users wishing to use the new feature can set "code=1" in xrdp.ini. This value is used to inform sesman that the VNC session is resizeable, and also to tell the VNC backend to request the ExtendedDesktopSize pseudo-encoding from Xvnc.

The module uses resize-on-reconnect in the same way that the Xorg backend does. When a single screen is used, the use can resize sessions on-the-fly by using 'xrandr -s', or by using the appropriate desktop utility.

For review purposes, I've split the PR into three commits. One is simply running astyle on the vnc module. Another is adding the extra functionality to the backend (plus removing some magic numbers), and the last is the changes to SCP and sesman. The last of these is the bit I'm least confident about. At the moment I haven't completely separated resizable VNC sessions from non-resizeable VNC sessions in sesman itself.  Would that be a better idea?