### PR TITLE
Add support for token authentication

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,3 +12,4 @@ as possible.
 Our email eddress for security report is:
 
 * [xrdp-core@googlegroups.com](mailto:xrdp-core@googlegroups.com)
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,8 @@ If you find a security vulnerability please kindly inform us about the problem i
 so that we can fix the security problem to protect a lot of users around the world as soon
 as possible.
 
-Our email eddress for security report is:
+Our email address for security report is below. This is a private mailing list and not open 
+for public viewing.
 
 * [xrdp-core@googlegroups.com](mailto:xrdp-core@googlegroups.com)
 

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -2591,6 +2591,19 @@ g_strcat(char *dest, const char *src)
 }
 
 /*****************************************************************************/
+/* returns dest */
+char *
+g_strncat(char *dest, const char *src, int len)
+{
+    if (dest == 0 || src == 0)
+    {
+        return dest;
+    }
+
+    return strncat(dest, src, len);
+}
+
+/*****************************************************************************/
 /* if in = 0, return 0 else return newly alloced copy of in */
 char *
 g_strdup(const char *in)

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -124,6 +124,7 @@ const char *g_strchr(const char *text, int c);
 char*    g_strcpy(char* dest, const char* src);
 char*    g_strncpy(char* dest, const char* src, int len);
 char*    g_strcat(char* dest, const char* src);
+char*    g_strncat(char* dest, const char* src, int len);
 char*    g_strdup(const char* in);
 char*    g_strndup(const char* in, const unsigned int maxlen);
 int      g_strcmp(const char* c1, const char* c2);

--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -161,6 +161,7 @@ struct xrdp_client_info
   int suppress_output;
 
   int enable_token_login;
+  char domain_user_separator[16];
 };
 
 #endif

--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -159,6 +159,8 @@ struct xrdp_client_info
   int use_cache_glyph_v2;
   int rail_enable;
   int suppress_output;
+
+  int enable_token_login;
 };
 
 #endif

--- a/docs/man/xrdp.ini.5.in
+++ b/docs/man/xrdp.ini.5.in
@@ -120,6 +120,18 @@ The default for RDP is \fB3389\fP.
 
 .TP
 \fBrequire_credentials\fP=\fI[true|false]\fP
+If set to \fB1\fP, \fBtrue\fP or \fByes\fP, \fBxrdp\fP will scan the user name provided by the
+client for the ASCII field separator character (0x1F). It will then copy over what is after the
+separator as the password supplied by the user and treats it as autologon. If not specified,
+defaults to \fBfalse\fP.
+
+.TP
+\domain_user_separator\fP=\separator\fP
+If specified the domain name supplied by the client is appended to the username separated
+by \fBseparator\fP.
+
+.TP
+\enable_token_login\fP=\fI[true|false]\fP
 If set to \fB1\fP, \fBtrue\fP or \fByes\fP, \fBxrdp\fP requires clients to include username and
 password initial connection phase. In other words, xrdp doesn't allow clients to show login
 screen if set to true. If not specified, defaults to \fBfalse\fP.

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -280,7 +280,11 @@ xrdp_rdp_read_config(struct xrdp_client_info *client_info)
                             client_info->key_file, g_get_strerror());
             }
         }
-
+        else if (g_strcasecmp(item, "domain_user_separator") == 0
+                 && g_strlen(value) > 0)
+        {
+            g_strncpy(client_info->domain_user_separator, value, sizeof(client_info->domain_user_separator) - 1);
+        }
     }
 
     list_delete(items);

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -144,6 +144,10 @@ xrdp_rdp_read_config(struct xrdp_client_info *client_info)
         {
             client_info->require_credentials = g_text2bool(value);
         }
