### PR TITLE
Fix Xorg path for Arch Linux

### DIFF
--- a/sesman/sesman.ini.in
+++ b/sesman/sesman.ini.in
@@ -80,7 +80,7 @@ SyslogLevel=DEBUG
 ; Fedora 26 or later    :  param=/usr/libexec/Xorg
 ; Debian 9 or later     :  param=/usr/lib/xorg/Xorg
 ; Ubuntu 16.04 or later :  param=/usr/lib/xorg/Xorg
-; Arch Linux            :  param=/usr/lib/xorg-server/Xorg
+; Arch Linux            :  param=/usr/lib/Xorg
 ; CentOS 7              :  param=/usr/bin/Xorg or param=Xorg
 ;
 param=Xorg


### PR DESCRIPTION
It has been moved: https://www.archlinux.org/packages/extra/x86_64/xorg-server/

Fixes: #1448