### PR TITLE
Fixed CVE-2020-4044 CI errors

### DIFF
--- a/sesman/libscp/libscp_v0.c
+++ b/sesman/libscp/libscp_v0.c
@@ -99,7 +99,7 @@ enum SCP_CLIENT_STATES_E
 scp_v0c_connect(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
 {
     tui32 version;
-    tui32 size;
+    int size;
     tui16 sz;
 
     init_stream(c->in_s, c->in_s->size);
@@ -187,8 +187,8 @@ scp_v0c_connect(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
     if (size < (8 + 2 + 2 + 2) || size > SCP_MAX_MESSAGE_SIZE)
     {
         log_message(LOG_LEVEL_WARNING,
-                    "[v0:%d] connection aborted: msg size = %u",
-                    __LINE__, (unsigned int)size);
+                    "[v0:%d] connection aborted: msg size = %d",
+                    __LINE__, size);
         return SCP_CLIENT_STATE_SIZE_ERR;
     }
 
@@ -240,7 +240,7 @@ scp_v0c_connect(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
 static enum SCP_SERVER_STATES_E
 scp_v0s_init_session(struct SCP_CONNECTION *c, struct SCP_SESSION *session)
 {
-    tui32 size;
+    int size;
     tui16 height;
     tui16 width;
     tui16 bpp;
@@ -254,8 +254,8 @@ scp_v0s_init_session(struct SCP_CONNECTION *c, struct SCP_SESSION *session)
     if (size < (8 + 2) || size > SCP_MAX_MESSAGE_SIZE)
     {
         log_message(LOG_LEVEL_WARNING,
-                    "[v0:%d] connection aborted: msg size = %u",
-                    __LINE__, (unsigned int)size);
+                    "[v0:%d] connection aborted: msg size = %d",
+                    __LINE__, size);
         return SCP_SERVER_STATE_SIZE_ERR;
     }
 

--- a/sesman/libscp/libscp_v1s.c
+++ b/sesman/libscp/libscp_v1s.c
@@ -218,7 +218,7 @@ enum SCP_SERVER_STATES_E scp_v1s_accept(struct SCP_CONNECTION *c, struct SCP_SES
     enum SCP_SERVER_STATES_E result;
     struct SCP_SESSION *session;
     tui32 version;
-    tui32 size;
+    int size;
     tui16 cmdset;
     tui16 cmd;
 
@@ -354,7 +354,7 @@ scp_v1s_request_password(struct SCP_CONNECTION *c, struct SCP_SESSION *s,
                          const char *reason)
 {
     tui32 version;
-    tui32 size;
+    int size;
     tui16 cmdset;
     tui16 cmd;
     int rlen;
@@ -539,7 +539,7 @@ enum SCP_SERVER_STATES_E
 scp_v1s_list_sessions(struct SCP_CONNECTION *c, int sescnt, struct SCP_DISCONNECTED_SESSION *ds, SCP_SID *sid)
 {
     tui32 version = 1;
-    tui32 size = 12;
+    int size = 12;
     tui16 cmd = 40;
     int pktcnt;
     int idx;

--- a/sesman/libscp/libscp_v1s_mng.c
+++ b/sesman/libscp/libscp_v1s_mng.c
@@ -381,7 +381,7 @@ static enum SCP_SERVER_STATES_E
 _scp_v1s_mng_check_response(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
 {
     tui32 version;
-    tui32 size;
+    int size;
     tui16 cmd;
     //   tui8 dim;
     //   char buf[257];


### PR DESCRIPTION
Fix errors identified by Travis CI in PR for above CVE.

In all cases where a tui32 has been replaced by an int, the read value is followed by a bounds check for both less-than or greater-than, so no unsigned overflows have been introduced by this change