+        else if (g_strcasecmp(item, "enable_token_login") == 0)
+        {
+            client_info->enable_token_login = g_text2bool(value);
+        }
         else if (g_strcasecmp(item, "use_fastpath") == 0)
         {
             if (g_strcasecmp(value, "output") == 0)

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -738,7 +738,7 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
 
     if (len_domain >= INFO_CLIENT_MAX_CB_LEN)
     {
-        DEBUG(("ERROR [xrdp_sec_process_logon_info()]: len_domain > 511"));
+        DEBUG(("ERROR [xrdp_sec_process_logon_info()]: len_domain >= %d", INFO_CLIENT_MAX_CB_LEN));
         return 1;
     }
 
@@ -760,7 +760,7 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
 
     if (len_user >= INFO_CLIENT_MAX_CB_LEN)
     {
-        DEBUG(("ERROR [xrdp_sec_process_logon_info()]: len_user > 511"));
+        DEBUG(("ERROR [xrdp_sec_process_logon_info()]: len_user >= %d", INFO_CLIENT_MAX_CB_LEN));
         return 1;
     }
 
@@ -772,7 +772,7 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
 
     if (len_password >= INFO_CLIENT_MAX_CB_LEN)
     {
-        DEBUG(("ERROR [xrdp_sec_process_logon_info()]: len_password > 511"));
+        DEBUG(("ERROR [xrdp_sec_process_logon_info()]: len_password >= %d", INFO_CLIENT_MAX_CB_LEN));
         return 1;
     }
 
@@ -784,7 +784,7 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
 
     if (len_program >= INFO_CLIENT_MAX_CB_LEN)
     {
-        DEBUG(("ERROR [xrdp_sec_process_logon_info()]: len_program > 511"));
+        DEBUG(("ERROR [xrdp_sec_process_logon_info()]: len_program >= %d", INFO_CLIENT_MAX_CB_LEN));
         return 1;
     }
 
@@ -796,7 +796,7 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
 
     if (len_directory >= INFO_CLIENT_MAX_CB_LEN)
     {
-        DEBUG(("ERROR [xrdp_sec_process_logon_info()]: len_directory > 511"));
+        DEBUG(("ERROR [xrdp_sec_process_logon_info()]: len_directory >= %d", INFO_CLIENT_MAX_CB_LEN));
         return 1;
     }
 
@@ -841,6 +841,13 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
             g_writeln("xrdp_sec_process_logon_info: credentials on cmd line is mandatory");
             return 1; /* credentials on cmd line is mandatory */
         }
+    }
+    if (self->rdp_layer->client_info.domain_user_separator[0] != '\0'
+        && self->rdp_layer->client_info.domain[0] != '\0')
+    {
+        int size = sizeof(self->rdp_layer->client_info.username);
+        g_strncat(self->rdp_layer->client_info.username, self->rdp_layer->client_info.domain_user_separator, size - 1 - g_strlen(self->rdp_layer->client_info.domain_user_separator));
+        g_strncat(self->rdp_layer->client_info.username, self->rdp_layer->client_info.domain, size - 1 - g_strlen(self->rdp_layer->client_info.domain));
     }
     DEBUG(("username %s", self->rdp_layer->client_info.username));
 

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -675,6 +675,7 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
     int len_ip = 0;
     int len_dll = 0;
     char tmpdata[256];
+    const char *sep;
 
     /* initialize (zero out) local variables */
     g_memset(tmpdata, 0, sizeof(char) * 256);
@@ -808,7 +809,6 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
     {
         return 1;
     }
-    DEBUG(("username %s", self->rdp_layer->client_info.username));
 
     if (flags & RDP_LOGON_AUTO)
     {
@@ -817,6 +817,17 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
             return 1;
         }
         DEBUG(("flag RDP_LOGON_AUTO found"));
+    }
+    else if (self->rdp_layer->client_info.enable_token_login
+             && len_user > 0
+             && len_password == 0
+             && (sep = g_strchr(self->rdp_layer->client_info.username, '\x1f')) != NULL)
+    {
+        DEBUG(("Logon token detected"));
+        g_strncpy(self->rdp_layer->client_info.password, sep + 1,
+                  sizeof(self->rdp_layer->client_info.password) - 1);
+        self->rdp_layer->client_info.username[sep - self->rdp_layer->client_info.username] = '\0';
+        self->rdp_layer->client_info.rdp_autologin = 1;
     }
     else
     {
@@ -831,6 +842,7 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
             return 1; /* credentials on cmd line is mandatory */
         }
     }
