### PR TITLE
xrdp: add newline at eol of PID file

### DIFF
--- a/xrdp/xrdp.c
+++ b/xrdp/xrdp.c
@@ -623,7 +623,7 @@ main(int argc, char **argv)
         }
         else
         {
-            g_sprintf(text, "%d", pid);
+            g_snprintf(text, "%d", pid);
             g_file_write(fd, text, g_strlen(text));
             g_file_close(fd);
         }


### PR DESCRIPTION
sesman puts newline at eol of PID file but xrdp don't. I found that it
is reported by Ubuntu user 11 years ago.

Reported by:    https://bugs.launchpad.net/ubuntu/+source/xrdp/+bug/484116