### PR TITLE
Check for overflow before g_malloc() calls

### DIFF
--- a/sesman/chansrv/chansrv.c
+++ b/sesman/chansrv/chansrv.c
@@ -21,6 +21,8 @@
 #include <config_ac.h>
 #endif
 
+#include <limits.h>
+
 #include "arch.h"
 #include "os_calls.h"
 #include "thread_calls.h"
@@ -1067,6 +1069,11 @@ my_api_trans_data_in(struct trans *trans)
         rv = 1;
         in_uint32_le(s, channel_name_bytes);
         //g_writeln("my_api_trans_data_in: channel_name_bytes %d", channel_name_bytes);
+        if (channel_name_bytes == INT_MAX)
+        {
+            // Adding one to this will overflow
+            return 1;
+        }
         chan_name = g_new0(char, channel_name_bytes + 1);
         if (chan_name == NULL)
         {

--- a/sesman/chansrv/smartcard_pcsc.c
+++ b/sesman/chansrv/smartcard_pcsc.c
@@ -27,6 +27,8 @@
 #include <config_ac.h>
 #endif
 
+#include <limits.h>
+
 #define JAY_TODO_CONTEXT    0
 #define JAY_TODO_WIDE       1
 
@@ -597,6 +599,11 @@ scard_process_list_readers(struct trans *con, struct stream *in_s)
     uds_client = (struct pcsc_uds_client *) (con->callback_data);
     in_uint32_le(in_s, hContext);
     in_uint32_le(in_s, bytes_groups);
+    if (bytes_groups == INT_MAX)
+    {
+        // Adding one to this will overflow
+        return 1;
+    }
     groups = (char *) g_malloc(bytes_groups + 1, 1);
     in_uint8a(in_s, groups, bytes_groups);
     in_uint32_le(in_s, cchReaders);

--- a/xrdp/xrdp_bitmap.c
+++ b/xrdp/xrdp_bitmap.c
@@ -25,6 +25,8 @@
 #include <config_ac.h>
 #endif
 
+#include <limits.h>
+
 #include "xrdp.h"
 #include "log.h"
 
@@ -123,6 +125,13 @@ xrdp_bitmap_create(int width, int height, int bpp,
 
     if (self->type == WND_TYPE_BITMAP || self->type == WND_TYPE_IMAGE)
     {
+        if (width > INT_MAX / Bpp / height)
+        {
+            LLOGLN(0, ("xrdp_bitmap_create: size overflow %dx%dx%d",
+                       width, height, Bpp));
+            g_free(self);
+            return NULL;
+        }
         self->data = (char *)g_malloc(width * height * Bpp, 0);
     }
 
@@ -130,6 +139,13 @@ xrdp_bitmap_create(int width, int height, int bpp,
     if (self->type == WND_TYPE_SCREEN) /* noorders */
     {
         LLOGLN(0, ("xrdp_bitmap_create: noorders"));
+        if (width > INT_MAX / Bpp / height)
+        {
+            LLOGLN(0, ("xrdp_bitmap_create: size overflow %dx%dx%d",
+                       width, height, Bpp));
+            g_free(self);
+            return NULL;
+        }
         self->data = (char *) g_malloc(width * height * Bpp, 0);
     }
 #endif


### PR DESCRIPTION
Fixes #1533, fixes #1534, fixes #1544

This is the simplest fix I could come up with. Arguably `g_malloc()` should take an unsigned type of some sort (`size_t` even) but I think implementing this would involve a lot of minor changes to many files, given the general absence of this type in the codebase. Maybe now is a good time to do that(?) Anyone got any thoughts on that?