### PR TITLE
Ignore TS_MULTIFRAGMENTUPDATE_CAPABILITYSET from client if fp disabled

### DIFF
--- a/libxrdp/xrdp_caps.c
+++ b/libxrdp/xrdp_caps.c
@@ -561,7 +561,10 @@ xrdp_caps_process_multifragmentupdate(struct xrdp_rdp *self, struct stream *s,
     int MaxRequestSize;
 
     in_uint32_le(s, MaxRequestSize);
-    self->client_info.max_fastpath_frag_bytes = MaxRequestSize;
+    if (self->client_info.use_fast_path & 1)
+    {
+        self->client_info.max_fastpath_frag_bytes = MaxRequestSize;
+    }
     return 0;
 }
 


### PR DESCRIPTION
Fixes #1569 

rdesktop 1.9.0 (as delivered with Ubuntu 20.04) sends a TS_MULTIFRAGMENTUPDATE_CAPABILITYSET structure ([MS-RDPBCGR] 2.2.7.2.6) with a MaxRequestSize of 65535.

If the user has disabled fastpath output using `use_fastpath` in `xrdp.ini`, the following happens:-

- An output buffer is created of size 32768 in `xrdp_orders_create()`.
- Receipt of TS_MULTIFRAGMENTUPDATE_CAPABILITYSET in `xrdp_caps_process_multifragmentupdate()` sets `client_info.max_fastpath_frag_bytes` to 65535.
- This value is used by `xrdp_orders_check()` va the `MAX_ORDERS_SIZE` macro to determine when to send the orders buffer. Consequently the buffer overflows when being written to.

This PR simply ignores any sent `MaxRequestSize` value if fastpath output is disabled.
