### PR TITLE
Fixing the build with --enable-xrdpdebug and CFLAGS=-Werror -Wall

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,17 @@ max_amd64_conf: &max_amd64_conf
       packages:
         - *max_amd64_deps
 
+max_debug_amd64_conf: &max_debug_amd64_conf
+  env:
+    - CONF_FLAGS="--enable-ipv6 --enable-jpeg --enable-fuse --enable-mp3lame
+                  --enable-fdkaac --enable-opus --enable-rfxcodec --enable-painter
+                  --enable-pixman --enable-xrdpdebug"
+    - DISTCHECK=1
+  addons:
+    apt:
+      packages:
+        - *max_amd64_deps
+
 max_x86_deps: &max_x86_deps
   - *common_deps
   - g++-multilib
@@ -123,6 +134,10 @@ matrix:
   - compiler: clang
     << : *max_amd64_conf
 
+  # Maximal debug amd64 build
+  - compiler: gcc
+    << : *max_debug_amd64_conf
+    
   # Maximal x86 build
   - compiler: gcc
     << : *max_x86_conf
@@ -139,5 +154,5 @@ matrix:
 script:
   - ./bootstrap
   - ./configure $CONF_FLAGS
-  - make CFLAGS="$CFLAGS -O2 -Wall -Wwrite-strings -Werror"
+  - make
   - test -z "$DISTCHECK" || make distcheck

--- a/common/pixman-region.c
+++ b/common/pixman-region.c
@@ -91,6 +91,8 @@
 
 #ifdef XRDP_DEBUG
 
+pixman_bool_t PREFIX(_selfcheck) (region_type_t *reg);
+
 #define GOOD(reg)                                                       \
     do                                                                  \
     {                                                                   \

--- a/configure.ac
+++ b/configure.ac
@@ -243,9 +243,12 @@ then
     [AC_MSG_ERROR([please install libjpeg-dev or libjpeg-devel])])
 fi
 
+CFLAGS="-Wall -Wwrite-strings -Werror"
 if test "x$enable_xrdpdebug" = "xyes"
 then
-  CFLAGS="-g -O0"
+  CFLAGS="-g -O0 $CFLAGS"
+else
+  CFLAGS="-O2 $CFLAGS"
 fi
 
 # checking for fuse

--- a/mc/mc.h
+++ b/mc/mc.h
@@ -54,7 +54,7 @@ struct mod
                            char* data, int width, int height, int srcx, int srcy);
   int (*server_set_cursor)(struct mod* v, int x, int y, char* data, char* mask);
   int (*server_palette)(struct mod* v, int* palette);
-  int (*server_msg)(struct mod* v, char* msg, int code);
+  int (*server_msg)(struct mod* v, const char* msg, int code);
   int (*server_is_term)(struct mod* v);
   int (*server_set_clip)(struct mod* v, int x, int y, int cx, int cy);
   int (*server_reset_clip)(struct mod* v);

--- a/sesman/access.c
+++ b/sesman/access.c
@@ -48,8 +48,7 @@ access_login_allowed(const char *user)
 
     if ((0 == g_cfg->sec.ts_users_enable) && (0==g_cfg->sec.ts_always_group_check))
     {
-        LOG_DBG("Terminal Server Users group is disabled, allowing authentication",
-                1);
+        LOG_DBG("Terminal Server Users group is disabled, allowing authentication");
         return 1;
     }
 
@@ -98,7 +97,7 @@ access_login_mng_allowed(const char *user)
     if (0 == g_cfg->sec.ts_admins_enable)
     {
         LOG_DBG("[MNG] Terminal Server Admin group is disabled, "
-                "allowing authentication", 1);
+                "allowing authentication");
         return 1;
     }
 

--- a/sesman/scp_v1.c
+++ b/sesman/scp_v1.c
@@ -60,7 +60,7 @@ scp_v1_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
 
     while ((!data) && ((retries == 0) || (current_try > 0)))
     {
-        LOG_DBG("data %d - retry %d - currenttry %d - expr %d",
+        LOG_DBG("data %ld - retry %d - currenttry %d - expr %d",
                 data, retries, current_try,
                 ((!data) && ((retries == 0) || (current_try > 0))));
 

--- a/sesman/scp_v1_mng.c
+++ b/sesman/scp_v1_mng.c
@@ -83,7 +83,7 @@ scp_v1_mng_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
             case SCP_SERVER_STATE_MNG_LISTREQ:
                 /* list disconnected sessions */
                 slist = session_get_byuser(NULL, &scount, SESMAN_SESSION_STATUS_ALL);
-                LOG_DBG("sessions on TS: %d (slist: %x)", scount, slist);
+                LOG_DBG("sessions on TS: %d (slist: %p)", scount, slist);
                 if (0 == slist)
                 {
                     log_message(LOG_LEVEL_INFO, "No sessions on Terminal Server");


### PR DESCRIPTION
This pull request fixes the build errors that occur when xrdp is built with --enable-xrdpdebug and CFLAGS=-Werror -Wall. This pull request also configures the build to use -Werror -Wall as the default CFLAGS for make when run on a veleopper's machine or on the build servers.

This issue was debugged by @matt335672 in https://github.com/neutrinolabs/xrdp/pull/1633#issuecomment-660892330 and this change should prevent this issue from affecting other developers.