### PR TITLE
Prevent chansrv input channels being scanned during a server reset

### DIFF
--- a/libxrdp/libxrdp.c
+++ b/libxrdp/libxrdp.c
@@ -47,6 +47,7 @@ libxrdp_init(tbus id, struct trans *trans)
     session->rdp = xrdp_rdp_create(session, trans);
     session->orders = xrdp_orders_create(session, (struct xrdp_rdp *)session->rdp);
     session->client_info = &(((struct xrdp_rdp *)session->rdp)->client_info);
+    session->check_for_app_input = 1;
     return session;
 }
 
@@ -1078,7 +1079,12 @@ libxrdp_reset(struct xrdp_session *session,
         return 1;
     }
 
-    /* shut down the rdp client */
+    /* shut down the rdp client
+     *
+     * When resetting the lib, disable application input checks, as
+     * otherwise we can send a channel message to the other end while
+     * the channels are inactive ([MS-RDPBCGR] 3.2.5.5.1 */
+    session->check_for_app_input = 0;
     if (xrdp_rdp_send_deactivate((struct xrdp_rdp *)session->rdp) != 0)
     {
         return 1;
@@ -1089,6 +1095,9 @@ libxrdp_reset(struct xrdp_session *session,
     {
         return 1;
     }
+
+    /* Re-enable application input checks */
+    session->check_for_app_input = 1;
 
     return 0;
 }

--- a/libxrdp/libxrdpinc.h
+++ b/libxrdp/libxrdpinc.h
@@ -66,6 +66,7 @@ struct xrdp_session
     struct trans *trans;
     int (*callback)(intptr_t id, int msg, intptr_t param1, intptr_t param2,
                     intptr_t param3, intptr_t param4);
+    int check_for_app_input;
     void *rdp;
     void *orders;
     struct xrdp_client_info *client_info;

--- a/libxrdp/xrdp_fastpath.c
+++ b/libxrdp/xrdp_fastpath.c
@@ -146,7 +146,10 @@ xrdp_fastpath_send(struct xrdp_fastpath *self, struct stream *s)
     {
         return 1;
     }
-    xrdp_fastpath_session_callback(self, 0x5556, 0, 0, 0, 0);
+    if (self->session->check_for_app_input)
+    {
+        xrdp_fastpath_session_callback(self, 0x5556, 0, 0, 0, 0);
+    }
     return 0;
 }
 

--- a/libxrdp/xrdp_mcs.c
+++ b/libxrdp/xrdp_mcs.c
@@ -997,8 +997,11 @@ xrdp_mcs_call_callback(struct xrdp_mcs *self)
     {
         if (session->callback != 0)
         {
-            /* in xrdp_wm.c */
-            rv = session->callback(session->id, 0x5556, 0, 0, 0, 0);
+            if (session->check_for_app_input)
+            {
+                /* in xrdp_wm.c */
+                rv = session->callback(session->id, 0x5556, 0, 0, 0, 0);
+            }
         }
         else
         {


### PR DESCRIPTION
A server reset is used to implement  a client resize.

Currently this is done by sending a TS_DEACTIVATE_ALL_PDU and then resending capabilities with TS_DEMAND_ACTIVE_PDU by `libxrdp_reset()`

It's possible at the moment for channel data to be read from chansrv and sent to the RDP client between these two messages. This is because at the end of `xrdp_mcs_send()` for the 'deactivate all' we call `xrdp_mcs_call_callback()`. If there's pending chansrv data it's sent to the client.

This appears to be at odds with [MS-RDPBCGR 3.2.5.5.1](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/e3dddf9e-ddc7-4622-a0d4-cc1d68f1f1ac) which calls for the client to disable all its input handlers.

This is also what FreeRDP 2.0.0 appears to do. If a message is received between TS_DEACTIVATE_ALL_PDU and TS_DEMAND_ACTIVE_PDU for a channel other than the MCS global channel an error is reported.

This PR disables the chansrv input checks while a `libxrdp_reset()` is in progress.