### PR TITLE
mkpamrules: Support openSUSE's usage of /usr/etc/pam.d to contain the pam configuration files.

### DIFF
--- a/instfiles/pam.d/mkpamrules
+++ b/instfiles/pam.d/mkpamrules
@@ -8,11 +8,17 @@ outfile="$3"
 
 service="xrdp-sesman"
 pamdir="/etc/pam.d"
+pamdir_suse="/usr/etc/pam.d"
 
 guess_rules ()
 {
   if test -s "$pamdir/password-auth"; then
     rules="redhat"
+    return
+  fi
+
+  if test -s "$pamdir_suse/common-account"; then
+    rules="suse"
     return
   fi
 


### PR DESCRIPTION
Please see the details in https://lists.opensuse.org/opensuse-factory/2019-08/msg00113.html. The old directory for probing the pam configuration file is also kept for backward compatibility reason.