### PR TITLE
Address possible memory out-of-bounds accesses on connect requests

### DIFF
--- a/common/trans.c
+++ b/common/trans.c
@@ -452,17 +452,14 @@ trans_force_read_s(struct trans *self, struct stream *in_s, int size)
 {
     int rcvd;
 
-    if (self->status != TRANS_STATUS_UP)
+    if (self->status != TRANS_STATUS_UP ||
+        size < 0 || !s_check_rem_out(in_s, size))
     {
         return 1;
     }
+
     while (size > 0)
     {
-        /* make sure stream has room */
-        if ((in_s->end + size) > (in_s->data + in_s->size))
-        {
-            return 1;
-        }
         rcvd = self->trans_recv(self, in_s->end, size);
         if (rcvd == -1)
         {

--- a/libxrdp/libxrdp.c
+++ b/libxrdp/libxrdp.c
@@ -125,24 +125,18 @@ libxrdp_force_read(struct trans* trans)
 
     if (trans_force_read(trans, 4) != 0)
     {
-        g_writeln("libxrdp_force_read: error");
+        g_writeln("libxrdp_force_read: header read error");
         return 0;
     }
     bytes = libxrdp_get_pdu_bytes(s->data);
-    if (bytes < 1)
+    if (bytes < 4 || bytes > s->size)
     {
-        g_writeln("libxrdp_force_read: error");
+        g_writeln("libxrdp_force_read: bad header length %d", bytes);
         return 0;
     }
-    if (bytes > 32 * 1024)
-    {
-        g_writeln("libxrdp_force_read: error");
-        return 0;
-    }
-
     if (trans_force_read(trans, bytes - 4) != 0)
     {
-        g_writeln("libxrdp_force_read: error");
+        g_writeln("libxrdp_force_read: Can't read PDU");
         return 0;
     }
     return s;


### PR DESCRIPTION
This PR addresses a couple of OOB accesses raised by @hac425xxx and contains a number of other fixes.

- `trans_force_read_s()` The max size check does not need to be part of the read loop. This change moves the check out of the loop and uses a macro from `parse.h` to do it.
- `libxrdp_force_read()` Error messages improved, plus fixed another possible unreported OOB if a length of 1-3 was passed in the TKTP header.
- `xrdp_iso_process_rdp_neg_req()` Added check that the stream contains the rest of the RDP_NEG_REQ ([MS-RDPCGR](https://winprotocoldoc.blob.core.windows.net/productionwindowsarchives/MS-RDPBCGR/%5bMS-RDPBCGR%5d.pdf) 2.2.1.1.1) before reading it.
- `xrdp_iso_recv_msg()` Added function header explaining purpose of function (took me a while to figure it out). Added check that enough data remained on stream for TPKT + first two bytes of X.224 CR-TPDU (fixes #1531) . Removed pointless check of length in TPKT header as this has already been checked when the stream was set up. Added check for reserved length value ([X.224](https://www.itu.int/rec/dologin_pub.asp?lang=e&id=T-REC-X.224-199511-I!!PDF-E&type=items) 13.2.1)
- `xrdp_iso_incoming()` Function header added with doc references. Checked that X.224 length indicator field is consistent with the TPKT length and rejected packet if not (See [MS-RDPCGR](https://winprotocoldoc.blob.core.windows.net/productionwindowsarchives/MS-RDPBCGR/%5bMS-RDPBCGR%5d.pdf) 3.3.5.3.1). This allows us to use the stream length for the remainder of the function and fixes #1530. Checked stream contains enough data for a RDP_NEG_CORRELATION_INFO ([MS-RDPCGR](https://winprotocoldoc.blob.core.windows.net/productionwindowsarchives/MS-RDPBCGR/%5bMS-RDPBCGR%5d.pdf) 2.2.1.1.2) if encountered. Simplifies parsing of routingToken / cookie fields if encountered.