### PR TITLE
Fixed compiler warnings/errors about snprintf truncations in log.c

### DIFF
--- a/common/log.c
+++ b/common/log.c
@@ -555,9 +555,7 @@ log_message(const enum logLevels lvl, const char *msg, ...)
     now_t = time(&now_t);
     now = localtime(&now_t);
 
-    snprintf(buff, 21, "[%.4d%.2d%.2d-%.2d:%.2d:%.2d] ", now->tm_year + 1900,
-             now->tm_mon + 1, now->tm_mday, now->tm_hour, now->tm_min,
-             now->tm_sec);
+    strftime(buff, 21, "[%Y%m%d-%H:%M:%S] ", now);
 
     internal_log_lvl2str(lvl, buff + 20);
 


### PR DESCRIPTION
Compiling the current development wavefront on Ubuntu 20.04 (gcc 9.3.0) results in the following errors:-

```
log.c: In function ‘log_message’:
log.c:558:30: error: ‘%.2d’ directive output may be truncated writing between 2 and 11 bytes into a region of size between 9 and 16 [-Werror=format-truncation=]
  558 |     snprintf(buff, 21, "[%.4d%.2d%.2d-%.2d:%.2d:%.2d] ", now->tm_year + 1900,
      |                              ^~~~
log.c:558:24: note: directive argument in the range [-2147483647, 2147483647]
  558 |     snprintf(buff, 21, "[%.4d%.2d%.2d-%.2d:%.2d:%.2d] ", now->tm_year + 1900,
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/stdio.h:867,
                 from log.c:28:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 21 and 73 bytes into a destination of size 21
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

These errors used to be warnings. However commit 7e58209b195052205831d53a9f4cd0b4604a293d (not in the last release) applies `-Werror` to the compilation.

This fix simply restricts the values passed to %.2d by using the modulus operator '%'.

We possibly need this for v0.9.14 to prevent the Ubuntu 20.04 builds from breaking.

Thanks to @endofreal for raising this as a side issue in #1658 