### PR TITLE
Added -c /--config option to xrdp

### DIFF
--- a/common/log.c
+++ b/common/log.c
@@ -279,7 +279,7 @@ internalReadConfiguration(const char *inFilename, const char *applicationName)
         return ret;
     }
 
-    fd = g_file_open(inFilename);
+    fd = g_file_open_ex(inFilename, 1, 0, 0, 0);
 
     if (-1 == fd)
     {

--- a/docs/man/xrdp.8.in
+++ b/docs/man/xrdp.8.in
@@ -3,7 +3,17 @@
 \fBxrdp\fR \- a Remote Desktop Protocol (RDP) server
 
 .SH "SYNTAX"
-xrdp [ \-\-nodaemon | \-\-kill | \-\-help ]
+.B xrdp
+\-\-kill
+.br
+.B xrdp
+\-\-help
+.br
+.B xrdp
+\-\-version
+.br
+.B xrdp
+[ \-\-nodaemon ] [ --port port ] [ --fork ] [ --config /path/to/xrdp.ini ]
 
 .SH "DESCRIPTION"
 \fBxrdp\fR is a Remote Desktop Protocol (RDP) Server.
@@ -14,14 +24,17 @@ It can also be used as a VNC\->RDP bridge.
 
 .SH "OPTIONS"
 .TP
-\fB\-n\fR, \fB\-\-nodaemon\fR
-Start \fBxrdp\fR in foreground instead of starting it as a daemon.
-.TP
 \fB\-k\fR, \fB\-\-kill\fR
 Kill running \fBxrdp\fR daemon.
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Output help information and exit.
+.TP
+\fB\-v\fR, \fB\-\-version\fR
+Output version information and exit.
+.TP
+\fB\-n\fR, \fB\-\-nodaemon\fR
+Start \fBxrdp\fR in foreground instead of starting it as a daemon.
 .TP
 \fB\-p\fR, \fB\-\-port\fR
 Specify TCP port to listen to. This overrides \fIport\fR setting in
@@ -31,6 +44,11 @@ Specify TCP port to listen to. This overrides \fIport\fR setting in
 Fork a new process on a new connection. If not enabled, use a new thread
 for every connection. This overrides \fIfork\fR setting in
 \fIxrdp.ini\fR file.
+.TP
+\fB\-c\fR, \fB\-\-config\fR
+Specify a path to a different \fIxrdp.ini\fR file. This option is intended
+to be used primarily for testing or for unusual configurations.
+
 
 .SH "FILES"
 @bindir@/xrdp

--- a/libxrdp/libxrdp.c
+++ b/libxrdp/libxrdp.c
@@ -37,13 +37,21 @@
 
 /******************************************************************************/
 struct xrdp_session *EXPORT_CC
-libxrdp_init(tbus id, struct trans *trans)
+libxrdp_init(tbus id, struct trans *trans, const char *xrdp_ini)
 {
     struct xrdp_session *session;
 
     session = (struct xrdp_session *)g_malloc(sizeof(struct xrdp_session), 1);
     session->id = id;
     session->trans = trans;
+    if (xrdp_ini != NULL)
+    {
+        session->xrdp_ini = g_strdup(xrdp_ini);
+    }
+    else
+    {
+        session->xrdp_ini = g_strdup(XRDP_CFG_PATH "/xrdp.ini");
+    }
     session->rdp = xrdp_rdp_create(session, trans);
     session->orders = xrdp_orders_create(session, (struct xrdp_rdp *)session->rdp);
     session->client_info = &(((struct xrdp_rdp *)session->rdp)->client_info);
@@ -62,6 +70,7 @@ libxrdp_exit(struct xrdp_session *session)
 
     xrdp_orders_delete((struct xrdp_orders *)session->orders);
     xrdp_rdp_delete((struct xrdp_rdp *)session->rdp);
+    g_free(session->xrdp_ini);
     g_free(session);
     return 0;
 }

--- a/libxrdp/libxrdpinc.h
+++ b/libxrdp/libxrdpinc.h
@@ -75,6 +75,7 @@ struct xrdp_session
     int in_process_data; /* inc / dec libxrdp_process_data calls */
 
     struct source_info si;
+    char *xrdp_ini; /* path to xrdp.ini */
 };
 
 struct xrdp_drdynvc_procs