+    DEBUG(("username %s", self->rdp_layer->client_info.username));
 
     if (unicode_utf16_in(s, len_program, self->rdp_layer->client_info.program, sizeof(self->rdp_layer->client_info.program) - 1) != 0)
     {

--- a/xrdp/xrdp.ini.in
+++ b/xrdp/xrdp.ini.in
@@ -76,6 +76,8 @@ new_cursors=true
 use_fastpath=both
 ; when true, userid/password *must* be passed on cmd line
 #require_credentials=true
+; when true, the userid will be used to try to authenticate
+#enable_token_login=true
 ; You can set the PAM error text in a gateway setup (MAX 256 chars)
 #pamerrortxt=change your password according to policy at http://url
 

--- a/xrdp/xrdp.ini.in
+++ b/xrdp/xrdp.ini.in
@@ -58,6 +58,10 @@ ssl_protocols=TLSv1.2, TLSv1.3
 ; set TLS cipher suites
 #tls_ciphers=HIGH
 
+; concats the domain name to the user if set for authentication with the separator
+; for example when the server is multi homed with SSSd
+#domain_user_separator=@
+
 ; Section name to use for automatic login if the client sends username
 ; and password. If empty, the domain name sent by the client is used.
 ; If empty and no domain name is given, the first suitable section in

--- a/xrdp/xrdp_login_wnd.c
+++ b/xrdp/xrdp_login_wnd.c
@@ -1001,6 +1001,11 @@ load_xrdp_config(struct xrdp_config *config, int bpp)
         else if (g_strncmp(n, "allow_multimon", 64) == 0)
             globals->allow_multimon = g_text2bool(v);
 
+        else if (g_strncmp(n, "enable_token_login", 64) == 0) {
+            log_message(LOG_LEVEL_DEBUG, "Token login detection enabled x");
+            globals->enable_token_login = g_text2bool(v);
+        }
+
         /* login screen values */
         else if (g_strncmp(n, "ls_top_window_bg_color", 64) == 0)
             globals->ls_top_window_bg_color = HCOLOR(bpp, xrdp_wm_htoi(v));
@@ -1109,12 +1114,13 @@ load_xrdp_config(struct xrdp_config *config, int bpp)
     g_writeln("new_cursors:             %d", globals->new_cursors);
     g_writeln("nego_sec_layer:          %d", globals->nego_sec_layer);
     g_writeln("allow_multimon:          %d", globals->allow_multimon);
+    g_writeln("enable_token_login:      %d", globals->enable_token_login)
 
     g_writeln("ls_top_window_bg_color:  %x", globals->ls_top_window_bg_color);
     g_writeln("ls_width:                %d", globals->ls_width);
     g_writeln("ls_height:               %d", globals->ls_height);
     g_writeln("ls_bg_color:             %x", globals->ls_bg_color);
-    g_writeln("ls_title:            %s", globals->ls_title);
+    g_writeln("ls_title:                %s", globals->ls_title);
     g_writeln("ls_logo_filename:        %s", globals->ls_logo_filename);
     g_writeln("ls_logo_x_pos:           %d", globals->ls_logo_x_pos);
     g_writeln("ls_logo_y_pos:           %d", globals->ls_logo_y_pos);

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -566,6 +566,7 @@ struct xrdp_cfg_globals
     int  new_cursors;
     int  nego_sec_layer;
     int  allow_multimon;
+    int  enable_token_login;
 
     /* colors */
 


### PR DESCRIPTION
This feature allows to embed a token in the username field. Tokens
are separated from the username by the ASCII field separator character
0x1F (unicode 0x001F).

See https://github.com/neutrinolabs/xrdp/issues/1667

cc @metalefty @matt335672 