### PR TITLE
chansrv improved config support

### DIFF
--- a/docs/man/xrdp-chansrv.8.in
+++ b/docs/man/xrdp-chansrv.8.in
@@ -7,10 +7,11 @@
 
 .SH "DESCRIPTION"
 \fBxrdp\-chansrv\fR is the \fBxrdp\fR(8) channel server, which manages the Remote Desktop Protocol (RDP) sub-channels.
+.PP
 This program is only forked internally by \fBxrdp\-sesman\fP(8).
-.br
+.PP
 Currently \fBxrdp\-chansrv\fP knows about the following channels:
-.RE 8
+.RS 8
 .TP
 .B cliprdr
 Clipboard Redirection
@@ -26,9 +27,45 @@ Remote Applications Integrated Locally
 .TP
 .B drdynvc
 Dynamic Virtual Channel
-.RS
+.RE
+
+.SH ENVIRONMENT
+.TP
+.I CHANSRV_LOG_LEVEL
+Logging level for chansrv. Case-insensitive. Takes one of these string values:
+.RS 8
+.TP
+.B LOG_LEVEL_ALWAYS
+Only log essential messages
+.TP
+.B LOG_LEVEL_ERROR
+Log errors and above
+.TP
+.B LOG_LEVEL_WARNING
+Log warnings and above
+.TP
+.B LOG_LEVEL_INFO
+Log info and above. This is the default if nothing is specified
+.TP
+.B LOG_LEVEL_DEBUG
+Log debug and above
+.TP
+.B LOG_LEVEL_TRACE
+Log everything
+.TP
+.RE
+.TP
+.I CHANSRV_LOG_PATH
+Path to the location where the log file is stored. If not specified,
+$\fBXDG_DATA_HOME/xrdp\fP or \fB$HOME/.local/share/xrdp\fP is used instead.
+.TP
+.I DISPLAY
+X11 display number. Must be specified.
 
 .SH FILES
+.TP
+.I @sysconfdir@/xrdp/sesman.ini
+Contains some settings for this program.
 .TP
 .I @socketdir@/xrdp_chansrv_socket_*
 UNIX socket used by external programs to implement channels.
@@ -36,8 +73,9 @@ UNIX socket used by external programs to implement channels.
 .I @socketdir@/xrdp_api_*
 UNIX socket used by \fBxrdp\-chansrv\fP to communicate with \fBxrdp\-sesman\fP.
 .TP
-.I $XDG_DATA_HOME/xrdp/xrdp-chansrv.%s.log
-Log file used by \fBxrdp\-chansrv\fP(8). \fB%s\fP is display number.
+.I xrdp-chansrv.%s.log
+Log file used by \fBxrdp\-chansrv\fP(8). \fB%s\fP is display number. See the
+description of \fBCHANSRV_LOG_PATH\fP above for the file's location.
 
 .SH "SEE ALSO"
 .BR xrdp\-sesman (8),

--- a/sesman/chansrv/Makefile.am
+++ b/sesman/chansrv/Makefile.am
@@ -51,6 +51,8 @@ xrdp_chansrv_SOURCES = \
   chansrv.h \
   chansrv_common.c \
   chansrv_common.h \
+  chansrv_config.c \
+  chansrv_config.h \
   chansrv_fuse.c \
   chansrv_fuse.h \
   chansrv_xfs.c \

