### PR TITLE
Fix empty rhost in /var/log/auth.log

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -1453,7 +1453,7 @@ g_write_ip_address(int rcv_sck, char *ip_address, int bytes)
 
         if (ok)
         {
-            g_snprintf(ip_address, bytes, "%s:%d - socket: %d", addr, port, rcv_sck);
+            g_snprintf(ip_address, bytes, "%s:%d", addr, port);
         }
     }
 
@@ -2533,6 +2533,18 @@ g_strchr(const char* text, int c)
     }
 
     return strchr(text,c);
+}
+
+/* locates char in text reversely */
+const char *
+g_strrchr(const char* text, int c)
+{
+    if (text == NULL)
+    {
+        return 0;
+    }
+
+    return strrchr(text, c);
 }
 
 /*****************************************************************************/

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -121,6 +121,7 @@ int      g_file_delete(const char* filename);
 int      g_file_get_size(const char* filename);
 int      g_strlen(const char* text);
 const char *g_strchr(const char *text, int c);
+const char *g_strrchr(const char *text, int c);
 char*    g_strcpy(char* dest, const char* src);
 char*    g_strncpy(char* dest, const char* src, int len);
 char*    g_strcat(char* dest, const char* src);

--- a/sesman/auth.h
+++ b/sesman/auth.h
@@ -32,11 +32,12 @@
  * @brief Validates user's password
  * @param user user's login name
  * @param pass user's password
+ * @param ip user's IP address
  * @return non-zero handle on success, 0 on failure
  *
  */
 long
-auth_userpass(const char *user, const char *pass, int *errorcode);
+auth_userpass(const char *user, const char *pass, char *ip, int *errorcode);
 
 /**
  *

--- a/sesman/scp_v0.c
+++ b/sesman/scp_v0.c
@@ -42,7 +42,7 @@ scp_v0_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
     int errorcode = 0;
     bool_t do_auth_end = 1;
 
-    data = auth_userpass(s->username, s->password, &errorcode);
+    data = auth_userpass(s->username, s->password, s->client_ip, &errorcode);
 
     if (s->type == SCP_GW_AUTHENTICATION)
     {

--- a/sesman/scp_v1.c
+++ b/sesman/scp_v1.c
@@ -55,7 +55,7 @@ scp_v1_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
     retries = g_cfg->sec.login_retry;
     current_try = retries;
 
-    data = auth_userpass(s->username, s->password,NULL);
+    data = auth_userpass(s->username, s->password, s->client_ip, NULL);
     /*LOG_DBG("user: %s\npass: %s", s->username, s->password);*/
 
     while ((!data) && ((retries == 0) || (current_try > 0)))
@@ -70,7 +70,7 @@ scp_v1_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
         {
             case SCP_SERVER_STATE_OK:
                 /* all ok, we got new username and password */
-                data = auth_userpass(s->username, s->password,NULL);
+                data = auth_userpass(s->username, s->password, s->client_ip, NULL);
 
                 /* one try less */
                 if (current_try > 0)

--- a/sesman/scp_v1_mng.c
+++ b/sesman/scp_v1_mng.c
@@ -46,7 +46,7 @@ scp_v1_mng_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
     int scount;
     int end = 0;
 
-    data = auth_userpass(s->username, s->password,NULL);
+    data = auth_userpass(s->username, s->password, s->client_ip, NULL);
     /*LOG_DBG("user: %s\npass: %s", s->username, s->password);*/
 
     if (!data)

--- a/sesman/verify_user.c
+++ b/sesman/verify_user.c
@@ -52,7 +52,7 @@ auth_account_disabled(struct spwd *stp);
 /******************************************************************************/
 /* returns boolean */
 long
-auth_userpass(const char *user, const char *pass, int *errorcode)
+auth_userpass(const char *user, const char *pass, char *ip, int *errorcode)
 {
     const char *encr;
     const char *epass;

--- a/sesman/verify_user_bsd.c
+++ b/sesman/verify_user_bsd.c
@@ -48,7 +48,7 @@ extern struct config_sesman* g_cfg; /* in sesman.c */
 /******************************************************************************/
 /* returns boolean */
 long
-auth_userpass(const char *user, const char *pass, int *errorcode)
+auth_userpass(const char *user, const char *pass, char *ip, int *errorcode)
 {
     int ret = auth_userokay(user, NULL, "auth-xrdp", pass);
     return ret;

--- a/sesman/verify_user_kerberos.c
+++ b/sesman/verify_user_kerberos.c
@@ -400,7 +400,7 @@ cleanup:
 /******************************************************************************/
 /* returns boolean */
 int
-auth_userpass(const char *user, const char *pass, int *errorcode)
+auth_userpass(const char *user, const char *pass, char *ip, int *errorcode)
 {
     struct k_opts opts;
     struct k5_data k5;

--- a/sesman/verify_user_pam.c
+++ b/sesman/verify_user_pam.c
@@ -107,11 +107,16 @@ get_service_name(char *service_name)
  Stores the detailed error code in the errorcode variable*/
 
 long
-auth_userpass(const char *user, const char *pass, int *errorcode)
+auth_userpass(const char *user, const char *pass, char *ip, int *errorcode)
 {
     int error;
     struct t_auth_info *auth_info;
     char service_name[256];
+    char* r_host;
+    const char* r_host_port_delim;
+
+    r_host_port_delim = g_strrchr(ip, ':');
+    r_host = r_host_port_delim ? g_strndup(ip, r_host_port_delim - ip) : g_strdup(ip);
 
     get_service_name(service_name);
     auth_info = g_new0(struct t_auth_info, 1);
@@ -139,6 +144,14 @@ auth_userpass(const char *user, const char *pass, int *errorcode)
         g_printf("pam_set_item failed: %s\r\n",
                  pam_strerror(auth_info->ph, error));
     }
+    error = pam_set_item(auth_info->ph, PAM_RHOST, r_host);
+    if (error != PAM_SUCCESS)
+    {
+        g_printf("pam_set_item failed: %s\r\n",
+                 pam_strerror(auth_info->ph, error));
+    }
+    g_free(r_host);
+    r_host = 0;
 
     error = pam_authenticate(auth_info->ph, 0);
 

--- a/sesman/verify_user_pam_userpass.c
+++ b/sesman/verify_user_pam_userpass.c
@@ -38,7 +38,7 @@
 /******************************************************************************/
 /* returns boolean */
 int
-auth_userpass(const char *user, const char *pass, int *errorcode)
+auth_userpass(const char *user, const char *pass, char *ip, int *errorcode)
 {
     pam_handle_t *pamh;
     pam_userpass_t userpass;


### PR DESCRIPTION
I found that the service xrdp-sesman writes an empty rhost into log file /var/log/auth.log. Because of this, the rule "pam-generic" (/etc/fail2ban/filter.d/pam-generic.conf) in the package "fail2ban" does not work. This PR fixing this issue.