### PR TITLE
genkeymap: Fix an array declaration conflict

### DIFF
--- a/genkeymap/genkeymap.c
+++ b/genkeymap/genkeymap.c
@@ -44,7 +44,7 @@
 #include <X11/XKBlib.h>
 #include <locale.h>
 
-extern int xfree86_to_evdev[137-8];
+extern int xfree86_to_evdev[137-8+1];
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
The conflict on the size of xfree86_to_evdev between genkeymap.c and
evdev-map.c is causing build failures in openSUSE builds