### PR TITLE
Read only configuration for virtual X server

### DIFF
--- a/sesman/sesman.ini.in
+++ b/sesman/sesman.ini.in
@@ -85,8 +85,8 @@ SyslogLevel=DEBUG
 ;
 param=Xorg
 ; Leave the rest paramaters as-is unless you understand what will happen.
-param=-config
-param=xrdp/xorg.conf
+param=-configdir
+param=xrdp
 param=-noreset
 param=-nolisten
 param=tcp


### PR DESCRIPTION
When the X server is launched, only the configuration _main file_
xrdp/xorg.conf is specified, but the configuration _directory_ is
retained as default, as is indicated by the output:

    (==) Using config directory: "/etc/X11/xorg.conf.d"

in ~/.xorgxrdp.10.log. If the host has an existing X server running for
the console, and this is not entirely auto-configured, configuration
files from this directory will be picked up and cause the virtual X
server that XRDP launches to attempt to load modules for it, which may
result in errors such as:

    (EE) parse_vt_settings: Cannot open /dev/tty0 (Permission denied)

or

    (EE) xf86OpenConsole: Cannot open virtual console 2 (Permission denied)

Searching the Internet for these errors will typically lead the user to
a myriad of non-solutions, involving added the user to the tty group, or
editing /etc/X11/Xwrapper.config.

This changeset changes the configuration of the virtual X server so that
it considers only /etc/X11/xrdp as its proper configuration directory,
and pick up the xorg.conf file by default from there.