### PR TITLE
Add cppcheck to travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,12 @@ addons:
     packages: &common_deps
       - nasm
 
+# This is required to use a version of cppcheck other than that
+# suplied with the operating system
+cppcheck_defs: &cppcheck_defs
+  - CPPCHECK_VER=1.90
+  - CPPCHECK_REPO=https://github.com/danmar/cppcheck.git
+
 min_amd64_deps: &min_amd64_deps
   - *common_deps
   - libpam0g-dev
@@ -81,6 +87,22 @@ max_x86_conf: &max_x86_conf
       packages:
         - *max_x86_deps
 
+# For cppcheck, we've got a custom script
+cppcheck_conf: &cppcheck_conf
+  env:
+    - *cppcheck_defs
+
+#  addons:
+#    apt:
+#      packages:
+#        - cppcheck
+
+  script:
+    - ./bootstrap
+    - scripts/install_cppcheck.sh $CPPCHECK_REPO $CPPCHECK_VER
+    - scripts/run_cppcheck.sh -v $CPPCHECK_VER
+
+
 matrix:
   include:
 
@@ -107,6 +129,11 @@ matrix:
     << : *max_x86_conf
   - compiler: clang
     << : *max_x86_conf
+
+  # cppcheck
+  - name: cppcheck
+    compiler: gcc
+    << : *cppcheck_conf
 
 script:
   - ./bootstrap

