### PR TITLE
Support Slackware with pam

### DIFF
--- a/instfiles/pam.d/mkpamrules
+++ b/instfiles/pam.d/mkpamrules
@@ -10,51 +10,87 @@ service="xrdp-sesman"
 pamdir="/etc/pam.d"
 pamdir_suse="/usr/etc/pam.d"
 
+# Modules needed by xrdp-sesman.unix, if we get to that
+unix_modules_needed="pam_unix.so pam_env.so pam_nologin.so"
+
+# Directories where pam modules might be installed
+# Add to this list as platforms are added
+pam_module_dir_searchpath="/lib*/security /usr/lib*/security /lib/*/security /usr/lib/*/security"
+
+find_pam_module_dir()
+{
+  # Looks for the pam security module directory
+  set -- $pam_module_dir_searchpath
+  for d in "$@"; do
+    if [ -s $d/pam_unix.so ]; then
+      echo $d
+      break
+    fi
+  done
+}
+
+can_apply_unix_config()
+{
+  result=0
+  module_dir="$1"
+  for m in $unix_modules_needed; do
+    if [ ! -s $module_dir/$m ]; then
+      echo "  ** $m not found" >&2
+      result=1
+    fi
+  done
+
+  return $result
+}
+
 guess_rules ()
 {
-  if test -s "$pamdir/password-auth"; then
+  rules=
+  if [ -s "$pamdir/password-auth" ]; then
     rules="redhat"
-    return
-  fi
 
-  if test -s "$pamdir_suse/common-account"; then
+  elif [ -s "$pamdir_suse/common-account" ]; then
     rules="suse"
-    return
-  fi
 
-  if test -s "$pamdir/common-account"; then
+  elif [ -s "$pamdir/common-account" ]; then
     if grep "^@include" "$pamdir/passwd" >/dev/null 2>&1; then
       rules="debian"
     else
       rules="suse"
     fi
-    return
-  fi
 
-  if test ! -f "$pamdir/system-auth" -a -s "$pamdir/system"; then
+  elif [ ! -f "$pamdir/system-auth" -a -s "$pamdir/system" ]; then
     rules="freebsd"
-    return
-  fi
 
-  if test -s "$pamdir/authorization"; then
+  elif [ -s "$pamdir/authorization" ]; then
     rules="macos"
-    return
-  fi
 
-  if test -s "$pamdir/system-remote-login"; then
+  elif [ -s "$pamdir/system-remote-login" ]; then
     rules="arch"
-    return
-  fi
 
-  rules="unix"
-  return
+  elif [ -s "$pamdir/system-auth" ]; then
+    rules="system"
+
+  else
+    module_dir=`find_pam_module_dir`
+    if [ -d "$module_dir" ]; then
+      #echo "- Found pam modules in $module_dir" >&2
+      if can_apply_unix_config "$module_dir" ; then
+        rules="unix"
+      fi
+    fi
+  fi
 }
 
-if test "$rules" = "auto"; then
+if [ "$rules" = "auto" ]; then
   guess_rules
+  if [ -z "$rules" ]; then
+    echo "** Can't guess PAM rules for this system"
+    exit 1
+  fi
 fi
 
-if test -s "$srcdir/$service.$rules"; then
+if [ -s "$srcdir/$service.$rules" ]; then
   ln -nsf "$srcdir/$service.$rules" "$outfile"
 else
   echo "Cannot find $srcdir/$service.$rules"

--- a/instfiles/pam.d/xrdp-sesman.system
+++ b/instfiles/pam.d/xrdp-sesman.system
@@ -1,0 +1,5 @@
+#%PAM-1.0
+auth        include     system-auth
+account     include     system-auth
+password    include     system-auth
+session     include     system-auth

--- a/instfiles/pam.d/xrdp-sesman.unix
+++ b/instfiles/pam.d/xrdp-sesman.unix
@@ -1,5 +1,16 @@
 #%PAM-1.0
-auth        include     system-auth
-account     include     system-auth
-password    include     system-auth
-session     include     system-auth
+#
+# Really basic authentication set when nothing else is available
+#
+# You may need to edit this to suit your system depending on the
+# required functionality.
+#
+auth       required     pam_unix.so shadow
+auth       required     pam_env.so
+
+password    required    pam_unix.so
+
+account     required    pam_unix.so
+account     required    pam_nologin.so
+
+session     required    pam_unix.so


### PR DESCRIPTION
Slackware recently acquired a pam package, which can be used with XRDP.

This PR adds an old-style PAM definition for sesman using `pam_unix.so`. This definition is now installed, if suitable, with `make install` and if no better definitions are found. The definition would work on other systems than Slackware.

The `mkpamrules` script has been tidied up slightly, while staying Bourne shell compatible. It will now fail if it can't install a usable PAM definition rather than installing something unusable.

This PR addresses half of the concerns raised in #1558 