### PR TITLE
chansrv-fuse Fix cppcheck 1.89+1.90 warnings

### DIFF
--- a/sesman/chansrv/chansrv_fuse.c
+++ b/sesman/chansrv/chansrv_fuse.c
@@ -2537,6 +2537,8 @@ static char *get_name_for_entry_in_parent(fuse_ino_t parent, const char *name)
                                     strlen(result) + 1 + strlen(name) + 1);
         if (p == NULL)
         {
+            /* See cppcheck trac #9292 and #9437 */
+            /* cppcheck-suppress doubleFree symbolName=result */
             free(result);
             result = NULL;
         }

--- a/sesman/chansrv/devredir.c
+++ b/sesman/chansrv/devredir.c
@@ -185,28 +185,10 @@ devredir_init(void)
 {
     struct  stream *s;
     int     bytes;
-    int     fd;
-
-    union _u
-    {
-        tui32 clientID;
-        char buf[4];
-    } u;
+    tui32 clientID;
 
     /* get a random number that will act as a unique clientID */
-    if ((fd = open("/dev/urandom", O_RDONLY)) != -1)
-    {
-        if (read(fd, u.buf, 4) != 4)
-        {
-        }
-        close(fd);
-    }
-    else
-    {
-        /* /dev/urandom did not work - use address of struct s */
-        tui64 u64 = (tui64) (tintptr) &s;
-        u.clientID = (tui32) u64;
-    }
+    g_random((char *) &clientID, sizeof(clientID));
 
     /* setup stream */
     xstream_new(s, 1024);
@@ -216,7 +198,7 @@ devredir_init(void)
     xstream_wr_u16_le(s, PAKID_CORE_SERVER_ANNOUNCE);
     xstream_wr_u16_le(s, 0x0001);  /* server major ver                      */
     xstream_wr_u16_le(s, 0x000C);  /* server minor ver  - pretend 2 b Win 7 */
-    xstream_wr_u32_le(s, u.clientID); /* unique ClientID                    */
+    xstream_wr_u32_le(s, clientID); /* unique ClientID                      */
 
     /* send data to client */
     bytes = xstream_len(s);


### PR DESCRIPTION
This PR addresses the cppcheck warning generated by cppcheck for `xrdp/xrdp_{xfs,fuse}.c` and `devredir.c` mentioned in #1473

The warning in `chansrv_fuse.c` generated by cppcheck 1.90 (but not 1.89 or 1.82) appears to be a regression in cppcheck which has already been reported - see cppcheck TRAC [9292](https://trac.cppcheck.net/ticket/9292) and [9437](https://trac.cppcheck.net/ticket/9437). Following a `realloc()` failure, a `free()` of the original region results in a false positive.

cppcheck allows for false positives to be flagged with specially formed comments. The `--inline-suppr` command-line flag is needed to enable these. This approach has been taken for this file.

The warning in `devredir.c` appears to be valid code used to generate a random number if `/dev/urandom` is unavailable. I've simply replaced the code with a call to `g_random()` in this case.

So despite the warnings, no actual bugs have been found here.

**Update:** After #1487 was merged, the warning which had previously been generated for `chansrv_xfs.c` has now gone. This file has been removed from the original PR.