--- a/sesman/chansrv/chansrv_config.c
+++ b/sesman/chansrv/chansrv_config.c
@@ -1,0 +1,294 @@
+/**
+ * xrdp: A Remote Desktop Protocol server.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This file implements the interface in chansrv_config.h
+ */
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+#include "arch.h"
+
+#include "list.h"
+#include "log.h"
+#include "file.h"
+#include "os_calls.h"
+
+#include "chansrv_config.h"
+
+/* Default settings */
+#define DEFAULT_USE_UNIX_SOCKET             0
+#define DEFAULT_RESTRICT_OUTBOUND_CLIPBOARD 0
+#define DEFAULT_FUSE_MOUNT_NAME             "xrdp-client"
+#define DEFAULT_FILE_UMASK                  077
+
+/**
+ * Type used for passing a logging function about
+ */
+typedef
+printflike(2, 3)
+enum logReturns (*log_func_t)(const enum logLevels lvl,
+                              const char *msg, ...);
+
+/***************************************************************************//**
+ * @brief Error logging function to use to log to stdout
+ *
+ * Has the same signature as the log_message() function
+ */
+static enum logReturns
+log_to_stdout(const enum logLevels lvl, const char *msg, ...)
+{
+    char buff[256];
+    va_list ap;
+
+    va_start(ap, msg);
+    vsnprintf(buff, sizeof(buff), msg, ap);
+    va_end(ap);
+    g_writeln("%s", buff);
+
+    return LOG_STARTUP_OK;
+}
+
+/***************************************************************************//**
+ * Reads the config values we need from the [Globals] section
+ *
+ * @param logmsg Function to use to log messages
+ * @param names List of definitions in the section
+ * @params values List of corresponding values for the names
+ * @params cfg Pointer to structure we're filling in
+ *
+ * @return 0 for success
+ */
+static int
+read_config_globals(log_func_t logmsg,
+                    struct list *names, struct list *values,
+                    struct config_chansrv *cfg)
+{
+    int error = 0;
+    int index;
+
+    for (index = 0; index < names->count; ++index)
+    {
+        const char *name = (const char *)list_get_item(names, index);
+        const char *value = (const char *)list_get_item(values, index);
+
+        if (g_strcasecmp(name, "ListenAddress") == 0)
+        {
+            if (g_strcasecmp(value, "127.0.0.1") == 0)
+            {
+                cfg->use_unix_socket = 1;
+            }
+        }
+    }
+
+    return error;
+}
+
+/***************************************************************************//**
+ * Reads the config values we need from the [Security] section
+ *
+ * @param logmsg Function to use to log messages
+ * @param names List of definitions in the section
+ * @params values List of corresponding values for the names
+ * @params cfg Pointer to structure we're filling in
+ *
+ * @return 0 for success
+ */
+static int
+read_config_security(log_func_t logmsg,
+                     struct list *names, struct list *values,
+                     struct config_chansrv *cfg)
+{
+    int error = 0;
+    int index;
+
+    for (index = 0; index < names->count; ++index)
+    {
+        const char *name = (const char *)list_get_item(names, index);
+        const char *value = (const char *)list_get_item(values, index);
+
+        if (g_strcasecmp(name, "RestrictOutboundClipboard") == 0)
+        {
+            cfg->restrict_outbound_clipboard = g_text2bool(value);
+        }
+    }
+
+    return error;
+}
+
+/***************************************************************************//**
+ * Reads the config values we need from the [Chansrv] section
+ *
+ * @param logmsg Function to use to log messages
+ * @param names List of definitions in the section
+ * @params values List of corresponding values for the names
+ * @params cfg Pointer to structure we're filling in
+ *
+ * @return 0 for success
+ */
+static int
+read_config_chansrv(log_func_t logmsg,
+                    struct list *names, struct list *values,
+                    struct config_chansrv *cfg)
+{
+    int error = 0;
+    int index;
+
+    for (index = 0; index < names->count; ++index)
+    {
+        const char *name = (const char *)list_get_item(names, index);
+        const char *value = (const char *)list_get_item(values, index);
+
+        if (g_strcasecmp(name, "FuseMountName") == 0)
+        {
+            g_free(cfg->fuse_mount_name);
+            cfg->fuse_mount_name = g_strdup(value);
+            if (cfg->fuse_mount_name == NULL)
+            {
+                logmsg(LOG_LEVEL_ERROR, "Can't alloc FuseMountName");
+                error = 1;
+                break;
+            }
+        }
+        else if (g_strcasecmp(name, "FileUmask") == 0)
+        {
+            cfg->file_umask = strtol(value, NULL, 0);
+        }
+    }
+
+    return error;
+}
+
+/***************************************************************************//**
+ * @brief returns a config block with default values
+ *
+ * @return Block, or NULL for no memory
+ */
+static struct config_chansrv *
+new_config(void)
+{
+    /* Do all the allocations at the beginning, then check them together */
+    struct config_chansrv *cfg = g_new0(struct config_chansrv, 1);
+    char *fuse_mount_name = g_strdup(DEFAULT_FUSE_MOUNT_NAME);
+    if (cfg == NULL || fuse_mount_name == NULL)
+    {
+        /* At least one memory allocation failed */
+        g_free(fuse_mount_name);
+        g_free(cfg);
+        cfg = NULL;
+    }
+    else
+    {
+        cfg->use_unix_socket = DEFAULT_USE_UNIX_SOCKET;
+        cfg->restrict_outbound_clipboard = DEFAULT_RESTRICT_OUTBOUND_CLIPBOARD;
+        cfg->fuse_mount_name = fuse_mount_name;
+        cfg->file_umask = DEFAULT_FILE_UMASK;
+    }
+
+    return cfg;
+}
+
+/******************************************************************************/
+struct config_chansrv *
+config_read(int use_logger, const char *sesman_ini)
+{
+    int error = 0;
+    struct config_chansrv *cfg = NULL;
+    log_func_t logmsg = (use_logger) ? log_message : log_to_stdout;
+    int fd;
+
+    fd = g_file_open_ex(sesman_ini, 1, 0, 0, 0);
+    if (fd < 0)
+    {
+        logmsg(LOG_LEVEL_ERROR, "Can't open config file %s", sesman_ini);
+        error = 1;
+    }
+    else
+    {
+        if ((cfg = new_config()) == NULL)
+        {
+            logmsg(LOG_LEVEL_ERROR, "Can't alloc config block");
+            error = 1;
+        }
+        else
+        {
+            struct list *names = list_create();
+            struct list *values = list_create();
+
+            names->auto_free = 1;
+            values->auto_free = 1;
+
+            if (!error && file_read_section(fd, "Globals", names, values) == 0)
+            {
+                error = read_config_globals(logmsg, names, values, cfg);
+            }
+
+
+            if (!error && file_read_section(fd, "Security", names, values) == 0)
+            {
+                error = read_config_security(logmsg, names, values, cfg);
+            }
+
+            if (!error && file_read_section(fd, "Chansrv", names, values) == 0)
+            {
+                error = read_config_chansrv(logmsg, names, values, cfg);
+            }
+
+            list_delete(names);
+            list_delete(values);
+        }
+
+        g_file_close(fd);
+    }
+
+    if (error)
+    {
+        config_free(cfg);
+        cfg = NULL;
+    }
+
+    return cfg;
+}
+
+/******************************************************************************/
+void
+config_dump(struct config_chansrv *config)
+{
+    g_writeln("Global configuration:");
+    g_writeln("    UseUnixSocket (derived):   %d", config->use_unix_socket);
+
+    g_writeln("\nSecurity configuration:");
+    g_writeln("    RestrictOutboundClipboard: %d",
+              config->restrict_outbound_clipboard);
+
+    g_writeln("\nChansrv configuration:");
+    g_writeln("    FuseMountName:             %s", config->fuse_mount_name);
+    g_writeln("    FileMask:                  0%o", config->file_umask);
+}
+
+/******************************************************************************/
+void
+config_free(struct config_chansrv *cc)
+{
+    if (cc != NULL)
+    {
+        g_free(cc->fuse_mount_name);
+        g_free(cc);
+    }
+}

