### PR TITLE
Cppcheck 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
 # This is required to use a version of cppcheck other than that
 # suplied with the operating system
 cppcheck_defs: &cppcheck_defs
-  - CPPCHECK_VER=1.90
+  - CPPCHECK_VER=2.1
   - CPPCHECK_REPO=https://github.com/danmar/cppcheck.git
 
 min_amd64_deps: &min_amd64_deps
@@ -92,10 +92,11 @@ cppcheck_conf: &cppcheck_conf
   env:
     - *cppcheck_defs
 
-#  addons:
-#    apt:
-#      packages:
-#        - cppcheck
+  addons:
+    apt:
+      packages:
+        - libz3-dev
+        - z3
 
   script:
     - ./bootstrap

--- a/common/log.c
+++ b/common/log.c
@@ -569,6 +569,7 @@ log_message(const enum logLevels lvl, const char *msg, ...)
     if (len > LOG_BUFFER_SIZE)
     {
         log_message(LOG_LEVEL_WARNING, "next message will be truncated");
+        len = LOG_BUFFER_SIZE;
     }
 
     /* forcing the end of message string */

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -2896,6 +2896,12 @@ g_strtrim(char *str, int trim_flags)
 
     text = (wchar_t *)malloc(len * sizeof(wchar_t) + 8);
     text1 = (wchar_t *)malloc(len * sizeof(wchar_t) + 8);
+    if (text == NULL || text1 == NULL)
+    {
+        free(text);
+        free(text1);
+        return 1;
+    }
     text1_index = 0;
     mbstowcs(text, str, len + 1);
 

--- a/common/pixman-region.c
+++ b/common/pixman-region.c
@@ -83,6 +83,12 @@
 #define GOOD_RECT(rect) ((rect)->x1 < (rect)->x2 && (rect)->y1 < (rect)->y2)
 #define BAD_RECT(rect) ((rect)->x1 > (rect)->x2 || (rect)->y1 > (rect)->y2)
 
+/* This file is included by pixman-region16.c which defines PREFIX(x).
+ * This check allows cppcheck 2.x to scan this file separately */
+#ifndef PREFIX
+#define PREFIX(x) pixman_region##x
+#endif
+
 #ifdef XRDP_DEBUG
 
 #define GOOD(reg)                                                       \


### PR DESCRIPTION
This PR adds support for the recently-released cppcheck 2.1.

There are two commits - one to support cppcheck 2.x and one to address the additional warnings generated by this utility.

# First commit
cppcheck 2.1 has an additional dependency on z3 which is apparently [highly recommended](https://sourceforge.net/p/cppcheck/news/2020/05/cppcheck-20/), but I have no more details on exactly what it does. In any case, this is supported here.

The cppcheck code expects a header file `z3_version.h` which is not present in the Xenial distro used by travis. A function `create_z3_version_h()` has been added to the install cppcheck to create this file in the cppcheck external directory if it is not available.

# Second commit
Running cppcheck 2.1 on the existing devel branch generates the following output:-

```
Cppcheck 2.1
Command: /home/mjb/cppcheck.local/2.1/bin/cppcheck --quiet --force --std=c11 --std=c++11 --inline-suppr --enable=warning --error-exitcode=1 .
common/log.c:578:9: warning: Either the condition 'len>1024' is redundant or the array 'buff[1055]' is accessed at index 1055, which is out of bounds. [arrayIndexOutOfBoundsCond]
    buff[len + 30] = '\0';
        ^
common/log.c:569:13: note: Assuming that condition 'len>1024' is not redundant
    if (len > LOG_BUFFER_SIZE)
            ^
common/log.c:578:9: note: Array index out of bounds
    buff[len + 30] = '\0';
        ^
common/os_calls.c:2900:14: error: Memory is allocated but not initialized: text [uninitdata]
    mbstowcs(text, str, len + 1);
             ^
common/pixman-region.c:293:1: error: There is an unknown macro here somewhere. Configuration is required. If PREFIX is a macro then please configure it. [unknownMacro]
PREFIX (_equal) (region_type_t *reg1, region_type_t *reg2)
```

I believe the warning in `common/log.c` represents an actual error. If the variable `len` is greater than `LOG_BUFFER_SIZE`, a write beyond the end of `buff` is made. This is a simple fix.

The warning in `common/os_calls.c` is not entirely correct, but it does highlight that the `text` buffer is malloc'd but not checked. Adding a check for malloc failure silences the error.

The warning in `common/pixman-region.c` is generated as cppcheck is unable to find the definition of the `PREFIX` macro. I've addressed this by adding a conditional definition of the macro in to the file. This is normally defined within `pixman-region16.c` which includes `pixman-region.c`