### PR TITLE
FreeBSD CI: simplify CI test for a while

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,14 +1,10 @@
 FreeBSD_task:
   matrix:
     env:
-      SSL: openssl
-    env:
       SSL: libressl
   matrix:
     freebsd_instance:
       image_family: freebsd-12-1
-    freebsd_instance:
-      image_family: freebsd-11-3-snap
   prepare_script:
     - pkg install -y $SSL git autoconf automake libtool pkgconf opus jpeg-turbo fdk-aac pixman libX11 libXfixes libXrandr nasm
     - git submodule update --init --recursive


### PR DESCRIPTION
some tests are failing due to FreeBSD OpenSSL version change.