### PR TITLE
xrdp_cache: Fix cppcheck 1.89+1.90 warnings

### DIFF
--- a/xrdp/xrdp_cache.c
+++ b/xrdp/xrdp_cache.c
@@ -231,7 +231,7 @@ xrdp_cache_reset(struct xrdp_cache *self,
 }
 
 #define COMPARE_WITH_CRC32(_b1, _b2) \
- ((_b1 != 0) && (_b2 != 0) && (_b1->crc32 == _b2->crc32) && \
+ ((_b1->crc32 == _b2->crc32) && \
   (_b1->bpp == _b2->bpp) && \
   (_b1->width == _b2->width) && (_b1->height == _b2->height))
 
@@ -368,8 +368,8 @@ xrdp_cache_add_bitmap(struct xrdp_cache *self, struct xrdp_bitmap *bitmap,
     for (jndex = 0; jndex < ll->count; jndex++)
     {
         cache_idx = list16_get_item(ll, jndex);
-        if (COMPARE_WITH_CRC32
-                 (self->bitmap_items[cache_id][cache_idx].bitmap, bitmap))
+        lbm = self->bitmap_items[cache_id][cache_idx].bitmap;
+        if ((lbm != NULL) && COMPARE_WITH_CRC32(lbm, bitmap))
         {
             LLOGLN(10, ("found bitmap at %d %d", index, jndex));
             found = 1;


### PR DESCRIPTION
This PR addresses the cppcheck warning generated by cppcheck for `xrdp/xrdp_cache.c` mentioned in #1473 

The `COMPARE_WITH_CRC32()` macro checks both its pointer arguments against NULL. cppcheck takes this as an indicator that either of the pointers could be NULL, and generates the warning accordingly against the 'bitmap' local variable

This variable cannot actually be NULL, and so the check performed by the macro is not needed.

In this case, the warning does not indicate an actual bug.