### PR TITLE
Check for overflow before g_malloc() calls

### DIFF
--- a/common/ms-rdpbcgr.h
+++ b/common/ms-rdpbcgr.h
@@ -74,8 +74,11 @@
 #define CONNECTION_TYPE_LAN            0x06
 #define CONNECTION_TYPE_AUTODETECT     0x07
 
-/* Virtual channel options */
-/* Channel Definition Structure: options (2.2.1.3.4.1) */
+/* Channel definition structure CHANNEL_DEF (2.2.1.3.4.1) */
+/* This isn't explicitly named in MS-RDPBCGR */
+#define CHANNEL_NAME_LEN                7
+
+/* Oprions field */
 /* NOTE: XR_ prefixed to avoid conflict with FreeRDP */
 #define XR_CHANNEL_OPTION_INITIALIZED   0x80000000
 #define XR_CHANNEL_OPTION_ENCRYPT_RDP   0x40000000

--- a/sesman/chansrv/chansrv.c
+++ b/sesman/chansrv/chansrv.c
@@ -39,6 +39,9 @@
 #include "xrdp_sockets.h"
 #include "audin.h"
 
+#define CHANNEL_NAME_BYTES 7
+#define MAX_PATH 260
+
 static struct trans *g_lis_trans = 0;
 static struct trans *g_con_trans = 0;
 static struct trans *g_api_lis_trans = 0;
@@ -1042,7 +1045,7 @@ my_api_trans_data_in(struct trans *trans)
     int rv;
     int bytes;
     int ver;
-    int channel_name_bytes;
+    unsigned int channel_name_bytes;
     struct chansrv_drdynvc_procs procs;
     char *chan_name;
 
@@ -1067,6 +1070,13 @@ my_api_trans_data_in(struct trans *trans)
         rv = 1;
         in_uint32_le(s, channel_name_bytes);
         //g_writeln("my_api_trans_data_in: channel_name_bytes %d", channel_name_bytes);
+        /*
+         * Name is limited to CHANNEL_NAME_BYTES for an SVC, or MAX_PATH
+         * bytes for a DVC */
+        if (channel_name_bytes > MAX(CHANNEL_NAME_BYTES, MAX_PATH))
+        {
+            return 1;
+        }
         chan_name = g_new0(char, channel_name_bytes + 1);
         if (chan_name == NULL)
         {

--- a/sesman/chansrv/chansrv.c
+++ b/sesman/chansrv/chansrv.c
@@ -39,7 +39,8 @@
 #include "xrdp_sockets.h"
 #include "audin.h"
 
-#define CHANNEL_NAME_BYTES 7
+#include "ms-rdpbcgr.h"
+
 #define MAX_PATH 260
 
 static struct trans *g_lis_trans = 0;
@@ -1047,10 +1048,10 @@ my_api_trans_data_in(struct trans *trans)
     int ver;
     struct chansrv_drdynvc_procs procs;
     /*
-     * Name is limited to CHANNEL_NAME_BYTES for an SVC, or MAX_PATH
+     * Name is limited to CHANNEL_NAME_LEN for an SVC, or MAX_PATH
      * bytes for a DVC
      */
-    char chan_name[MAX(CHANNEL_NAME_BYTES, MAX_PATH) + 1];
+    char chan_name[MAX(CHANNEL_NAME_LEN, MAX_PATH) + 1];
     unsigned int channel_name_bytes;
 
     //g_writeln("my_api_trans_data_in: extra_flags %d", trans->extra_flags);


### PR DESCRIPTION
Here's a better attempt to replace #1551 

Fixes  #1533, fixes #1534, fixes #1544

#1533 - Checked the supported strings for the group parameter (see here). They're all relatively small, so code restructured to just allow a short string here, and check for it.
#1534 - Similarly the allowed string for a virtual channel name is quite small here - see here.
#1544 - Checked for integer overflow explicitly when requesting buffer.

I've not attempted to change the argument to g_malloc() to an unsigned integer here - I think that needs more thought and a separate PR