### PR TITLE
sesman/chansrv/chansrv_fuse.c: resolve double free found by cppcheck

### DIFF
--- a/sesman/chansrv/chansrv_fuse.c
+++ b/sesman/chansrv/chansrv_fuse.c
@@ -1691,7 +1691,6 @@ static void xfuse_cb_unlink(fuse_req_t req, fuse_ino_t parent,
             log_error("system out of memory");
             fuse_reply_err(req, ENOMEM);
             free(fip);
-            free(full_path);
         }
         else
         {


### PR DESCRIPTION
sesman/chansrv/chansrv_fuse.c:1719:9: error: Memory pointed to by 'full_path' is freed twice. [doubleFree]