--- a/scripts/install_cppcheck.sh
+++ b/scripts/install_cppcheck.sh
@@ -1,0 +1,105 @@
+#!/bin/sh
+
+# Script to install a version of cppcheck in ~/cppcheck.local/
+#
+# Used by Travis-CI builds, until Travis supports cppcheck natively
+#
+# Currently only supports git repos as sources
+#
+# Usage: /path/to/install_cppcheck.sh <cppcheck-git-repo> <version-tag>
+
+INSTALL_ROOT=~/cppcheck.local
+
+# ----------------------------------------------------------------------------
+# U S A G E
+# ----------------------------------------------------------------------------
+usage()
+{
+    echo "** Usage: $0 <git-repo URL> <version-tag>"
+    echo "   e.g. $0 https://github.com/danmar/cppcheck.git 1.90"
+} >&2
+
+# ----------------------------------------------------------------------------
+# C A L L _ M A K E
+#
+# Calls make with the specified parameters, but only displays the error
+# log if it fails
+# ----------------------------------------------------------------------------
+call_make()
+{
+    # Disable set -e, if active
+    set_entry_opts=`set +o`
+    set +e
+
+    status=1
+    log=`mktemp /tmp/cppcheck-log.XXXXXXXXXX`
+    if [ -n "$log" ]; then
+        make "$@" >$log 2>&1
+        status=$?
+        if [ $status -ne 0 ]; then
+            cat $log >&2
+        fi
+        rm $log
+    fi
+
+    # Re-enable `set -e` if active before
+    $set_entry_opts
+
+    return $status
+}
+
+# ----------------------------------------------------------------------------
+# M A I N
+# ----------------------------------------------------------------------------
+if [ $# -ne 2 ]; then
+    usage
+    exit 1
+fi
+REPO_URL="$1"
+CPPCHECK_VER="$2"
+
+# Already installed?
+exe=$INSTALL_ROOT/$CPPCHECK_VER/bin/cppcheck
+if [ -x "$exe" ]; then
+    echo "cppcheck version $CPPCHECK_VER is already installed at $exe" >&2
+    exit 0
+fi
+
+workdir=`mktemp -d /tmp/cppcheck.XXXXXXXXXX`
+if [ -z "$workdir" ]; then
+    echo "** Unable to create temporary working directory" 2>&1
+    exit 1
+fi
+
+# Use a sub-process for the next bit to restrict the scope of 'set -e'
+(
+    set -e ; # Exit sub-process on first error
+
+    # Put everything in this directory
+    FILESDIR=$INSTALL_ROOT/$CPPCHECK_VER
+
+    # CFGDIR is needed for cppcheck before 1.86
+    make_args="FILESDIR=$FILESDIR PREFIX=$FILESDIR CFGDIR=$FILESDIR"
+
+    # See https://stackoverflow.com/questions/
+    #     791959/download-a-specific-tag-with-git
+    git clone -b $CPPCHECK_VER --depth 1 $REPO_URL $workdir
+
+    cd $workdir
+    echo "Making cppcheck..."
+    # CFGDIR is needed for cppcheck before 1.86
+    call_make $make_args
+
+    echo "Installing cppcheck..."
+    mkdir -p $FILESDIR
+    call_make install $make_args
+)
+status=$?
+
+if [ $status -eq 0 ]; then
+    rm -rf $workdir
+else
+    "** Script failed. Work dir is $workdir" >&2
+fi
+
+exit $status

--- a/scripts/run_cppcheck.sh
+++ b/scripts/run_cppcheck.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+# Script to run cppcheck
+#
+# Usage: /path/to/run_cppcheck.sh [ -v CPPCHECK_VER] [<extra_opts_and_dirs>]
+#
+# - If <extra_opts_and_dirs> is missing, '.' is assumed
+# - If -v CPPCHECK_VER is specified, that version of cppcheck is run from
+#   ~/cppcheck.local (whether or not it's there!). Use install_cppcheck.sh
+#   to install a new version.
+#
+# Environment (all optional):-
+#
+# CPPCHECK       : Override the default cppcheck command ('cppcheck').
+#                  Ignored if -v is specified
+# CPPCHECK_FLAGS : Override the default cppcheck flags
+
+INSTALL_ROOT=~/cppcheck.local
+
+# Figure out CPPCHECK setting, if any. Currently '-v' must be the first
+# argument on the command line.
+case "$1" in
+    -v) # Version is separate parameter
+        if [ $# -ge 2 ]; then
+            CPPCHECK="$INSTALL_ROOT/$2/bin/cppcheck"
+            shift 2
+        else
+            echo "** ignoring '-v' with no arg" >&2
+            shift 1
+        fi
+        ;;
+    -v*) # Version is in same parameter
+        # ${parameter#word} is not supported by classic Bourne shell,
+        # but it is on bash, dash, etc. If it doesn't work on your shell,
+        # don't use this form!
+        CPPCHECK="$INSTALL_ROOT/${1#-v}/bin/cppcheck"
+        shift 1
+esac
+if [ -z "$CPPCHECK" ]; then
+    CPPCHECK=cppcheck
+fi
+
+# Supply default flags passed to cppcheck if necessary
+if [ -z "$CPPCHECK_FLAGS" ]; then
+    CPPCHECK_FLAGS="--quiet --force --std=c11 --std=c++11 --inline-suppr \
+                    --enable=warning --error-exitcode=1"
+fi
+
+# Any options/directories specified?
+if [ $# -eq 0 ]; then
+    set -- .
+fi
+
+# Display the cppcheck version and command for debugging
+"$CPPCHECK" --version && {
+    echo Command: $CPPCHECK $CPPCHECK_FLAGS "$@"
+    "$CPPCHECK" $CPPCHECK_FLAGS "$@"
+}


### PR DESCRIPTION
Adds a Travis CI job to run cppcheck automatically.

Since the default version of cppcheck used by the xenial image on Travis is fairly old (1.72), this PR downloads a later version of cppcheck and builds it before running it on XRDP. AFAICT travis-ci does not support a better way to do this currently - see travis-ci/travis-ci#1734. This obviously adds time to the check, but it's not enormous. My last run of this job on Travis took 3-and-a-half minutes.

The scripts used to download and run cppcheck are designed to be used by developers without needing to invoke travis-ci. TI can document this in the Wiki.

The version of cppcheck used is parameterized in `.travis.yml` so it can be easily updated.

**Edit 4/3/20:** Following the merge of #1481 and #1485, the CI job for this PR succeeds.
