### PR TITLE
startwm.sh: Additionally support /usr/etc/X11/xdm/Xsession

### DIFF
--- a/sesman/startwm.sh
+++ b/sesman/startwm.sh
@@ -85,6 +85,9 @@ wm_start()
     # do not execute the pseudo login shell scripts
     . /etc/X11/xdm/Xsession
     exit 0
+  elif [ -r /usr/etc/X11/xdm/Xsession ]; then
+    . /usr/etc/X11/xdm/Xsession
+    exit 0
   fi
 
   pre_start


### PR DESCRIPTION
SUSE distributions are switched to use /usr/etc for system configuration, Xsession startup files is involved.

https://lists.opensuse.org/opensuse-factory/2019-08/msg00113.html