@@ -85,8 +86,16 @@ struct xrdp_drdynvc_procs
     int (*data)(intptr_t id, int chan_id, char *data, int bytes);
 };
 
+/***
+ * Initialise the XRDP library
+ *
+ * @param id Channel ID (xrdp_process* as integer type)
+ * @param trans Transport object to use for this instance
+ * @param xrdp_ini Path to xrdp.ini config file, or NULL for default
+ * @return an allocated xrdp_session object
+ */
 struct xrdp_session *
-libxrdp_init(tbus id, struct trans *trans);
+libxrdp_init(tbus id, struct trans *trans, const char *xrdp_ini);
 int
 libxrdp_exit(struct xrdp_session *session);
 int

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -42,28 +42,24 @@
 
 /*****************************************************************************/
 static int
-xrdp_rdp_read_config(struct xrdp_client_info *client_info)
+xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
 {
     int index = 0;
     struct list *items = (struct list *)NULL;
     struct list *values = (struct list *)NULL;
     char *item = NULL;
     char *value = NULL;
-    char cfg_file[256];
     int pos;
     char *tmp = NULL;
     int tmp_length = 0;
 
     /* initialize (zero out) local variables: */
-    g_memset(cfg_file, 0, sizeof(char) * 256);
-
     items = list_create();
     items->auto_free = 1;
     values = list_create();
     values->auto_free = 1;
-    g_snprintf(cfg_file, 255, "%s/xrdp.ini", XRDP_CFG_PATH);
-    DEBUG(("cfg_file %s", cfg_file));
-    file_by_name_read_section(cfg_file, "globals", items, values);
+    DEBUG(("xrdp_ini %s", xrdp_ini));
+    file_by_name_read_section(xrdp_ini, "globals", items, values);
 
     for (index = 0; index < items->count; index++)
     {
@@ -358,7 +354,7 @@ xrdp_rdp_create(struct xrdp_session *session, struct trans *trans)
     self->session = session;
     self->share_id = 66538;
     /* read ini settings */
-    xrdp_rdp_read_config(&self->client_info);
+    xrdp_rdp_read_config(session->xrdp_ini, &self->client_info);
     /* create sec layer */
     self->sec_layer = xrdp_sec_create(self, trans);
     /* default 8 bit v1 color bitmap cache entries and size */

--- a/xrdp/xrdp.c
+++ b/xrdp/xrdp.c
@@ -22,6 +22,8 @@
 #include <config_ac.h>
 #endif
 
+#include <stdarg.h>
+
 #include "xrdp.h"
 #include "log.h"
 #include "xrdp_configure_options.h"
@@ -47,13 +49,13 @@ static long g_sync_param2 = 0;
 static long (*g_sync_func)(long param1, long param2);
 
 /*****************************************************************************/
-void
+static void
 print_version(void)
 {
     g_writeln("xrdp %s", PACKAGE_VERSION);
     g_writeln("  A Remote Desktop Protocol Server.");
-    g_writeln("  Copyright (C) 2004-2018 Jay Sorg, "
-                "Neutrino Labs, and all contributors.");
+    g_writeln("  Copyright (C) 2004-2020 Jay Sorg, "
+              "Neutrino Labs, and all contributors.");
     g_writeln("  See https://github.com/neutrinolabs/xrdp for more information.");
     g_writeln("%s", "");
 
@@ -67,15 +69,17 @@ print_version(void)
 }
 
 /*****************************************************************************/
-void
+static void
 print_help(void)
 {
     g_writeln("Usage: xrdp [options]");
-    g_writeln("   -h, --help       show help");
-    g_writeln("   -n, --nodaemon   don't fork into background");
     g_writeln("   -k, --kill       shut down xrdp");
+    g_writeln("   -h, --help       show help");
+    g_writeln("   -v, --version    show version");
+    g_writeln("   -n, --nodaemon   don't fork into background");
     g_writeln("   -p, --port       tcp listen port");
     g_writeln("   -f, --fork       fork on new connection");
+    g_writeln("   -c, --config     Specify new path to xrdp.ini");
 }
 
 /*****************************************************************************/
@@ -137,7 +141,7 @@ g_xrdp_sync(long (*sync_func)(long param1, long param2), long sync_param1,
 }
 
 /*****************************************************************************/
-void
+static void
 xrdp_shutdown(int sig)
 {
     tbus threadid;
@@ -153,7 +157,7 @@ xrdp_shutdown(int sig)
 }
 
 /*****************************************************************************/
-void
+static void
 xrdp_child(int sig)
 {
     int safety;
@@ -164,7 +168,7 @@ xrdp_child(int sig)
 }
 
 /*****************************************************************************/
-void
+static void
 xrdp_hang_up(int sig)
 {
     log_message(LOG_LEVEL_INFO, "caught SIGHUP, noop...");
@@ -225,7 +229,7 @@ g_get_sync_event(void)
 }
 
 /*****************************************************************************/
-void
+static void
 pipe_sig(int sig_num)
 {
     /* do nothing */
@@ -258,68 +262,87 @@ g_process_waiting_function(void)
 
 /*****************************************************************************/
 /**
+ * @brief looks for a case-insensitive match of a string in a list
+ * @param candidate  String to match
+ * @param ... NULL-terminated list of strings to compare the candidate with
+ * @return !=0 if the candidate is found in the list
+ */
+static int nocase_matches(const char *candidate, ...)
+{
+    va_list vl;
+    const char *member;
+    int result = 0;
+
+    va_start(vl, candidate);
+    while ((member = va_arg(vl, const char *)) != NULL)
+    {
+        if (g_strcasecmp(candidate, member) == 0)
+        {
+            result = 1;
+            break;
+        }
+    }
+
+    va_end(vl);
+    return result;
+}
+
+
+/*****************************************************************************/
+/**
  *
  * @brief  Command line argument parser
  * @param  number of command line arguments
  * @param  pointer array of commandline arguments
+ * @param  [out] Returned startup parameters
  * @return 0 on success, n on nth argument is unknown
  *
  */
-int
+static int
 xrdp_process_params(int argc, char **argv,
                     struct xrdp_startup_params *startup_params)
 {
     int index;
-    char option[128];
-    char value[128];
+    const char *option;
+    const char *value;
 
     index = 1;
 
     while (index < argc)
     {
-        g_strncpy(option, argv[index], 127);
+        option = argv[index];
 
         if (index + 1 < argc)
         {
-            g_strncpy(value, argv[index + 1], 127);
+            value = argv[index + 1];
         }
         else
         {
-            value[0] = 0;
+            value = "";
         }
 
-        if ((g_strncasecmp(option, "-help", 255)) == 0 ||
-                (g_strncasecmp(option, "--help", 255)) == 0 ||
-                (g_strncasecmp(option, "-h", 255)) == 0)
+        if (nocase_matches(option, "-help", "--help", "-h", NULL))
         {
             startup_params->help = 1;
         }
-        else if ((g_strncasecmp(option, "-kill", 255) == 0) ||
-                 (g_strncasecmp(option, "--kill", 255) == 0) ||
-                 (g_strncasecmp(option, "-k", 255) == 0))
+        else if (nocase_matches(option, "-kill", "--kill", "-k", NULL))
         {
             startup_params->kill = 1;
         }
-        else if ((g_strncasecmp(option, "-nodaemon", 255) == 0) ||
-                 (g_strncasecmp(option, "--nodaemon", 255) == 0) ||
-                 (g_strncasecmp(option, "-n", 255) == 0) ||
-                 (g_strncasecmp(option, "-nd", 255) == 0) ||
-                 (g_strncasecmp(option, "--nd", 255) == 0) ||
-                 (g_strncasecmp(option, "-ns", 255) == 0) ||
-                 (g_strncasecmp(option, "--ns", 255) == 0))
+        else if (nocase_matches(option, "-nodaemon", "--nodaemon", "-n",
+                                "-nd", "--nd", "-ns", "--ns", NULL))
         {
             startup_params->no_daemon = 1;
         }
-        else if ((g_strncasecmp(option, "-v", 255) == 0) ||
-                 (g_strncasecmp(option, "--version", 255) == 0))
+        else if (nocase_matches(option, "-v", "--version", NULL))
         {
             startup_params->version = 1;
         }
-        else if ((g_strncasecmp(option, "-p", 255) == 0) ||
-                 (g_strncasecmp(option, "--port", 255) == 0))
+        else if (nocase_matches(option, "-p", "--port", NULL))
         {
             index++;
-            g_strncpy(startup_params->port, value, 127);
+            g_strncpy(startup_params->port, value,
+                      sizeof(startup_params->port) - 1);
 
             if (g_strlen(startup_params->port) < 1)
             {
@@ -332,11 +355,15 @@ xrdp_process_params(int argc, char **argv,
                           startup_params->port);
             }
         }
-        else if ((g_strncasecmp(option, "-f", 255) == 0) ||
-                 (g_strncasecmp(option, "--fork", 255) == 0))
+        else if (nocase_matches(option, "-f", "--fork", NULL))
         {
             startup_params->fork = 1;
             g_writeln("--fork parameter found, ini override");
+        }
+        else if (nocase_matches(option, "-c", "--config", NULL))
+        {
+            index++;
+            startup_params->xrdp_ini = value;
         }
         else /* unknown option */
         {
@@ -351,12 +378,12 @@ xrdp_process_params(int argc, char **argv,
 
 /*****************************************************************************/
 /* Basic sanity checks before any forking */
-int
+static int
 xrdp_sanity_check(void)
 {
     int intval = 1;
     int host_be;
-    char key_file[256];
+    const char *key_file = XRDP_CFG_PATH "/rsakeys.ini";
 
     /* check compiled endian with actual endian */
     host_be = !((int)(*(unsigned char *)(&intval)));
@@ -401,7 +428,6 @@ xrdp_sanity_check(void)
         return 1;
     }
 
-    g_snprintf(key_file, 255, "%s/rsakeys.ini", XRDP_CFG_PATH);
     if (!g_file_exist(key_file))
     {
         g_writeln("File %s is missing, create it using xrdp-keygen", key_file);
@@ -417,14 +443,14 @@ main(int argc, char **argv)
 {
     int exit_status = 0;
     int test;
-    char cfg_file[256];
     enum logReturns error;
-    struct xrdp_startup_params *startup_params;
+    struct xrdp_startup_params startup_params = {0};
     int pid;
     int fd;
-    int no_daemon;
+    int daemon;
     char text[256];
-    char pid_file[256];
+    const char *pid_file = XRDP_PID_PATH "/xrdp.pid";
+
     int errored_argc;
 
     g_init("xrdp");
@@ -435,12 +461,9 @@ main(int argc, char **argv)
         DEBUG(("Argument %i - %s", test, argv[test]));
     }
 
-    g_snprintf(cfg_file, 255, "%s/xrdp.ini", XRDP_CFG_PATH);
+    startup_params.xrdp_ini = XRDP_CFG_PATH "/xrdp.ini";
 
-    startup_params = (struct xrdp_startup_params *)
-                     g_malloc(sizeof(struct xrdp_startup_params), 1);
-
-    errored_argc = xrdp_process_params(argc, argv, startup_params);
+    errored_argc = xrdp_process_params(argc, argv, &startup_params);
     if (errored_argc > 0)
     {
         print_version();
@@ -453,10 +476,7 @@ main(int argc, char **argv)
         g_exit(1);
     }
 
-    g_snprintf(pid_file, 255, "%s/xrdp.pid", XRDP_PID_PATH);
-    no_daemon = 0;
-
-    if (startup_params->help)
+    if (startup_params.help)
     {
         print_version();
         g_writeln("%s", "");
@@ -466,7 +486,7 @@ main(int argc, char **argv)
         g_exit(0);
     }
 
-    if (startup_params->version)
+    if (startup_params.version)
     {
         print_version();
         g_deinit();
@@ -480,7 +500,7 @@ main(int argc, char **argv)
         g_exit(1);
     }
 
-    if (startup_params->kill)
+    if (startup_params.kill)
     {
         g_writeln("stopping xrdp");
         /* read the xrdp.pid file */
@@ -515,22 +535,26 @@ main(int argc, char **argv)
     }
 
     /* starting logging subsystem */
-    error = log_start(cfg_file, "xrdp");
+    error = log_start(startup_params.xrdp_ini, "xrdp");
 
     if (error != LOG_STARTUP_OK)
     {
         switch (error)
         {
-            case LOG_ERROR_MALLOC:
-                g_writeln("error on malloc. cannot start logging. quitting.");
-                break;
-            case LOG_ERROR_FILE_OPEN:
-                g_writeln("error opening log file [%s]. quitting.",
-                          getLogFile(text, 255));
-                break;
-            default:
-                g_writeln("log_start error");
-                break;
+        case LOG_ERROR_MALLOC:
+            g_writeln("error on malloc. cannot start logging. quitting.");
+            break;
+        case LOG_ERROR_FILE_OPEN:
+            g_writeln("error opening log file [%s]. quitting.",
+                      getLogFile(text, 255));
+            break;
+        case LOG_ERROR_NO_CFG:
+            g_writeln("config file %s unreadable or missing",
+                      startup_params.xrdp_ini);
+            break;
+        default:
+            g_writeln("log_start error");
+            break;
         }
 
         g_deinit();
@@ -547,13 +571,10 @@ main(int argc, char **argv)
         g_exit(0);
     }
 
-    if (startup_params->no_daemon)
-    {
-        no_daemon = 1;
-    }
+    daemon = !startup_params.no_daemon;
 
 
-    if (!no_daemon)
+    if (daemon)
     {
 
         /* make sure containing directory exists */
@@ -580,13 +601,13 @@ main(int argc, char **argv)
         g_file_delete(pid_file);
     }
 
-    if (!no_daemon)
+    if (daemon)
     {
         /* if can't listen, exit with failure status */
-        if (xrdp_listen_test(startup_params) != 0)
+        if (xrdp_listen_test(&startup_params) != 0)
         {
             log_message(LOG_LEVEL_ERROR, "Failed to start xrdp daemon, "
-                                         "possibly address already in use.");
+                        "possibly address already in use.");
             g_deinit();
             /* must exit with failure status,
                or systemd cannot detect xrdp daemon couldn't start properly */
@@ -675,7 +696,7 @@ main(int argc, char **argv)
         g_writeln("error creating g_sync_event");
     }
 
-    g_listen->startup_params = startup_params;
+    g_listen->startup_params = &startup_params;
     exit_status = xrdp_listen_main_loop(g_listen);
     xrdp_listen_delete(g_listen);
     tc_mutex_delete(g_sync_mutex);
@@ -684,13 +705,12 @@ main(int argc, char **argv)
     g_delete_wait_obj(g_sync_event);
 
     /* only main process should delete pid file */
-    if ((!no_daemon) && (pid == g_getpid()))
+    if (daemon && (pid == g_getpid()))
     {
         /* delete the xrdp.pid file */
         g_file_delete(pid_file);
     }
 
-    g_free(startup_params);
     log_end();
     g_deinit();
 

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -40,6 +40,8 @@ long
 g_xrdp_sync(long (*sync_func)(long param1, long param2), long sync_param1,
             long sync_param2);
 int
+xrdp_child_fork(void);
+int
 g_is_term(void);
 void
 g_set_term(int in_val);
@@ -49,10 +51,6 @@ tbus
 g_get_sync_event(void);
 void
 g_process_waiting_function(void);
-void
-print_version(void);
-void
-print_help(void);
 
 /* xrdp_cache.c */
 struct xrdp_cache*
@@ -359,7 +357,7 @@ get_keymaps(int keylayout, struct xrdp_keymap* keymap);
 int
 xrdp_login_wnd_create(struct xrdp_wm* self);
 int
-load_xrdp_config(struct xrdp_config *config, int bpp);
+load_xrdp_config(struct xrdp_config *config, const char *xrdp_ini, int bpp);
 
 /* xrdp_bitmap_compress.c */
 int
@@ -434,8 +432,6 @@ int
 server_msg(struct xrdp_mod* mod, char* msg, int code);
 int
 server_is_term(struct xrdp_mod* mod);
-int
-xrdp_child_fork(void);
 int
 server_set_clip(struct xrdp_mod* mod, int x, int y, int cx, int cy);
 int

--- a/xrdp/xrdp_listen.c
+++ b/xrdp/xrdp_listen.c
@@ -164,14 +164,12 @@ xrdp_listen_get_startup_params(struct xrdp_listen *self)
     char *val;
     struct list *names;
     struct list *values;
-    char cfg_file[256];
     struct xrdp_startup_params *startup_params;
 
     startup_params = self->startup_params;
     port_override = startup_params->port[0] != 0;
     fork_override = startup_params->fork;
-    g_snprintf(cfg_file, 255, "%s/xrdp.ini", XRDP_CFG_PATH);
-    fd = g_file_open(cfg_file);
+    fd = g_file_open(startup_params->xrdp_ini);
     if (fd != -1)
     {
         names = list_create();

--- a/xrdp/xrdp_login_wnd.c
+++ b/xrdp/xrdp_login_wnd.c
@@ -559,8 +559,8 @@ xrdp_wm_login_fill_in_combo(struct xrdp_wm *self, struct xrdp_bitmap *b)
     char *q;
     char *r;
     char name[256];
-    char cfg_file[256];
     struct xrdp_mod_data *mod_data;
+    const char *xrdp_ini = self->session->xrdp_ini;
 
     sections = list_create();
     sections->auto_free = 1;
@@ -568,12 +568,12 @@ xrdp_wm_login_fill_in_combo(struct xrdp_wm *self, struct xrdp_bitmap *b)
     section_names->auto_free = 1;
     section_values = list_create();
     section_values->auto_free = 1;
-    g_snprintf(cfg_file, 255, "%s/xrdp.ini", XRDP_CFG_PATH);
-    fd = g_file_open(cfg_file); /* xrdp.ini */
+    fd = g_file_open(xrdp_ini);
 
     if (fd < 0)
     {
-        log_message(LOG_LEVEL_ERROR, "Could not read xrdp ini file %s", cfg_file);
+        log_message(LOG_LEVEL_ERROR, "Could not read xrdp ini file %s",
+                    xrdp_ini);
         list_delete(sections);
         list_delete(section_names);
         list_delete(section_values);
@@ -829,10 +829,14 @@ xrdp_login_wnd_create(struct xrdp_wm *self)
 /**
  * Load configuration from xrdp.ini file
  *
+ * @param config XRDP configuration to initialise
+ * @param xrdp_ini Path to xrdp.ini
+ * @param bpp bits-per-pixel for this connection
+ *
  * @return 0 on success, -1 on failure
  *****************************************************************************/
 int
-load_xrdp_config(struct xrdp_config *config, int bpp)
+load_xrdp_config(struct xrdp_config *config, const char *xrdp_ini, int bpp)
 {
     struct xrdp_cfg_globals  *globals;
 
@@ -841,7 +845,6 @@ load_xrdp_config(struct xrdp_config *config, int bpp)
 
     char *n;
     char *v;
-    char  buf[256];
     int   fd;
     int   i;
 
@@ -873,11 +876,10 @@ load_xrdp_config(struct xrdp_config *config, int bpp)
     globals->ls_btn_cancel_height = 30;
 
     /* open xrdp.ini file */
-    g_snprintf(buf, 255, "%s/xrdp.ini", XRDP_CFG_PATH);
-    if ((fd = g_file_open(buf)) < 0)
+    if ((fd = g_file_open(xrdp_ini)) < 0)
     {
         log_message(LOG_LEVEL_ERROR,"load_config: Could not read "
-                    "xrdp.ini file %s", buf);
+                    "xrdp.ini file %s", xrdp_ini);
         return -1;
 
     }
@@ -893,7 +895,7 @@ load_xrdp_config(struct xrdp_config *config, int bpp)
         list_delete(values);
         g_file_close(fd);
         log_message(LOG_LEVEL_ERROR,"load_config: Could not read globals "
-                    "section from xrdp.ini file %s", buf);
+                    "section from xrdp.ini file %s", xrdp_ini);
         return -1;
     }
 

--- a/xrdp/xrdp_process.c
+++ b/xrdp/xrdp_process.c
@@ -235,7 +235,8 @@ xrdp_process_main_loop(struct xrdp_process *self)
     self->server_trans->trans_data_in = xrdp_process_data_in;
     self->server_trans->callback_data = self;
     init_stream(self->server_trans->in_s, 8192 * 4);
-    self->session = libxrdp_init((tbus)self, self->server_trans);
+    self->session = libxrdp_init((tbus)self, self->server_trans,
+                                 self->lis_layer->startup_params->xrdp_ini);
     self->server_trans->si = &(self->session->si);
     self->server_trans->my_source = XRDP_SOURCE_CLIENT;
     /* this callback function is in xrdp_wm.c */

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -528,6 +528,8 @@ struct xrdp_mod_data
 
 struct xrdp_startup_params
 {
+  /* xrdp_ini is not malloc'd and has at least the same lifetime as main() */
+  const char *xrdp_ini;
   char port[1024];
   int kill;
   int no_daemon;

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -396,7 +396,6 @@ xrdp_wm_load_static_colors_plus(struct xrdp_wm *self, char *autorun_name)
     char *val;
     struct list *names;
     struct list *values;
-    char cfg_file[256];
 
     if (autorun_name != 0)
     {
@@ -415,8 +414,7 @@ xrdp_wm_load_static_colors_plus(struct xrdp_wm *self, char *autorun_name)
     self->background = HCOLOR(self->screen->bpp, 0x000000);
 
     /* now load them from the globals in xrdp.ini if defined */
-    g_snprintf(cfg_file, 255, "%s/xrdp.ini", XRDP_CFG_PATH);
-    fd = g_file_open(cfg_file);
+    fd = g_file_open(self->session->xrdp_ini);
 
     if (fd >= 0)
     {
@@ -507,7 +505,7 @@ xrdp_wm_load_static_colors_plus(struct xrdp_wm *self, char *autorun_name)
     }
     else
     {
-        log_message(LOG_LEVEL_ERROR,"xrdp_wm_load_static_colors: Could not read xrdp.ini file %s", cfg_file);
+        log_message(LOG_LEVEL_ERROR,"xrdp_wm_load_static_colors: Could not read xrdp.ini file %s", self->session->xrdp_ini);
     }
 
     if (self->screen->bpp == 8)
@@ -569,20 +567,20 @@ xrdp_wm_init(struct xrdp_wm *self)
     char param[256];
     char default_section_name[256];
     char section_name[256];
-    char cfg_file[256];
     char autorun_name[256];
 
     g_writeln("in xrdp_wm_init: ");
 
-    load_xrdp_config(self->xrdp_config, self->screen->bpp);
+    load_xrdp_config(self->xrdp_config, self->session->xrdp_ini,
+                     self->screen->bpp);
 
     /* global channels allow */
     names = list_create();
     names->auto_free = 1;
     values = list_create();
     values->auto_free = 1;
-    g_snprintf(cfg_file, 255, "%s/xrdp.ini", XRDP_CFG_PATH);
-    if (file_by_name_read_section(cfg_file, "Channels", names, values) == 0)
+    if (file_by_name_read_section(self->session->xrdp_ini,
+                                  "Channels", names, values) == 0)
     {
         int error;
         int ii;
@@ -649,8 +647,7 @@ xrdp_wm_init(struct xrdp_wm *self)
          * NOTE: this should eventually be accessed from self->xrdp_config
          */
 
-        g_snprintf(cfg_file, 255, "%s/xrdp.ini", XRDP_CFG_PATH);
-        fd = g_file_open(cfg_file); /* xrdp.ini */
+        fd = g_file_open(self->session->xrdp_ini);
         if (fd != -1)
         {
             names = list_create();
@@ -790,7 +787,9 @@ xrdp_wm_init(struct xrdp_wm *self)
         }
         else
         {
-            log_message(LOG_LEVEL_ERROR,"xrdp_wm_init: Could not read xrdp.ini file %s", cfg_file);
+            log_message(LOG_LEVEL_ERROR,
+                        "xrdp_wm_init: Could not read xrdp.ini file %s",
+                        self->session->xrdp_ini);
         }
     }
     else


### PR DESCRIPTION
This is the third and last PR in a series to implement #1588  (separate config file for xrdp and sesman).

The other two are for sesman (#1650) and chansrv (#1635), and are largely independent of this PR. This PR affects xrdp and libxrdp.

This PR makes the following changes:-

### common/log.c
Opened the .ini file read-only with `g_file_open_ex` rather than `g_file_open`. Without this change, the logging code creates an empty ini file if one wasn't present, which is probably not what is required!

### xrdp.c
- A few methods were made static where not required to be global
- File run through astyle which found a few issues.
- A few hard-coded string value sizes have been removed.
- local variable `no_daemon` replaced with `daemon` to avoid double-negatives (i.e. `!no_daemon`)

### xrdp (other files)
- Manpage updated
- Other changes made to remove hard-coded references to the location of xrdp.ini

### libxrdp
- Extra parameter added to `libxrdp_init()` which allows the location of `xrdp.ini` to be specified for the session. NULL can be specified for this parameter to implement the existing behaviour with the default file.
