### PR TITLE
xrdpvr/xrdpvr.c: remove redundant condition

### DIFF
--- a/xrdpvr/xrdpvr.c
+++ b/xrdpvr/xrdpvr.c
@@ -923,11 +923,6 @@ xrdpvr_write_to_client(void *channel, STREAM *s)
         index += bytes_written;
         bytes_to_send -= bytes_written;
 
-        if ((rv == 0) && (bytes_to_send == 0))
-        {
-            return 0;
-        }
-
         usleep(1000 * 3);
     }
 }


### PR DESCRIPTION
[xrdpvr/xrdpvr.c:918] -> [xrdpvr/xrdpvr.c:926]: (warning) Identical condition 'rv==0', second condition is always false