### PR TITLE
Adding checks to prevent buffer overruns during data chunk re-assembly

### DIFF
--- a/libxrdp/xrdp_channel.c
+++ b/libxrdp/xrdp_channel.c
@@ -463,6 +463,10 @@ xrdp_channel_process_drdynvc(struct xrdp_channel *self,
     {
         case 0:
             length = (int) (s->end - s->p);
+            if (!s_check_rem_out(self->s, length))
+            {
+                return 1;
+            }
             out_uint8a(self->s, s->p, length);
             in_uint8s(s, length);
             return 0;
@@ -471,11 +475,19 @@ xrdp_channel_process_drdynvc(struct xrdp_channel *self,
             make_stream(self->s);
             init_stream(self->s, total_length);
             length = (int) (s->end - s->p);
+            if (!s_check_rem_out(self->s, length))
+            {
+                return 1;
+            }
             out_uint8a(self->s, s->p, length);
             in_uint8s(s, length);
             return 0;
         case 2:
             length = (int) (s->end - s->p);
+            if (!s_check_rem_out(self->s, length))
+            {
+                return 1;
+            }
             out_uint8a(self->s, s->p, length);
             in_uint8s(s, length);
             ls = self->s;


### PR DESCRIPTION
Problem:
The data chunk buffer is allocated based on the total length field in a DYNVC_DATA_FIRST message. Upon receiving subsequent DYNVC_DATA messages, the data payload is appended to the chunk buffer without first checking that there is enough space remaining in the chunk buffer. This could lead to a buffer overrun in the server.

Solution:
This pull request adds a check to verify that the chunk buffer has enough remaining space to accept the received payload, and returns an error if there is not enough space in the buffer.