--- a/sesman/chansrv/chansrv_config.h
+++ b/sesman/chansrv/chansrv_config.h
@@ -1,0 +1,72 @@
+/**
+ * xrdp: A Remote Desktop Protocol server.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This file contains the chansrv configuration parameters from sesman.ini
+ */
+
+#ifndef _CHANSRV_CONFIG
+#define _CHANSRV_CONFIG
+
+#include <sys/stat.h>
+
+struct config_chansrv
+{
+    /** Whether to use a UNIX socket for chansrv */
+    int use_unix_socket;
+
+    /** RestrictOutboundClipboard setting from sesman.ini */
+    int restrict_outbound_clipboard;
+
+    /** * FuseMountName from sesman.ini */
+    char *fuse_mount_name;
+    /** FileUmask from sesman.ini */
+    mode_t file_umask;
+};
+
+
+/**
+ *
+ * @brief Reads sesman configuration
+ * @param use_logger Use logger to log errors (otherwise stdout)
+ * @param sesman_ini Name of configuration file to read
+ *
+ * @return configuration on success, NULL on failure
+ *
+ * @pre logging is assumed to be active
+ * @post pass return value to config_free() to prevent memory leaks
+ *
+ */
+struct config_chansrv *
+config_read(int use_logger, const char *sesman_ini);
+
+/**
+ *
+ * @brief Dumps configuration to stdout
+ * @param pointer to a config_chansrv struct
+ *
+ */
+void
+config_dump(struct config_chansrv *config);
+
+/**
+ *
+ * @brief Frees configuration allocated by config_read()
+ * @param pointer to a config_chansrv struct (may be NULL)
+ *
+ */
+void
+config_free(struct config_chansrv *cs);
+
+#endif /* _CHANSRV_CONFIG */

