### PR TITLE
common: flush stream in g_deinit()

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -166,6 +166,8 @@ g_deinit(void)
 #if defined(_WIN32)
     WSACleanup();
 #endif
+    fflush(stdout);
+    fflush(stderr);
     g_rm_temp_dir();
 }
 

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -3400,7 +3400,7 @@ g_getenv(const char *name)
 int
 g_exit(int exit_code)
 {
-    _exit(exit_code);
+    exit(exit_code);
     return 0;
 }
 


### PR DESCRIPTION
unless flushing stream before exitting, `xrdp --version | cat` will
show empty output.

Fixes #1471.

Actually, I'm not sure why `_exit()` is called in `g_exit()` instead of `exit()`.

@jsorg71 can you review if `g_deinit()` is a fair place to flush stream?
CC: @matt335672 I'd appreciate if you also have a look at this.