### PR TITLE
Check before free

### DIFF
--- a/sesman/chansrv/chansrv_xfs.c
+++ b/sesman/chansrv/chansrv_xfs.c
@@ -397,7 +397,8 @@ xfs_delete_xfs_fs(struct xfs_fs *xfs)
         size_t i;
         for (i = 0 ; i < xfs->inode_count; ++i)
         {
-            free(xfs->inode_table[i]);
+            if(xfs->inode_table[i] != NULL)
+                free(xfs->inode_table[i]);
         }
     }
     free(xfs->inode_table);


### PR DESCRIPTION
  -- inode table array element can be null (ex: element zero intentionally null)