--- a/sesman/chansrv/clipboard.c
+++ b/sesman/chansrv/clipboard.c
@@ -170,6 +170,7 @@ x-special/gnome-copied-files
 #include "parse.h"
 #include "os_calls.h"
 #include "chansrv.h"
+#include "chansrv_config.h"
 #include "clipboard.h"
 #include "clipboard_file.h"
 #include "clipboard_common.h"
@@ -235,7 +236,7 @@ extern tbus g_x_wait_obj;       /* in xcommon.c */
 extern Screen *g_screen;        /* in xcommon.c */
 extern int g_screen_num;        /* in xcommon.c */
 
-extern int g_restrict_outbound_clipboard; /* in chansrv.c */
+extern struct config_chansrv *g_cfg; /* in chansrv.c */
 
 int g_clip_up = 0;
 
@@ -2499,7 +2500,7 @@ clipboard_xevent(void *xevent)
     switch (lxevent->type)
     {
         case SelectionNotify:
-            if (g_restrict_outbound_clipboard == 0)
+            if (g_cfg->restrict_outbound_clipboard == 0)
             {
                 clipboard_event_selection_notify(lxevent);
             }

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -371,11 +371,6 @@ session_start_chansrv(char *username, int display)
                      g_cfg->env_names,
                      g_cfg->env_values);
 
-        if (g_cfg->sec.restrict_outbound_clipboard == 1)
-        {
-            g_setenv("CHANSRV_RESTRICT_OUTBOUND_CLIPBOARD", "1", 1);
-        }
-
         /* executing chansrv */
         g_execvp(exe_path, (char **) (chansrv_params->items));
         /* should not get here */


### PR DESCRIPTION
This pull request:-
- Creates a config module for chansrv similar to the one in sesman.
- adds an optional -c (or --config) option to chansrv to allow the path to `sesman.ini` to be specified.
- removes the `CHANSRV_RESTRICT_OUTBOUND_CLIPBOARD` environment variable used between sesman and chansrv to pass `RestrictOutboundClipboard` over - it's now read directly from the config file.

This is one of three PRs to implement #1588. This one does not depend on the other two and has two other uses:-
1. It could be easily expanded to read chansrv logging parameters from sesman.ini (See #1633) 
2. Removing `CHANSRV_RESTRICT_OUTBOUND_CLIPBOARD`  allows for a manual chansrv restart process to be implemented as follows:-
   - unmount ~/thinclient_drives if mounted.
   - Run chansrv directly from the command line in the same session
   - Disconnect and reconnect so xrdp picks up the new chansrv.

   At present this is only likely to be of use to developers as it allows for chansrv to be run under a debugger or valgrind, etc.

I've also tidied up the manpage and made some minor changes to the cleanup code in chansrv.c