### PR TITLE
Unify logging in sesman

### DIFF
--- a/sesman/access.c
+++ b/sesman/access.c
@@ -41,32 +41,32 @@ access_login_allowed(const char *user)
 
     if ((0 == g_strncmp(user, "root", 5)) && (0 == g_cfg->sec.allow_root))
     {
-        log_message(LOG_LEVEL_WARNING,
-                    "ROOT login attempted, but root login is disabled");
+        LOG(LOG_LEVEL_WARNING,
+            "ROOT login attempted, but root login is disabled");
         return 0;
     }
 
-    if ((0 == g_cfg->sec.ts_users_enable) && (0==g_cfg->sec.ts_always_group_check))
+    if ((0 == g_cfg->sec.ts_users_enable) && (0 == g_cfg->sec.ts_always_group_check))
     {
-        log_message(LOG_LEVEL_INFO, "Terminal Server Users group is disabled, allowing authentication");
+        LOG(LOG_LEVEL_INFO, "Terminal Server Users group is disabled, allowing authentication");
         return 1;
     }
 
     if (0 != g_getuser_info(user, &gid, 0, 0, 0, 0))
     {
-        log_message(LOG_LEVEL_ERROR, "Cannot read user info! - login denied");
+        LOG(LOG_LEVEL_ERROR, "Cannot read user info! - login denied");
         return 0;
     }
 
     if (g_cfg->sec.ts_users == gid)
     {
-        log_message(LOG_LEVEL_DEBUG,"ts_users is user's primary group");
+        LOG(LOG_LEVEL_DEBUG, "ts_users is user's primary group");
         return 1;
     }
 
     if (0 != g_check_user_in_group(user, g_cfg->sec.ts_users, &ok))
     {
-        log_message(LOG_LEVEL_ERROR, "Cannot read group info! - login denied");
+        LOG(LOG_LEVEL_ERROR, "Cannot read group info! - login denied");
         return 0;
     }
 
@@ -75,7 +75,7 @@ access_login_allowed(const char *user)
         return 1;
     }
 
-    log_message(LOG_LEVEL_INFO, "login denied for user %s", user);
+    LOG(LOG_LEVEL_INFO, "login denied for user %s", user);
 
     return 0;
 }
@@ -89,21 +89,21 @@ access_login_mng_allowed(const char *user)
 
     if ((0 == g_strncmp(user, "root", 5)) && (0 == g_cfg->sec.allow_root))
     {
-        log_message(LOG_LEVEL_WARNING,
-                    "[MNG] ROOT login attempted, but root login is disabled");
+        LOG(LOG_LEVEL_WARNING,
+            "[MNG] ROOT login attempted, but root login is disabled");
         return 0;
     }
 
     if (0 == g_cfg->sec.ts_admins_enable)
     {
-        log_message(LOG_LEVEL_INFO, "[MNG] Terminal Server Admin group is disabled, "
-                "allowing authentication");
+        LOG(LOG_LEVEL_INFO, "[MNG] Terminal Server Admin group is disabled, "
+            "allowing authentication");
         return 1;
     }
 
     if (0 != g_getuser_info(user, &gid, 0, 0, 0, 0))
     {
-        log_message(LOG_LEVEL_ERROR, "[MNG] Cannot read user info! - login denied");
+        LOG(LOG_LEVEL_ERROR, "[MNG] Cannot read user info! - login denied");
         return 0;
     }
 
@@ -115,7 +115,7 @@ access_login_mng_allowed(const char *user)
 
     if (0 != g_check_user_in_group(user, g_cfg->sec.ts_admins, &ok))
     {
-        log_message(LOG_LEVEL_ERROR, "[MNG] Cannot read group info! - login denied");
+        LOG(LOG_LEVEL_ERROR, "[MNG] Cannot read group info! - login denied");
         return 0;
     }
 
@@ -124,7 +124,7 @@ access_login_mng_allowed(const char *user)
         return 1;
     }
 
-    log_message(LOG_LEVEL_INFO, "[MNG] login denied for user %s", user);
+    LOG(LOG_LEVEL_INFO, "[MNG] login denied for user %s", user);
 
     return 0;
 }

--- a/sesman/chansrv/audin.c
+++ b/sesman/chansrv/audin.c
@@ -153,8 +153,8 @@ audin_send_formats(int chan_id)
     {
         wf = g_server_formats[index];
         LOG_DEVEL(LOG_LEVEL_INFO, "audin_send_formats: sending format wFormatTag 0x%4.4x "
-            "nChannels %d nSamplesPerSec %d",
-            wf->wFormatTag, wf->nChannels, wf->nSamplesPerSec);
+                  "nChannels %d nSamplesPerSec %d",
+                  wf->wFormatTag, wf->nChannels, wf->nSamplesPerSec);
         out_uint16_le(s, wf->wFormatTag);
         out_uint16_le(s, wf->nChannels);
         out_uint32_le(s, wf->nSamplesPerSec);
@@ -261,8 +261,8 @@ audin_process_formats(int chan_id, struct stream *s)
         in_uint16_le(s, wf->wBitsPerSample);
         in_uint16_le(s, wf->cbSize);
         LOG_DEVEL(LOG_LEVEL_INFO, "audin_process_formats: recved format wFormatTag 0x%4.4x "
-            "nChannels %d nSamplesPerSec %d",
-            wf->wFormatTag, wf->nChannels, wf->nSamplesPerSec);
+                  "nChannels %d nSamplesPerSec %d",
+                  wf->wFormatTag, wf->nChannels, wf->nSamplesPerSec);
         if (wf->cbSize > 0)
         {
             if (!s_check_rem(s, wf->cbSize))
@@ -334,7 +334,7 @@ audin_process_format_change(int chan_id, struct stream *s)
     }
     in_uint32_le(s, g_current_format);
     LOG_DEVEL(LOG_LEVEL_INFO, "audin_process_format_change: g_current_format %d",
-        g_current_format);
+              g_current_format);
     return 0;
 }
 
@@ -406,8 +406,8 @@ audin_data_fragment(int chan_id, char *data, int bytes)
     LOG_DEVEL(LOG_LEVEL_DEBUG, "audin_data_fragment:");
     if (!s_check_rem(g_in_s, bytes))
     {
-        LOG_DEVEL(LOG_LEVEL_ERROR, "audin_data_fragment: error bytes %d left %d", 
-                bytes, (int) (g_in_s->end - g_in_s->p));
+        LOG_DEVEL(LOG_LEVEL_ERROR, "audin_data_fragment: error bytes %d left %d",
+                  bytes, (int) (g_in_s->end - g_in_s->p));
         return 1;
     }
     out_uint8a(g_in_s, data, bytes);
@@ -444,8 +444,7 @@ audin_data(int chan_id, char *data, int bytes)
 {
     struct stream ls;
 
-    LOG_DEVEL(LOG_LEVEL_DEBUG, "audin_data:");
-    //g_hexdump(data, bytes);
+    LOG_DEVEL_HEXDUMP(LOG_LEVEL_TRACE, "audin_data:", data, bytes);
     if (g_in_s == NULL)
     {
         g_memset(&ls, 0, sizeof(ls));
@@ -485,7 +484,7 @@ int
 audin_start(void)
 {
     int error;
-    struct stream* s;
+    struct stream *s;
 
     LOG_DEVEL(LOG_LEVEL_INFO, "audin_start:");
     if (g_audin_chanid != 0)

--- a/sesman/chansrv/chansrv.c
+++ b/sesman/chansrv/chansrv.c
@@ -263,8 +263,8 @@ send_channel_data(int chan_id, const char *data, int size)
     struct stream *s;
 
     if ((chan_id < 0) || (chan_id > 31) ||
-        (data == NULL) ||
-        (size < 1) || (size > MAX_CHANNEL_BYTES))
+            (data == NULL) ||
+            (size < 1) || (size > MAX_CHANNEL_BYTES))
     {
         /* bad param */
         return 1;
@@ -308,11 +308,11 @@ send_channel_data(int chan_id, const char *data, int size)
 /*****************************************************************************/
 /* returns error */
 int
-send_rail_drawing_orders(char* data, int size)
+send_rail_drawing_orders(char *data, int size)
 {
     LOG_DEVEL(LOG_LEVEL_DEBUG, "chansrv::send_rail_drawing_orders: size %d", size);
 
-    struct stream* s;
+    struct stream *s;
     int error;
 
     s = trans_get_out_s(g_con_trans, 8192);
@@ -352,7 +352,7 @@ process_message_channel_setup(struct stream *s)
     LOG_DEVEL(LOG_LEVEL_DEBUG, "process_message_channel_setup:");
     in_uint16_le(s, num_chans);
     LOG_DEVEL(LOG_LEVEL_DEBUG, "process_message_channel_setup: num_chans %d",
-          num_chans);
+              num_chans);
 
     for (index = 0; index < num_chans; index++)
     {
@@ -362,7 +362,7 @@ process_message_channel_setup(struct stream *s)
         in_uint16_le(s, ci->id);
         in_uint16_le(s, ci->flags);
         LOG_DEVEL(LOG_LEVEL_DEBUG, "process_message_channel_setup: chan name '%s' "
-              "id %d flags %8.8x", ci->name, ci->id, ci->flags);
+                  "id %d flags %8.8x", ci->name, ci->id, ci->flags);
 
         if (g_strcasecmp(ci->name, "cliprdr") == 0)
         {
@@ -443,7 +443,7 @@ process_message_channel_data(struct stream *s)
     in_uint16_le(s, length);
     in_uint32_le(s, total_length);
     LOG_DEVEL(LOG_LEVEL_DEBUG, "process_message_channel_data: chan_id %d "
-          "chan_flags %d", chan_id, chan_flags);
+              "chan_flags %d", chan_id, chan_flags);
     rv = 0;
 
     if (rv == 0)
@@ -1259,7 +1259,7 @@ setup_listen(void)
     if (error != 0)
     {
         LOG_DEVEL(LOG_LEVEL_ERROR, "setup_listen: trans_listen failed for port %s",
-              port);
+                  port);
         return 1;
     }
 
@@ -1282,7 +1282,7 @@ setup_api_listen(void)
     if (error != 0)
     {
         LOG_DEVEL(LOG_LEVEL_ERROR, "setup_api_listen: trans_listen failed for port %s",
-              port);
+                  port);
         return 1;
     }
 
@@ -1299,11 +1299,11 @@ api_con_trans_list_get_wait_objs_rw(intptr_t *robjs, int *rcount,
     struct trans *ltran;
 
     for (api_con_index = g_api_con_trans_list->count - 1;
-         api_con_index >= 0;
-         api_con_index--)
+            api_con_index >= 0;
+            api_con_index--)
     {
         ltran = (struct trans *)
-            list_get_item(g_api_con_trans_list, api_con_index);
+                list_get_item(g_api_con_trans_list, api_con_index);
         if (ltran != NULL)
         {
             trans_get_wait_objs_rw(ltran, robjs, rcount, wobjs, wcount,
@@ -1323,11 +1323,11 @@ api_con_trans_list_check_wait_objs(void)
     struct xrdp_api_data *ad;
 
     for (api_con_index = g_api_con_trans_list->count - 1;
-         api_con_index >= 0;
-         api_con_index--)
+            api_con_index >= 0;
+            api_con_index--)
     {
         ltran = (struct trans *)
-            list_get_item(g_api_con_trans_list, api_con_index);
+                list_get_item(g_api_con_trans_list, api_con_index);
         if (ltran != NULL)
         {
             if (trans_check_wait_objs(ltran) != 0)
@@ -1340,8 +1340,8 @@ api_con_trans_list_check_wait_objs(void)
                     chansrv_drdynvc_close(ad->chan_id);
                 }
                 for (drdynvc_index = 0;
-                     drdynvc_index < (int) ARRAYSIZE(g_drdynvcs);
-                     drdynvc_index++)
+                        drdynvc_index < (int) ARRAYSIZE(g_drdynvcs);
+                        drdynvc_index++)
                 {
                     if (g_drdynvcs[drdynvc_index].xrdp_api_trans == ltran)
                     {
@@ -1364,11 +1364,11 @@ api_con_trans_list_remove_all(void)
     struct trans *ltran;
 
     for (api_con_index = g_api_con_trans_list->count - 1;
-         api_con_index >= 0;
-         api_con_index--)
+            api_con_index >= 0;
+            api_con_index--)
     {
         ltran = (struct trans *)
-            list_get_item(g_api_con_trans_list, api_con_index);
+                list_get_item(g_api_con_trans_list, api_con_index);
         if (ltran != NULL)
         {
             list_remove_item(g_api_con_trans_list, api_con_index);
@@ -1426,7 +1426,7 @@ channel_thread_loop(void *in_val)
                 if (trans_check_wait_objs(g_lis_trans) != 0)
                 {
                     LOG_DEVEL(LOG_LEVEL_INFO, "channel_thread_loop: "
-                          "trans_check_wait_objs error");
+                              "trans_check_wait_objs error");
                 }
             }
 
@@ -1435,7 +1435,7 @@ channel_thread_loop(void *in_val)
                 if (trans_check_wait_objs(g_con_trans) != 0)
                 {
                     LOG_DEVEL(LOG_LEVEL_INFO, "channel_thread_loop: "
-                          "trans_check_wait_objs error resetting");
+                              "trans_check_wait_objs error resetting");
                     clipboard_deinit();
                     sound_deinit();
                     devredir_deinit();
@@ -1643,7 +1643,7 @@ main_cleanup(void)
 static int
 get_log_path(char *path, int bytes)
 {
-    char* log_path;
+    char *log_path;
     int rv;
 
     rv = 1;
@@ -1778,7 +1778,7 @@ main(int argc, char **argv)
     logconfig->log_file = NULL;
     log_config_free(logconfig);
     logconfig = NULL;
-    
+
     if (error != LOG_STARTUP_OK)
     {
         switch (error)

--- a/sesman/chansrv/chansrv_fuse.c
+++ b/sesman/chansrv/chansrv_fuse.c
@@ -41,60 +41,86 @@ char g_fuse_clipboard_path[256] = ""; /* for clipboard use */
 #include "chansrv_xfs.h"
 
 /* dummy calls when XRDP_FUSE is not defined */
-int xfuse_init(void)            { return 0; }
-int xfuse_deinit(void)          { return 0; }
-int xfuse_check_wait_objs(void) { return 0; }
-int xfuse_get_wait_objs(tbus *objs, int *count, int *timeout) { return 0; }
-int xfuse_create_share(tui32 device_id, const char *dirname)                       { return 0; }
+int xfuse_init(void)
+{
+    return 0;
+}
+int xfuse_deinit(void)
+{
+    return 0;
+}
+int xfuse_check_wait_objs(void)
+{
+    return 0;
+}
+int xfuse_get_wait_objs(tbus *objs, int *count, int *timeout)
+{
+    return 0;
+}
+int xfuse_create_share(tui32 device_id, const char *dirname)
+{
+    return 0;
+}
 void xfuse_delete_share(tui32 share_id) {}
-int xfuse_clear_clip_dir(void)  { return 0; }
-int xfuse_file_contents_range(int stream_id, const char *data, int data_bytes)     { return 0; }
+int xfuse_clear_clip_dir(void)
+{
+    return 0;
+}
+int xfuse_file_contents_range(int stream_id, const char *data, int data_bytes)
+{
+    return 0;
+}
 int xfuse_file_contents_size(int stream_id, int file_size)
-   { return 0; }
+{
+    return 0;
+}
 int xfuse_add_clip_dir_item(const char *filename,
-                            int flags, int size, int lindex) { return 0; }
+                            int flags, int size, int lindex)
+{
+    return 0;
+}
 
 void xfuse_devredir_cb_enum_dir_add_entry(
-                                 struct state_dirscan *fip,
-                                 const char *name,
-                                 const struct file_attr *fattr)
-   {}
+    struct state_dirscan *fip,
+    const char *name,
+    const struct file_attr *fattr)
+{}
 void xfuse_devredir_cb_enum_dir_done(struct state_dirscan *fip,
                                      enum NTSTATUS IoStatus)
-   {}
+{}
 void xfuse_devredir_cb_lookup_entry(struct state_lookup *fip,
                                     enum NTSTATUS IoStatus,
                                     const struct file_attr *file_info)
-   {}
+{}
 void xfuse_devredir_cb_setattr(struct state_setattr *fip,
                                enum NTSTATUS IoStatus)
-   {}
+{}
 void xfuse_devredir_cb_create_file(struct state_create *fip,
                                    enum NTSTATUS IoStatus,
                                    tui32 DeviceId, tui32 FileId)
-   {}
+{}
 void xfuse_devredir_cb_open_file(struct state_open *fip,
                                  enum NTSTATUS IoStatus,
                                  tui32 DeviceId, tui32 FileId)
-   {}
+{}
 void xfuse_devredir_cb_read_file(struct state_read *fip,
                                  enum NTSTATUS IoStatus,
                                  const char *buf, size_t length)
-   {}
+{}
 void xfuse_devredir_cb_write_file(
-                                 struct state_write *fip,
-                                 enum NTSTATUS IoStatus,
-                                 off_t offset,
-                                 size_t length)
-   {}
+    struct state_write *fip,
+    enum NTSTATUS IoStatus,
+    off_t offset,
+    size_t length)
+{}
 void xfuse_devredir_cb_rmdir_or_file(struct state_remove *fip,
                                      enum NTSTATUS IoStatus)
-   {}
+{}
 void xfuse_devredir_cb_rename_file(struct state_rename *fip,
                                    enum NTSTATUS IoStatus)
-   {}
+{}
 void xfuse_devredir_cb_file_close(struct state_close *fip)
-   {}
+{}
 
 #else
 
@@ -161,11 +187,11 @@ struct state_lookup
     fuse_req_t        req;        /* Original FUSE request from lookup  */
     fuse_ino_t        pinum;      /* inum of parent directory           */
     char              name[XFS_MAXFILENAMELEN];
-                                  /* Name to look up                    */
+    /* Name to look up                    */
     fuse_ino_t        existing_inum;
-                                  /* inum of an existing entry          */
+    /* inum of an existing entry          */
     tui32             existing_generation;
-                                  /* generation of the above            */
+    /* generation of the above            */
 };
 
 /*
@@ -200,7 +226,7 @@ struct state_create
     struct fuse_file_info fi;     /* File info struct passed to open    */
     fuse_ino_t        pinum;      /* inum of parent directory           */
     char              name[XFS_MAXFILENAMELEN];
-                                  /* Name of file in parent directory   */
+    /* Name of file in parent directory   */
     mode_t            mode;       /* Mode of file to create             */
 };
 
@@ -239,7 +265,7 @@ struct state_rename
     fuse_ino_t        pinum;      /* inum of parent of file             */
     fuse_ino_t        new_pinum;  /* inum of new parent of file         */
     char              name[XFS_MAXFILENAMELEN];
-                                  /* New name of file in new parent dir */
+    /* New name of file in new parent dir */
 };
 
 /*
@@ -257,11 +283,11 @@ struct xfuse_handle
     tui32 DeviceId;
     tui32 FileId;
     int   is_loc_resource; /* this is not a redirected resource */
-    
+
     /* a directory handle, if this xfuse_handle represents a directory.
      * NULL, if this xfuse_handle represents a file.
      *
-     * Note: when this xfuse_handle represents a directory, then the other 
+     * Note: when this xfuse_handle represents a directory, then the other
      *       fields of this structure contain invalid values.
      */
     struct xfs_dir_handle *dir_handle;
@@ -359,12 +385,12 @@ static void xfuse_cb_releasedir(fuse_req_t req, fuse_ino_t ino,
 
 /* miscellaneous functions */
 static void xfs_inode_to_fuse_entry_param(const XFS_INODE *xinode,
-                                          struct fuse_entry_param *e);
+        struct fuse_entry_param *e);
 static void make_fuse_entry_reply(fuse_req_t req, const XFS_INODE *xinode);
 static void make_fuse_attr_reply(fuse_req_t req, const XFS_INODE *xinode);
 static const char *filename_on_device(const char *full_path);
 static void update_inode_file_attributes(const struct file_attr *fattr,
-                                         tui32 change_mask, XFS_INODE *xinode);
+        tui32 change_mask, XFS_INODE *xinode);
 static char *get_name_for_entry_in_parent(fuse_ino_t parent, const char *name);
 
 /*****************************************************************************/
@@ -375,7 +401,7 @@ load_fuse_config(void)
 }
 
 /*****************************************************************************/
-XFUSE_HANDLE*
+XFUSE_HANDLE *
 xfuse_handle_create()
 {
     return g_new0(XFUSE_HANDLE, 1);
@@ -389,7 +415,7 @@ xfuse_handle_delete(XFUSE_HANDLE *self)
     {
         return;
     }
-    
+
     if (self->dir_handle != NULL)
     {
         free(self->dir_handle);
@@ -405,7 +431,7 @@ xfuse_handle_to_fuse_handle(XFUSE_HANDLE *self)
 }
 
 /*****************************************************************************/
-XFUSE_HANDLE*
+XFUSE_HANDLE *
 xfuse_handle_from_fuse_handle(uint64_t handle)
 {
     return (XFUSE_HANDLE *) (tintptr) handle;
@@ -460,7 +486,9 @@ xfuse_init(void)
 
     /* setup xrdp file system */
     if (xfuse_init_xrdp_fs())
+    {
         return -1;
+    }
 
     /* setup FUSE callbacks */
     g_memset(&g_xfuse_ops, 0, sizeof(g_xfuse_ops));
@@ -547,7 +575,9 @@ int xfuse_check_wait_objs(void)
     int               rval;
 
     if (g_ch == 0)
+    {
         return 0;
+    }
 
     if (g_tcp_select(g_fd, 0) & 1)
     {
@@ -555,13 +585,19 @@ int xfuse_check_wait_objs(void)
 
         rval = fuse_chan_recv(&tmpch, g_buffer, g_bufsize);
         if (rval == -EINTR)
+        {
             return -1;
+        }
 
         if (rval == -ENODEV)
+        {
             return -1;
+        }
 
         if (rval <= 0)
+        {
             return -1;
+        }
 
         fuse_session_process(g_se, g_buffer, rval, tmpch);
     }
@@ -580,7 +616,9 @@ int xfuse_get_wait_objs(tbus *objs, int *count, int *timeout)
     int lcount;
 
     if (g_ch == 0)
+    {
         return 0;
+    }
 
     lcount = *count;
     objs[lcount] = g_fd;
@@ -604,7 +642,7 @@ int xfuse_create_share(tui32 device_id, const char *dirname)
     XFS_INODE  *xinode;
 
     if (dirname != NULL && strlen(dirname) > 0 &&
-        xfuse_init_xrdp_fs() == 0)
+            xfuse_init_xrdp_fs() == 0)
     {
         xinode = xfs_add_entry(g_xfs, FUSE_ROOT_ID, dirname, (0777 | S_IFDIR));
         if (xinode == NULL)
@@ -694,7 +732,7 @@ xfuse_file_contents_range(int stream_id, const char *data, int data_bytes)
     LOG_DEVEL(LOG_LEVEL_DEBUG, "requesting clipboard file data");
 
     clipboard_request_file_data(rli->stream_id, rli->lindex,
-                                    rli->off, rli->size);
+                                rli->off, rli->size);
 
     return 0;
 }
@@ -828,7 +866,7 @@ static int xfuse_init_xrdp_fs(void)
         {
             g_clipboard_inum = xino->inum;
             result = 0;
-         }
+        }
     }
     return result;
 }
@@ -863,9 +901,9 @@ static int xfuse_deinit_xrdp_fs(void)
  *****************************************************************************/
 
 void xfuse_devredir_cb_enum_dir_add_entry(
-                                 struct state_dirscan *fip,
-                                 const char *name,
-                                 const struct file_attr *fattr)
+    struct state_dirscan *fip,
+    const char *name,
+    const struct file_attr *fattr)
 {
     XFS_INODE *xinode = NULL;
 
@@ -947,9 +985,9 @@ void xfuse_devredir_cb_enum_dir_done(struct state_dirscan *fip,
     {
         struct fuse_file_info *fi = &fip->fi;
         XFUSE_HANDLE *xhandle = xfuse_handle_create();
-        
+
         if (xhandle == NULL
-            || (xhandle->dir_handle = xfs_opendir(g_xfs, fip->pinum)) == NULL)
+                || (xhandle->dir_handle = xfs_opendir(g_xfs, fip->pinum)) == NULL)
         {
             xfuse_handle_delete(xhandle);
             fuse_reply_err(fip->req, ENOMEM);
@@ -965,7 +1003,7 @@ void xfuse_devredir_cb_enum_dir_done(struct state_dirscan *fip,
 }
 
 /**
- * This routine is caused as a result of a devredir remote lookup 
+ * This routine is caused as a result of a devredir remote lookup
  * instigated by xfuse_cb_lookup()
  *****************************************************************************/
 
@@ -980,8 +1018,8 @@ void xfuse_devredir_cb_lookup_entry(struct state_lookup *fip,
         switch (IoStatus)
         {
             case STATUS_SHARING_VIOLATION:
-                /* This can happen when trying to read the attributes of
-                 * some system files (e.g. pagefile.sys) */
+            /* This can happen when trying to read the attributes of
+             * some system files (e.g. pagefile.sys) */
             case STATUS_ACCESS_DENIED:
                 fuse_reply_err(fip->req, EACCES);
                 break;
@@ -994,10 +1032,10 @@ void xfuse_devredir_cb_lookup_entry(struct state_lookup *fip,
 
             case STATUS_NO_SUCH_FILE:
                 /* Remove our copy, if any */
-                if (fip->existing_inum  && 
-                    (xinode = xfs_get(g_xfs, fip->existing_inum)) != NULL &&
-                     xinode->generation == fip->existing_generation)
-                { 
+                if (fip->existing_inum  &&
+                        (xinode = xfs_get(g_xfs, fip->existing_inum)) != NULL &&
+                        xinode->generation == fip->existing_generation)
+                {
                     xfs_remove_entry(g_xfs, fip->existing_inum);
                 }
                 fuse_reply_err(fip->req, ENOENT);
@@ -1024,7 +1062,7 @@ void xfuse_devredir_cb_lookup_entry(struct state_lookup *fip,
         {
             /* Is the existing file the same type ? */
             if ((xinode->mode & (S_IFREG | S_IFDIR)) ==
-                (file_info->mode & (S_IFREG | S_IFDIR)))
+                    (file_info->mode & (S_IFREG | S_IFDIR)))
             {
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "inode=%ld name=%s already exists in xrdp_fs as %ld",
                           fip->pinum, fip->name, xinode->inum);
@@ -1105,14 +1143,14 @@ void xfuse_devredir_cb_setattr(struct state_setattr *fip,
         switch (IoStatus)
         {
             case STATUS_SHARING_VIOLATION:
-                /* This can happen when trying to read the attributes of
-                 * some system files (e.g. pagefile.sys) */
+            /* This can happen when trying to read the attributes of
+             * some system files (e.g. pagefile.sys) */
             case STATUS_ACCESS_DENIED:
                 fuse_reply_err(fip->req, EACCES);
                 break;
 
             case STATUS_UNSUCCESSFUL:
-                /* Happens if we try to lookup an illegal filename */
+            /* Happens if we try to lookup an illegal filename */
             case STATUS_NO_SUCH_FILE:
                 fuse_reply_err(fip->req, ENOENT);
                 break;
@@ -1148,18 +1186,18 @@ void xfuse_devredir_cb_create_file(struct state_create *fip,
     {
         switch (IoStatus)
         {
-        case STATUS_ACCESS_DENIED:
-            fuse_reply_err(fip->req, EACCES);
-            break;
+            case STATUS_ACCESS_DENIED:
+                fuse_reply_err(fip->req, EACCES);
+                break;
 
-        case STATUS_OBJECT_NAME_INVALID:
-        case STATUS_OBJECT_NAME_NOT_FOUND:
-            fuse_reply_err(fip->req, ENOENT);
-            break;
+            case STATUS_OBJECT_NAME_INVALID:
+            case STATUS_OBJECT_NAME_NOT_FOUND:
+                fuse_reply_err(fip->req, ENOENT);
+                break;
 
-        default:
-            fuse_reply_err(fip->req, EIO);
-            break;
+            default:
+                fuse_reply_err(fip->req, EIO);
+                break;
         }
     }
     else
@@ -1250,18 +1288,18 @@ void xfuse_devredir_cb_open_file(struct state_open *fip,
     {
         switch (IoStatus)
         {
-        case STATUS_ACCESS_DENIED:
-            fuse_reply_err(fip->req, EACCES);
-            break;
+            case STATUS_ACCESS_DENIED:
+                fuse_reply_err(fip->req, EACCES);
+                break;
 
-        case STATUS_OBJECT_NAME_INVALID:
-        case STATUS_OBJECT_NAME_NOT_FOUND:
-            fuse_reply_err(fip->req, ENOENT);
-            break;
+            case STATUS_OBJECT_NAME_INVALID:
+            case STATUS_OBJECT_NAME_NOT_FOUND:
+                fuse_reply_err(fip->req, ENOENT);
+                break;
 
-        default:
-            fuse_reply_err(fip->req, EIO);
-            break;
+            default:
+                fuse_reply_err(fip->req, EIO);
+                break;
         }
     }
     else
@@ -1311,10 +1349,10 @@ void xfuse_devredir_cb_read_file(struct state_read *fip,
 }
 
 void xfuse_devredir_cb_write_file(
-                                 struct state_write *fip,
-                                 enum NTSTATUS IoStatus,
-                                 off_t offset,
-                                 size_t length)
+    struct state_write *fip,
+    enum NTSTATUS IoStatus,
+    off_t offset,
+    size_t length)
 {
     XFS_INODE   *xinode;
 
@@ -1381,7 +1419,7 @@ void xfuse_devredir_cb_rename_file(struct state_rename *fip,
         status =
             (IoStatus == STATUS_SHARING_VIOLATION) ? EBUSY  :
             (IoStatus == STATUS_ACCESS_DENIED)     ? EACCES :
-                /* default */                        EEXIST ;
+            /* default */                        EEXIST ;
     }
     else
     {
@@ -1480,7 +1518,7 @@ static void xfuse_cb_lookup(fuse_req_t req, fuse_ino_t parent, const char *name)
                     fip->existing_generation = xinode->generation;
                 }
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "Looking up %s in %s on %d", name, cptr,
-                                                      parent_xinode->device_id);
+                          parent_xinode->device_id);
                 /*
                  * If this call succeeds, further request processing happens in
                  * xfuse_devredir_cb_lookup_entry()
@@ -1505,7 +1543,7 @@ static void xfuse_cb_lookup(fuse_req_t req, fuse_ino_t parent, const char *name)
  *****************************************************************************/
 
 static void xfuse_cb_getattr(fuse_req_t req, fuse_ino_t ino,
-                            struct fuse_file_info *fi)
+                             struct fuse_file_info *fi)
 {
     XFS_INODE *xino;
 
@@ -1550,12 +1588,12 @@ static int xfuse_dirbuf_add1(fuse_req_t req, struct dirbuf1 *b,
      *    still returned."
      */
     len = fuse_add_direntry(req,
-                      &b->buf[b->len], /* index where new entry will be added to buf */
-                      sizeof(b->buf) - b->len,  /* Space left */
-                      xinode->name,             /* name of entry */
-                      &stbuf,                   /* file attributes */
-                      offset                    /* offset of next entry */
-                     );
+                            &b->buf[b->len], /* index where new entry will be added to buf */
+                            sizeof(b->buf) - b->len,  /* Space left */
+                            xinode->name,             /* name of entry */
+                            &stbuf,                   /* file attributes */
+                            offset                    /* offset of next entry */
+                           );
     if (len + b->len <= sizeof(b->buf))
     {
         /* Entry fitted in OK */
@@ -1589,7 +1627,7 @@ static void xfuse_cb_readdir(fuse_req_t req, fuse_ino_t ino, size_t size,
         fuse_reply_err(req, ENOENT);
     }
     else if ((xhandle = xfuse_handle_from_fuse_handle(fi->fh)) == NULL
-              || (dh = xhandle->dir_handle) == NULL)
+             || (dh = xhandle->dir_handle) == NULL)
     {
         /* something seriously wrong somewhere! */
         fuse_reply_buf(req, 0, 0);
@@ -1723,7 +1761,7 @@ static void xfuse_cb_rename(fuse_req_t req,
               old_parent, old_name, new_parent, new_name);
 
     if (strlen(old_name) > XFS_MAXFILENAMELEN ||
-        strlen(new_name) > XFS_MAXFILENAMELEN)
+            strlen(new_name) > XFS_MAXFILENAMELEN)
     {
         fuse_reply_err(req, ENAMETOOLONG);
     }
@@ -1766,7 +1804,7 @@ static void xfuse_cb_rename(fuse_req_t req,
         struct state_rename *fip = g_new0(struct state_rename, 1);
         char *old_full_path = xfs_get_full_path(g_xfs, old_xinode->inum);
         char *new_full_path = get_name_for_entry_in_parent(new_parent,
-                                                           new_name);
+                              new_name);
 
         if (!old_full_path || !new_full_path || !fip)
         {
@@ -1967,10 +2005,10 @@ static void xfuse_cb_open(fuse_req_t req, fuse_ino_t ino,
 
         if (!full_path || !fip)
         {
-           LOG_DEVEL(LOG_LEVEL_ERROR, "system out of memory");
-           fuse_reply_err(req, ENOMEM);
-           free(fip);
-           free(full_path);
+            LOG_DEVEL(LOG_LEVEL_ERROR, "system out of memory");
+            fuse_reply_err(req, ENOMEM);
+            free(fip);
+            free(full_path);
         }
         else
         {
@@ -2201,7 +2239,7 @@ static void xfuse_cb_create(fuse_req_t req, fuse_ino_t parent,
     LOG_DEVEL(LOG_LEVEL_DEBUG, "entered: parent_inode=%ld, name=%s fi=%p",
               parent, name, fi);
 
-    xfuse_create_dir_or_file(req, parent, name, mode & ~S_IFDIR , fi);
+    xfuse_create_dir_or_file(req, parent, name, mode & ~S_IFDIR, fi);
 }
 
 /**
@@ -2249,13 +2287,13 @@ static void xfuse_cb_setattr(fuse_req_t req, fuse_ino_t ino, struct stat *attr,
         fuse_reply_err(req, EPERM);
     }
     else if ((to_set & FUSE_SET_ATTR_MODE) &&
-              (attr->st_mode & ~(0777 | S_IFDIR | S_IFREG)) != 0)
+             (attr->st_mode & ~(0777 | S_IFDIR | S_IFREG)) != 0)
     {
         /* We only support standard mode bits and S_IFDIR / S_IFREG */
         LOG_DEVEL(LOG_LEVEL_ERROR, "Asking for invalid mode bits 0%o to be set", attr->st_mode);
         fuse_reply_err(req, EINVAL);
     }
-    else    
+    else
     {
         struct file_attr attrs = {0};
         tui32 change_mask = 0;
@@ -2344,7 +2382,7 @@ static void xfuse_cb_setattr(fuse_req_t req, fuse_ino_t ino, struct stat *attr,
  *          to reply to FUSE immediately
  *****************************************************************************/
 static void xfuse_cb_opendir(fuse_req_t req, fuse_ino_t ino,
-                                  struct fuse_file_info *fi)
+                             struct fuse_file_info *fi)
 {
     XFS_INODE      *xinode;
     XFUSE_HANDLE   *xhandle;
@@ -2440,7 +2478,7 @@ static void xfuse_cb_releasedir(fuse_req_t req, fuse_ino_t ino,
  *****************************************************************************/
 
 static void xfs_inode_to_fuse_entry_param(const XFS_INODE *xinode,
-                                          struct fuse_entry_param *e)
+        struct fuse_entry_param *e)
 {
     memset(e, 0, sizeof(*e));
     e->ino = xinode->inum;
@@ -2508,7 +2546,7 @@ static const char *filename_on_device(const char *full_path)
  * setattr devredir call
  */
 static void update_inode_file_attributes(const struct file_attr *fattr,
-                                         tui32 change_mask, XFS_INODE *xinode)
+        tui32 change_mask, XFS_INODE *xinode)
 {
     int updated = 0;
 
@@ -2551,8 +2589,8 @@ static char *get_name_for_entry_in_parent(fuse_ino_t parent, const char *name)
 
     if ((result = xfs_get_full_path(g_xfs, parent)) != NULL)
     {
-        char * p = (char *) realloc(result,
-                                    strlen(result) + 1 + strlen(name) + 1);
+        char *p = (char *) realloc(result,
+                                   strlen(result) + 1 + strlen(name) + 1);
         if (p == NULL)
         {
             /* See cppcheck trac #9292 and #9437 */

--- a/sesman/chansrv/chansrv_xfs.c
+++ b/sesman/chansrv/chansrv_xfs.c
@@ -780,7 +780,7 @@ xfs_get_file_open_count(struct xfs_fs *xfs, fuse_ino_t inum)
 /*  ------------------------------------------------------------------------ */
 void
 xfs_delete_redirected_entries_with_device_id(struct xfs_fs *xfs,
-                                             tui32 device_id)
+        tui32 device_id)
 {
     fuse_ino_t inum;
     XFS_INODE_ALL *xino;

--- a/sesman/chansrv/clipboard.c
+++ b/sesman/chansrv/clipboard.c
@@ -367,10 +367,10 @@ clipboard_init(void)
     if (rv == 0)
     {
         LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_init: g_xfixes_event_base %d",
-              g_xfixes_event_base);
+                  g_xfixes_event_base);
         st = XFixesQueryVersion(g_display, &ver_maj, &ver_min);
         LOG(LOG_LEVEL_DEBUG, "clipboard_init st %d, maj %d min %d", st,
-              ver_maj, ver_min);
+            ver_maj, ver_min);
         g_clip_property_atom = XInternAtom(g_display, "XRDP_CLIP_PROPERTY_ATOM",
                                            False);
         g_get_time_atom = XInternAtom(g_display, "XRDP_GET_TIME_ATOM",
@@ -390,7 +390,7 @@ clipboard_init(void)
         if (g_image_bmp_atom == None)
         {
             LOG_DEVEL(LOG_LEVEL_ERROR, "clipboard_init: g_image_bmp_atom was "
-                  "not allocated");
+                      "not allocated");
         }
 
         g_wnd = XCreateSimpleWindow(g_display, RootWindowOfScreen(g_screen),
@@ -425,12 +425,12 @@ clipboard_init(void)
         s_mark_end(s);
         size = (int)(s->end - s->data);
         LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_init: data out, sending "
-              "CB_CLIP_CAPS (clip_msg_id = 1)");
+                  "CB_CLIP_CAPS (clip_msg_id = 1)");
         rv = send_channel_data(g_cliprdr_chan_id, s->data, size);
         if (rv != 0)
         {
             LOG_DEVEL(LOG_LEVEL_ERROR, "clipboard_init: send_channel_data failed "
-                  "rv = %d", rv);
+                      "rv = %d", rv);
             rv = 4;
         }
     }
@@ -446,12 +446,12 @@ clipboard_init(void)
         s_mark_end(s);
         size = (int)(s->end - s->data);
         LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_init: data out, sending "
-              "CB_MONITOR_READY (clip_msg_id = 1)");
+                  "CB_MONITOR_READY (clip_msg_id = 1)");
         rv = send_channel_data(g_cliprdr_chan_id, s->data, size);
         if (rv != 0)
         {
             LOG_DEVEL(LOG_LEVEL_ERROR, "clipboard_init: send_channel_data failed "
-                  "rv = %d", rv);
+                      "rv = %d", rv);
             rv = 4;
         }
     }
@@ -516,7 +516,7 @@ clipboard_send_data_request(int format_id)
     s_mark_end(s);
     size = (int)(s->end - s->data);
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_send_data_request: data out, sending "
-          "CLIPRDR_DATA_REQUEST (clip_msg_id = 4)");
+              "CLIPRDR_DATA_REQUEST (clip_msg_id = 4)");
     rv = send_channel_data(g_cliprdr_chan_id, s->data, size);
     free_stream(s);
     return rv;
@@ -539,7 +539,7 @@ clipboard_send_format_ack(void)
     s_mark_end(s);
     size = (int)(s->end - s->data);
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_send_format_ack: data out, sending "
-          "CLIPRDR_FORMAT_ACK (clip_msg_id = 3)");
+              "CLIPRDR_FORMAT_ACK (clip_msg_id = 3)");
     rv = send_channel_data(g_cliprdr_chan_id, s->data, size);
     free_stream(s);
     return rv;
@@ -677,7 +677,7 @@ clipboard_send_format_announce(int xrdp_clip_type)
                 break;
             default:
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_send_format_announce: unknown "
-                            "xrdp_clip_type %d", xrdp_clip_type);
+                          "xrdp_clip_type %d", xrdp_clip_type);
                 break;
         }
     }
@@ -721,7 +721,7 @@ clipboard_send_format_announce(int xrdp_clip_type)
                 break;
             default:
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_send_format_announce: unknown "
-                            "xrdp_clip_type %d", xrdp_clip_type);
+                          "xrdp_clip_type %d", xrdp_clip_type);
                 break;
         }
     }
@@ -734,9 +734,9 @@ clipboard_send_format_announce(int xrdp_clip_type)
     out_uint32_le(s, 0);
     s_mark_end(s);
     size = (int)(s->end - s->data);
-    //g_hexdump(s->data, size);
+    LOG_DEVEL_HEXDUMP(LOG_LEVEL_TRACE, "clipboard data:", s->data, size);
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_send_format_announce: data out, sending "
-          "CLIPRDR_FORMAT_ANNOUNCE (clip_msg_id = 2)");
+              "CLIPRDR_FORMAT_ANNOUNCE (clip_msg_id = 2)");
     rv = send_channel_data(g_cliprdr_chan_id, s->data, size);
     free_stream(s);
     return rv;
@@ -751,7 +751,7 @@ clipboard_send_data_response_for_image(const char *data, int data_size)
     int rv;
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_send_data_response_for_image: data_size %d",
-                data_size);
+              data_size);
     make_stream(s);
     init_stream(s, 64 + data_size);
     out_uint16_le(s, CB_FORMAT_DATA_RESPONSE); /* 5 CLIPRDR_DATA_RESPONSE */
@@ -776,17 +776,17 @@ clipboard_send_data_response_for_text(const char *data, int data_size)
     int num_chars;
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_send_data_response_for_text: data_size %d",
-                 data_size);
-    //g_hexdump(data, data_size);
+              data_size);
+    LOG_DEVEL_HEXDUMP(LOG_LEVEL_TRACE, "clipboard send data response:", data, data_size);
     num_chars = g_mbstowcs(0, data, 0);
     if (num_chars < 0)
     {
         LOG_DEVEL(LOG_LEVEL_ERROR, "clipboard_send_data_response_for_text: "
-             "bad string");
+                  "bad string");
         num_chars = 0;
     }
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_send_data_response_for_text: data_size %d "
-                "num_chars %d", data_size, num_chars);
+              "num_chars %d", data_size, num_chars);
     make_stream(s);
     init_stream(s, 64 + num_chars * 2);
     out_uint16_le(s, CB_FORMAT_DATA_RESPONSE); /* 5 CLIPRDR_DATA_RESPONSE */
@@ -795,15 +795,15 @@ clipboard_send_data_response_for_text(const char *data, int data_size)
     if (clipboard_out_unicode(s, data, num_chars) != num_chars * 2)
     {
         LOG_DEVEL(LOG_LEVEL_ERROR, "clipboard_send_data_response_for_text: error "
-              "clipboard_out_unicode didn't write right number of bytes");
+                  "clipboard_out_unicode didn't write right number of bytes");
     }
     out_uint16_le(s, 0); /* nil for string */
     out_uint32_le(s, 0);
     s_mark_end(s);
     size = (int)(s->end - s->data);
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_send_data_response_for_text: data out, "
-          "sending CLIPRDR_DATA_RESPONSE (clip_msg_id = 5) size %d "
-          "num_chars %d", size, num_chars);
+              "sending CLIPRDR_DATA_RESPONSE (clip_msg_id = 5) size %d "
+              "num_chars %d", size, num_chars);
     rv = send_channel_data(g_cliprdr_chan_id, s->data, size);
     free_stream(s);
     return rv;
@@ -831,7 +831,7 @@ clipboard_send_data_response(int xrdp_clip_type, const char *data, int data_size
         else
         {
             LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_send_data_response: unknown "
-                       "xrdp_clip_type %d", xrdp_clip_type);
+                      "xrdp_clip_type %d", xrdp_clip_type);
         }
     }
     else
@@ -870,7 +870,7 @@ clipboard_provide_selection_c2s(XSelectionRequestEvent *req, Atom type)
     long val1[2];
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_provide_selection_c2s: bytes %d",
-                g_clip_c2s.total_bytes);
+              g_clip_c2s.total_bytes);
     if (g_clip_c2s.total_bytes < g_incr_max_req_size)
     {
         XChangeProperty(g_display, req->requestor, req->property,
@@ -896,8 +896,8 @@ clipboard_provide_selection_c2s(XSelectionRequestEvent *req, Atom type)
         g_clip_c2s.property = req->property;
         g_clip_c2s.window = req->requestor;
         LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_provide_selection_c2s: start INCR property %s "
-                    "type %s", get_atom_text(req->property),
-                   get_atom_text(type));
+                  "type %s", get_atom_text(req->property),
+                  get_atom_text(type));
         val1[0] = g_clip_c2s.total_bytes;
         val1[1] = 0;
         XChangeProperty(g_display, req->requestor, req->property,
@@ -982,7 +982,7 @@ clipboard_process_format_announce(struct stream *s, int clip_msg_status,
     char *holdp;
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_format_announce: "
-          "CLIPRDR_FORMAT_ANNOUNCE");
+              "CLIPRDR_FORMAT_ANNOUNCE");
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_format_announce %d", clip_msg_len);
     clipboard_send_format_ack();
 
@@ -1014,8 +1014,8 @@ clipboard_process_format_announce(struct stream *s, int clip_msg_status,
             clip_msg_len -= 32;
         }
         LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_format_announce: formatId 0x%8.8x "
-                    "wszFormatName [%s] clip_msg_len %d", formatId, desc,
-                    clip_msg_len);
+                  "wszFormatName [%s] clip_msg_len %d", formatId, desc,
+                  clip_msg_len);
         if (g_num_formatIds <= 15)
         {
             g_formatIds[g_num_formatIds] = formatId;
@@ -1041,7 +1041,7 @@ clipboard_process_format_announce(struct stream *s, int clip_msg_status,
         if (clipboard_set_selection_owner() != 0)
         {
             LOG_DEVEL(LOG_LEVEL_ERROR, "clipboard_process_format_announce: "
-                  "XSetSelectionOwner failed");
+                      "XSetSelectionOwner failed");
         }
     }
 
@@ -1092,7 +1092,7 @@ clipboard_process_data_request(struct stream *s, int clip_msg_status,
     int requestedFormatId;
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_data_request: "
-          "CLIPRDR_DATA_REQUEST");
+              "CLIPRDR_DATA_REQUEST");
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_data_request:");
     LOG_DEVEL(LOG_LEVEL_DEBUG, "  %d", g_clip_s2c.xrdp_clip_type);
     in_uint32_le(s, requestedFormatId);
@@ -1108,7 +1108,7 @@ clipboard_process_data_request(struct stream *s, int clip_msg_status,
             else
             {
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_data_request: CB_FORMAT_FILE, "
-                            "calling XConvertSelection to g_utf8_atom");
+                          "calling XConvertSelection to g_utf8_atom");
                 g_clip_s2c.xrdp_clip_type = XRDP_CB_FILE;
                 XConvertSelection(g_display, g_clipboard_atom, g_clip_s2c.type,
                                   g_clip_property_atom, g_wnd, CurrentTime);
@@ -1124,7 +1124,7 @@ clipboard_process_data_request(struct stream *s, int clip_msg_status,
             else
             {
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_data_request: CB_FORMAT_DIB, "
-                            "calling XConvertSelection to g_image_bmp_atom");
+                          "calling XConvertSelection to g_image_bmp_atom");
                 g_clip_s2c.xrdp_clip_type = XRDP_CB_BITMAP;
                 XConvertSelection(g_display, g_clipboard_atom, g_image_bmp_atom,
                                   g_clip_property_atom, g_wnd, CurrentTime);
@@ -1140,7 +1140,7 @@ clipboard_process_data_request(struct stream *s, int clip_msg_status,
             else
             {
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_data_request: CB_FORMAT_UNICODETEXT, "
-                            "calling XConvertSelection to g_utf8_atom");
+                          "calling XConvertSelection to g_utf8_atom");
                 g_clip_s2c.xrdp_clip_type = XRDP_CB_TEXT;
                 XConvertSelection(g_display, g_clipboard_atom, g_utf8_atom,
                                   g_clip_property_atom, g_wnd, CurrentTime);
@@ -1148,7 +1148,7 @@ clipboard_process_data_request(struct stream *s, int clip_msg_status,
             break;
         default:
             LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_data_request: unknown type %d",
-                        requestedFormatId);
+                      requestedFormatId);
             clipboard_send_data_response_failed();
             break;
     }
@@ -1170,7 +1170,7 @@ clipboard_process_data_response_for_image(struct stream *s,
     int len;
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_data_response_for_image: "
-          "CLIPRDR_DATA_RESPONSE_FOR_IMAGE");
+              "CLIPRDR_DATA_RESPONSE_FOR_IMAGE");
     lxev = &g_saved_selection_req_event;
     len = (int)(s->end - s->p);
     if (len < 1)
@@ -1193,7 +1193,7 @@ clipboard_process_data_response_for_image(struct stream *s,
     g_memcpy(g_clip_c2s.data, g_bmp_image_header, 14);
     in_uint8a(s, g_clip_c2s.data + 14, len);
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_data_response_for_image: calling "
-                "clipboard_provide_selection_c2s");
+              "clipboard_provide_selection_c2s");
     clipboard_provide_selection_c2s(lxev, lxev->target);
     return 0;
 }
@@ -1249,7 +1249,7 @@ clipboard_process_data_response(struct stream *s, int clip_msg_status,
         return 0;
     }
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_data_response: "
-          "CLIPRDR_DATA_RESPONSE");
+              "CLIPRDR_DATA_RESPONSE");
     len = (int)(s->end - s->p);
     if (len < 1)
     {
@@ -1310,7 +1310,7 @@ clipboard_process_clip_caps(struct stream *s, int clip_msg_status,
     char *holdp;
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_clip_caps:");
-    //g_hexdump(s->p, s->end - s->p);
+    //LOG_DEVEL_HEXDUMP(LOG_LEVEL_TRACE, "", s->p, s->end - s->p);
     in_uint16_le(s, cCapabilitiesSets);
     in_uint8s(s, 2); /* pad */
     for (index = 0; index < cCapabilitiesSets; index++)
@@ -1324,10 +1324,10 @@ clipboard_process_clip_caps(struct stream *s, int clip_msg_status,
                 in_uint32_le(s, version); /* version */
                 in_uint32_le(s, flags); /* generalFlags */
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_clip_caps: "
-                           "g_cliprdr_version %d version %d "
-                           "g_cliprdr_flags 0x%x flags 0x%x",
-                           g_cliprdr_version, version,
-                           g_cliprdr_flags, flags);
+                          "g_cliprdr_version %d version %d "
+                          "g_cliprdr_flags 0x%x flags 0x%x",
+                          g_cliprdr_version, version,
+                          g_cliprdr_flags, flags);
                 if (version < g_cliprdr_version)
                 {
                     g_cliprdr_version = version;
@@ -1336,7 +1336,7 @@ clipboard_process_clip_caps(struct stream *s, int clip_msg_status,
                 break;
             default:
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_clip_caps: unknown "
-                           "capabilitySetType %d", capabilitySetType);
+                          "capabilitySetType %d", capabilitySetType);
                 break;
         }
         s->p = holdp + lengthCapability;
@@ -1514,16 +1514,16 @@ clipboard_data_in(struct stream *s, int chan_id, int chan_flags, int length,
     if (!g_clip_up)
     {
         LOG_DEVEL(LOG_LEVEL_ERROR, "aborting clipboard_data_in - clipboard has not "
-            "been initialized");
+                  "been initialized");
         /* we return 0 here to indicate no protocol problem occurred */
         return 0;
     }
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_data_in: chan_id %d "
-            "chan_flags 0x%x length %d total_length %d "
-            "in_request %d g_ins->size %d",
-            chan_id, chan_flags, length, total_length,
-            g_clip_c2s.in_request, g_ins->size);
+              "chan_flags 0x%x length %d total_length %d "
+              "in_request %d g_ins->size %d",
+              chan_id, chan_flags, length, total_length,
+              g_clip_c2s.in_request, g_ins->size);
 
     if (g_clip_c2s.doing_response_ss)
     {
@@ -1583,8 +1583,8 @@ clipboard_data_in(struct stream *s, int chan_id, int chan_flags, int length,
     in_uint32_le(ls, clip_msg_len);
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_data_in: clip_msg_id %d "
-             "clip_msg_status %d clip_msg_len %d",
-             clip_msg_id, clip_msg_status, clip_msg_len);
+              "clip_msg_status %d clip_msg_len %d",
+              clip_msg_id, clip_msg_status, clip_msg_len);
     rv = 0;
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_data_in: %d", clip_msg_id);
@@ -1663,14 +1663,14 @@ clipboard_event_selection_owner_notify(XEvent *xevent)
     lxevent = (XFixesSelectionNotifyEvent *)xevent;
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_event_selection_owner_notify: 0x%lx", lxevent->owner);
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_event_selection_owner_notify: "
-          "window %ld subtype %d owner %ld g_wnd %ld",
-          lxevent->window, lxevent->subtype, lxevent->owner, g_wnd);
+              "window %ld subtype %d owner %ld g_wnd %ld",
+              lxevent->window, lxevent->subtype, lxevent->owner, g_wnd);
 
     if (lxevent->owner == g_wnd)
     {
         LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_event_selection_owner_notify: matches g_wnd");
         LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_event_selection_owner_notify: skipping, "
-              "owner == g_wnd");
+                  "owner == g_wnd");
         g_got_selection = 1;
         return 0;
     }
@@ -1832,41 +1832,41 @@ clipboard_event_selection_notify(XEvent *xevent)
     if (lxevent->property == None)
     {
         LOG_DEVEL(LOG_LEVEL_ERROR, "clipboard_event_selection_notify: clip could "
-              "not be converted");
+                  "not be converted");
         rv = 1;
     }
 
     if (rv == 0)
     {
         LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_event_selection_notify: wnd 0x%lx prop %s",
-                    lxevent->requestor,
-                    get_atom_text(lxevent->property));
+                  lxevent->requestor,
+                  get_atom_text(lxevent->property));
         rv = clipboard_get_window_property(lxevent->requestor, lxevent->property,
                                            &type, &fmt,
                                            &n_items, &data, &data_size);
         if (rv != 0)
         {
             LOG_DEVEL(LOG_LEVEL_ERROR, "clipboard_event_selection_notify: "
-                  "clipboard_get_window_property failed error %d", rv);
+                      "clipboard_get_window_property failed error %d", rv);
             return 0;
         }
-        //g_hexdump(data, data_size);
+        //LOG_DEVEL_HEXDUMP(LOG_LEVEL_TRACE, "", data, data_size);
         XDeleteProperty(g_display, lxevent->requestor, lxevent->property);
         if (type == g_incr_atom)
         {
             /* nothing more to do here, the data is coming in through
                PropertyNotify */
             LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_event_selection_notify: type is INCR "
-                        "data_size %d property name %s type %s", data_size,
-                        get_atom_text(lxevent->property),
-                        get_atom_text(lxevent->type));
+                      "data_size %d property name %s type %s", data_size,
+                      get_atom_text(lxevent->property),
+                      get_atom_text(lxevent->type));
             g_clip_s2c.incr_in_progress = 1;
             g_clip_s2c.property = lxevent->property;
             g_clip_s2c.type = lxevent->target;
             g_clip_s2c.total_bytes = 0;
             g_free(g_clip_s2c.data);
             g_clip_s2c.data = 0;
-            //g_hexdump(data, sizeof(long));
+            //LOG_DEVEL_HEXDUMP(LOG_LEVEL_TRACE, "", data, sizeof(long));
             g_free(data);
             return 0;
         }
@@ -1886,10 +1886,10 @@ clipboard_event_selection_notify(XEvent *xevent)
                     {
                         atom = atoms[index];
                         LOG_DEVEL(LOG_LEVEL_DEBUG,
-                              "clipboard_event_selection_notify: 0x%lx %s 0x%lx",
-                              atom, get_atom_text(atom), XA_STRING);
+                                  "clipboard_event_selection_notify: 0x%lx %s 0x%lx",
+                                  atom, get_atom_text(atom), XA_STRING);
                         LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_event_selection_notify: 0x%lx %s",
-                                    atom, get_atom_text(atom));
+                                  atom, get_atom_text(atom));
                         if (atom == g_utf8_atom)
                         {
                             got_utf8 = 1;
@@ -1916,14 +1916,14 @@ clipboard_event_selection_notify(XEvent *xevent)
                 else
                 {
                     LOG_DEVEL(LOG_LEVEL_ERROR, "clipboard_event_selection_notify: error, "
-                          "target is 'TARGETS' and type[%ld] or fmt[%d] not right, "
-                          "should be type[%ld], fmt[%d]", type, fmt, XA_ATOM, 32);
+                              "target is 'TARGETS' and type[%ld] or fmt[%d] not right, "
+                              "should be type[%ld], fmt[%d]", type, fmt, XA_ATOM, 32);
                 }
             }
             else if (lxevent->target == g_utf8_atom)
             {
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_event_selection_notify: UTF8_STRING "
-                      "data_size %d", data_size);
+                          "data_size %d", data_size);
                 if ((g_clip_s2c.incr_in_progress == 0) && (data_size > 0))
                 {
                     g_free(g_clip_s2c.data);
@@ -1946,7 +1946,7 @@ clipboard_event_selection_notify(XEvent *xevent)
             else if (lxevent->target == XA_STRING)
             {
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_event_selection_notify: XA_STRING "
-                      "data_size %d", data_size);
+                          "data_size %d", data_size);
                 if ((g_clip_s2c.incr_in_progress == 0) && (data_size > 0))
                 {
                     g_free(g_clip_s2c.data);
@@ -1961,7 +1961,7 @@ clipboard_event_selection_notify(XEvent *xevent)
             else if (lxevent->target == g_image_bmp_atom)
             {
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_event_selection_notify: image/bmp "
-                      "data_size %d", data_size);
+                          "data_size %d", data_size);
                 if ((g_clip_s2c.incr_in_progress == 0) && (data_size > 14))
                 {
                     g_free(g_clip_s2c.data);
@@ -1975,7 +1975,7 @@ clipboard_event_selection_notify(XEvent *xevent)
             else if (lxevent->target == g_file_atom1)
             {
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_event_selection_notify: text/uri-list "
-                      "data_size %d", data_size);
+                          "data_size %d", data_size);
                 if ((g_clip_s2c.incr_in_progress == 0) && (data_size > 0))
                 {
                     g_free(g_clip_s2c.data);
@@ -1990,7 +1990,7 @@ clipboard_event_selection_notify(XEvent *xevent)
             else if (lxevent->target == g_file_atom2)
             {
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_event_selection_notify: text/uri-list "
-                      "data_size %d", data_size);
+                          "data_size %d", data_size);
                 if ((g_clip_s2c.incr_in_progress == 0) && (data_size > 0))
                 {
                     g_free(g_clip_s2c.data);
@@ -2005,13 +2005,13 @@ clipboard_event_selection_notify(XEvent *xevent)
             else
             {
                 LOG_DEVEL(LOG_LEVEL_ERROR, "clipboard_event_selection_notify: "
-                      "unknown target");
+                          "unknown target");
             }
         }
         else
         {
             LOG_DEVEL(LOG_LEVEL_ERROR, "clipboard_event_selection_notify: "
-                  "unknown selection");
+                      "unknown selection");
         }
     }
 
@@ -2096,22 +2096,22 @@ clipboard_event_selection_request(XEvent *xevent)
     lxev = (XSelectionRequestEvent *)xevent;
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_event_selection_request: 0x%lx", lxev->property);
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_event_selection_request: g_wnd %ld, "
-          ".requestor %ld .owner %ld .selection %ld '%s' .target %ld .property %ld",
-          g_wnd, lxev->requestor, lxev->owner, lxev->selection,
-          get_atom_text(lxev->selection),
-          lxev->target, lxev->property);
+              ".requestor %ld .owner %ld .selection %ld '%s' .target %ld .property %ld",
+              g_wnd, lxev->requestor, lxev->owner, lxev->selection,
+              get_atom_text(lxev->selection),
+              lxev->target, lxev->property);
 
     if (lxev->property == None)
     {
         LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_event_selection_request: "
-              "lxev->property is None");
+                  "lxev->property is None");
     }
     else if (lxev->target == g_targets_atom)
     {
         LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_event_selection_request: g_targets_atom");
         /* requestor is asking what the selection can be converted to */
         LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_event_selection_request: "
-              "g_targets_atom");
+                  "g_targets_atom");
         atom_buf[0] = g_targets_atom;
         atom_buf[1] = g_timestamp_atom;
         atom_buf[2] = g_multiple_atom;
@@ -2142,7 +2142,7 @@ clipboard_event_selection_request(XEvent *xevent)
     {
         /* requestor is asking the time I got the selection */
         LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_event_selection_request: "
-              "g_timestamp_atom");
+                  "g_timestamp_atom");
         atom_buf[0] = g_selection_time;
         atom_buf[1] = 0;
         return clipboard_provide_selection(lxev, XA_INTEGER, 32,
@@ -2152,7 +2152,7 @@ clipboard_event_selection_request(XEvent *xevent)
     {
         /* target, property pairs */
         LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_event_selection_request: "
-              "g_multiple_atom");
+                  "g_multiple_atom");
 
         xdata = 0;
         if (clipboard_get_window_property(lxev->requestor, lxev->property,
@@ -2160,7 +2160,7 @@ clipboard_event_selection_request(XEvent *xevent)
                                           &xdata_size) == 0)
         {
             LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_event_selection_request: g_multiple_atom "
-                  "n_items %d", n_items);
+                      "n_items %d", n_items);
             /* todo */
             g_free(xdata);
         }
@@ -2225,7 +2225,7 @@ clipboard_event_selection_request(XEvent *xevent)
     else
     {
         LOG(LOG_LEVEL_ERROR, "clipboard_event_selection_request: unknown "
-              "target %s", get_atom_text(lxev->target));
+            "target %s", get_atom_text(lxev->target));
     }
 
     clipboard_refuse_selection(lxev);
@@ -2278,9 +2278,9 @@ clipboard_event_property_notify(XEvent *xevent)
     char *cptr;
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_event_property_notify: PropertyNotify .window %ld "
-          ".state %d .atom %ld %s", xevent->xproperty.window,
-          xevent->xproperty.state, xevent->xproperty.atom,
-          get_atom_text(xevent->xproperty.atom));
+              ".state %d .atom %ld %s", xevent->xproperty.window,
+              xevent->xproperty.state, xevent->xproperty.atom,
+              get_atom_text(xevent->xproperty.atom));
 
     if (g_clip_c2s.incr_in_progress &&
             (xevent->xproperty.window == g_clip_c2s.window) &&
@@ -2352,7 +2352,7 @@ clipboard_event_property_notify(XEvent *xevent)
             if (g_clip_s2c.type == g_image_bmp_atom)
             {
                 g_clip_s2c.xrdp_clip_type = XRDP_CB_BITMAP;
-                //g_hexdump(g_last_clip_data, 64);
+                //LOG_DEVEL_HEXDUMP(LOG_LEVEL_TRACE, "", g_last_clip_data, 64);
                 /* skip header */
                 clipboard_send_data_response(g_clip_s2c.xrdp_clip_type,
                                              g_clip_s2c.data + 14,
@@ -2369,7 +2369,7 @@ clipboard_event_property_notify(XEvent *xevent)
             else
             {
                 LOG_DEVEL(LOG_LEVEL_ERROR, "clipboard_event_property_notify: error unknown type %ld",
-                           g_clip_s2c.type);
+                          g_clip_s2c.type);
                 clipboard_send_data_response_failed();
             }
 

--- a/sesman/chansrv/clipboard_file.c
+++ b/sesman/chansrv/clipboard_file.c
@@ -170,19 +170,19 @@ clipboard_get_file(const char *file, int bytes)
     if (g_directory_exist(full_fn))
     {
         LOG_DEVEL(LOG_LEVEL_ERROR, "clipboard_get_file: file [%s] is a directory, "
-                   "not supported", full_fn);
+                  "not supported", full_fn);
         flags |= CB_FILE_ATTRIBUTE_DIRECTORY;
         return 1;
     }
     if (!g_file_exist(full_fn))
     {
         LOG_DEVEL(LOG_LEVEL_ERROR, "clipboard_get_file: file [%s] does not exist",
-                   full_fn);
+                  full_fn);
         return 1;
     }
     else
     {
-        cfi = (struct cb_file_info*)g_malloc(sizeof(struct cb_file_info), 1);
+        cfi = (struct cb_file_info *)g_malloc(sizeof(struct cb_file_info), 1);
         list_add_item(g_files_list, (tintptr)cfi);
         g_strcpy(cfi->filename, filename);
         g_strcpy(cfi->pathname, pathname);
@@ -190,7 +190,7 @@ clipboard_get_file(const char *file, int bytes)
         cfi->flags = flags;
         cfi->time = (g_time1() + CB_EPOCH_DIFF) * 10000000LL;
         LOG_DEVEL(LOG_LEVEL_DEBUG, "ok filename [%s] pathname [%s] size [%d]",
-                    cfi->filename, cfi->pathname, cfi->size);
+                  cfi->filename, cfi->pathname, cfi->size);
     }
     return 0;
 }
@@ -253,8 +253,8 @@ clipboard_send_data_response_for_file(const char *data, int data_size)
     struct cb_file_info *cfi;
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_send_data_response_for_file: data_size %d",
-                data_size);
-    //g_hexdump(data, data_size);
+              data_size);
+    LOG_DEVEL_HEXDUMP(LOG_LEVEL_TRACE, "", data, data_size);
     if (g_files_list == 0)
     {
         g_files_list = list_create();
@@ -326,7 +326,7 @@ clipboard_send_file_size(int streamId, int lindex)
     }
     file_size = cfi->size;
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_send_file_size: streamId %d file_size %d",
-                streamId, file_size);
+              streamId, file_size);
     make_stream(s);
     init_stream(s, 8192);
     out_uint16_le(s, CB_FILECONTENTS_RESPONSE); /* 9 */
@@ -356,7 +356,7 @@ clipboard_request_file_size(int stream_id, int lindex)
     if (g_file_request_sent_type != 0)
     {
         LOG_DEVEL(LOG_LEVEL_ERROR, "clipboard_request_file_size: warning, still waiting "
-                   "for CB_FILECONTENTS_RESPONSE");
+                  "for CB_FILECONTENTS_RESPONSE");
     }
     make_stream(s);
     init_stream(s, 8192);
@@ -404,20 +404,20 @@ clipboard_send_file_data(int streamId, int lindex,
         return 1;
     }
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_send_file_data: streamId %d lindex %d "
-                "nPositionLow %d cbRequested %d", streamId, lindex,
-                nPositionLow, cbRequested);
+              "nPositionLow %d cbRequested %d", streamId, lindex,
+              nPositionLow, cbRequested);
     g_snprintf(full_fn, 255, "%s/%s", cfi->pathname, cfi->filename);
     fd = g_file_open_ex(full_fn, 1, 0, 0, 0);
     if (fd == -1)
     {
         LOG_DEVEL(LOG_LEVEL_ERROR, "clipboard_send_file_data: file open [%s] failed",
-                   full_fn);
+                  full_fn);
         return 1;
     }
     if (g_file_seek(fd, nPositionLow) < 0)
     {
         LOG_DEVEL(LOG_LEVEL_ERROR, "clipboard_send_file_data: seek error "
-            "in file: %s", full_fn);
+                  "in file: %s", full_fn);
         g_file_close(fd);
         return 1;
     }
@@ -427,7 +427,7 @@ clipboard_send_file_data(int streamId, int lindex,
     if (size < 1)
     {
         LOG_DEVEL(LOG_LEVEL_ERROR, "clipboard_send_file_data: read error, want %d got %d",
-                   cbRequested, size);
+                  cbRequested, size);
         free_stream(s);
         g_file_close(fd);
         return 1;
@@ -457,12 +457,12 @@ clipboard_request_file_data(int stream_id, int lindex, int offset,
     int rv;
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_request_file_data: stream_id=%d lindex=%d off=%d request_bytes=%d",
-               stream_id, lindex, offset, request_bytes);
+              stream_id, lindex, offset, request_bytes);
 
     if (g_file_request_sent_type != 0)
     {
         LOG_DEVEL(LOG_LEVEL_ERROR, "clipboard_request_file_data: warning, still waiting "
-                   "for CB_FILECONTENTS_RESPONSE");
+                  "for CB_FILECONTENTS_RESPONSE");
     }
     make_stream(s);
     init_stream(s, 8192);
@@ -500,7 +500,7 @@ clipboard_process_file_request(struct stream *s, int clip_msg_status,
     //int clipDataId;
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_file_request:");
-    //g_hexdump(s->p, clip_msg_len);
+    LOG_DEVEL_HEXDUMP(LOG_LEVEL_TRACE, "", s->p, clip_msg_len);
     in_uint32_le(s, streamId);
     in_uint32_le(s, lindex);
     in_uint32_le(s, dwFlags);
@@ -536,7 +536,7 @@ clipboard_process_file_response(struct stream *s, int clip_msg_status,
         in_uint32_le(s, streamId);
         in_uint32_le(s, file_size);
         LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_file_response: streamId %d "
-                   "file_size %d", streamId, file_size);
+                  "file_size %d", streamId, file_size);
         xfuse_file_contents_size(streamId, file_size);
     }
     else if (g_file_request_sent_type == CB_FILECONTENTS_RANGE)
@@ -579,9 +579,9 @@ clipboard_c2s_in_file_info(struct stream *s, struct clip_file_desc *cfd)
     LOG_DEVEL(LOG_LEVEL_DEBUG, "  flags 0x%8.8x", cfd->flags);
     LOG_DEVEL(LOG_LEVEL_DEBUG, "  fileAttributes 0x%8.8x", cfd->fileAttributes);
     LOG_DEVEL(LOG_LEVEL_DEBUG, "  lastWriteTime 0x%8.8x%8.8x", cfd->lastWriteTimeHigh,
-                cfd->lastWriteTimeLow);
+              cfd->lastWriteTimeLow);
     LOG_DEVEL(LOG_LEVEL_DEBUG, "  fileSize 0x%8.8x%8.8x", cfd->fileSizeHigh,
-                cfd->fileSizeLow);
+              cfd->fileSizeLow);
     LOG_DEVEL(LOG_LEVEL_DEBUG, "  num_chars %d cFileName [%s]", num_chars, cfd->cFileName);
     return 0;
 }
@@ -619,10 +619,10 @@ clipboard_c2s_in_files(struct stream *s, char *file_list)
         g_memset(cfd, 0, sizeof(struct clip_file_desc));
         clipboard_c2s_in_file_info(s, cfd);
         if ((g_pos(cfd->cFileName, "\\") >= 0) ||
-            (cfd->fileAttributes & CB_FILE_ATTRIBUTE_DIRECTORY))
+                (cfd->fileAttributes & CB_FILE_ATTRIBUTE_DIRECTORY))
         {
             LOG_DEVEL(LOG_LEVEL_ERROR, "clipboard_c2s_in_files: skipping directory not "
-                       "supported [%s]", cfd->cFileName);
+                      "supported [%s]", cfd->cFileName);
             continue;
         }
         if (xfuse_add_clip_dir_item(cfd->cFileName, 0, cfd->fileSizeLow, lindex) == -1)

--- a/sesman/chansrv/devredir.c
+++ b/sesman/chansrv/devredir.c
@@ -115,10 +115,10 @@ struct stream *g_input_stream = NULL;
  */
 static void devredir_proc_cid_rmdir_or_file(IRP *irp, enum NTSTATUS IoStatus);
 static void devredir_proc_cid_rmdir_or_file_resp(IRP *irp,
-                                                 enum NTSTATUS IoStatus);
+        enum NTSTATUS IoStatus);
 static void devredir_proc_cid_rename_file(IRP *irp, enum NTSTATUS IoStatus);
 static void devredir_proc_cid_rename_file_resp(IRP *irp,
-                                               enum NTSTATUS IoStatus);
+        enum NTSTATUS IoStatus);
 static void devredir_proc_cid_lookup(  IRP *irp,
                                        struct stream *s_in,
                                        enum NTSTATUS IoStatus);
@@ -135,10 +135,10 @@ static void devredir_proc_client_devlist_announce_req(struct stream *s);
 static void devredir_proc_client_devlist_remove_req(struct stream *s);
 static void devredir_proc_device_iocompletion(struct stream *s);
 static void devredir_proc_query_dir_response(IRP *irp,
-                                 struct stream *s_in,
-                                 tui32 DeviceId,
-                                 tui32 CompletionId,
-                                 enum NTSTATUS IoStatus);
+        struct stream *s_in,
+        tui32 DeviceId,
+        tui32 CompletionId,
+        enum NTSTATUS IoStatus);
 
 static void devredir_cvt_slash(char *path);
 static void devredir_cvt_to_unicode(char *unicode, const char *path);
@@ -189,21 +189,21 @@ devredir_deinit(void)
  */
 const char *completion_type_to_str(enum COMPLETION_TYPE cid)
 {
-    return 
-        (cid == CID_CREATE_DIR_REQ)     ?  "CID_CREATE_DIR_REQ" : 
-        (cid == CID_DIRECTORY_CONTROL)  ?  "CID_DIRECTORY_CONTROL" : 
-        (cid == CID_CREATE_REQ)         ?  "CID_CREATE_REQ" : 
-        (cid == CID_OPEN_REQ)           ?  "CID_OPEN_REQ" : 
-        (cid == CID_READ)               ?  "CID_READ" : 
-        (cid == CID_WRITE)              ?  "CID_WRITE" : 
-        (cid == CID_CLOSE)              ?  "CID_CLOSE" : 
-        (cid == CID_FILE_CLOSE)         ?  "CID_FILE_CLOSE" : 
-        (cid == CID_RMDIR_OR_FILE)      ?  "CID_RMDIR_OR_FILE" : 
-        (cid == CID_RMDIR_OR_FILE_RESP) ?  "CID_RMDIR_OR_FILE_RESP" : 
-        (cid == CID_RENAME_FILE)        ?  "CID_RENAME_FILE" : 
-        (cid == CID_RENAME_FILE_RESP)   ?  "CID_RENAME_FILE_RESP" : 
-        (cid == CID_LOOKUP)             ?  "CID_LOOKUP" : 
-        (cid == CID_SETATTR)            ?  "CID_SETATTR" : 
+    return
+        (cid == CID_CREATE_DIR_REQ)     ?  "CID_CREATE_DIR_REQ" :
+        (cid == CID_DIRECTORY_CONTROL)  ?  "CID_DIRECTORY_CONTROL" :
+        (cid == CID_CREATE_REQ)         ?  "CID_CREATE_REQ" :
+        (cid == CID_OPEN_REQ)           ?  "CID_OPEN_REQ" :
+        (cid == CID_READ)               ?  "CID_READ" :
+        (cid == CID_WRITE)              ?  "CID_WRITE" :
+        (cid == CID_CLOSE)              ?  "CID_CLOSE" :
+        (cid == CID_FILE_CLOSE)         ?  "CID_FILE_CLOSE" :
+        (cid == CID_RMDIR_OR_FILE)      ?  "CID_RMDIR_OR_FILE" :
+        (cid == CID_RMDIR_OR_FILE_RESP) ?  "CID_RMDIR_OR_FILE_RESP" :
+        (cid == CID_RENAME_FILE)        ?  "CID_RENAME_FILE" :
+        (cid == CID_RENAME_FILE_RESP)   ?  "CID_RENAME_FILE_RESP" :
+        (cid == CID_LOOKUP)             ?  "CID_LOOKUP" :
+        (cid == CID_SETATTR)            ?  "CID_SETATTR" :
         /* default */                      "<unknown>";
 };
 
@@ -227,10 +227,16 @@ WindowsToLinuxFilePerm(tui32 wperm)
     else
     {
         result = S_IFREG | 0444; /* files are always readable */
-        if (wperm & W_FILE_ATTRIBUTE_SYSTEM) result |= 0111; /* Executable */
+        if (wperm & W_FILE_ATTRIBUTE_SYSTEM)
+        {
+            result |= 0111;    /* Executable */
+        }
     }
 
-    if ((wperm & W_FILE_ATTRIBUTE_READONLY) == 0) result |= 0222;
+    if ((wperm & W_FILE_ATTRIBUTE_READONLY) == 0)
+    {
+        result |= 0222;
+    }
 
     return result;
 }
@@ -298,13 +304,17 @@ devredir_data_in(struct stream *s, int chan_id, int chan_flags, int length,
     {
         /* is this is the first packet? */
         if (chan_flags & 1)
+        {
             xstream_new(g_input_stream, total_length);
+        }
 
         xstream_copyin(g_input_stream, s->p, length);
 
         /* in last packet, chan_flags & 0x02 will be true */
         if ((chan_flags & 2) == 0)
+        {
             return 0;
+        }
 
         g_input_stream->p = g_input_stream->data;
         ls = g_input_stream;
@@ -441,8 +451,8 @@ devredir_send_server_core_cap_req(void)
     /* setup general capability */
     xstream_wr_u16_le(s, CAP_GENERAL_TYPE); /* CapabilityType                 */
     xstream_wr_u16_le(s, 44);               /* CapabilityLength - len of this */
-                                            /* CAPABILITY_SET in bytes, inc   */
-                                            /* the header                     */
+    /* CAPABILITY_SET in bytes, inc   */
+    /* the header                     */
     xstream_wr_u32_le(s, 2);                /* Version                        */
     xstream_wr_u32_le(s, 2);                /* O.S type                       */
     xstream_wr_u32_le(s, 0);                /* O.S version                    */
@@ -468,8 +478,8 @@ devredir_send_server_core_cap_req(void)
     /* setup file system capability */
     xstream_wr_u16_le(s, CAP_DRIVE_TYPE);   /* CapabilityType                 */
     xstream_wr_u16_le(s, 8);                /* CapabilityLength - len of this */
-                                            /* CAPABILITY_SET in bytes, inc   */
-                                            /* the header                     */
+    /* CAPABILITY_SET in bytes, inc   */
+    /* the header                     */
     xstream_wr_u32_le(s, 2);                /* Version                        */
 
     /* setup smart card capability */
@@ -527,7 +537,7 @@ devredir_send_server_user_logged_on(void)
 
 static void
 devredir_send_server_device_announce_resp(tui32 device_id,
-                                          enum NTSTATUS result_code)
+        enum NTSTATUS result_code)
 {
     struct stream *s;
     int            bytes;
@@ -566,13 +576,13 @@ devredir_send_drive_create_request(tui32 device_id,
     tui32          SharedAccess;
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "device_id=%d path=\"%s\""
-          " DesiredAccess=0x%x CreateDisposition=0x%x"
-          " FileAttributes=0x%x CreateOptions=0x%x"
-          " CompletionId=%d",
-          device_id, path,
-          DesiredAccess, CreateDisposition,
-          FileAttributes, CreateOptions,
-          completion_id);
+              " DesiredAccess=0x%x CreateDisposition=0x%x"
+              " FileAttributes=0x%x CreateOptions=0x%x"
+              " CompletionId=%d",
+              device_id, path,
+              DesiredAccess, CreateDisposition,
+              FileAttributes, CreateOptions,
+              completion_id);
 
     /* path in unicode needs this much space */
     len = ((g_mbstowcs(NULL, path, 0) * sizeof(twchar)) / 2) + 2;
@@ -632,7 +642,9 @@ devredir_send_drive_close_request(tui16 Component, tui16 PacketId,
                                     MajorFunction, MinorFunc);
 
     if (pad_len)
+    {
         xstream_seek(s, pad_len);
+    }
 
     /* send to client */
     bytes = xstream_len(s);
@@ -722,7 +734,7 @@ devredir_proc_client_core_cap_resp(struct stream *s)
     tui16 cap_type;
     tui16 cap_len;
     tui32 cap_version;
-    char* holdp;
+    char *holdp;
 
     xstream_rd_u16_le(s, num_caps);
     xstream_seek(s, 2);  /* padding */
@@ -808,7 +820,7 @@ devredir_proc_client_devlist_announce_req(struct stream *s)
                 if (device_data_len)
                 {
                     xstream_rd_string(g_full_name_for_filesystem, s,
-                                     device_data_len);
+                                      device_data_len);
                 }
 
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "device_type=FILE_SYSTEM device_id=0x%x dosname=%s "
@@ -835,33 +847,33 @@ devredir_proc_client_devlist_announce_req(struct stream *s)
                 break;
 
             case RDPDR_DTYP_SERIAL:
-                LOG_DEVEL(LOG_LEVEL_DEBUG, 
-                      "device_type=SERIAL device_id=0x%x dosname=%s",
-                      g_device_id, preferred_dos_name);
+                LOG_DEVEL(LOG_LEVEL_DEBUG,
+                          "device_type=SERIAL device_id=0x%x dosname=%s",
+                          g_device_id, preferred_dos_name);
                 break;
 
             case RDPDR_DTYP_PARALLEL:
-                LOG_DEVEL(LOG_LEVEL_DEBUG, 
-                      "device_type=PARALLEL device_id=0x%x dosname=%s",
-                      g_device_id, preferred_dos_name);
+                LOG_DEVEL(LOG_LEVEL_DEBUG,
+                          "device_type=PARALLEL device_id=0x%x dosname=%s",
+                          g_device_id, preferred_dos_name);
                 break;
 
             case RDPDR_DTYP_PRINT:
                 LOG_DEVEL(LOG_LEVEL_DEBUG,
-                      "device_type=PRINT device_id=0x%x dosname=%s",
-                      g_device_id, preferred_dos_name);
+                          "device_type=PRINT device_id=0x%x dosname=%s",
+                          g_device_id, preferred_dos_name);
                 break;
 
             default:
-                LOG_DEVEL(LOG_LEVEL_DEBUG, 
-                      "device_type=UNKNOWN device_id=0x%x dosname=%s",
-                      g_device_id, preferred_dos_name);
+                LOG_DEVEL(LOG_LEVEL_DEBUG,
+                          "device_type=UNKNOWN device_id=0x%x dosname=%s",
+                          g_device_id, preferred_dos_name);
                 break;
         }
 
         /* Tell the client wheth or not we're supporting this one */
         devredir_send_server_device_announce_resp(g_device_id,
-                                                  response_status);
+                response_status);
     }
 }
 
@@ -905,8 +917,7 @@ devredir_proc_device_iocompletion(struct stream *s)
     {
         LOG_DEVEL(LOG_LEVEL_ERROR, "IRP with completion ID %d not found", CompletionId);
     }
-    else 
-    if (irp->callback)
+    else if (irp->callback)
     {
         /* Callback has been set -  call it */
         (*irp->callback)(s, irp, DeviceId, CompletionId, IoStatus);
@@ -916,8 +927,8 @@ devredir_proc_device_iocompletion(struct stream *s)
         comp_type = (enum COMPLETION_TYPE) irp->completion_type;
         /* Log something about the IRP */
         if (IoStatus == STATUS_SUCCESS ||
-            IoStatus == STATUS_NO_MORE_FILES ||
-            (IoStatus == STATUS_NO_SUCH_FILE && comp_type == CID_LOOKUP))
+                IoStatus == STATUS_NO_MORE_FILES ||
+                (IoStatus == STATUS_NO_SUCH_FILE && comp_type == CID_LOOKUP))
         {
             /* Successes or common occurrences - debug logging only */
             LOG_DEVEL(LOG_LEVEL_DEBUG, "got %s", completion_type_to_str(comp_type));
@@ -933,105 +944,105 @@ devredir_proc_device_iocompletion(struct stream *s)
 
         switch (comp_type)
         {
-        case CID_CREATE_DIR_REQ:
-            if (IoStatus != STATUS_SUCCESS)
-            {
-                xfuse_devredir_cb_enum_dir_done(
-                             (struct state_dirscan *) irp->fuse_info, IoStatus);
-                devredir_irp_delete(irp);
-            }
-            else
-            {
+            case CID_CREATE_DIR_REQ:
+                if (IoStatus != STATUS_SUCCESS)
+                {
+                    xfuse_devredir_cb_enum_dir_done(
+                        (struct state_dirscan *) irp->fuse_info, IoStatus);
+                    devredir_irp_delete(irp);
+                }
+                else
+                {
+                    xstream_rd_u32_le(s, irp->FileId);
+                    devredir_send_drive_dir_request(irp, DeviceId,
+                                                    1, irp->pathname);
+                }
+                break;
+
+            case CID_CREATE_REQ:
                 xstream_rd_u32_le(s, irp->FileId);
-                devredir_send_drive_dir_request(irp, DeviceId,
-                                                1, irp->pathname);
-            }
-            break;
 
-        case CID_CREATE_REQ:
-            xstream_rd_u32_le(s, irp->FileId);
+                xfuse_devredir_cb_create_file(
+                    (struct state_create *) irp->fuse_info,
+                    IoStatus, DeviceId, irp->FileId);
+                if (irp->gen.create.creating_dir || IoStatus != STATUS_SUCCESS)
+                {
+                    devredir_irp_delete(irp);
+                }
+                break;
 
-            xfuse_devredir_cb_create_file(
-                              (struct state_create *) irp->fuse_info,
-                              IoStatus, DeviceId, irp->FileId);
-            if (irp->gen.create.creating_dir || IoStatus != STATUS_SUCCESS)
-            {
+            case CID_OPEN_REQ:
+                xstream_rd_u32_le(s, irp->FileId);
+
+                xfuse_devredir_cb_open_file((struct state_open *) irp->fuse_info,
+                                            IoStatus, DeviceId, irp->FileId);
+                if (IoStatus != STATUS_SUCCESS)
+                {
+                    devredir_irp_delete(irp);
+                }
+                break;
+
+            case CID_READ:
+                xstream_rd_u32_le(s, Length);
+                xfuse_devredir_cb_read_file((struct state_read *) irp->fuse_info,
+                                            IoStatus,
+                                            s->p, Length);
                 devredir_irp_delete(irp);
-            }
-            break;
+                break;
 
-        case CID_OPEN_REQ:
-            xstream_rd_u32_le(s, irp->FileId);
-
-            xfuse_devredir_cb_open_file((struct state_open *) irp->fuse_info,
-                                        IoStatus, DeviceId, irp->FileId);
-            if (IoStatus != STATUS_SUCCESS)
-            {
+            case CID_WRITE:
+                xstream_rd_u32_le(s, Length);
+                xfuse_devredir_cb_write_file((struct state_write *) irp->fuse_info,
+                                             IoStatus,
+                                             irp->gen.write.offset, Length);
                 devredir_irp_delete(irp);
-            }
-            break;
+                break;
 
-        case CID_READ:
-            xstream_rd_u32_le(s, Length);
-            xfuse_devredir_cb_read_file((struct state_read *) irp->fuse_info,
-                                         IoStatus,
-                                         s->p, Length);
-            devredir_irp_delete(irp);
-            break;
+            case CID_CLOSE:
+                devredir_irp_delete(irp);
+                break;
 
-        case CID_WRITE:
-            xstream_rd_u32_le(s, Length);
-            xfuse_devredir_cb_write_file((struct state_write *) irp->fuse_info,
-                                         IoStatus,
-                                         irp->gen.write.offset, Length);
-            devredir_irp_delete(irp);
-            break;
+            case CID_FILE_CLOSE:
+                xfuse_devredir_cb_file_close((struct state_close *) irp->fuse_info);
+                devredir_irp_delete(irp);
+                break;
 
-        case CID_CLOSE:
-            devredir_irp_delete(irp);
-            break;
+            case CID_DIRECTORY_CONTROL:
+                devredir_proc_query_dir_response(irp, s, DeviceId,
+                                                 CompletionId, IoStatus);
+                break;
 
-        case CID_FILE_CLOSE:
-            xfuse_devredir_cb_file_close((struct state_close *) irp->fuse_info);
-            devredir_irp_delete(irp);
-            break;
+            case CID_RMDIR_OR_FILE:
+                xstream_rd_u32_le(s, irp->FileId);
+                devredir_proc_cid_rmdir_or_file(irp, IoStatus);
+                break;
 
-        case CID_DIRECTORY_CONTROL:
-            devredir_proc_query_dir_response(irp, s, DeviceId,
-                                             CompletionId, IoStatus);
-            break;
+            case CID_RMDIR_OR_FILE_RESP:
+                devredir_proc_cid_rmdir_or_file_resp(irp, IoStatus);
+                break;
 
-        case CID_RMDIR_OR_FILE:
-            xstream_rd_u32_le(s, irp->FileId);
-            devredir_proc_cid_rmdir_or_file(irp, IoStatus);
-            break;
+            case CID_RENAME_FILE:
+                xstream_rd_u32_le(s, irp->FileId);
+                devredir_proc_cid_rename_file(irp, IoStatus);
+                break;
 
-        case CID_RMDIR_OR_FILE_RESP:
-            devredir_proc_cid_rmdir_or_file_resp(irp, IoStatus);
-            break;
+            case CID_RENAME_FILE_RESP:
+                devredir_proc_cid_rename_file_resp(irp, IoStatus);
+                break;
 
-        case CID_RENAME_FILE:
-            xstream_rd_u32_le(s, irp->FileId);
-            devredir_proc_cid_rename_file(irp, IoStatus);
-            break;
+            case CID_LOOKUP:
+                devredir_proc_cid_lookup(irp, s, IoStatus);
+                break;
 
-        case CID_RENAME_FILE_RESP:
-            devredir_proc_cid_rename_file_resp(irp, IoStatus);
-            break;
+            case CID_SETATTR:
+                devredir_proc_cid_setattr(irp, s, IoStatus);
+                break;
 
-        case CID_LOOKUP:
-            devredir_proc_cid_lookup(irp, s, IoStatus);
-            break;
-
-        case CID_SETATTR:
-            devredir_proc_cid_setattr(irp, s, IoStatus);
-            break;
-
-        default:
-            LOG_DEVEL(LOG_LEVEL_ERROR, "got unknown CompletionID: DeviceId=0x%x "
-                      "CompletionId=0x%x IoStatus=0x%x",
-                      DeviceId, CompletionId, IoStatus);
-            break;
+            default:
+                LOG_DEVEL(LOG_LEVEL_ERROR, "got unknown CompletionID: DeviceId=0x%x "
+                          "CompletionId=0x%x IoStatus=0x%x",
+                          DeviceId, CompletionId, IoStatus);
+                break;
         }
     }
 }
@@ -1089,8 +1100,8 @@ devredir_proc_query_dir_response(IRP *irp,
 
             /* add this entry to xrdp file system */
             xfuse_devredir_cb_enum_dir_add_entry(
-                            (struct state_dirscan *) irp->fuse_info,
-                            filename, &fattr);
+                (struct state_dirscan *) irp->fuse_info,
+                filename, &fattr);
         }
 
         /* Ask for more directory entries */
@@ -1155,13 +1166,13 @@ devredir_get_dir_listing(struct state_dirscan *fusep, tui32 device_id,
         CreateDisposition = CD_FILE_OPEN;
 
         rval = devredir_send_drive_create_request(device_id, irp->pathname,
-                                                  DesiredAccess, CreateOptions,
-                                                  0, CreateDisposition,
-                                                  irp->CompletionId);
+                DesiredAccess, CreateOptions,
+                0, CreateDisposition,
+                irp->CompletionId);
 
         LOG_DEVEL(LOG_LEVEL_DEBUG, "looking for device_id=%d path=%s", device_id, irp->pathname);
 
-        /* when we get a response to devredir_send_drive_create_request(), we 
+        /* when we get a response to devredir_send_drive_create_request(), we
          * call devredir_send_drive_dir_request(), which needs the following
          * at the end of the path argument */
         if (devredir_string_ends_with(irp->pathname, '\\'))
@@ -1222,10 +1233,10 @@ devredir_lookup_entry(struct state_lookup *fusep, tui32 device_id,
                   device_id, irp->pathname, irp->CompletionId);
 
         rval = devredir_send_drive_create_request(device_id,
-                                                  irp->pathname,
-                                                  DesiredAccess, CreateOptions,
-                                                  0, CreateDisposition,
-                                                  irp->CompletionId);
+                irp->pathname,
+                DesiredAccess, CreateOptions,
+                0, CreateDisposition,
+                irp->CompletionId);
     }
 
     return rval;
@@ -1288,13 +1299,13 @@ devredir_setattr_for_entry(struct state_setattr *fusep, tui32 device_id,
         CreateDisposition = CD_FILE_OPEN;
 
         LOG_DEVEL(LOG_LEVEL_DEBUG, "lookup for device_id=%d path=%s",
-              device_id, irp->pathname);
+                  device_id, irp->pathname);
 
         rval = devredir_send_drive_create_request(device_id,
-                                                  irp->pathname,
-                                                  DesiredAccess, CreateOptions,
-                                                  0, CreateDisposition,
-                                                  irp->CompletionId);
+                irp->pathname,
+                DesiredAccess, CreateOptions,
+                0, CreateDisposition,
+                irp->CompletionId);
     }
 
     return rval;
@@ -1343,10 +1354,10 @@ devredir_file_create(struct state_create *fusep, tui32 device_id,
         CreateDisposition  = 0x02; /* got this value from windows */
 
         rval = devredir_send_drive_create_request(device_id, path,
-                                                  DesiredAccess, CreateOptions,
-                                                  FileAttributes,
-                                                  CreateDisposition,
-                                                  irp->CompletionId);
+                DesiredAccess, CreateOptions,
+                FileAttributes,
+                CreateDisposition,
+                irp->CompletionId);
     }
 
     return rval;
@@ -1377,7 +1388,7 @@ devredir_file_open(struct state_open *fusep, tui32 device_id,
 
         irp->fuse_info = fusep;
 
-        switch(flags & O_ACCMODE)
+        switch (flags & O_ACCMODE)
         {
             case O_RDONLY:
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "open file in O_RDONLY");
@@ -1397,7 +1408,7 @@ devredir_file_open(struct state_open *fusep, tui32 device_id,
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "open file in O_RDWR");
                 /* without the 0x00000010 rdesktop opens files in */
                 /* O_RDONLY instead of O_RDWR mode                */
-                DesiredAccess = DA_FILE_READ_DATA | DA_FILE_WRITE_DATA | 
+                DesiredAccess = DA_FILE_READ_DATA | DA_FILE_WRITE_DATA |
                                 DA_SYNCHRONIZE | 0x00000010;
         }
 
@@ -1405,10 +1416,10 @@ devredir_file_open(struct state_open *fusep, tui32 device_id,
         CreateDisposition = CD_FILE_OPEN; // WAS 1
 
         rval = devredir_send_drive_create_request(device_id, path,
-                                                  DesiredAccess, CreateOptions,
-                                                  FileAttributes,
-                                                  CreateDisposition,
-                                                  irp->CompletionId);
+                DesiredAccess, CreateOptions,
+                FileAttributes,
+                CreateDisposition,
+                irp->CompletionId);
     }
 
     return rval;
@@ -1424,7 +1435,9 @@ int devredir_file_close(struct state_close *fusep, tui32 device_id,
 
 #if 0
     if ((irp = devredir_irp_new()) == NULL)
+    {
         return -1;
+    }
 
     irp->CompletionId = g_completion_id++;
 #else
@@ -1439,12 +1452,12 @@ int devredir_file_close(struct state_close *fusep, tui32 device_id,
     irp->fuse_info = fusep;
 
     return devredir_send_drive_close_request(RDPDR_CTYP_CORE,
-                                             PAKID_CORE_DEVICE_IOREQUEST,
-                                             device_id,
-                                             FileId,
-                                             irp->CompletionId,
-                                             IRP_MJ_CLOSE,
-                                             IRP_MN_NONE, 32);
+            PAKID_CORE_DEVICE_IOREQUEST,
+            device_id,
+            FileId,
+            irp->CompletionId,
+            IRP_MJ_CLOSE,
+            IRP_MN_NONE, 32);
 }
 
 /**
@@ -1483,9 +1496,9 @@ devredir_rmdir_or_file(struct state_remove *fusep, tui32 device_id,
         CreateDisposition = 0x01; /* got this value from windows */
 
         rval = devredir_send_drive_create_request(device_id, path,
-                                                  DesiredAccess, CreateOptions,
-                                                  0, CreateDisposition,
-                                                  irp->CompletionId);
+                DesiredAccess, CreateOptions,
+                0, CreateDisposition,
+                irp->CompletionId);
     }
 
     return rval;
@@ -1625,7 +1638,7 @@ int devredir_file_rename(struct state_rename *fusep, tui32 device_id,
     int    rval = -1;
     IRP   *irp;
     unsigned int len;
-    
+
     LOG_DEVEL(LOG_LEVEL_DEBUG, "device_id=%d old_name=%s new_name=%s",
               device_id, old_name, new_name);
 
@@ -1661,10 +1674,10 @@ int devredir_file_rename(struct state_rename *fusep, tui32 device_id,
         CreateDisposition = CD_FILE_OPEN; // WAS 1
 
         rval = devredir_send_drive_create_request(device_id, old_name,
-                                                  DesiredAccess, CreateOptions,
-                                                  FileAttributes,
-                                                  CreateDisposition,
-                                                  irp->CompletionId);
+                DesiredAccess, CreateOptions,
+                FileAttributes,
+                CreateDisposition,
+                irp->CompletionId);
     }
 
     return rval;
@@ -1705,7 +1718,9 @@ devredir_cvt_slash(char *path)
     while (*cptr != 0)
     {
         if (*cptr == '/')
+        {
             *cptr = '\\';
+        }
         cptr++;
     }
 }
@@ -1791,7 +1806,7 @@ devredir_proc_cid_rmdir_or_file(IRP *irp, enum NTSTATUS IoStatus)
     if (IoStatus != STATUS_SUCCESS)
     {
         xfuse_devredir_cb_rmdir_or_file((struct state_remove *) irp->fuse_info,
-                                         IoStatus);
+                                        IoStatus);
         devredir_irp_delete(irp);
         return;
     }
@@ -1857,7 +1872,7 @@ devredir_proc_cid_rename_file(IRP *irp, enum NTSTATUS IoStatus)
 
     /* Path in unicode needs this much space */
     flen = ((g_mbstowcs(NULL, irp->gen.rename.new_name, 0)
-                                                    * sizeof(twchar)) / 2) + 2;
+             * sizeof(twchar)) / 2) + 2;
     sblen = 6 + flen;
 
     xstream_new(s, 1024 + flen);
@@ -1900,11 +1915,11 @@ devredir_proc_cid_rename_file_resp(IRP *irp, enum NTSTATUS IoStatus)
 
     irp->completion_type = CID_CLOSE;
     devredir_send_drive_close_request(RDPDR_CTYP_CORE,
-                                       PAKID_CORE_DEVICE_IOREQUEST,
-                                       irp->DeviceId,
-                                       irp->FileId,
-                                       irp->CompletionId,
-                                       IRP_MJ_CLOSE, IRP_MN_NONE, 32);
+                                      PAKID_CORE_DEVICE_IOREQUEST,
+                                      irp->DeviceId,
+                                      irp->FileId,
+                                      irp->CompletionId,
+                                      IRP_MJ_CLOSE, IRP_MN_NONE, 32);
 }
 
 
@@ -1993,7 +2008,7 @@ static void lookup_read_standard_attributes(IRP *irp, struct stream *s_in)
 static void lookup_done(IRP *irp, enum NTSTATUS IoStatus)
 {
     LOG_DEVEL(LOG_LEVEL_DEBUG, "Lookup with completion_id=%d returning 0x%x",
-            irp->CompletionId, IoStatus);
+              irp->CompletionId, IoStatus);
     xfuse_devredir_cb_lookup_entry((struct state_lookup *)irp->fuse_info,
                                    IoStatus,
                                    &irp->gen.lookup.fattr);
@@ -2008,11 +2023,11 @@ static void lookup_done(IRP *irp, enum NTSTATUS IoStatus)
         /* Close the file handle */
         irp->completion_type = CID_CLOSE;
         devredir_send_drive_close_request(RDPDR_CTYP_CORE,
-                                           PAKID_CORE_DEVICE_IOREQUEST,
-                                           irp->DeviceId,
-                                           irp->FileId,
-                                           irp->CompletionId,
-                                           IRP_MJ_CLOSE, IRP_MN_NONE, 32);
+                                          PAKID_CORE_DEVICE_IOREQUEST,
+                                          irp->DeviceId,
+                                          irp->FileId,
+                                          irp->CompletionId,
+                                          IRP_MJ_CLOSE, IRP_MN_NONE, 32);
     }
 }
 
@@ -2028,7 +2043,7 @@ devredir_proc_cid_lookup(IRP *irp,
 {
     tui32 Length;
 
-    LOG_DEVEL(LOG_LEVEL_DEBUG, "entry state is %d",irp->gen.lookup.state);
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "entry state is %d", irp->gen.lookup.state);
     if (IoStatus != STATUS_SUCCESS)
     {
         /* This is common to all setattr states */
@@ -2038,7 +2053,7 @@ devredir_proc_cid_lookup(IRP *irp,
     else
     {
         /* Read and validate any data we've got queued up */
-        switch(irp->gen.lookup.state)
+        switch (irp->gen.lookup.state)
         {
             case E_LOOKUP_GET_FH:
                 /* We've been sent the file ID */
@@ -2123,7 +2138,7 @@ static void issue_setattr_basic(IRP *irp)
 
     xstream_wr_u32_le(s, FileBasicInformation);
     xstream_wr_u32_le(s, FILE_BASIC_INFORMATION_SIZE);
-                                     /* buffer length                 */
+    /* buffer length                 */
     xstream_seek(s, 24);             /* padding                       */
 
     xstream_wr_u64_le(s, 0LL);            /* CreationTime */
@@ -2156,10 +2171,10 @@ static void issue_setattr_eof(IRP *irp)
 
     xstream_wr_u32_le(s, FileEndOfFileInformation);
     xstream_wr_u32_le(s, FILE_END_OF_FILE_INFORMATION_SIZE);
-                                 /* buffer length             */
+    /* buffer length             */
     xstream_seek(s, 24);         /* padding                   */
     xstream_wr_u64_le(s, (tui64)irp->gen.setattr.fattr.size);
-                                 /* File size                 */
+    /* File size                 */
     /* send to client */
     bytes = xstream_len(s);
     send_channel_data(g_rdpdr_chan_id, s->data, bytes);
@@ -2184,11 +2199,11 @@ static void setattr_done(IRP *irp, enum NTSTATUS IoStatus)
         /* Close the file handle */
         irp->completion_type = CID_CLOSE;
         devredir_send_drive_close_request(RDPDR_CTYP_CORE,
-                                           PAKID_CORE_DEVICE_IOREQUEST,
-                                           irp->DeviceId,
-                                           irp->FileId,
-                                           irp->CompletionId,
-                                           IRP_MJ_CLOSE, IRP_MN_NONE, 32);
+                                          PAKID_CORE_DEVICE_IOREQUEST,
+                                          irp->DeviceId,
+                                          irp->FileId,
+                                          irp->CompletionId,
+                                          IRP_MJ_CLOSE, IRP_MN_NONE, 32);
     }
 }
 
@@ -2206,7 +2221,7 @@ devredir_proc_cid_setattr(IRP *irp,
                             TO_SET_ATIME | TO_SET_MTIME)
     tui32 Length;
 
-    LOG_DEVEL(LOG_LEVEL_DEBUG, "entry state is %d",irp->gen.setattr.state);
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "entry state is %d", irp->gen.setattr.state);
     if (IoStatus != STATUS_SUCCESS)
     {
         /* This is common to all setattr states */
@@ -2216,7 +2231,7 @@ devredir_proc_cid_setattr(IRP *irp,
     else
     {
         /* Read and validate any data we've got queued up */
-        switch(irp->gen.setattr.state)
+        switch (irp->gen.setattr.state)
         {
             case E_SETATTR_GET_FH:
                 /* We've been sent the file ID */

--- a/sesman/chansrv/fifo.c
+++ b/sesman/chansrv/fifo.c
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
- /* FIFO implementation to store a pointer to a user struct */
+/* FIFO implementation to store a pointer to a user struct */
 
 /* module based logging */
 #if defined(HAVE_CONFIG_H)
@@ -39,7 +39,7 @@
  * @return 0 on success, -1 on failure
  *****************************************************************************/
 int
-fifo_init(FIFO* fp, int num_entries)
+fifo_init(FIFO *fp, int num_entries)
 {
     LOG_DEVEL(LOG_LEVEL_TRACE, "entered");
 
@@ -51,7 +51,9 @@ fifo_init(FIFO* fp, int num_entries)
     }
 
     if (num_entries < 1)
+    {
         num_entries = 10;
+    }
 
     fp->rd_ptr = 0;
     fp->wr_ptr = 0;
@@ -61,7 +63,7 @@ fifo_init(FIFO* fp, int num_entries)
     {
         fp->entries = num_entries;
         LOG_DEVEL(LOG_LEVEL_DEBUG, "FIFO created; rd_ptr=%d wr_ptr=%d entries=%d",
-                      fp->rd_ptr, fp->wr_ptr, fp->entries);
+                  fp->rd_ptr, fp->wr_ptr, fp->entries);
         return 0;
     }
     else
@@ -80,7 +82,7 @@ fifo_init(FIFO* fp, int num_entries)
  * @return 0 on success, -1 on error
  *****************************************************************************/
 int
-fifo_deinit(FIFO* fp)
+fifo_deinit(FIFO *fp)
 {
     LOG_DEVEL(LOG_LEVEL_TRACE, "entered");
 
@@ -110,7 +112,7 @@ fifo_deinit(FIFO* fp)
  * @return 1 if FIFO is empty, 0 otherwise
  *****************************************************************************/
 int
-fifo_is_empty(FIFO* fp)
+fifo_is_empty(FIFO *fp)
 {
     LOG_DEVEL(LOG_LEVEL_TRACE, "entered");
 
@@ -133,9 +135,9 @@ fifo_is_empty(FIFO* fp)
  *****************************************************************************/
 
 int
-fifo_insert(FIFO* fp, void* data)
+fifo_insert(FIFO *fp, void *data)
 {
-    long* lp;
+    long *lp;
     int   next_val; /* next value for wr_ptr */
     int   i;
 
@@ -149,7 +151,9 @@ fifo_insert(FIFO* fp, void* data)
 
     next_val = fp->wr_ptr + 1;
     if (next_val >= fp->entries)
+    {
         next_val = 0;
+    }
 
     if (next_val == fp->rd_ptr)
     {
@@ -168,7 +172,9 @@ fifo_insert(FIFO* fp, void* data)
         {
             lp[i] = fp->user_data[fp->rd_ptr++];
             if (fp->rd_ptr >= fp->entries)
+            {
                 fp->rd_ptr = 0;
+            }
         }
 
         /* update pointers */
@@ -197,8 +203,8 @@ fifo_insert(FIFO* fp, void* data)
  *
  * @param data on success, NULL on error
  *****************************************************************************/
-void*
-fifo_remove(FIFO* fp)
+void *
+fifo_remove(FIFO *fp)
 {
     long data;
 
@@ -236,8 +242,8 @@ fifo_remove(FIFO* fp)
  *
  * @param data on success, NULL on error
  *****************************************************************************/
-void*
-fifo_peek(FIFO* fp)
+void *
+fifo_peek(FIFO *fp)
 {
     LOG_DEVEL(LOG_LEVEL_TRACE, "entered");
 

--- a/sesman/chansrv/irp.c
+++ b/sesman/chansrv/irp.c
@@ -38,7 +38,7 @@ IRP *g_irp_head = NULL;
  * @return new IRP or NULL on error
  *****************************************************************************/
 
-IRP * devredir_irp_new(void)
+IRP *devredir_irp_new(void)
 {
     IRP *irp;
     IRP *irp_last;
@@ -78,10 +78,10 @@ IRP * devredir_irp_new(void)
  * @return new IRP or NULL on error
  *****************************************************************************/
 
-IRP * devredir_irp_with_pathname_new(const char *pathname)
+IRP *devredir_irp_with_pathname_new(const char *pathname)
 {
     unsigned int len = g_strlen(pathname);
-    IRP * irp = devredir_irp_with_pathnamelen_new(len);
+    IRP *irp = devredir_irp_with_pathnamelen_new(len);
     if (irp != NULL)
     {
         g_strcpy(irp->pathname, pathname);
@@ -100,7 +100,7 @@ IRP * devredir_irp_with_pathname_new(const char *pathname)
  * @return new IRP or NULL on error
  *****************************************************************************/
 
-IRP * devredir_irp_with_pathnamelen_new(unsigned int pathnamelen)
+IRP *devredir_irp_with_pathnamelen_new(unsigned int pathnamelen)
 {
     IRP *irp;
     IRP *irp_last;
@@ -144,7 +144,9 @@ int devredir_irp_delete(IRP *irp)
     IRP *lirp = g_irp_head;
 
     if ((irp == NULL) || (lirp == NULL))
+    {
         return -1;
+    }
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "irp=%p completion_id=%d type=%d",
               irp, irp->CompletionId, irp->completion_type);
@@ -154,13 +156,17 @@ int devredir_irp_delete(IRP *irp)
     while (lirp)
     {
         if (lirp == irp)
+        {
             break;
+        }
 
         lirp = lirp->next;
     }
 
     if (lirp == NULL)
-        return -1; /* did not find specified irp */
+    {
+        return -1;    /* did not find specified irp */
+    }
 
     if (lirp->prev == NULL)
     {
@@ -220,7 +226,7 @@ IRP *devredir_irp_find(tui32 completion_id)
     return NULL;
 }
 
-IRP * devredir_irp_find_by_fileid(tui32 FileId)
+IRP *devredir_irp_find_by_fileid(tui32 FileId)
 {
     IRP *irp = g_irp_head;
 
@@ -243,14 +249,16 @@ IRP * devredir_irp_find_by_fileid(tui32 FileId)
  * Return last IRP in linked list
  *****************************************************************************/
 
-IRP * devredir_irp_get_last(void)
+IRP *devredir_irp_get_last(void)
 {
     IRP *irp = g_irp_head;
 
     while (irp)
     {
         if (irp->next == NULL)
+        {
             break;
+        }
 
         irp = irp->next;
     }

--- a/sesman/chansrv/pcsc/wrapper/winscard.c
+++ b/sesman/chansrv/pcsc/wrapper/winscard.c
@@ -73,7 +73,7 @@ static int g_true = 1;
 
 /*****************************************************************************/
 static int
-writeln(const char* format, ...)
+writeln(const char *format, ...)
 {
     va_list ap;
     char text[256];
@@ -86,13 +86,13 @@ writeln(const char* format, ...)
 }
 
 #define LLOAD(_func, _type, _name) \
-do { \
-    _func = (_type) GetProcAddress(lib, _name); \
-    if (_func == 0) \
-    { \
-        writeln("LLOAD error %s", _name); \
-    } \
-} while (0)
+    do { \
+        _func = (_type) GetProcAddress(lib, _name); \
+        if (_func == 0) \
+        { \
+            writeln("LLOAD error %s", _name); \
+        } \
+    } while (0)
 
 static int g_funcs_loaded = 0;
 

--- a/sesman/chansrv/pcsc/xrdp_pcsc.c
+++ b/sesman/chansrv/pcsc/xrdp_pcsc.c
@@ -63,9 +63,9 @@ PCSC_API SCARD_IO_REQUEST g_rgSCardRawPci = { SCARD_PROTOCOL_RAW, 8 };
 
 #define LLOG_LEVEL 5
 #define LLOGLN(_level, _args) \
-  do { if (_level < LLOG_LEVEL) { printf _args ; printf("\n"); } } while (0)
+    do { if (_level < LLOG_LEVEL) { printf _args ; printf("\n"); } } while (0)
 #define LHEXDUMP(_level, _args) \
-  do { if  (_level < LLOG_LEVEL) { lhexdump _args ; } } while (0)
+    do { if  (_level < LLOG_LEVEL) { lhexdump _args ; } } while (0)
 
 #define SCARD_ESTABLISH_CONTEXT  0x01
 #define SCARD_RELEASE_CONTEXT    0x02
@@ -88,16 +88,16 @@ PCSC_API SCARD_IO_REQUEST g_rgSCardRawPci = { SCARD_PROTOCOL_RAW, 8 };
 #define SCARD_F_INTERNAL_ERROR ((LONG)0x80100001)
 
 #define SET_UINT32(_data, _offset, _val) do { \
-  (((BYTE*)(_data)) + (_offset))[0] = ((_val) >> 0)  & 0xff; \
-  (((BYTE*)(_data)) + (_offset))[1] = ((_val) >> 8)  & 0xff; \
-  (((BYTE*)(_data)) + (_offset))[2] = ((_val) >> 16) & 0xff; \
-  (((BYTE*)(_data)) + (_offset))[3] = ((_val) >> 24) & 0xff; } while (0)
+        (((BYTE*)(_data)) + (_offset))[0] = ((_val) >> 0)  & 0xff; \
+        (((BYTE*)(_data)) + (_offset))[1] = ((_val) >> 8)  & 0xff; \
+        (((BYTE*)(_data)) + (_offset))[2] = ((_val) >> 16) & 0xff; \
+        (((BYTE*)(_data)) + (_offset))[3] = ((_val) >> 24) & 0xff; } while (0)
 
 #define GET_UINT32(_data, _offset) \
-  ((((BYTE*)(_data)) + (_offset))[0] << 0)  | \
-  ((((BYTE*)(_data)) + (_offset))[1] << 8)  | \
-  ((((BYTE*)(_data)) + (_offset))[2] << 16) | \
-  ((((BYTE*)(_data)) + (_offset))[3] << 24)
+    ((((BYTE*)(_data)) + (_offset))[0] << 0)  | \
+    ((((BYTE*)(_data)) + (_offset))[1] << 8)  | \
+    ((((BYTE*)(_data)) + (_offset))[2] << 16) | \
+    ((((BYTE*)(_data)) + (_offset))[3] << 24)
 
 #define LMIN(_val1, _val2) (_val1) < (_val2) ? (_val1) : (_val2)
 #define LMAX(_val1, _val2) (_val1) > (_val2) ? (_val1) : (_val2)
@@ -208,7 +208,7 @@ get_display_num_from_display(const char *display_text)
     disp[disp_index] = 0;
     scre[scre_index] = 0;
     LLOGLN(10, ("get_display_num_from_display: host [%s] disp [%s] scre [%s]",
-           host, disp, scre));
+                host, disp, scre));
     rv = atoi(disp);
     return rv;
 }
@@ -359,7 +359,7 @@ get_message(int *code, char *data, int *bytes)
                     else
                     {
                         LLOGLN(10, ("get_message: lcode %d *code %d",
-                               lcode, *code));
+                                    lcode, *code));
                     }
                 }
                 else if (recv_rv == 0)
@@ -421,7 +421,7 @@ SCardEstablishContext(DWORD dwScope, LPCVOID pvReserved1, LPCVOID pvReserved2,
         if (connect_to_chansrv() != 0)
         {
             LLOGLN(0, ("SCardEstablishContext: error, can not connect "
-                   "to chansrv"));
+                       "to chansrv"));
             return SCARD_F_INTERNAL_ERROR;
         }
     }
@@ -515,8 +515,8 @@ SCardConnect(SCARDCONTEXT hContext, LPCSTR szReader, DWORD dwShareMode,
 
     LLOGLN(10, ("SCardConnect:"));
     LLOGLN(10, ("SCardConnect: hContext 0x%8.8x szReader %s dwShareMode %d "
-           "dwPreferredProtocols %d",
-           (int)hContext, szReader, (int)dwShareMode, (int)dwPreferredProtocols));
+                "dwPreferredProtocols %d",
+                (int)hContext, szReader, (int)dwShareMode, (int)dwPreferredProtocols));
     if (g_sck == -1)
     {
         LLOGLN(0, ("SCardConnect: error, not connected"));
@@ -559,8 +559,8 @@ SCardConnect(SCARDCONTEXT hContext, LPCSTR szReader, DWORD dwShareMode,
     *pdwActiveProtocol = GET_UINT32(msg, 4);
     status = GET_UINT32(msg, 8);
     LLOGLN(10, ("SCardConnect: got status 0x%8.8x hCard 0x%8.8x "
-           "dwActiveProtocol %d",
-           status, (int)*phCard, (int)*pdwActiveProtocol));
+                "dwActiveProtocol %d",
+                status, (int)*phCard, (int)*pdwActiveProtocol));
     return status;
 }
 
@@ -589,7 +589,7 @@ SCardDisconnect(SCARDHANDLE hCard, DWORD dwDisposition)
     int status;
 
     LLOGLN(10, ("SCardDisconnect: hCard 0x%8.8x dwDisposition %d",
-           (int)hCard, (int)dwDisposition));
+                (int)hCard, (int)dwDisposition));
     if (g_sck == -1)
     {
         LLOGLN(0, ("SCardDisconnect: error, not connected"));
@@ -1051,10 +1051,10 @@ SCardTransmit(SCARDHANDLE hCard, const SCARD_IO_REQUEST *pioSendPci,
     offset += 4;
     SET_UINT32(msg, offset, pioSendPci->dwProtocol);
     offset += 4;
-/*  SET_UINT32(msg, offset, pioSendPci->cbPciLength); */
+    /*  SET_UINT32(msg, offset, pioSendPci->cbPciLength); */
     SET_UINT32(msg, offset, 8);
     offset += 4;
-/*  extra_len = pioSendPci->cbPciLength - 8;  */
+    /*  extra_len = pioSendPci->cbPciLength - 8;  */
     extra_len = 0;
     SET_UINT32(msg, offset, extra_len);
     offset += 4;
@@ -1158,8 +1158,8 @@ PCSC_API LONG
 SCardListReaders(SCARDCONTEXT hContext, LPCSTR mszGroups, LPSTR mszReaders,
                  LPDWORD pcchReaders)
 {
-    char* msg;
-    char* reader_names;
+    char *msg;
+    char *reader_names;
     int reader_names_index;
     int code;
     int bytes;
@@ -1229,7 +1229,7 @@ SCardListReaders(SCARDCONTEXT hContext, LPCSTR mszGroups, LPSTR mszReaders,
     num_readers = GET_UINT32(msg, offset);
     offset += 4;
     LLOGLN(10, ("SCardListReaders: mszReaders %p pcchReaders %p num_readers %d",
-           mszReaders, pcchReaders, num_readers));
+                mszReaders, pcchReaders, num_readers));
     reader_names = (char *) malloc(8192);
     reader_names_index = 0;
     for (index = 0; index < num_readers; index++)

--- a/sesman/chansrv/rail.c
+++ b/sesman/chansrv/rail.c
@@ -65,7 +65,7 @@ int g_rail_up = 0;
 /* for rail_is_another_wm_running */
 static int g_rail_running = 1;
 /* list of valid rail windows */
-static struct list* g_window_list = 0;
+static struct list *g_window_list = 0;
 
 static int g_got_focus = 0;
 static int g_focus_counter = 0;
@@ -185,7 +185,7 @@ rail_send_key_esc(int window_id)
 }
 
 /*****************************************************************************/
-static struct rail_window_data*
+static struct rail_window_data *
 rail_get_window_data(Window window)
 {
     unsigned int bytes;
@@ -193,8 +193,8 @@ rail_get_window_data(Window window)
     int actual_format_return;
     unsigned long nitems_return;
     unsigned long bytes_after_return;
-    unsigned char* prop_return;
-    struct rail_window_data* rv;
+    unsigned char *prop_return;
+    struct rail_window_data *rv;
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "chansrv::rail_get_window_data:");
     rv = 0;
@@ -213,29 +213,29 @@ rail_get_window_data(Window window)
     }
     if (nitems_return == bytes)
     {
-        rv = (struct rail_window_data*)prop_return;
+        rv = (struct rail_window_data *)prop_return;
     }
     return rv;
 }
 
 /*****************************************************************************/
 static int
-rail_set_window_data(Window window, struct rail_window_data* rwd)
+rail_set_window_data(Window window, struct rail_window_data *rwd)
 {
     int bytes;
 
     bytes = sizeof(struct rail_window_data);
     XChangeProperty(g_display, window, g_rwd_atom, XA_STRING, 8,
-                    PropModeReplace, (unsigned char*)rwd, bytes);
+                    PropModeReplace, (unsigned char *)rwd, bytes);
     return 0;
 }
 
 /*****************************************************************************/
 /* get the rail window data, if not exist, try to create it and return */
-static struct rail_window_data*
+static struct rail_window_data *
 rail_get_window_data_safe(Window window)
 {
-    struct rail_window_data* rv;
+    struct rail_window_data *rv;
 
     rv = rail_get_window_data(window);
     if (rv != 0)
@@ -369,8 +369,8 @@ rail_startup(void)
 
     if (rail_is_another_wm_running())
     {
-        log_message(LOG_LEVEL_ERROR, "rail_init: another window manager "
-                    "is running");
+        LOG(LOG_LEVEL_ERROR, "rail_init: another window manager "
+            "is running");
     }
 
     list_delete(g_window_list);
@@ -382,7 +382,7 @@ rail_startup(void)
     if (!XRRQueryExtension(g_display, &g_xrr_event_base, &dummy))
     {
         g_xrr_event_base = 0;
-        log_message(LOG_LEVEL_ERROR, "rail_init: RandR extension not found");
+        LOG(LOG_LEVEL_ERROR, "rail_init: RandR extension not found");
     }
 
     if (g_xrr_event_base > 0)
@@ -462,9 +462,9 @@ rail_process_exec(struct stream *s, int size)
     WorkingDir = read_uni(s, WorkingDirLength);
     Arguments = read_uni(s, ArgumentsLen);
     LOG(LOG_LEVEL_DEBUG, "  flags 0x%8.8x ExeOrFileLength %d WorkingDirLength %d "
-             "ArgumentsLen %d ExeOrFile [%s] WorkingDir [%s] "
-             "Arguments [%s]", flags, ExeOrFileLength, WorkingDirLength,
-             ArgumentsLen, ExeOrFile, WorkingDir, Arguments);
+        "ArgumentsLen %d ExeOrFile [%s] WorkingDir [%s] "
+        "Arguments [%s]", flags, ExeOrFileLength, WorkingDirLength,
+        ArgumentsLen, ExeOrFile, WorkingDir, Arguments);
 
     if (g_strlen(ExeOrFile) > 0)
     {
@@ -495,7 +495,7 @@ rail_win_popdown(void)
     unsigned int nchild;
     Window r;
     Window p;
-    Window* children;
+    Window *children;
     XWindowAttributes window_attributes;
 
     /*
@@ -509,8 +509,8 @@ rail_win_popdown(void)
     {
         XGetWindowAttributes(g_display, children[i], &window_attributes);
         if (window_attributes.override_redirect &&
-            window_attributes.map_state == IsViewable &&
-            list_index_of(g_window_list, children[i]) >= 0)
+                window_attributes.map_state == IsViewable &&
+                list_index_of(g_window_list, children[i]) >= 0)
         {
             LOG_DEVEL(LOG_LEVEL_DEBUG, "  dismiss pop up 0x%8.8lx", children[i]);
             rail_send_key_esc(children[i]);
@@ -547,7 +547,7 @@ rail_close_window(int window_id)
 
 /*****************************************************************************/
 void
-my_timeout(void* data)
+my_timeout(void *data)
 {
     LOG_DEVEL(LOG_LEVEL_DEBUG, "my_timeout: g_got_focus %d", g_got_focus);
     if (g_focus_counter == (int)(long)data)
@@ -575,7 +575,7 @@ rail_process_activate(struct stream *s, int size)
     if (index < 0)
     {
         LOG_DEVEL(LOG_LEVEL_DEBUG, "chansrv::rail_process_activate: window 0x%8.8x not in list",
-                 window_id);
+                  window_id);
         return 0;
     }
 
@@ -615,10 +615,12 @@ rail_process_activate(struct stream *s, int size)
         XRaiseWindow(g_display, window_id);
         LOG_DEVEL(LOG_LEVEL_DEBUG, "chansrv::rail_process_activate: calling XSetInputFocus 0x%8.8x", window_id);
         XSetInputFocus(g_display, window_id, RevertToParent, CurrentTime);
-    } else {
+    }
+    else
+    {
         LOG_DEVEL(LOG_LEVEL_DEBUG, "  window attributes: override_redirect %d",
-                 window_attributes.override_redirect);
-        add_timeout(200, my_timeout, (void*)(long)g_focus_counter);
+                  window_attributes.override_redirect);
+        add_timeout(200, my_timeout, (void *)(long)g_focus_counter);
     }
     return 0;
 }
@@ -643,7 +645,7 @@ rail_restore_windows(void)
     unsigned int nchild;
     Window r;
     Window p;
-    Window* children;
+    Window *children;
 
     XQueryTree(g_display, g_root_window, &r, &p, &children, &nchild);
     for (i = 0; i < nchild; i++)
@@ -690,13 +692,13 @@ rail_process_system_param(struct stream *s, int size)
 
 /*****************************************************************************/
 static int
-rail_get_property(Display* display, Window target, Atom type, Atom property,
-                                 unsigned char** data, unsigned long* count)
+rail_get_property(Display *display, Window target, Atom type, Atom property,
+                  unsigned char **data, unsigned long *count)
 {
     Atom atom_return;
     int size;
     unsigned long nitems, bytes_left;
-    char* prop_name;
+    char *prop_name;
 
     int ret = XGetWindowProperty(display, target, property,
                                  0l, 1l, False,
@@ -734,7 +736,7 @@ rail_win_get_state(Window win)
 {
     unsigned long nitems = 0;
     int rv = -1;
-    char* data = 0;
+    char *data = 0;
 
     rail_get_property(g_display, win, g_wm_state, g_wm_state,
                       (unsigned char **)&data,
@@ -823,7 +825,9 @@ rail_minmax_window(int window_id, int max)
     if (max)
     {
 
-    } else {
+    }
+    else
+    {
         XUnmapWindow(g_display, window_id);
         /* change window state to IconicState (3) */
         rail_win_set_state(window_id, 0x3);
@@ -870,7 +874,7 @@ rail_process_system_command(struct stream *s, int size)
     if (index < 0)
     {
         LOG_DEVEL(LOG_LEVEL_DEBUG, "chansrv::rail_process_system_command: window 0x%8.8x not in list",
-                 window_id);
+                  window_id);
         return 0;
     }
 
@@ -905,7 +909,7 @@ rail_process_system_command(struct stream *s, int size)
             break;
         default:
             LOG_DEVEL(LOG_LEVEL_DEBUG, "  window_id 0x%8.8x unknown command command %d",
-                     window_id, command);
+                      window_id, command);
             break;
     }
 
@@ -937,7 +941,7 @@ rail_process_notify_event(struct stream *s, int size)
     in_uint32_le(s, notify_id);
     in_uint32_le(s, message);
     LOG(LOG_LEVEL_DEBUG, "  window_id 0x%8.8x notify_id 0x%8.8x message 0x%8.8x",
-             window_id, notify_id, message);
+        window_id, notify_id, message);
     return 0;
 }
 
@@ -951,7 +955,7 @@ rail_process_window_move(struct stream *s, int size)
     int right;
     int bottom;
     tsi16 si16;
-    struct rail_window_data* rwd;
+    struct rail_window_data *rwd;
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "chansrv::rail_process_window_move:");
     in_uint32_le(s, window_id);
@@ -964,10 +968,10 @@ rail_process_window_move(struct stream *s, int size)
     in_uint16_le(s, si16);
     bottom = si16;
     LOG_DEVEL(LOG_LEVEL_DEBUG, "  window_id 0x%8.8x left %d top %d right %d bottom %d width %d height %d",
-             window_id, left, top, right, bottom, right - left, bottom - top);
+              window_id, left, top, right, bottom, right - left, bottom - top);
     XMoveResizeWindow(g_display, window_id, left, top, right - left, bottom - top);
-    rwd = (struct rail_window_data*)
-    g_malloc(sizeof(struct rail_window_data), 1);
+    rwd = (struct rail_window_data *)
+          g_malloc(sizeof(struct rail_window_data), 1);
     rwd->x = left;
     rwd->y = top;
     rwd->width = right - left;
@@ -997,8 +1001,8 @@ rail_process_local_move_size(struct stream *s, int size)
     in_uint16_le(s, si16);
     pos_y = si16;
     LOG(LOG_LEVEL_DEBUG, "  window_id 0x%8.8x is_move_size_start %d move_size_type %d "
-             "pos_x %d pos_y %d", window_id, is_move_size_start, move_size_type,
-             pos_x, pos_y);
+        "pos_x %d pos_y %d", window_id, is_move_size_start, move_size_type,
+        pos_x, pos_y);
     return 0;
 }
 
@@ -1199,12 +1203,12 @@ static const unsigned int g_crc_table[256] =
 
 #define CRC_START(in_crc) (in_crc) = g_crc_seed
 #define CRC_PASS(in_pixel, in_crc) \
-  (in_crc) = g_crc_table[((in_crc) ^ (in_pixel)) & 0xff] ^ ((in_crc) >> 8)
+    (in_crc) = g_crc_table[((in_crc) ^ (in_pixel)) & 0xff] ^ ((in_crc) >> 8)
 #define CRC_END(in_crc) (in_crc) = ((in_crc) ^ g_crc_seed)
 
 /*****************************************************************************/
 static int
-get_string_crc(const char* text)
+get_string_crc(const char *text)
 {
     int index;
     int crc;
@@ -1225,12 +1229,12 @@ get_string_crc(const char* text)
 static int
 rail_win_send_text(Window win)
 {
-    char* data = 0;
-    struct stream* s;
+    char *data = 0;
+    struct stream *s;
     int len = 0;
     int flags;
     int crc;
-    struct rail_window_data* rwd;
+    struct rail_window_data *rwd;
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "chansrv::rail_win_send_text:");
     len = rail_win_get_text(win, &data);
@@ -1261,7 +1265,7 @@ rail_win_send_text(Window win)
     if (data && len > 0)
     {
         LOG_DEVEL(LOG_LEVEL_DEBUG, "chansrv::rail_win_send_text: 0x%8.8lx text %s length %d",
-                 win, data, len);
+                  win, data, len);
         make_stream(s);
         init_stream(s, len + 1024);
         flags = WINDOW_ORDER_TYPE_WINDOW | WINDOW_ORDER_FIELD_TITLE;
@@ -1308,7 +1312,7 @@ static int
 rail_show_window(Window window_id, int show_state)
 {
     int flags;
-    struct stream* s;
+    struct stream *s;
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "chansrv::rail_show_window 0x%8.8lx 0x%x", window_id, show_state);
     make_stream(s);
@@ -1336,7 +1340,7 @@ rail_create_window(Window window_id, Window owner_id)
     tui32 border;
     Window root;
     tui32 depth;
-    char* title_bytes = 0;
+    char *title_bytes = 0;
     int title_size = 0;
     XWindowAttributes attributes;
     int style;
@@ -1349,8 +1353,8 @@ rail_create_window(Window window_id, Window owner_id)
     int index;
     int crc;
     Window transient_for = 0;
-    struct rail_window_data* rwd;
-    struct stream* s;
+    struct rail_window_data *rwd;
+    struct stream *s;
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "chansrv::rail_create_window 0x%8.8lx", window_id);
 
@@ -1365,7 +1369,7 @@ rail_create_window(Window window_id, Window owner_id)
     XGetWindowAttributes(g_display, window_id, &attributes);
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "  x %d y %d width %d height %d border_width %d", x, y, width,
-             height, border);
+              height, border);
 
     index = list_index_of(g_window_list, window_id);
     if (index == -1)
@@ -1488,7 +1492,7 @@ rail_create_window(Window window_id, Window owner_id)
 /*****************************************************************************/
 /* returns 0, event handled, 1 unhandled */
 int
-rail_configure_request_window(XConfigureRequestEvent* config)
+rail_configure_request_window(XConfigureRequestEvent *config)
 {
     int num_window_rects = 1;
     int num_visibility_rects = 1;
@@ -1498,9 +1502,9 @@ rail_configure_request_window(XConfigureRequestEvent* config)
     int window_id;
     int mask;
     int resized = 0;
-    struct rail_window_data* rwd;
+    struct rail_window_data *rwd;
 
-    struct stream* s;
+    struct stream *s;
 
     window_id = config->window;
     mask = config->value_mask;
@@ -1508,11 +1512,11 @@ rail_configure_request_window(XConfigureRequestEvent* config)
     if (mask & CWStackMode)
     {
         LOG_DEVEL(LOG_LEVEL_DEBUG, "chansrv::rail_configure_request_window: CWStackMode "
-                 "detail 0x%8.8x above 0x%8.8lx", config->detail, config->above);
+                  "detail 0x%8.8x above 0x%8.8lx", config->detail, config->above);
         if (config->detail == Above)
         {
             LOG_DEVEL(LOG_LEVEL_DEBUG, "chansrv::rail_configure_request_window: bring to front "
-                     "window_id 0x%8.8x", window_id);
+                      "window_id 0x%8.8x", window_id);
             /* 0x05 - Show the window in its current size and position. */
             rail_show_window(window_id, 5);
         }
@@ -1520,7 +1524,7 @@ rail_configure_request_window(XConfigureRequestEvent* config)
     rwd = rail_get_window_data(window_id);
     if (rwd == 0)
     {
-        rwd = (struct rail_window_data*)g_malloc(sizeof(struct rail_window_data), 1);
+        rwd = (struct rail_window_data *)g_malloc(sizeof(struct rail_window_data), 1);
         rwd->x = config->x;
         rwd->y = config->y;
         rwd->width = config->width;
@@ -1625,7 +1629,7 @@ rail_configure_request_window(XConfigureRequestEvent* config)
 
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "  x %d y %d width %d height %d border_width %d", config->x,
-             config->y, config->width, config->height, config->border_width);
+              config->y, config->width, config->height, config->border_width);
 
     index = list_index_of(g_window_list, window_id);
     if (index == -1)
@@ -1702,7 +1706,7 @@ rail_configure_window(XConfigureEvent *config)
     int index;
     int window_id;
 
-    struct stream* s;
+    struct stream *s;
 
     window_id = config->window;
 
@@ -1710,7 +1714,7 @@ rail_configure_window(XConfigureEvent *config)
 
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "  x %d y %d width %d height %d border_width %d", config->x,
-             config->y, config->width, config->height, config->border_width);
+              config->y, config->width, config->height, config->border_width);
 
     index = list_index_of(g_window_list, window_id);
     if (index == -1)
@@ -1793,7 +1797,7 @@ rail_xevent(void *xevent)
     int rv;
     int index;
     XWindowAttributes wnd_attributes;
-    char* prop_name;
+    char *prop_name;
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "chansrv::rail_xevent:");
 
@@ -1810,8 +1814,8 @@ rail_xevent(void *xevent)
         case PropertyNotify:
             prop_name = XGetAtomName(g_display, lxevent->xproperty.atom);
             LOG_DEVEL(LOG_LEVEL_DEBUG, "  got PropertyNotify window_id 0x%8.8lx %s state new %d",
-                     lxevent->xproperty.window, prop_name,
-                     lxevent->xproperty.state == PropertyNewValue);
+                      lxevent->xproperty.window, prop_name,
+                      lxevent->xproperty.state == PropertyNewValue);
 
             if (list_index_of(g_window_list, lxevent->xproperty.window) < 0)
             {
@@ -1819,7 +1823,7 @@ rail_xevent(void *xevent)
             }
 
             if (g_strcmp(prop_name, "WM_NAME") == 0 ||
-                g_strcmp(prop_name, "_NET_WM_NAME") == 0)
+                    g_strcmp(prop_name, "_NET_WM_NAME") == 0)
             {
                 XGetWindowAttributes(g_display, lxevent->xproperty.window, &wnd_attributes);
                 if (wnd_attributes.map_state == IsViewable)
@@ -1851,13 +1855,13 @@ rail_xevent(void *xevent)
 
         case CreateNotify:
             LOG_DEVEL(LOG_LEVEL_DEBUG, " got CreateNotify window 0x%8.8lx parent 0x%8.8lx",
-                     lxevent->xcreatewindow.window, lxevent->xcreatewindow.parent);
+                      lxevent->xcreatewindow.window, lxevent->xcreatewindow.parent);
             rail_select_input(lxevent->xcreatewindow.window);
             break;
 
         case DestroyNotify:
             LOG_DEVEL(LOG_LEVEL_DEBUG, "  got DestroyNotify window 0x%8.8lx event 0x%8.8lx",
-                     lxevent->xdestroywindow.window, lxevent->xdestroywindow.event);
+                      lxevent->xdestroywindow.window, lxevent->xdestroywindow.event);
             if (lxevent->xdestroywindow.window != lxevent->xdestroywindow.event)
             {
                 break;
@@ -1878,7 +1882,7 @@ rail_xevent(void *xevent)
 
         case MapNotify:
             LOG_DEVEL(LOG_LEVEL_DEBUG, "  got MapNotify window 0x%8.8lx event 0x%8.8lx",
-                     lxevent->xmap.window, lxevent->xmap.event);
+                      lxevent->xmap.window, lxevent->xmap.event);
             if (lxevent->xmap.window != lxevent->xmap.event)
             {
                 break;
@@ -1920,8 +1924,10 @@ rail_xevent(void *xevent)
                         // remove popups
                         rail_destroy_window(lxevent->xunmap.window);
                         list_remove_item(g_window_list, index);
-                    } else {
-                    rail_show_window(lxevent->xunmap.window, 0x0);
+                    }
+                    else
+                    {
+                        rail_show_window(lxevent->xunmap.window, 0x0);
                     }
 
                     rv = 0;
@@ -1931,10 +1937,10 @@ rail_xevent(void *xevent)
 
         case ConfigureNotify:
             LOG_DEVEL(LOG_LEVEL_DEBUG, "  got ConfigureNotify 0x%8.8lx event 0x%8.8lx", lxevent->xconfigure.window,
-                     lxevent->xconfigure.event);
+                      lxevent->xconfigure.event);
             rv = 0;
             if (lxevent->xconfigure.event != lxevent->xconfigure.window ||
-                lxevent->xconfigure.override_redirect)
+                    lxevent->xconfigure.override_redirect)
             {
                 break;
             }
@@ -1944,7 +1950,7 @@ rail_xevent(void *xevent)
                                           ConfigureNotify, &lastevent))
             {
                 if (lastevent.xconfigure.event == lastevent.xconfigure.window &&
-                    lxevent->xconfigure.override_redirect == 0)
+                        lxevent->xconfigure.override_redirect == 0)
                 {
                     lxevent = &lastevent;
                 }
@@ -1977,10 +1983,10 @@ rail_xevent(void *xevent)
 
         case ReparentNotify:
             LOG_DEVEL(LOG_LEVEL_DEBUG, "  got ReparentNotify window 0x%8.8lx parent 0x%8.8lx "
-                     "event 0x%8.8lx x %d y %d override redirect %d",
-                     lxevent->xreparent.window, lxevent->xreparent.parent,
-                     lxevent->xreparent.event, lxevent->xreparent.x,
-                     lxevent->xreparent.y, lxevent->xreparent.override_redirect);
+                      "event 0x%8.8lx x %d y %d override redirect %d",
+                      lxevent->xreparent.window, lxevent->xreparent.parent,
+                      lxevent->xreparent.event, lxevent->xreparent.x,
+                      lxevent->xreparent.y, lxevent->xreparent.override_redirect);
 
             if (lxevent->xreparent.window != lxevent->xreparent.event)
             {

--- a/sesman/chansrv/sound.c
+++ b/sesman/chansrv/sound.c
@@ -43,9 +43,9 @@ static HANDLE_AACENCODER g_fdk_aac_encoder = 0;
 
 #define AACENCODER_LIB_VER_GTEQ(vl0, vl1, vl2) \
     (defined(AACENCODER_LIB_VL0) && \
-        ((AACENCODER_LIB_VL0 > vl0) || \
-         (AACENCODER_LIB_VL0 == vl0 && AACENCODER_LIB_VL1 >= vl1) || \
-         (AACENCODER_LIB_VL0 == vl0 && AACENCODER_LIB_VL1 == vl1 && AACENCODER_LIB_VL2 > vl2)))
+     ((AACENCODER_LIB_VL0 > vl0) || \
+      (AACENCODER_LIB_VL0 == vl0 && AACENCODER_LIB_VL1 >= vl1) || \
+      (AACENCODER_LIB_VL0 == vl0 && AACENCODER_LIB_VL1 == vl1 && AACENCODER_LIB_VL2 > vl2)))
 #endif
 
 #if defined(XRDP_OPUS)
@@ -249,9 +249,9 @@ static int g_server_input_format_index = 0;
 /* microphone related */
 static int sound_send_server_input_formats(void);
 static int sound_process_input_format(int aindex, int wFormatTag,
-                           int nChannels, int nSamplesPerSec,
-                           int nAvgBytesPerSec, int nBlockAlign,
-                           int wBitsPerSample, int cbSize, char *data);
+                                      int nChannels, int nSamplesPerSec,
+                                      int nAvgBytesPerSec, int nBlockAlign,
+                                      int wBitsPerSample, int cbSize, char *data);
 static int sound_process_input_formats(struct stream *s, int size);
 static int sound_input_start_recording(void);
 static int sound_input_stop_recording(void);
@@ -378,15 +378,15 @@ sound_process_output_format(int aindex, int wFormatTag, int nChannels,
     LOG_DEVEL(LOG_LEVEL_INFO, "      wBitsPerSample  %d", wBitsPerSample);
     LOG_DEVEL(LOG_LEVEL_INFO, "      cbSize          %d", cbSize);
 
-    g_hexdump(data, cbSize);
+    LOG_DEVEL_HEXDUMP(LOG_LEVEL_TRACE, "", data, cbSize);
 
     /* select CD quality audio */
     if (wFormatTag == g_pcm_44100.wFormatTag &&
-        nChannels == g_pcm_44100.nChannels &&
-        nSamplesPerSec == g_pcm_44100.nSamplesPerSec &&
-        nAvgBytesPerSec == g_pcm_44100.nAvgBytesPerSec &&
-        nBlockAlign == g_pcm_44100.nBlockAlign &&
-        wBitsPerSample == g_pcm_44100.wBitsPerSample)
+            nChannels == g_pcm_44100.nChannels &&
+            nSamplesPerSec == g_pcm_44100.nSamplesPerSec &&
+            nAvgBytesPerSec == g_pcm_44100.nAvgBytesPerSec &&
+            nBlockAlign == g_pcm_44100.nBlockAlign &&
+            wBitsPerSample == g_pcm_44100.wBitsPerSample)
     {
         g_current_client_format_index = aindex;
         g_current_server_format_index = 0;
@@ -395,11 +395,11 @@ sound_process_output_format(int aindex, int wFormatTag, int nChannels,
     for (lindex = 0; lindex < NUM_BUILT_IN; lindex++)
     {
         if (wFormatTag == g_wave_formats[lindex]->wFormatTag &&
-            nChannels == g_wave_formats[lindex]->nChannels &&
-            nSamplesPerSec == g_wave_formats[lindex]->nSamplesPerSec &&
-            nAvgBytesPerSec == g_wave_formats[lindex]->nAvgBytesPerSec &&
-            nBlockAlign == g_wave_formats[lindex]->nBlockAlign &&
-            wBitsPerSample == g_wave_formats[lindex]->wBitsPerSample)
+                nChannels == g_wave_formats[lindex]->nChannels &&
+                nSamplesPerSec == g_wave_formats[lindex]->nSamplesPerSec &&
+                nAvgBytesPerSec == g_wave_formats[lindex]->nAvgBytesPerSec &&
+                nBlockAlign == g_wave_formats[lindex]->nBlockAlign &&
+                wBitsPerSample == g_wave_formats[lindex]->wBitsPerSample)
         {
             g_current_client_format_index = aindex;
             g_current_server_format_index = lindex;
@@ -407,7 +407,7 @@ sound_process_output_format(int aindex, int wFormatTag, int nChannels,
     }
 #endif
 
-    switch(wFormatTag)
+    switch (wFormatTag)
     {
         case WAVE_FORMAT_AAC:
             LOG_DEVEL(LOG_LEVEL_INFO, "wFormatTag, fdk aac");
@@ -415,7 +415,7 @@ sound_process_output_format(int aindex, int wFormatTag, int nChannels,
             g_client_fdk_aac_index = aindex;
             break;
         case WAVE_FORMAT_MPEGLAYER3:
-           LOG_DEVEL(LOG_LEVEL_INFO, "wFormatTag, mp3");
+            LOG_DEVEL(LOG_LEVEL_INFO, "wFormatTag, mp3");
             g_client_does_mp3lame = 1;
             g_client_mp3lame_index = aindex;
             break;
@@ -451,7 +451,9 @@ sound_process_output_formats(struct stream *s, int size)
     char *data;
 
     if (size < 16)
+    {
         return 1;
+    }
 
     in_uint8s(s, 14);
     in_uint16_le(s, num_formats);
@@ -534,7 +536,7 @@ sound_wave_compress_fdk_aac(char *data, int data_bytes, int *format_index)
         if (error != AACENC_OK)
         {
             LOG_DEVEL(LOG_LEVEL_INFO, "sound_wave_compress_fdk_aac: aacEncoder_SetParam() "
-                    "AACENC_AOT failed");
+                      "AACENC_AOT failed");
         }
 
         sample_rate = g_fdk_aac_44100.nSamplesPerSec;
@@ -543,7 +545,7 @@ sound_wave_compress_fdk_aac(char *data, int data_bytes, int *format_index)
         if (error != AACENC_OK)
         {
             LOG_DEVEL(LOG_LEVEL_INFO, "sound_wave_compress_fdk_aac: aacEncoder_SetParam() "
-                    "AACENC_SAMPLERATE failed");
+                      "AACENC_SAMPLERATE failed");
         }
 
         mode = MODE_2;
@@ -552,7 +554,7 @@ sound_wave_compress_fdk_aac(char *data, int data_bytes, int *format_index)
         if (error != AACENC_OK)
         {
             LOG_DEVEL(LOG_LEVEL_INFO, "sound_wave_compress_fdk_aac: aacEncoder_SetParam() "
-                    "AACENC_CHANNELMODE failed");
+                      "AACENC_CHANNELMODE failed");
         }
 
         channel_order = 1; /* WAVE file format channel ordering */
@@ -561,7 +563,7 @@ sound_wave_compress_fdk_aac(char *data, int data_bytes, int *format_index)
         if (error != AACENC_OK)
         {
             LOG_DEVEL(LOG_LEVEL_INFO, "sound_wave_compress_fdk_aac: aacEncoder_SetParam() "
-                    "AACENC_CHANNELORDER failed");
+                      "AACENC_CHANNELORDER failed");
         }
 
         /* bytes rate to bit rate */
@@ -571,14 +573,14 @@ sound_wave_compress_fdk_aac(char *data, int data_bytes, int *format_index)
         if (error != AACENC_OK)
         {
             LOG_DEVEL(LOG_LEVEL_INFO, "sound_wave_compress_fdk_aac: aacEncoder_SetParam() "
-                    "AACENC_BITRATE failed");
+                      "AACENC_BITRATE failed");
         }
 
         error = aacEncoder_SetParam(g_fdk_aac_encoder, AACENC_TRANSMUX, 0);
         if (error != AACENC_OK)
         {
             LOG_DEVEL(LOG_LEVEL_INFO, "sound_wave_compress_fdk_aac: aacEncoder_SetParam() "
-                    "AACENC_TRANSMUX failed");
+                      "AACENC_TRANSMUX failed");
         }
 
         afterburner = 1;
@@ -587,14 +589,14 @@ sound_wave_compress_fdk_aac(char *data, int data_bytes, int *format_index)
         if (error != AACENC_OK)
         {
             LOG_DEVEL(LOG_LEVEL_INFO, "sound_wave_compress_fdk_aac: aacEncoder_SetParam() "
-                    "AACENC_AFTERBURNER failed");
+                      "AACENC_AFTERBURNER failed");
         }
 
         error = aacEncEncode(g_fdk_aac_encoder, NULL, NULL, NULL, NULL);
         if (error != AACENC_OK)
         {
             LOG_DEVEL(LOG_LEVEL_INFO, "sound_wave_compress_fdk_aac: Unable to initialize "
-                    "the encoder");
+                      "the encoder");
         }
 
         g_memset(&info, 0, sizeof(info));
@@ -663,7 +665,7 @@ sound_wave_compress_fdk_aac(char *data, int data_bytes, int *format_index)
     {
         cdata_bytes = out_args.numOutBytes;
         LOG_DEVEL(LOG_LEVEL_DEBUG, "sound_wave_compress_fdk_aac: aacEncEncode ok "
-                 "cdata_bytes %d", cdata_bytes);
+                  "cdata_bytes %d", cdata_bytes);
         *format_index = g_client_fdk_aac_index;
         g_memcpy(data, cdata, cdata_bytes);
         rv = cdata_bytes;
@@ -819,14 +821,14 @@ sound_wave_compress_mp3lame(char *data, int data_bytes, int *format_index)
         data_bytes = g_bbuf_size;
     }
     cdata_bytes = lame_encode_buffer_interleaved(g_lame_encoder,
-                                                 (short int *) data,
-                                                 data_bytes / 4,
-                                                 cdata,
-                                                 cdata_bytes);
+                  (short int *) data,
+                  data_bytes / 4,
+                  cdata,
+                  cdata_bytes);
     if (cdata_bytes < 0)
     {
         LOG_DEVEL(LOG_LEVEL_ERROR, "sound_wave_compress: lame_encode_buffer_interleaved() "
-                "failed, error %d", cdata_bytes);
+                  "failed, error %d", cdata_bytes);
         return rv;
     }
     if ((cdata_bytes > 0) && (cdata_bytes < odata_bytes))
@@ -913,7 +915,7 @@ sound_send_wave_data_chunk(char *data, int data_bytes)
     g_sent_time[g_cBlockNo & 0xff] = time;
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "sound_send_wave_data_chunk: sending time %d, g_cBlockNo %d",
-             time & 0xffff, g_cBlockNo & 0xff);
+              time & 0xffff, g_cBlockNo & 0xff);
 
     out_uint8s(s, 3);
     out_uint8a(s, data, 4);
@@ -1115,10 +1117,14 @@ sound_sndsrvr_sink_data_in(struct trans *trans)
     int error;
 
     if (trans == 0)
+    {
         return 0;
+    }
 
     if (trans != g_audio_c_trans_out)
+    {
         return 1;
+    }
 
     s = trans_get_in_s(trans);
     in_uint32_le(s, id);
@@ -1153,16 +1159,24 @@ sound_sndsrvr_sink_conn_in(struct trans *trans, struct trans *new_trans)
     LOG_DEVEL(LOG_LEVEL_INFO, "sound_sndsrvr_sink_conn_in:");
 
     if (trans == 0)
+    {
         return 1;
+    }
 
     if (trans != g_audio_l_trans_out)
+    {
         return 1;
+    }
 
     if (g_audio_c_trans_out != 0) /* if already set, error */
+    {
         return 1;
+    }
 
     if (new_trans == 0)
+    {
         return 1;
+    }
 
     g_audio_c_trans_out = new_trans;
     g_audio_c_trans_out->trans_data_in = sound_sndsrvr_sink_data_in;
@@ -1183,16 +1197,24 @@ sound_sndsrvr_source_conn_in(struct trans *trans, struct trans *new_trans)
     LOG_DEVEL(LOG_LEVEL_INFO, "sound_sndsrvr_source_conn_in: client connected");
 
     if (trans == 0)
+    {
         return 1;
+    }
 
     if (trans != g_audio_l_trans_in)
+    {
         return 1;
+    }
 
     if (g_audio_c_trans_in != 0) /* if already set, error */
+    {
         return 1;
+    }
 
     if (new_trans == 0)
+    {
         return 1;
+    }
 
     g_audio_c_trans_in = new_trans;
     g_audio_c_trans_in->trans_data_in = sound_sndsrvr_source_data_in;
@@ -1524,11 +1546,11 @@ sound_process_input_format(int aindex, int wFormatTag, int nChannels,
 #if 1
     /* select CD quality audio */
     if (wFormatTag == g_pcm_inp_44100.wFormatTag &&
-        nChannels == g_pcm_inp_44100.nChannels &&
-        nSamplesPerSec == g_pcm_inp_44100.nSamplesPerSec &&
-        nAvgBytesPerSec == g_pcm_inp_44100.nAvgBytesPerSec &&
-        nBlockAlign == g_pcm_inp_44100.nBlockAlign &&
-        wBitsPerSample == g_pcm_inp_44100.wBitsPerSample)
+            nChannels == g_pcm_inp_44100.nChannels &&
+            nSamplesPerSec == g_pcm_inp_44100.nSamplesPerSec &&
+            nAvgBytesPerSec == g_pcm_inp_44100.nAvgBytesPerSec &&
+            nBlockAlign == g_pcm_inp_44100.nBlockAlign &&
+            wBitsPerSample == g_pcm_inp_44100.wBitsPerSample)
     {
         g_client_input_format_index = aindex;
         g_server_input_format_index = 0;
@@ -1536,11 +1558,11 @@ sound_process_input_format(int aindex, int wFormatTag, int nChannels,
 #else
     /* select half of CD quality audio */
     if (wFormatTag == g_pcm_inp_22050.wFormatTag &&
-        nChannels == g_pcm_inp_22050.nChannels &&
-        nSamplesPerSec == g_pcm_inp_22050.nSamplesPerSec &&
-        nAvgBytesPerSec == g_pcm_inp_22050.nAvgBytesPerSec &&
-        nBlockAlign == g_pcm_inp_22050.nBlockAlign &&
-        wBitsPerSample == g_pcm_inp_22050.wBitsPerSample)
+            nChannels == g_pcm_inp_22050.nChannels &&
+            nSamplesPerSec == g_pcm_inp_22050.nSamplesPerSec &&
+            nAvgBytesPerSec == g_pcm_inp_22050.nAvgBytesPerSec &&
+            nBlockAlign == g_pcm_inp_22050.nBlockAlign &&
+            wBitsPerSample == g_pcm_inp_22050.wBitsPerSample)
     {
         g_client_input_format_index = aindex;
         g_server_input_format_index = 0;
@@ -1606,7 +1628,7 @@ sound_process_input_formats(struct stream *s, int size)
 static int
 sound_input_start_recording(void)
 {
-    struct stream* s;
+    struct stream *s;
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "sound_input_start_recording:");
 
@@ -1645,7 +1667,7 @@ sound_input_start_recording(void)
 static int
 sound_input_stop_recording(void)
 {
-    struct stream* s;
+    struct stream *s;
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "sound_input_stop_recording:");
 
@@ -1678,7 +1700,7 @@ sound_process_input_data(struct stream *s, int bytes)
     struct stream *ls;
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "sound_process_input_data: bytes %d g_bytes_in_fifo %d",
-        bytes, g_bytes_in_fifo);
+              bytes, g_bytes_in_fifo);
 #if 0 /* no need to cap anymore */
     /* cap data in fifo */
     if (g_bytes_in_fifo > 8 * 1024)
@@ -1712,14 +1734,20 @@ sound_sndsrvr_source_data_in(struct trans *trans)
     int      i;
 
     if (trans == 0)
+    {
         return 0;
+    }
 
     if (trans != g_audio_c_trans_in)
+    {
         return 1;
+    }
 
     ts = trans_get_in_s(trans);
     if (trans_force_read(trans, 3))
-        log_message(LOG_LEVEL_ERROR, "sound.c: error reading from transport");
+    {
+        LOG(LOG_LEVEL_ERROR, "sound.c: error reading from transport");
+    }
 
     ts->p = ts->data + 8;
     in_uint8(ts, cmd);
@@ -1753,7 +1781,9 @@ sound_sndsrvr_source_data_in(struct trans *trans)
             else
             {
                 if (g_bytes_in_stream == 0)
+                {
                     g_bytes_in_stream = g_stream_inp->size;
+                }
 
                 i = bytes_req - bytes_read;
 
@@ -1825,7 +1855,9 @@ sound_start_source_listener(void)
     g_snprintf(port, 255, CHANSRV_PORT_IN_STR, g_display_num);
     g_audio_l_trans_in->trans_conn_in = sound_sndsrvr_source_conn_in;
     if (trans_listen(g_audio_l_trans_in, port) != 0)
+    {
         LOG_DEVEL(LOG_LEVEL_ERROR, "trans_listen failed");
+    }
     return 0;
 }
 
@@ -1842,7 +1874,9 @@ sound_start_sink_listener(void)
     g_snprintf(port, 255, CHANSRV_PORT_OUT_STR, g_display_num);
     g_audio_l_trans_out->trans_conn_in = sound_sndsrvr_sink_conn_in;
     if (trans_listen(g_audio_l_trans_out, port) != 0)
+    {
         LOG_DEVEL(LOG_LEVEL_ERROR, "trans_listen failed");
+    }
     return 0;
 }
 

--- a/sesman/chansrv/xcommon.c
+++ b/sesman/chansrv/xcommon.c
@@ -57,8 +57,8 @@ xcommon_error_handler(Display *dis, XErrorEvent *xer)
 
     XGetErrorText(dis, xer->error_code, text, 255);
     LOG_DEVEL(LOG_LEVEL_ERROR, "X error [%s](%d) opcodes %d/%d "
-          "resource 0x%lx", text, xer->error_code,
-          xer->request_code, xer->minor_code, xer->resourceid);
+              "resource 0x%lx", text, xer->error_code,
+              xer->request_code, xer->minor_code, xer->resourceid);
     return 0;
 }
 
@@ -186,7 +186,7 @@ xcommon_check_wait_objs(void)
         if ((clip_rv == 1) && (rail_rv == 1))
         {
             LOG_DEVEL(LOG_LEVEL_DEBUG, "xcommon_check_wait_objs unknown xevent type %d",
-                     xevent.type);
+                      xevent.type);
         }
     }
     return 0;

--- a/sesman/env.c
+++ b/sesman/env.c
@@ -76,9 +76,9 @@ env_check_password_file(const char *filename, const char *passwd)
     fd = g_file_open_ex(filename, 0, 1, 1, 1);
     if (fd == -1)
     {
-        log_message(LOG_LEVEL_WARNING,
-                    "Cannot write VNC password hash to file %s: %s",
-                    filename, g_get_strerror());
+        LOG(LOG_LEVEL_WARNING,
+            "Cannot write VNC password hash to file %s: %s",
+            filename, g_get_strerror());
         return 1;
     }
     g_file_write(fd, encryptedPasswd, 8);
@@ -151,7 +151,7 @@ env_set_user(const char *username, char **passwd_file, int display,
             g_snprintf(text, sizeof(text) - 1, CHANSRV_PORT_IN_BASE_STR, display);
             g_setenv("XRDP_PULSE_SOURCE_SOCKET", text, 1);
             if ((env_names != 0) && (env_values != 0) &&
-                (env_names->count == env_values->count))
+                    (env_names->count == env_values->count))
             {
                 for (index = 0; index < env_names->count; index++)
                 {
@@ -172,9 +172,9 @@ env_set_user(const char *username, char **passwd_file, int display,
                     {
                         if (g_mkdir(".vnc") < 0)
                         {
-                            log_message(LOG_LEVEL_ERROR,
-                                        "Error creating .vnc directory: %s",
-                                        g_get_strerror());
+                            LOG(LOG_LEVEL_ERROR,
+                                "Error creating .vnc directory: %s",
+                                g_get_strerror());
                         }
                     }
 
@@ -189,16 +189,16 @@ env_set_user(const char *username, char **passwd_file, int display,
                                   pw_dir, username, display);
                         if (g_file_exist(*passwd_file))
                         {
-                            log_message(LOG_LEVEL_WARNING, "Removing old "
-                                        "password file %s", *passwd_file);
+                            LOG(LOG_LEVEL_WARNING, "Removing old "
+                                "password file %s", *passwd_file);
                             g_file_delete(*passwd_file);
                         }
                         g_sprintf(*passwd_file, "%s/.vnc/sesman_%s_passwd",
                                   pw_dir, username);
                         if (g_file_exist(*passwd_file))
                         {
-                            log_message(LOG_LEVEL_WARNING, "Removing insecure "
-                                        "password file %s", *passwd_file);
+                            LOG(LOG_LEVEL_WARNING, "Removing insecure "
+                                "password file %s", *passwd_file);
                             g_file_delete(*passwd_file);
                         }
                         g_sprintf(*passwd_file, "%s/.vnc/sesman_passwd-%s@%s:%d",
@@ -229,9 +229,9 @@ env_set_user(const char *username, char **passwd_file, int display,
     }
     else
     {
-        log_message(LOG_LEVEL_ERROR,
-                    "error getting user info for user %s",
-                    username);
+        LOG(LOG_LEVEL_ERROR,
+            "error getting user info for user %s",
+            username);
     }
 
     return error;

--- a/sesman/libscp/libscp_connection.c
+++ b/sesman/libscp/libscp_connection.c
@@ -41,7 +41,7 @@ scp_connection_create(int sck)
 
     if (0 == conn)
     {
-        log_message(LOG_LEVEL_ERROR, "[connection:%d] connection create: malloc error", __LINE__);
+        LOG(LOG_LEVEL_ERROR, "[connection:%d] connection create: malloc error", __LINE__);
         return 0;
     }
 

--- a/sesman/libscp/libscp_init.c
+++ b/sesman/libscp/libscp_init.c
@@ -47,7 +47,7 @@ scp_init(void)
 
     scp_lock_init();
 
-    log_message(LOG_LEVEL_DEBUG, "libscp initialized");
+    LOG(LOG_LEVEL_DEBUG, "libscp initialized");
 
     return 0;
 }

--- a/sesman/libscp/libscp_session.c
+++ b/sesman/libscp/libscp_session.c
@@ -46,7 +46,7 @@ scp_session_create(void)
 
     if (0 == s)
     {
-        log_message(LOG_LEVEL_ERROR, "[session:%d] session create: malloc error", __LINE__);
+        LOG(LOG_LEVEL_ERROR, "[session:%d] session create: malloc error", __LINE__);
         return 0;
     }
 
@@ -81,14 +81,14 @@ scp_session_set_type(struct SCP_SESSION *s, tui8 type)
 
             if (NULL == s->mng)
             {
-                log_message(LOG_LEVEL_ERROR, "[session:%d] set_type: internal error", __LINE__);
+                LOG(LOG_LEVEL_ERROR, "[session:%d] set_type: internal error", __LINE__);
                 return 1;
             }
 
             break;
 
         default:
-            log_message(LOG_LEVEL_WARNING, "[session:%d] set_type: unknown type", __LINE__);
+            LOG(LOG_LEVEL_WARNING, "[session:%d] set_type: unknown type", __LINE__);
             return 1;
     }
 
@@ -108,7 +108,7 @@ scp_session_set_version(struct SCP_SESSION *s, tui32 version)
             s->version = 1;
             break;
         default:
-            log_message(LOG_LEVEL_WARNING, "[session:%d] set_version: unknown version", __LINE__);
+            LOG(LOG_LEVEL_WARNING, "[session:%d] set_version: unknown version", __LINE__);
             return 1;
     }
 
@@ -172,7 +172,7 @@ scp_session_set_locale(struct SCP_SESSION *s, const char *str)
 {
     if (0 == str)
     {
-        log_message(LOG_LEVEL_WARNING, "[session:%d] set_locale: null locale", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[session:%d] set_locale: null locale", __LINE__);
         s->locale[0] = '\0';
         return 1;
     }
@@ -188,7 +188,7 @@ scp_session_set_username(struct SCP_SESSION *s, const char *str)
 {
     if (0 == str)
     {
-        log_message(LOG_LEVEL_WARNING, "[session:%d] set_username: null username", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[session:%d] set_username: null username", __LINE__);
         return 1;
     }
 
@@ -201,7 +201,7 @@ scp_session_set_username(struct SCP_SESSION *s, const char *str)
 
     if (0 == s->username)
     {
-        log_message(LOG_LEVEL_WARNING, "[session:%d] set_username: strdup error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[session:%d] set_username: strdup error", __LINE__);
         return 1;
     }
 
@@ -214,7 +214,7 @@ scp_session_set_password(struct SCP_SESSION *s, const char *str)
 {
     if (0 == str)
     {
-        log_message(LOG_LEVEL_WARNING, "[session:%d] set_password: null password", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[session:%d] set_password: null password", __LINE__);
         return 1;
     }
 
@@ -227,7 +227,7 @@ scp_session_set_password(struct SCP_SESSION *s, const char *str)
 
     if (0 == s->password)
     {
-        log_message(LOG_LEVEL_WARNING, "[session:%d] set_password: strdup error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[session:%d] set_password: strdup error", __LINE__);
         return 1;
     }
 
@@ -240,7 +240,7 @@ scp_session_set_domain(struct SCP_SESSION *s, const char *str)
 {
     if (0 == str)
     {
-        log_message(LOG_LEVEL_WARNING, "[session:%d] set_domain: null domain", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[session:%d] set_domain: null domain", __LINE__);
         return 1;
     }
 
@@ -253,7 +253,7 @@ scp_session_set_domain(struct SCP_SESSION *s, const char *str)
 
     if (0 == s->domain)
     {
-        log_message(LOG_LEVEL_WARNING, "[session:%d] set_domain: strdup error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[session:%d] set_domain: strdup error", __LINE__);
         return 1;
     }
 
@@ -266,7 +266,7 @@ scp_session_set_program(struct SCP_SESSION *s, const char *str)
 {
     if (0 == str)
     {
-        log_message(LOG_LEVEL_WARNING, "[session:%d] set_program: null program", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[session:%d] set_program: null program", __LINE__);
         return 1;
     }
 
@@ -279,7 +279,7 @@ scp_session_set_program(struct SCP_SESSION *s, const char *str)
 
     if (0 == s->program)
     {
-        log_message(LOG_LEVEL_WARNING, "[session:%d] set_program: strdup error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[session:%d] set_program: strdup error", __LINE__);
         return 1;
     }
 
@@ -292,7 +292,7 @@ scp_session_set_directory(struct SCP_SESSION *s, const char *str)
 {
     if (0 == str)
     {
-        log_message(LOG_LEVEL_WARNING, "[session:%d] set_directory: null directory", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[session:%d] set_directory: null directory", __LINE__);
         return 1;
     }
 
@@ -305,7 +305,7 @@ scp_session_set_directory(struct SCP_SESSION *s, const char *str)
 
     if (0 == s->directory)
     {
-        log_message(LOG_LEVEL_WARNING, "[session:%d] set_directory: strdup error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[session:%d] set_directory: strdup error", __LINE__);
         return 1;
     }
 
@@ -318,7 +318,7 @@ scp_session_set_client_ip(struct SCP_SESSION *s, const char *str)
 {
     if (0 == str)
     {
-        log_message(LOG_LEVEL_WARNING, "[session:%d] set_client_ip: null ip", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[session:%d] set_client_ip: null ip", __LINE__);
         return 1;
     }
 
@@ -331,7 +331,7 @@ scp_session_set_client_ip(struct SCP_SESSION *s, const char *str)
 
     if (0 == s->client_ip)
     {
-        log_message(LOG_LEVEL_WARNING, "[session:%d] set_client_ip: strdup error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[session:%d] set_client_ip: strdup error", __LINE__);
         return 1;
     }
 
@@ -344,7 +344,7 @@ scp_session_set_hostname(struct SCP_SESSION *s, const char *str)
 {
     if (0 == str)
     {
-        log_message(LOG_LEVEL_WARNING, "[session:%d] set_hostname: null hostname", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[session:%d] set_hostname: null hostname", __LINE__);
         return 1;
     }
 
@@ -357,7 +357,7 @@ scp_session_set_hostname(struct SCP_SESSION *s, const char *str)
 
     if (0 == s->hostname)
     {
-        log_message(LOG_LEVEL_WARNING, "[session:%d] set_hostname: strdup error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[session:%d] set_hostname: strdup error", __LINE__);
         return 1;
     }
 
@@ -370,7 +370,7 @@ scp_session_set_errstr(struct SCP_SESSION *s, const char *str)
 {
     if (0 == str)
     {
-        log_message(LOG_LEVEL_WARNING, "[session:%d] set_errstr: null string", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[session:%d] set_errstr: null string", __LINE__);
         return 1;
     }
 
@@ -383,7 +383,7 @@ scp_session_set_errstr(struct SCP_SESSION *s, const char *str)
 
     if (0 == s->errstr)
     {
-        log_message(LOG_LEVEL_WARNING, "[session:%d] set_errstr: strdup error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[session:%d] set_errstr: strdup error", __LINE__);
         return 1;
     }
 
@@ -425,7 +425,7 @@ scp_session_set_guid(struct SCP_SESSION *s, const tui8 *guid)
 {
     if (0 == guid)
     {
-        log_message(LOG_LEVEL_WARNING, "[session:%d] set_guid: null guid", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[session:%d] set_guid: null guid", __LINE__);
         return 1;
     }
 

--- a/sesman/libscp/libscp_v0.c
+++ b/sesman/libscp/libscp_v0.c
@@ -68,7 +68,7 @@ int in_string16(struct stream *s, char str[], const char *param)
         if (sz > STRING16_MAX_LEN)
         {
             LOG(LOG_LEVEL_WARNING,
-                        "connection aborted: %s too long (%u chars)",  param, sz);
+                "connection aborted: %s too long (%u chars)",  param, sz);
             result = 0;
         }
         else
@@ -308,7 +308,7 @@ scp_v0s_init_session(struct SCP_CONNECTION *c, struct SCP_SESSION *session)
         if (0 != scp_session_set_bpp(session, (tui8)bpp))
         {
             LOG(LOG_LEVEL_WARNING,
-                        "connection aborted: unsupported bpp: %d", (tui8)bpp);
+                "connection aborted: unsupported bpp: %d", (tui8)bpp);
             return SCP_SERVER_STATE_INTERNAL_ERR;
         }
 

--- a/sesman/libscp/libscp_v1c.c
+++ b/sesman/libscp/libscp_v1c.c
@@ -47,8 +47,8 @@ scp_v1c_connect(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
     init_stream(c->out_s, c->out_s->size);
     init_stream(c->in_s, c->in_s->size);
 
-    size = 19 + 17 + 4 + g_strlen(s->hostname) + g_strlen(s->username) +
-           g_strlen(s->password);
+    size = (19 + 17 + 4 + g_strlen(s->hostname) + g_strlen(s->username) +
+            g_strlen(s->password));
 
     if (s->addr_type == SCP_ADDRESS_TYPE_IPV4)
     {

--- a/sesman/libscp/libscp_v1c_mng.c
+++ b/sesman/libscp/libscp_v1c_mng.c
@@ -49,8 +49,8 @@ scp_v1c_mng_connect(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
     init_stream(c->out_s, c->out_s->size);
     init_stream(c->in_s, c->in_s->size);
 
-    size = 12 + 4 + g_strlen(s->hostname) + g_strlen(s->username) +
-           g_strlen(s->password);
+    size = (12 + 4 + g_strlen(s->hostname) + g_strlen(s->username) +
+            g_strlen(s->password));
 
     if (s->addr_type == SCP_ADDRESS_TYPE_IPV4)
     {
@@ -96,7 +96,7 @@ scp_v1c_mng_connect(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
 
     if (0 != scp_tcp_force_send(c->in_sck, c->out_s->data, size))
     {
-        log_message(LOG_LEVEL_WARNING, "[v1c_mng:%d] connection aborted: network error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1c_mng:%d] connection aborted: network error", __LINE__);
         return SCP_CLIENT_STATE_NETWORK_ERR;
     }
 
@@ -132,7 +132,7 @@ scp_v1c_mng_get_session_list(struct SCP_CONNECTION *c, int *scount,
 
     if (0 != scp_tcp_force_send(c->in_sck, c->out_s->data, size))
     {
-        log_message(LOG_LEVEL_WARNING, "[v1c_mng:%d] connection aborted: network error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1c_mng:%d] connection aborted: network error", __LINE__);
         return SCP_CLIENT_STATE_NETWORK_ERR;
     }
 
@@ -143,7 +143,7 @@ scp_v1c_mng_get_session_list(struct SCP_CONNECTION *c, int *scount,
 
         if (0 != scp_tcp_force_recv(c->in_sck, c->in_s->data, 8))
         {
-            log_message(LOG_LEVEL_WARNING, "[v1c_mng:%d] connection aborted: network error", __LINE__);
+            LOG(LOG_LEVEL_WARNING, "[v1c_mng:%d] connection aborted: network error", __LINE__);
             g_free(ds);
             return SCP_CLIENT_STATE_NETWORK_ERR;
         }
@@ -152,7 +152,7 @@ scp_v1c_mng_get_session_list(struct SCP_CONNECTION *c, int *scount,
 
         if (version != 1)
         {
-            log_message(LOG_LEVEL_WARNING, "[v1c_mng:%d] connection aborted: version error", __LINE__);
+            LOG(LOG_LEVEL_WARNING, "[v1c_mng:%d] connection aborted: version error", __LINE__);
             g_free(ds);
             return SCP_CLIENT_STATE_VERSION_ERR;
         }
@@ -161,7 +161,7 @@ scp_v1c_mng_get_session_list(struct SCP_CONNECTION *c, int *scount,
 
         if (size < 12)
         {
-            log_message(LOG_LEVEL_WARNING, "[v1c_mng:%d] connection aborted: size error", __LINE__);
+            LOG(LOG_LEVEL_WARNING, "[v1c_mng:%d] connection aborted: size error", __LINE__);
             g_free(ds);
             return SCP_CLIENT_STATE_SIZE_ERR;
         }
@@ -170,7 +170,7 @@ scp_v1c_mng_get_session_list(struct SCP_CONNECTION *c, int *scount,
 
         if (0 != scp_tcp_force_recv(c->in_sck, c->in_s->data, size - 8))
         {
-            log_message(LOG_LEVEL_WARNING, "[v1c_mng:%d] connection aborted: network error", __LINE__);
+            LOG(LOG_LEVEL_WARNING, "[v1c_mng:%d] connection aborted: network error", __LINE__);
             g_free(ds);
             return SCP_CLIENT_STATE_NETWORK_ERR;
         }
@@ -179,7 +179,7 @@ scp_v1c_mng_get_session_list(struct SCP_CONNECTION *c, int *scount,
 
         if (cmd != SCP_COMMAND_SET_MANAGE)
         {
-            log_message(LOG_LEVEL_WARNING, "[v1c_mng:%d] connection aborted: sequence error", __LINE__);
+            LOG(LOG_LEVEL_WARNING, "[v1c_mng:%d] connection aborted: sequence error", __LINE__);
             g_free(ds);
             return SCP_CLIENT_STATE_SEQUENCE_ERR;
         }
@@ -188,7 +188,7 @@ scp_v1c_mng_get_session_list(struct SCP_CONNECTION *c, int *scount,
 
         if (cmd != SCP_CMD_MNG_LIST) /* session list */
         {
-            log_message(LOG_LEVEL_WARNING, "[v1c_mng:%d] connection aborted: sequence error", __LINE__);
+            LOG(LOG_LEVEL_WARNING, "[v1c_mng:%d] connection aborted: sequence error", __LINE__);
             g_free(ds);
             return SCP_CLIENT_STATE_SEQUENCE_ERR;
         }
@@ -213,7 +213,7 @@ scp_v1c_mng_get_session_list(struct SCP_CONNECTION *c, int *scount,
 
             if (ds == 0)
             {
-                log_message(LOG_LEVEL_WARNING, "[v1c_mng:%d] connection aborted: internal error", __LINE__);
+                LOG(LOG_LEVEL_WARNING, "[v1c_mng:%d] connection aborted: internal error", __LINE__);
                 return SCP_CLIENT_STATE_INTERNAL_ERR;
             }
         }
@@ -373,7 +373,7 @@ _scp_v1c_mng_check_response(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
 
     if (0 != scp_tcp_force_recv(c->in_sck, c->in_s->data, 8))
     {
-        log_message(LOG_LEVEL_WARNING, "[v1c_mng:%d] connection aborted: network error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1c_mng:%d] connection aborted: network error", __LINE__);
         return SCP_CLIENT_STATE_NETWORK_ERR;
     }
 
@@ -381,7 +381,7 @@ _scp_v1c_mng_check_response(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
 
     if (version != 1)
     {
-        log_message(LOG_LEVEL_WARNING, "[v1c_mng:%d] connection aborted: version error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1c_mng:%d] connection aborted: version error", __LINE__);
         return SCP_CLIENT_STATE_VERSION_ERR;
     }
 
@@ -392,7 +392,7 @@ _scp_v1c_mng_check_response(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
     /* read the rest of the packet */
     if (0 != scp_tcp_force_recv(c->in_sck, c->in_s->data, size - 8))
     {
-        log_message(LOG_LEVEL_WARNING, "[v1c_mng:%d] connection aborted: network error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1c_mng:%d] connection aborted: network error", __LINE__);
         return SCP_CLIENT_STATE_NETWORK_ERR;
     }
 
@@ -400,7 +400,7 @@ _scp_v1c_mng_check_response(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
 
     if (cmd != SCP_COMMAND_SET_MANAGE)
     {
-        log_message(LOG_LEVEL_WARNING, "[v1c_mng:%d] connection aborted: sequence error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1c_mng:%d] connection aborted: sequence error", __LINE__);
         return SCP_CLIENT_STATE_SEQUENCE_ERR;
     }
 
@@ -408,7 +408,7 @@ _scp_v1c_mng_check_response(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
 
     if (cmd == SCP_CMD_MNG_LOGIN_ALLOW) /* connection ok */
     {
-        log_message(LOG_LEVEL_INFO, "[v1c_mng:%d] connection ok", __LINE__);
+        LOG(LOG_LEVEL_INFO, "[v1c_mng:%d] connection ok", __LINE__);
         return SCP_CLIENT_STATE_OK;
     }
     else if (cmd == SCP_CMD_MNG_LOGIN_DENY) /* connection denied */
@@ -418,10 +418,10 @@ _scp_v1c_mng_check_response(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
         in_uint8a(c->in_s, buf, dim);
         scp_session_set_errstr(s, buf);
 
-        log_message(LOG_LEVEL_INFO, "[v1c_mng:%d] connection denied: %s", __LINE__ , s->errstr);
+        LOG(LOG_LEVEL_INFO, "[v1c_mng:%d] connection denied: %s", __LINE__, s->errstr);
         return SCP_CLIENT_STATE_CONNECTION_DENIED;
     }
 
-    log_message(LOG_LEVEL_WARNING, "[v1c-mng:%d] connection aborted: sequence error", __LINE__);
+    LOG(LOG_LEVEL_WARNING, "[v1c-mng:%d] connection aborted: sequence error", __LINE__);
     return SCP_CLIENT_STATE_SEQUENCE_ERR;
 }

--- a/sesman/libscp/libscp_v1s.c
+++ b/sesman/libscp/libscp_v1s.c
@@ -57,9 +57,9 @@ int in_string8(struct stream *s, char str[], const char *param, int line)
 
     if (!s_check_rem(s, 1))
     {
-        log_message(LOG_LEVEL_WARNING,
-                    "[v1s:%d] connection aborted: %s len missing",
-                    line, param);
+        LOG(LOG_LEVEL_WARNING,
+            "[v1s:%d] connection aborted: %s len missing",
+            line, param);
         result = 0;
     }
     else
@@ -70,9 +70,9 @@ int in_string8(struct stream *s, char str[], const char *param, int line)
         result = s_check_rem(s, sz);
         if (!result)
         {
-            log_message(LOG_LEVEL_WARNING,
-                        "[v1s:%d] connection aborted: %s data missing",
-                        line, param);
+            LOG(LOG_LEVEL_WARNING,
+                "[v1s:%d] connection aborted: %s data missing",
+                line, param);
         }
         else
         {
@@ -109,9 +109,9 @@ scp_v1s_init_session(struct SCP_CONNECTION *c, struct SCP_SESSION *session)
      * bpp, the resource sharing indicator and the locale */
     if (!s_check_rem(c->in_s, 1 + 2 + 2 + 1 + 1 + 17))
     {
-        log_message(LOG_LEVEL_WARNING,
-                    "[v1s:%d] connection aborted: short packet",
-                    __LINE__);
+        LOG(LOG_LEVEL_WARNING,
+            "[v1s:%d] connection aborted: short packet",
+            __LINE__);
         return SCP_SERVER_STATE_SIZE_ERR;
     }
 
@@ -119,7 +119,7 @@ scp_v1s_init_session(struct SCP_CONNECTION *c, struct SCP_SESSION *session)
 
     if ((type != SCP_SESSION_TYPE_XVNC) && (type != SCP_SESSION_TYPE_XRDP))
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: unknown session type", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: unknown session type", __LINE__);
         return SCP_SERVER_STATE_SESSION_TYPE_ERR;
     }
 
@@ -132,9 +132,9 @@ scp_v1s_init_session(struct SCP_CONNECTION *c, struct SCP_SESSION *session)
     in_uint8(c->in_s, bpp);
     if (0 != scp_session_set_bpp(session, bpp))
     {
-        log_message(LOG_LEVEL_WARNING,
-                    "[v1s:%d] connection aborted: unsupported bpp: %d",
-                    __LINE__, bpp);
+        LOG(LOG_LEVEL_WARNING,
+            "[v1s:%d] connection aborted: unsupported bpp: %d",
+            __LINE__, bpp);
         return SCP_SERVER_STATE_INTERNAL_ERR;
     }
     in_uint8(c->in_s, sz);
@@ -146,9 +146,9 @@ scp_v1s_init_session(struct SCP_CONNECTION *c, struct SCP_SESSION *session)
     /* Check there's enough data left for at least an IPv4 address (+len) */
     if (!s_check_rem(c->in_s, 1 + 4))
     {
-        log_message(LOG_LEVEL_WARNING,
-                    "[v1s:%d] connection aborted: IP addr len missing",
-                    __LINE__);
+        LOG(LOG_LEVEL_WARNING,
+            "[v1s:%d] connection aborted: IP addr len missing",
+            __LINE__);
         return SCP_SERVER_STATE_SIZE_ERR;
     }
 
@@ -164,9 +164,9 @@ scp_v1s_init_session(struct SCP_CONNECTION *c, struct SCP_SESSION *session)
     {
         if (!s_check_rem(c->in_s, 16))
         {
-            log_message(LOG_LEVEL_WARNING,
-                        "[v1s:%d] connection aborted: IP addr missing",
-                        __LINE__);
+            LOG(LOG_LEVEL_WARNING,
+                "[v1s:%d] connection aborted: IP addr missing",
+                __LINE__);
             return SCP_SERVER_STATE_SIZE_ERR;
         }
         in_uint8a(c->in_s, buf, 16);
@@ -181,7 +181,7 @@ scp_v1s_init_session(struct SCP_CONNECTION *c, struct SCP_SESSION *session)
 
     if (0 != scp_session_set_hostname(session, buf))
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: internal error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: internal error", __LINE__);
         return SCP_SERVER_STATE_INTERNAL_ERR;
     }
 
@@ -193,7 +193,7 @@ scp_v1s_init_session(struct SCP_CONNECTION *c, struct SCP_SESSION *session)
 
     if (0 != scp_session_set_username(session, buf))
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: internal error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: internal error", __LINE__);
         return SCP_SERVER_STATE_INTERNAL_ERR;
     }
 
@@ -205,7 +205,7 @@ scp_v1s_init_session(struct SCP_CONNECTION *c, struct SCP_SESSION *session)
 
     if (0 != scp_session_set_password(session, buf))
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: internal error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: internal error", __LINE__);
         return SCP_SERVER_STATE_INTERNAL_ERR;
     }
 
@@ -233,13 +233,13 @@ enum SCP_SERVER_STATES_E scp_v1s_accept(struct SCP_CONNECTION *c, struct SCP_SES
 
             if (version != 1)
             {
-                log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: version error", __LINE__);
+                LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: version error", __LINE__);
                 return SCP_SERVER_STATE_VERSION_ERR;
             }
         }
         else
         {
-            log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
+            LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
             return SCP_SERVER_STATE_NETWORK_ERR;
         }
     }
@@ -250,7 +250,7 @@ enum SCP_SERVER_STATES_E scp_v1s_accept(struct SCP_CONNECTION *c, struct SCP_SES
      * the command (but not too big) */
     if (size < (8 + 2 + 2) || size > SCP_MAX_MESSAGE_SIZE)
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: size error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: size error", __LINE__);
         return SCP_SERVER_STATE_SIZE_ERR;
     }
 
@@ -258,7 +258,7 @@ enum SCP_SERVER_STATES_E scp_v1s_accept(struct SCP_CONNECTION *c, struct SCP_SES
 
     if (0 != scp_tcp_force_recv(c->in_sck, c->in_s->data, (size - 8)))
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
         return SCP_SERVER_STATE_NETWORK_ERR;
     }
 
@@ -270,7 +270,7 @@ enum SCP_SERVER_STATES_E scp_v1s_accept(struct SCP_CONNECTION *c, struct SCP_SES
     /* if we are starting a management session */
     if (cmdset == SCP_COMMAND_SET_MANAGE)
     {
-        log_message(LOG_LEVEL_DEBUG, "[v1s:%d] requested management connection", __LINE__);
+        LOG(LOG_LEVEL_DEBUG, "[v1s:%d] requested management connection", __LINE__);
         /* should return SCP_SERVER_STATE_START_MANAGE */
         return scp_v1s_mng_accept(c, s);
     }
@@ -278,7 +278,7 @@ enum SCP_SERVER_STATES_E scp_v1s_accept(struct SCP_CONNECTION *c, struct SCP_SES
     /* if we started with resource sharing... */
     if (cmdset == SCP_COMMAND_SET_RSR)
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: sequence error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: sequence error", __LINE__);
         return SCP_SERVER_STATE_SEQUENCE_ERR;
     }
 
@@ -287,7 +287,7 @@ enum SCP_SERVER_STATES_E scp_v1s_accept(struct SCP_CONNECTION *c, struct SCP_SES
 
     if (cmd != 1)
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: sequence error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: sequence error", __LINE__);
         return SCP_SERVER_STATE_SEQUENCE_ERR;
     }
 
@@ -295,9 +295,9 @@ enum SCP_SERVER_STATES_E scp_v1s_accept(struct SCP_CONNECTION *c, struct SCP_SES
 
     if (NULL == session)
     {
-        log_message(LOG_LEVEL_WARNING,
-                    "[v1s:%d] connection aborted: internal error "
-                    "(malloc returned NULL)", __LINE__);
+        LOG(LOG_LEVEL_WARNING,
+            "[v1s:%d] connection aborted: internal error "
+            "(malloc returned NULL)", __LINE__);
         result = SCP_SERVER_STATE_INTERNAL_ERR;
     }
     else
@@ -342,7 +342,7 @@ scp_v1s_deny_connection(struct SCP_CONNECTION *c, const char *reason)
 
     if (0 != scp_tcp_force_send(c->in_sck, c->out_s->data, rlen + 14))
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
         return SCP_SERVER_STATE_NETWORK_ERR;
     }
 
@@ -385,14 +385,14 @@ scp_v1s_request_password(struct SCP_CONNECTION *c, struct SCP_SESSION *s,
 
     if (0 != scp_tcp_force_send(c->in_sck, c->out_s->data, 14 + rlen))
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
         return SCP_SERVER_STATE_NETWORK_ERR;
     }
 
     /* receive password & username */
     if (0 != scp_tcp_force_recv(c->in_sck, c->in_s->data, 8))
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
         return SCP_SERVER_STATE_NETWORK_ERR;
     }
 
@@ -400,7 +400,7 @@ scp_v1s_request_password(struct SCP_CONNECTION *c, struct SCP_SESSION *s,
 
     if (version != 1)
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: version error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: version error", __LINE__);
         return SCP_SERVER_STATE_VERSION_ERR;
     }
 
@@ -410,9 +410,9 @@ scp_v1s_request_password(struct SCP_CONNECTION *c, struct SCP_SESSION *s,
      * the command (but not too big) */
     if (size < (8 + 2 + 2) || size > SCP_MAX_MESSAGE_SIZE)
     {
-        log_message(LOG_LEVEL_WARNING,
-                    "[v1s:%d] connection aborted: size error",
-                    __LINE__);
+        LOG(LOG_LEVEL_WARNING,
+            "[v1s:%d] connection aborted: size error",
+            __LINE__);
         return SCP_SERVER_STATE_SIZE_ERR;
     }
 
@@ -420,7 +420,7 @@ scp_v1s_request_password(struct SCP_CONNECTION *c, struct SCP_SESSION *s,
 
     if (0 != scp_tcp_force_recv(c->in_sck, c->in_s->data, (size - 8)))
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
         return SCP_SERVER_STATE_NETWORK_ERR;
     }
 
@@ -430,7 +430,7 @@ scp_v1s_request_password(struct SCP_CONNECTION *c, struct SCP_SESSION *s,
 
     if (cmdset != SCP_COMMAND_SET_DEFAULT)
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: sequence error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: sequence error", __LINE__);
         return SCP_SERVER_STATE_SEQUENCE_ERR;
     }
 
@@ -438,7 +438,7 @@ scp_v1s_request_password(struct SCP_CONNECTION *c, struct SCP_SESSION *s,
 
     if (cmd != 4)
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: sequence error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: sequence error", __LINE__);
         return SCP_SERVER_STATE_SEQUENCE_ERR;
     }
 
@@ -450,7 +450,7 @@ scp_v1s_request_password(struct SCP_CONNECTION *c, struct SCP_SESSION *s,
 
     if (0 != scp_session_set_username(s, buf))
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: internal error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: internal error", __LINE__);
         return SCP_SERVER_STATE_INTERNAL_ERR;
     }
 
@@ -462,7 +462,7 @@ scp_v1s_request_password(struct SCP_CONNECTION *c, struct SCP_SESSION *s,
 
     if (0 != scp_session_set_password(s, buf))
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: internal error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: internal error", __LINE__);
         return SCP_SERVER_STATE_INTERNAL_ERR;
     }
 
@@ -503,7 +503,7 @@ scp_v1s_connect_new_session(struct SCP_CONNECTION *c, SCP_DISPLAY d)
 
     if (0 != scp_tcp_force_send(c->in_sck, c->out_s->data, 14))
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
         return SCP_SERVER_STATE_NETWORK_ERR;
     }
 
@@ -557,7 +557,7 @@ scp_v1s_list_sessions(struct SCP_CONNECTION *c, int sescnt, struct SCP_DISCONNEC
 
     if (0 != scp_tcp_force_send(c->in_sck, c->out_s->data, size))
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
         return SCP_SERVER_STATE_NETWORK_ERR;
     }
 
@@ -571,7 +571,7 @@ scp_v1s_list_sessions(struct SCP_CONNECTION *c, int sescnt, struct SCP_DISCONNEC
 
     if (0 != scp_tcp_force_recv(c->in_sck, c->in_s->data, 8))
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
         return SCP_SERVER_STATE_NETWORK_ERR;
     }
 
@@ -579,7 +579,7 @@ scp_v1s_list_sessions(struct SCP_CONNECTION *c, int sescnt, struct SCP_DISCONNEC
 
     if (version != 1)
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: version error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: version error", __LINE__);
         return SCP_SERVER_STATE_VERSION_ERR;
     }
 
@@ -589,7 +589,7 @@ scp_v1s_list_sessions(struct SCP_CONNECTION *c, int sescnt, struct SCP_DISCONNEC
      * the command (but not too big) */
     if (size < (8 + 2 + 2) || size > SCP_MAX_MESSAGE_SIZE)
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: size error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: size error", __LINE__);
         return SCP_SERVER_STATE_SIZE_ERR;
     }
 
@@ -597,7 +597,7 @@ scp_v1s_list_sessions(struct SCP_CONNECTION *c, int sescnt, struct SCP_DISCONNEC
 
     if (0 != scp_tcp_force_recv(c->in_sck, c->in_s->data, (size - 8)))
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
         return SCP_SERVER_STATE_NETWORK_ERR;
     }
 
@@ -607,7 +607,7 @@ scp_v1s_list_sessions(struct SCP_CONNECTION *c, int sescnt, struct SCP_DISCONNEC
 
     if (cmd != SCP_COMMAND_SET_DEFAULT)
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: sequence error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: sequence error", __LINE__);
         return SCP_SERVER_STATE_SEQUENCE_ERR;
     }
 
@@ -615,7 +615,7 @@ scp_v1s_list_sessions(struct SCP_CONNECTION *c, int sescnt, struct SCP_DISCONNEC
 
     if (cmd != 41)
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: sequence error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: sequence error", __LINE__);
         return SCP_SERVER_STATE_SEQUENCE_ERR;
     }
 
@@ -703,7 +703,7 @@ scp_v1s_list_sessions(struct SCP_CONNECTION *c, int sescnt, struct SCP_DISCONNEC
 
         if (0 != scp_tcp_force_send(c->in_sck, c->out_s->data, size))
         {
-            log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
+            LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
             return SCP_SERVER_STATE_NETWORK_ERR;
         }
     }
@@ -713,7 +713,7 @@ scp_v1s_list_sessions(struct SCP_CONNECTION *c, int sescnt, struct SCP_DISCONNEC
 
     if (0 != scp_tcp_force_recv(c->in_sck, c->in_s->data, (8)))
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
         return SCP_SERVER_STATE_NETWORK_ERR;
     }
 
@@ -721,7 +721,7 @@ scp_v1s_list_sessions(struct SCP_CONNECTION *c, int sescnt, struct SCP_DISCONNEC
 
     if (version != 1)
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: version error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: version error", __LINE__);
         return SCP_SERVER_STATE_VERSION_ERR;
     }
 
@@ -731,7 +731,7 @@ scp_v1s_list_sessions(struct SCP_CONNECTION *c, int sescnt, struct SCP_DISCONNEC
      * the command (but not too big) */
     if (size < (8 + 2 + 2) || size > SCP_MAX_MESSAGE_SIZE)
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: size error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: size error", __LINE__);
         return SCP_SERVER_STATE_SIZE_ERR;
     }
 
@@ -740,7 +740,7 @@ scp_v1s_list_sessions(struct SCP_CONNECTION *c, int sescnt, struct SCP_DISCONNEC
 
     if (0 != scp_tcp_force_recv(c->in_sck, c->in_s->data, (size - 8)))
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
         return SCP_SERVER_STATE_NETWORK_ERR;
     }
 
@@ -750,7 +750,7 @@ scp_v1s_list_sessions(struct SCP_CONNECTION *c, int sescnt, struct SCP_DISCONNEC
 
     if (cmd != SCP_COMMAND_SET_DEFAULT)
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: sequence error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: sequence error", __LINE__);
         return SCP_SERVER_STATE_SEQUENCE_ERR;
     }
 
@@ -760,7 +760,7 @@ scp_v1s_list_sessions(struct SCP_CONNECTION *c, int sescnt, struct SCP_DISCONNEC
     {
         if (!s_check_rem(c->in_s, 4))
         {
-            log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: missing session", __LINE__);
+            LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: missing session", __LINE__);
             return SCP_SERVER_STATE_SIZE_ERR;
         }
         /* select session */
@@ -779,7 +779,7 @@ scp_v1s_list_sessions(struct SCP_CONNECTION *c, int sescnt, struct SCP_DISCONNEC
 
         /* if we got here, the requested sid wasn't one from the list we sent */
         /* we should kill the connection                                      */
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: internal error (no such session in list)", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: internal error (no such session in list)", __LINE__);
         return SCP_SERVER_STATE_INTERNAL_ERR;
     }
     else if (cmd == 44)
@@ -795,7 +795,7 @@ scp_v1s_list_sessions(struct SCP_CONNECTION *c, int sescnt, struct SCP_DISCONNEC
     else
     {
         /* wrong response */
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: sequence error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: sequence error", __LINE__);
         return SCP_SERVER_STATE_SEQUENCE_ERR;
     }
 
@@ -832,7 +832,7 @@ scp_v1s_reconnect_session(struct SCP_CONNECTION *c, SCP_DISPLAY d)
 
     if (0 != scp_tcp_force_send(c->in_sck, c->out_s->data, size))
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s:%d] connection aborted: network error", __LINE__);
         return SCP_SERVER_STATE_NETWORK_ERR;
     }
 

--- a/sesman/libscp/libscp_v1s_mng.c
+++ b/sesman/libscp/libscp_v1s_mng.c
@@ -60,9 +60,9 @@ int in_string8(struct stream *s, char str[], const char *param, int line)
 
     if (!s_check_rem(s, 1))
     {
-        log_message(LOG_LEVEL_WARNING,
-                    "[v1s_mng:%d] connection aborted: %s len missing",
-                    line, param);
+        LOG(LOG_LEVEL_WARNING,
+            "[v1s_mng:%d] connection aborted: %s len missing",
+            line, param);
         result = 0;
     }
     else
@@ -73,9 +73,9 @@ int in_string8(struct stream *s, char str[], const char *param, int line)
         result = s_check_rem(s, sz);
         if (!result)
         {
-            log_message(LOG_LEVEL_WARNING,
-                        "[v1s_mng:%d] connection aborted: %s data missing",
-                        line, param);
+            LOG(LOG_LEVEL_WARNING,
+                "[v1s_mng:%d] connection aborted: %s data missing",
+                line, param);
         }
         else
         {
@@ -144,9 +144,9 @@ scp_v1s_mng_init_session(struct SCP_CONNECTION *c, struct SCP_SESSION *session)
      * Check there's enough data left for at least an IPv4 address (+len) */
     if (!s_check_rem(c->in_s, 1 + 4))
     {
-        log_message(LOG_LEVEL_WARNING,
-                    "[v1s_mng:%d] connection aborted: IP addr len missing",
-                    __LINE__);
+        LOG(LOG_LEVEL_WARNING,
+            "[v1s_mng:%d] connection aborted: IP addr len missing",
+            __LINE__);
         return SCP_SERVER_STATE_SIZE_ERR;
     }
 
@@ -160,9 +160,9 @@ scp_v1s_mng_init_session(struct SCP_CONNECTION *c, struct SCP_SESSION *session)
     {
         if (!s_check_rem(c->in_s, 16))
         {
-            log_message(LOG_LEVEL_WARNING,
-                        "[v1s_mng:%d] connection aborted: IP addr missing",
-                        __LINE__);
+            LOG(LOG_LEVEL_WARNING,
+                "[v1s_mng:%d] connection aborted: IP addr missing",
+                __LINE__);
             return SCP_SERVER_STATE_SIZE_ERR;
         }
         in_uint8a(c->in_s, buf, 16);
@@ -282,16 +282,16 @@ scp_v1s_mng_list_sessions(struct SCP_CONNECTION *c, struct SCP_SESSION *s,
     /* calculating the number of packets to send */
     if (sescnt == 0)
     {
-      pktcnt = 1;
+        pktcnt = 1;
     }
     else
     {
-      pktcnt = sescnt / SCP_SERVER_MAX_LIST_SIZE;
+        pktcnt = sescnt / SCP_SERVER_MAX_LIST_SIZE;
 
-      if ((sescnt % SCP_SERVER_MAX_LIST_SIZE) != 0)
-      {
-          pktcnt++;
-      }
+        if ((sescnt % SCP_SERVER_MAX_LIST_SIZE) != 0)
+        {
+            pktcnt++;
+        }
     }
 
     for (idx = 0; idx < pktcnt; idx++)
@@ -369,7 +369,7 @@ scp_v1s_mng_list_sessions(struct SCP_CONNECTION *c, struct SCP_SESSION *s,
 
         if (0 != scp_tcp_force_send(c->in_sck, c->out_s->data, size))
         {
-            log_message(LOG_LEVEL_WARNING, "[v1s_mng:%d] connection aborted: network error", __LINE__);
+            LOG(LOG_LEVEL_WARNING, "[v1s_mng:%d] connection aborted: network error", __LINE__);
             return SCP_SERVER_STATE_NETWORK_ERR;
         }
     }
@@ -390,7 +390,7 @@ _scp_v1s_mng_check_response(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
 
     if (0 != scp_tcp_force_recv(c->in_sck, c->in_s->data, 8))
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s_mng:%d] connection aborted: network error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s_mng:%d] connection aborted: network error", __LINE__);
         return SCP_SERVER_STATE_NETWORK_ERR;
     }
 
@@ -398,7 +398,7 @@ _scp_v1s_mng_check_response(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
 
     if (version != 1)
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s_mng:%d] connection aborted: version error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s_mng:%d] connection aborted: version error", __LINE__);
         return SCP_SERVER_STATE_VERSION_ERR;
     }
 
@@ -408,7 +408,7 @@ _scp_v1s_mng_check_response(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
      * the command (but not too big) */
     if (size < (8 + 2 + 2) || size > SCP_MAX_MESSAGE_SIZE)
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s_mng:%d] connection aborted: size error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s_mng:%d] connection aborted: size error", __LINE__);
         return SCP_SERVER_STATE_SIZE_ERR;
     }
 
@@ -417,7 +417,7 @@ _scp_v1s_mng_check_response(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
     /* read the rest of the packet */
     if (0 != scp_tcp_force_recv(c->in_sck, c->in_s->data, size - 8))
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s_mng:%d] connection aborted: network error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s_mng:%d] connection aborted: network error", __LINE__);
         return SCP_SERVER_STATE_NETWORK_ERR;
     }
 
@@ -427,7 +427,7 @@ _scp_v1s_mng_check_response(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
 
     if (cmd != SCP_COMMAND_SET_MANAGE)
     {
-        log_message(LOG_LEVEL_WARNING, "[v1s_mng:%d] connection aborted: sequence error", __LINE__);
+        LOG(LOG_LEVEL_WARNING, "[v1s_mng:%d] connection aborted: sequence error", __LINE__);
         return SCP_SERVER_STATE_SEQUENCE_ERR;
     }
 
@@ -435,7 +435,7 @@ _scp_v1s_mng_check_response(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
 
     if (cmd == SCP_CMD_MNG_LIST_REQ) /* request session list */
     {
-        log_message(LOG_LEVEL_INFO, "[v1s_mng:%d] request session list", __LINE__);
+        LOG(LOG_LEVEL_INFO, "[v1s_mng:%d] request session list", __LINE__);
         return SCP_SERVER_STATE_MNG_LISTREQ;
     }
     else if (cmd == SCP_CMD_MNG_ACTION) /* execute an action */
@@ -445,7 +445,7 @@ _scp_v1s_mng_check_response(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
         in_uint8a(c->in_s, buf, dim);
         scp_session_set_errstr(s, buf);*/
 
-        log_message(LOG_LEVEL_INFO, "[v1s_mng:%d] action request", __LINE__);
+        LOG(LOG_LEVEL_INFO, "[v1s_mng:%d] action request", __LINE__);
         return SCP_SERVER_STATE_MNG_ACTION;
     }
 
@@ -460,7 +460,7 @@ _scp_v1s_mng_check_response(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
       return SCP_SERVER_STATE_SESSION_LIST;
     }*/
 
-    log_message(LOG_LEVEL_WARNING, "[v1s_mng:%d] connection aborted: sequence error", __LINE__);
+    LOG(LOG_LEVEL_WARNING, "[v1s_mng:%d] connection aborted: sequence error", __LINE__);
     return SCP_SERVER_STATE_SEQUENCE_ERR;
 }
 

--- a/sesman/scp.c
+++ b/sesman/scp.c
@@ -71,8 +71,8 @@ scp_process_start(void *sck)
             break;
         case SCP_SERVER_STATE_START_MANAGE:
             /* starting a management session */
-            log_message(LOG_LEVEL_WARNING,
-                        "starting a sesman management session...");
+            LOG(LOG_LEVEL_WARNING,
+                "starting a sesman management session...");
             scp_v1_mng_process(&scon, sdata);
             break;
         case SCP_SERVER_STATE_VERSION_ERR:
@@ -80,21 +80,21 @@ scp_process_start(void *sck)
             /* an unknown scp version was requested, or the message sizes
                are inconsistent. Shut down the connection and log the
                fact */
-            log_message(LOG_LEVEL_WARNING,
-                        "protocol violation. connection refused.");
+            LOG(LOG_LEVEL_WARNING,
+                "protocol violation. connection refused.");
             break;
         case SCP_SERVER_STATE_NETWORK_ERR:
-            log_message(LOG_LEVEL_WARNING, "libscp network error.");
+            LOG(LOG_LEVEL_WARNING, "libscp network error.");
             break;
         case SCP_SERVER_STATE_SEQUENCE_ERR:
-            log_message(LOG_LEVEL_WARNING, "libscp sequence error.");
+            LOG(LOG_LEVEL_WARNING, "libscp sequence error.");
             break;
         case SCP_SERVER_STATE_INTERNAL_ERR:
             /* internal error occurred (eg. malloc() error, ecc.) */
-            log_message(LOG_LEVEL_ERROR, "libscp internal error occurred.");
+            LOG(LOG_LEVEL_ERROR, "libscp internal error occurred.");
             break;
         default:
-            log_message(LOG_LEVEL_ALWAYS, "unknown return from scp_vXs_accept()");
+            LOG(LOG_LEVEL_ALWAYS, "unknown return from scp_vXs_accept()");
             break;
     }
 

--- a/sesman/scp_v0.c
+++ b/sesman/scp_v0.c
@@ -54,23 +54,23 @@ scp_v0_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
             {
                 /* the user is member of the correct groups. */
                 scp_v0s_replyauthentication(c, errorcode);
-                log_message(LOG_LEVEL_INFO, "Access permitted for user: %s",
-                            s->username);
+                LOG(LOG_LEVEL_INFO, "Access permitted for user: %s",
+                    s->username);
                 /* g_writeln("Connection allowed"); */
             }
             else
             {
                 scp_v0s_replyauthentication(c, 32 + 3); /* all first 32 are reserved for PAM errors */
-                log_message(LOG_LEVEL_INFO, "Username okey but group problem for "
-                            "user: %s", s->username);
+                LOG(LOG_LEVEL_INFO, "Username okey but group problem for "
+                    "user: %s", s->username);
                 /* g_writeln("user password ok, but group problem"); */
             }
         }
         else
         {
             /* g_writeln("username or password error"); */
-            log_message(LOG_LEVEL_INFO, "Username or password error for user: %s",
-                        s->username);
+            LOG(LOG_LEVEL_INFO, "Username or password error for user: %s",
+                s->username);
             scp_v0s_replyauthentication(c, errorcode);
         }
     }
@@ -85,15 +85,15 @@ scp_v0_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
             g_memcpy(s->guid, s_item->guid, 16);
             if (0 != s->client_ip)
             {
-                log_message( LOG_LEVEL_INFO, "++ reconnected session: username %s, "
-                             "display :%d.0, session_pid %d, ip %s",
-                             s->username, display, s_item->pid, s->client_ip);
+                LOG( LOG_LEVEL_INFO, "++ reconnected session: username %s, "
+                     "display :%d.0, session_pid %d, ip %s",
+                     s->username, display, s_item->pid, s->client_ip);
             }
             else
             {
-                log_message(LOG_LEVEL_INFO, "++ reconnected session: username %s, "
-                            "display :%d.0, session_pid %d", s->username, display,
-                            s_item->pid);
+                LOG(LOG_LEVEL_INFO, "++ reconnected session: username %s, "
+                    "display :%d.0, session_pid %d", s->username, display,
+                    s_item->pid);
             }
 
             session_reconnect(display, s->username, data);
@@ -106,34 +106,34 @@ scp_v0_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
             {
                 tui8 guid[16];
 
-                g_random((char*)guid, 16);
+                g_random((char *)guid, 16);
                 scp_session_set_guid(s, guid);
 
                 if (0 != s->client_ip)
                 {
-                    log_message(LOG_LEVEL_INFO, "++ created session (access granted): "
-                                "username %s, ip %s", s->username, s->client_ip);
+                    LOG(LOG_LEVEL_INFO, "++ created session (access granted): "
+                        "username %s, ip %s", s->username, s->client_ip);
                 }
                 else
                 {
-                    log_message(LOG_LEVEL_INFO, "++ created session (access granted): "
-                                "username %s", s->username);
+                    LOG(LOG_LEVEL_INFO, "++ created session (access granted): "
+                        "username %s", s->username);
                 }
 
                 if (SCP_SESSION_TYPE_XVNC == s->type)
                 {
-                    log_message( LOG_LEVEL_INFO, "starting Xvnc session...");
+                    LOG( LOG_LEVEL_INFO, "starting Xvnc session...");
                     display = session_start(data, SESMAN_SESSION_TYPE_XVNC, c, s);
                 }
                 else if (SCP_SESSION_TYPE_XRDP == s->type)
                 {
-                    log_message(LOG_LEVEL_INFO, "starting X11rdp session...");
+                    LOG(LOG_LEVEL_INFO, "starting X11rdp session...");
                     display = session_start(data, SESMAN_SESSION_TYPE_XRDP, c, s);
                 }
                 else if (SCP_SESSION_TYPE_XORG == s->type)
                 {
                     /* type is SCP_SESSION_TYPE_XORG */
-                    log_message(LOG_LEVEL_INFO, "starting Xorg session...");
+                    LOG(LOG_LEVEL_INFO, "starting Xorg session...");
                     display = session_start(data, SESMAN_SESSION_TYPE_XORG, c, s);
                 }
                 /* if the session started up ok, auth_end will be called on

--- a/sesman/scp_v1.c
+++ b/sesman/scp_v1.c
@@ -55,14 +55,14 @@ scp_v1_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
     retries = g_cfg->sec.login_retry;
     current_try = retries;
 
-    data = auth_userpass(s->username, s->password,NULL);
+    data = auth_userpass(s->username, s->password, NULL);
     /*LOG_DEVEL(LOG_LEVEL_DEBUG, "user: %s\npass: %s", s->username, s->password);*/
 
     while ((!data) && ((retries == 0) || (current_try > 0)))
     {
         LOG_DEVEL(LOG_LEVEL_DEBUG, "data %ld - retry %d - currenttry %d - expr %d",
-                data, retries, current_try,
-                ((!data) && ((retries == 0) || (current_try > 0))));
+                  data, retries, current_try,
+                  ((!data) && ((retries == 0) || (current_try > 0))));
 
         e = scp_v1s_request_password(c, s, "Wrong username and/or password");
 
@@ -70,7 +70,7 @@ scp_v1_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
         {
             case SCP_SERVER_STATE_OK:
                 /* all ok, we got new username and password */
-                data = auth_userpass(s->username, s->password,NULL);
+                data = auth_userpass(s->username, s->password, NULL);
 
                 /* one try less */
                 if (current_try > 0)
@@ -90,8 +90,8 @@ scp_v1_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
     if (!data)
     {
         scp_v1s_deny_connection(c, "Login failed");
-        log_message( LOG_LEVEL_INFO,
-                     "Login failed for user %s. Connection terminated", s->username);
+        LOG( LOG_LEVEL_INFO,
+             "Login failed for user %s. Connection terminated", s->username);
         return;
     }
 
@@ -99,8 +99,8 @@ scp_v1_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
     if (0 == access_login_allowed(s->username))
     {
         scp_v1s_deny_connection(c, "Access to Terminal Server not allowed.");
-        log_message(LOG_LEVEL_INFO,
-                    "User %s not allowed on TS. Connection terminated", s->username);
+        LOG(LOG_LEVEL_INFO,
+            "User %s not allowed on TS. Connection terminated", s->username);
         return;
     }
 
@@ -112,31 +112,31 @@ scp_v1_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
     if (scount == 0)
     {
         /* no disconnected sessions - start a new one */
-        log_message(LOG_LEVEL_DEBUG, "No disconnected sessions for this user "
-                    "- we create a new one");
+        LOG(LOG_LEVEL_DEBUG, "No disconnected sessions for this user "
+            "- we create a new one");
 
         if (0 != s->client_ip)
         {
-            log_message(LOG_LEVEL_INFO, "++ created session (access granted): username %s, ip %s", s->username, s->client_ip);
+            LOG(LOG_LEVEL_INFO, "++ created session (access granted): username %s, ip %s", s->username, s->client_ip);
         }
         else
         {
-            log_message(LOG_LEVEL_INFO, "++ created session (access granted): username %s", s->username);
+            LOG(LOG_LEVEL_INFO, "++ created session (access granted): username %s", s->username);
         }
 
         if (SCP_SESSION_TYPE_XVNC == s->type)
         {
-            log_message(LOG_LEVEL_INFO, "starting Xvnc session...");
+            LOG(LOG_LEVEL_INFO, "starting Xvnc session...");
             display = session_start(data, SESMAN_SESSION_TYPE_XVNC, c, s);
         }
         else if (SCP_SESSION_TYPE_XRDP == s->type)
         {
-            log_message(LOG_LEVEL_INFO, "starting X11rdp session...");
+            LOG(LOG_LEVEL_INFO, "starting X11rdp session...");
             display = session_start(data, SESMAN_SESSION_TYPE_XRDP, c, s);
         }
         else if (SCP_SESSION_TYPE_XORG == s->type)
         {
-            log_message(LOG_LEVEL_INFO, "starting Xorg session...");
+            LOG(LOG_LEVEL_INFO, "starting Xorg session...");
             display = session_start(data, SESMAN_SESSION_TYPE_XORG, c, s);
         }
         /* if the session started up ok, auth_end will be called on
@@ -161,10 +161,10 @@ scp_v1_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
 
         switch (e)
         {
-                /*case SCP_SERVER_STATE_FORCE_NEW:*/
-                /* we should check for MaxSessions */
+            /*case SCP_SERVER_STATE_FORCE_NEW:*/
+            /* we should check for MaxSessions */
             case SCP_SERVER_STATE_SELECTION_CANCEL:
-                log_message( LOG_LEVEL_INFO, "Connection cancelled after session listing");
+                LOG( LOG_LEVEL_INFO, "Connection cancelled after session listing");
                 break;
             case SCP_SERVER_STATE_OK:
                 /* ok, reconnecting... */
@@ -173,7 +173,7 @@ scp_v1_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
                 if (0 == sitem)
                 {
                     e = scp_v1s_connection_error(c, "Internal error");
-                    log_message(LOG_LEVEL_INFO, "Cannot find session item on the chain");
+                    LOG(LOG_LEVEL_INFO, "Cannot find session item on the chain");
                 }
                 else
                 {
@@ -183,11 +183,11 @@ scp_v1_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
 
                     if (0 != s->client_ip)
                     {
-                        log_message(LOG_LEVEL_INFO, "++ reconnected session: username %s, display :%d.0, session_pid %d, ip %s", s->username, display, sitem->pid, s->client_ip);
+                        LOG(LOG_LEVEL_INFO, "++ reconnected session: username %s, display :%d.0, session_pid %d, ip %s", s->username, display, sitem->pid, s->client_ip);
                     }
                     else
                     {
-                        log_message(LOG_LEVEL_INFO, "++ reconnected session: username %s, display :%d.0, session_pid %d", s->username, display, sitem->pid);
+                        LOG(LOG_LEVEL_INFO, "++ reconnected session: username %s, display :%d.0, session_pid %d", s->username, display, sitem->pid);
                     }
 
                     g_free(sitem);
@@ -220,27 +220,27 @@ static void parseCommonStates(enum SCP_SERVER_STATES_E e, const char *f)
     switch (e)
     {
         case SCP_SERVER_STATE_VERSION_ERR:
-            log_message(LOG_LEVEL_WARNING, "version error");
+            LOG(LOG_LEVEL_WARNING, "version error");
         case SCP_SERVER_STATE_SIZE_ERR:
             /* an unknown scp version was requested, so we shut down the */
             /* connection (and log the fact)                             */
-            log_message(LOG_LEVEL_WARNING,
-                        "protocol violation. connection closed.");
+            LOG(LOG_LEVEL_WARNING,
+                "protocol violation. connection closed.");
             break;
         case SCP_SERVER_STATE_NETWORK_ERR:
-            log_message(LOG_LEVEL_WARNING, "libscp network error.");
+            LOG(LOG_LEVEL_WARNING, "libscp network error.");
             break;
         case SCP_SERVER_STATE_SEQUENCE_ERR:
-            log_message(LOG_LEVEL_WARNING, "libscp sequence error.");
+            LOG(LOG_LEVEL_WARNING, "libscp sequence error.");
             break;
         case SCP_SERVER_STATE_INTERNAL_ERR:
             /* internal error occurred (eg. malloc() error, ecc.) */
-            log_message(LOG_LEVEL_ERROR, "libscp internal error occurred.");
+            LOG(LOG_LEVEL_ERROR, "libscp internal error occurred.");
             break;
         default:
             /* dummy: scp_v1s_request_password won't generate any other */
             /* error other than the ones before                         */
-            log_message(LOG_LEVEL_ALWAYS, "unknown return from %s", f);
+            LOG(LOG_LEVEL_ALWAYS, "unknown return from %s", f);
             break;
     }
 }

--- a/sesman/scp_v1_mng.c
+++ b/sesman/scp_v1_mng.c
@@ -46,14 +46,14 @@ scp_v1_mng_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
     int scount;
     int end = 0;
 
-    data = auth_userpass(s->username, s->password,NULL);
+    data = auth_userpass(s->username, s->password, NULL);
     /*LOG_DEVEL(LOG_LEVEL_DEBUG, "user: %s\npass: %s", s->username, s->password);*/
 
     if (!data)
     {
         scp_v1s_mng_deny_connection(c, "Login failed");
-        log_message(LOG_LEVEL_INFO,
-                    "[MNG] Login failed for user %s. Connection terminated", s->username);
+        LOG(LOG_LEVEL_INFO,
+            "[MNG] Login failed for user %s. Connection terminated", s->username);
         auth_end(data);
         return;
     }
@@ -62,8 +62,8 @@ scp_v1_mng_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
     if (0 == access_login_mng_allowed(s->username))
     {
         scp_v1s_mng_deny_connection(c, "Access to Terminal Server not allowed.");
-        log_message(LOG_LEVEL_INFO,
-                    "[MNG] User %s not allowed on TS. Connection terminated", s->username);
+        LOG(LOG_LEVEL_INFO,
+            "[MNG] User %s not allowed on TS. Connection terminated", s->username);
         auth_end(data);
         return;
     }
@@ -77,7 +77,7 @@ scp_v1_mng_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
         switch (e)
         {
             case SCP_SERVER_STATE_MNG_ACTION:
-                log_message(LOG_LEVEL_INFO, "Connection cancelled after session listing");
+                LOG(LOG_LEVEL_INFO, "Connection cancelled after session listing");
                 break;
 
             case SCP_SERVER_STATE_MNG_LISTREQ:
@@ -86,7 +86,7 @@ scp_v1_mng_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "sessions on TS: %d (slist: %p)", scount, slist);
                 if (0 == slist)
                 {
-                    log_message(LOG_LEVEL_INFO, "No sessions on Terminal Server");
+                    LOG(LOG_LEVEL_INFO, "No sessions on Terminal Server");
                 }
 
                 e = scp_v1s_mng_list_sessions(c, s, scount, slist);
@@ -109,27 +109,27 @@ static void parseCommonStates(enum SCP_SERVER_STATES_E e, const char *f)
     switch (e)
     {
         case SCP_SERVER_STATE_VERSION_ERR:
-            log_message(LOG_LEVEL_WARNING, "version error");
+            LOG(LOG_LEVEL_WARNING, "version error");
         case SCP_SERVER_STATE_SIZE_ERR:
             /* an unknown scp version was requested, so we shut down the */
             /* connection (and log the fact)                             */
-            log_message(LOG_LEVEL_WARNING,
-                        "protocol violation. connection closed.");
+            LOG(LOG_LEVEL_WARNING,
+                "protocol violation. connection closed.");
             break;
         case SCP_SERVER_STATE_NETWORK_ERR:
-            log_message(LOG_LEVEL_WARNING, "libscp network error.");
+            LOG(LOG_LEVEL_WARNING, "libscp network error.");
             break;
         case SCP_SERVER_STATE_SEQUENCE_ERR:
-            log_message(LOG_LEVEL_WARNING, "libscp sequence error.");
+            LOG(LOG_LEVEL_WARNING, "libscp sequence error.");
             break;
         case SCP_SERVER_STATE_INTERNAL_ERR:
             /* internal error occurred (eg. malloc() error, ecc.) */
-            log_message(LOG_LEVEL_ERROR, "libscp internal error occurred.");
+            LOG(LOG_LEVEL_ERROR, "libscp internal error occurred.");
             break;
         default:
             /* dummy: scp_v1s_request_password won't generate any other */
             /* error other than the ones before                         */
-            log_message(LOG_LEVEL_ALWAYS, "unknown return from %s", f);
+            LOG(LOG_LEVEL_ALWAYS, "unknown return from %s", f);
             break;
     }
 }

--- a/sesman/sesman.c
+++ b/sesman/sesman.c
@@ -50,8 +50,8 @@ int sesman_listen_test(struct config_sesman *cfg)
         return 1;
     }
 
-    log_message(LOG_LEVEL_DEBUG, "Testing if xrdp-sesman can listen on %s port %s.",
-                                 cfg->listen_address, cfg->listen_port);
+    LOG(LOG_LEVEL_DEBUG, "Testing if xrdp-sesman can listen on %s port %s.",
+        cfg->listen_address, cfg->listen_port);
     g_tcp_set_non_blocking(sck);
     error = scp_tcp_bind(sck, cfg->listen_address, cfg->listen_port);
     if (error == 0)
@@ -96,7 +96,7 @@ sesman_main_loop(void)
     g_sck = g_tcp_socket();
     if (g_sck < 0)
     {
-        log_message(LOG_LEVEL_ERROR, "error opening socket, g_tcp_socket() failed...");
+        LOG(LOG_LEVEL_ERROR, "error opening socket, g_tcp_socket() failed...");
         return 1;
     }
 
@@ -109,8 +109,8 @@ sesman_main_loop(void)
 
         if (error == 0)
         {
-            log_message(LOG_LEVEL_INFO, "listening to port %s on %s",
-                        g_cfg->listen_port, g_cfg->listen_address);
+            LOG(LOG_LEVEL_INFO, "listening to port %s on %s",
+                g_cfg->listen_port, g_cfg->listen_address);
             sck_obj = g_create_wait_obj_from_socket(g_sck, 0);
             cont = 1;
 
@@ -151,7 +151,7 @@ sesman_main_loop(void)
                     {
                         /* we've got a connection, so we pass it to scp code */
                         LOG_DEVEL(LOG_LEVEL_DEBUG, "new connection");
-                        scp_process_start((void*)(tintptr)in_sck);
+                        scp_process_start((void *)(tintptr)in_sck);
                         g_sck_close(in_sck);
                     }
                 }
@@ -161,16 +161,16 @@ sesman_main_loop(void)
         }
         else
         {
-            log_message(LOG_LEVEL_ERROR, "listen error %d (%s)",
-                        g_get_errno(), g_get_strerror());
+            LOG(LOG_LEVEL_ERROR, "listen error %d (%s)",
+                g_get_errno(), g_get_strerror());
             rv = 1;
         }
     }
     else
     {
-        log_message(LOG_LEVEL_ERROR, "bind error on "
-                    "port '%s': %d (%s)", g_cfg->listen_port,
-                    g_get_errno(), g_get_strerror());
+        LOG(LOG_LEVEL_ERROR, "bind error on "
+            "port '%s': %d (%s)", g_cfg->listen_port,
+            g_get_errno(), g_get_strerror());
         rv = 1;
     }
     g_tcp_close(g_sck);
@@ -342,14 +342,14 @@ main(int argc, char **argv)
         g_exit(1);
     }
 
-    log_message(LOG_LEVEL_TRACE, "config loaded in %s at %s:%d", __func__, __FILE__, __LINE__);
-    log_message(LOG_LEVEL_TRACE, "    listen_address    = %s", g_cfg->listen_address);
-    log_message(LOG_LEVEL_TRACE, "    listen_port       = %s", g_cfg->listen_port);
-    log_message(LOG_LEVEL_TRACE, "    enable_user_wm    = %d", g_cfg->enable_user_wm);
-    log_message(LOG_LEVEL_TRACE, "    default_wm        = %s", g_cfg->default_wm);
-    log_message(LOG_LEVEL_TRACE, "    user_wm           = %s", g_cfg->user_wm);
-    log_message(LOG_LEVEL_TRACE, "    reconnect_sh      = %s", g_cfg->reconnect_sh);
-    log_message(LOG_LEVEL_TRACE, "    auth_file_path    = %s", g_cfg->auth_file_path);
+    LOG(LOG_LEVEL_TRACE, "config loaded in %s at %s:%d", __func__, __FILE__, __LINE__);
+    LOG(LOG_LEVEL_TRACE, "    listen_address    = %s", g_cfg->listen_address);
+    LOG(LOG_LEVEL_TRACE, "    listen_port       = %s", g_cfg->listen_port);
+    LOG(LOG_LEVEL_TRACE, "    enable_user_wm    = %d", g_cfg->enable_user_wm);
+    LOG(LOG_LEVEL_TRACE, "    default_wm        = %s", g_cfg->default_wm);
+    LOG(LOG_LEVEL_TRACE, "    user_wm           = %s", g_cfg->user_wm);
+    LOG(LOG_LEVEL_TRACE, "    reconnect_sh      = %s", g_cfg->reconnect_sh);
+    LOG(LOG_LEVEL_TRACE, "    auth_file_path    = %s", g_cfg->auth_file_path);
 
     if (daemon)
     {
@@ -381,8 +381,8 @@ main(int argc, char **argv)
         if (sesman_listen_test(g_cfg) != 0)
         {
 
-            log_message(LOG_LEVEL_ERROR, "Failed to start xrdp-sesman daemon, "
-                                         "possibly address already in use.");
+            LOG(LOG_LEVEL_ERROR, "Failed to start xrdp-sesman daemon, "
+                "possibly address already in use.");
             g_deinit();
             g_exit(1);
         }
@@ -419,9 +419,9 @@ main(int argc, char **argv)
 
         if (-1 == fd)
         {
-            log_message(LOG_LEVEL_ERROR,
-                        "error opening pid file[%s]: %s",
-                        pid_file, g_get_strerror());
+            LOG(LOG_LEVEL_ERROR,
+                "error opening pid file[%s]: %s",
+                pid_file, g_get_strerror());
             log_end();
             g_deinit();
             g_exit(1);
@@ -433,8 +433,8 @@ main(int argc, char **argv)
     }
 
     /* start program main loop */
-    log_message(LOG_LEVEL_INFO,
-                "starting xrdp-sesman with pid %d", g_pid);
+    LOG(LOG_LEVEL_INFO,
+        "starting xrdp-sesman with pid %d", g_pid);
 
     /* make sure the socket directory exists */
     g_mk_socket_path("xrdp-sesman");
@@ -444,7 +444,7 @@ main(int argc, char **argv)
     {
         if (!g_create_dir("/tmp/.X11-unix"))
         {
-            log_message(LOG_LEVEL_ERROR,
+            LOG(LOG_LEVEL_ERROR,
                 "sesman.c: error creating dir /tmp/.X11-unix");
         }
         g_chmod_hex("/tmp/.X11-unix", 0x1777);

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -70,7 +70,7 @@ dumpItemsToString(struct list *self, char *outstr, int len)
     g_memset(outstr, 0, len);
     if (self->count == 0)
     {
-        g_writeln("List is empty");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "List is empty");
     }
 
     for (index = 0; index < self->count; index++)
@@ -116,15 +116,15 @@ session_get_bydata(const char *name, int width, int height, int bpp, int type,
     }
 
 #if 0
-    log_message(LOG_LEVEL_INFO,
-            "session_get_bydata: search policy %d U %s W %d H %d bpp %d T %d IP %s",
-            policy, name, width, height, bpp, type, client_ip);
+    LOG(LOG_LEVEL_INFO,
+        "session_get_bydata: search policy %d U %s W %d H %d bpp %d T %d IP %s",
+        policy, name, width, height, bpp, type, client_ip);
 #endif
 
     while (tmp != 0)
     {
 #if 0
-        log_message(LOG_LEVEL_INFO,
+        LOG(LOG_LEVEL_INFO,
             "session_get_bydata: try %p U %s W %d H %d bpp %d T %d IP %s",
             tmp->item,
             tmp->item->name,
@@ -134,14 +134,14 @@ session_get_bydata(const char *name, int width, int height, int bpp, int type,
 #endif
 
         if (g_strncmp(name, tmp->item->name, 255) == 0 &&
-            (!(policy & SESMAN_CFG_SESS_POLICY_D) ||
-             (tmp->item->width == width && tmp->item->height == height)) &&
-            (!(policy & SESMAN_CFG_SESS_POLICY_I) ||
-             (g_strncmp_d(client_ip, tmp->item->client_ip, ':', 255) == 0)) &&
-            (!(policy & SESMAN_CFG_SESS_POLICY_C) ||
-             (g_strncmp(client_ip, tmp->item->client_ip, 255) == 0)) &&
-            tmp->item->bpp == bpp &&
-            tmp->item->type == type)
+                (!(policy & SESMAN_CFG_SESS_POLICY_D) ||
+                 (tmp->item->width == width && tmp->item->height == height)) &&
+                (!(policy & SESMAN_CFG_SESS_POLICY_I) ||
+                 (g_strncmp_d(client_ip, tmp->item->client_ip, ':', 255) == 0)) &&
+                (!(policy & SESMAN_CFG_SESS_POLICY_C) ||
+                 (g_strncmp(client_ip, tmp->item->client_ip, 255) == 0)) &&
+                tmp->item->bpp == bpp &&
+                tmp->item->type == type)
         {
             return tmp->item;
         }
@@ -313,7 +313,7 @@ session_get_avail_display_from_chain(void)
         display++;
     }
 
-    log_message(LOG_LEVEL_ERROR, "X server -- no display in range is available");
+    LOG(LOG_LEVEL_ERROR, "X server -- no display in range is available");
     return 0;
 }
 
@@ -333,9 +333,9 @@ wait_for_xserver(int display)
 
         if (i > 40)
         {
-            log_message(LOG_LEVEL_ERROR,
-                        "X server for display %d startup timeout",
-                        display);
+            LOG(LOG_LEVEL_ERROR,
+                "X server for display %d startup timeout",
+                display);
             break;
         }
 
@@ -373,8 +373,8 @@ session_start_chansrv(char *username, int display)
         /* executing chansrv */
         g_execvp(exe_path, (char **) (chansrv_params->items));
         /* should not get here */
-        log_message(LOG_LEVEL_ALWAYS, "error starting chansrv "
-                    "- user %s - pid %d", username, g_getpid());
+        LOG(LOG_LEVEL_ALWAYS, "error starting chansrv "
+            "- user %s - pid %d", username, g_getpid());
         list_delete(chansrv_params);
         g_exit(1);
     }
@@ -420,8 +420,8 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
     /* check to limit concurrent sessions */
     if (g_session_count >= g_cfg->sess.max_sessions)
     {
-        log_message(LOG_LEVEL_INFO, "max concurrent session limit "
-                    "exceeded. login for user %s denied", s->username);
+        LOG(LOG_LEVEL_INFO, "max concurrent session limit "
+            "exceeded. login for user %s denied", s->username);
         return 0;
     }
 
@@ -429,8 +429,8 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
 
     if (temp == 0)
     {
-        log_message(LOG_LEVEL_ERROR, "cannot create new chain "
-                    "element - user %s", s->username);
+        LOG(LOG_LEVEL_ERROR, "cannot create new chain "
+            "element - user %s", s->username);
         return 0;
     }
 
@@ -439,8 +439,8 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
     if (temp->item == 0)
     {
         g_free(temp);
-        log_message(LOG_LEVEL_ERROR, "cannot create new session "
-                    "item - user %s", s->username);
+        LOG(LOG_LEVEL_ERROR, "cannot create new session "
+            "item - user %s", s->username);
         return 0;
     }
 
@@ -461,8 +461,8 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
     }
     else if (pid == 0)
     {
-        log_message(LOG_LEVEL_INFO, "calling auth_start_session from pid %d",
-                    g_getpid());
+        LOG(LOG_LEVEL_INFO, "calling auth_start_session from pid %d",
+            g_getpid());
         auth_start_session(data, display);
         g_delete_wait_obj(g_term_event);
         g_tcp_close(g_sck);
@@ -493,15 +493,15 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
              */
             if (g_setsid() < 0)
             {
-                log_message(LOG_LEVEL_ERROR,
-                            "setsid failed - pid %d", g_getpid());
+                LOG(LOG_LEVEL_ERROR,
+                    "setsid failed - pid %d", g_getpid());
             }
 
             if (g_setlogin(s->username) < 0)
             {
-                log_message(LOG_LEVEL_ERROR,
-                            "setlogin failed for user %s - pid %d", s->username,
-                            g_getpid());
+                LOG(LOG_LEVEL_ERROR,
+                    "setlogin failed for user %s - pid %d", s->username,
+                    g_getpid());
             }
         }
 
@@ -543,21 +543,21 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
                 {
                     if (s->program[0] != 0)
                     {
-                        log_message(LOG_LEVEL_DEBUG, 
-                                    "starting program with parameters: %s ",
-                                    s->program);
-                        if(g_strchr(s->program, ' ') != 0 || g_strchr(s->program, '\t') != 0)
+                        LOG(LOG_LEVEL_DEBUG,
+                            "starting program with parameters: %s ",
+                            s->program);
+                        if (g_strchr(s->program, ' ') != 0 || g_strchr(s->program, '\t') != 0)
                         {
                             const char *params[] = {"sh", "-c", s->program, NULL};
                             g_execvp("/bin/sh", (char **)params);
                         }
                         else
                         {
-                           g_execlp3(s->program, s->program, 0);
+                            g_execlp3(s->program, s->program, 0);
                         }
-                        log_message(LOG_LEVEL_ALWAYS,
-                                    "error starting program %s for user %s - pid %d",
-                                    s->program, s->username, g_getpid());
+                        LOG(LOG_LEVEL_ALWAYS,
+                            "error starting program %s for user %s - pid %d",
+                            s->program, s->username, g_getpid());
                     }
                 }
                 /* try to execute user window manager if enabled */
@@ -567,51 +567,51 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
                     if (g_file_exist(text))
                     {
                         g_execlp3(text, g_cfg->user_wm, 0);
-                        log_message(LOG_LEVEL_ALWAYS, "error starting user "
-                                    "wm for user %s - pid %d", s->username, g_getpid());
+                        LOG(LOG_LEVEL_ALWAYS, "error starting user "
+                            "wm for user %s - pid %d", s->username, g_getpid());
                         /* logging parameters */
-                        log_message(LOG_LEVEL_DEBUG, "errno: %d, "
-                                    "description: %s", g_get_errno(), g_get_strerror());
-                        log_message(LOG_LEVEL_DEBUG, "execlp3 parameter "
-                                    "list:");
-                        log_message(LOG_LEVEL_DEBUG, "        argv[0] = %s",
-                                    text);
-                        log_message(LOG_LEVEL_DEBUG, "        argv[1] = %s",
-                                    g_cfg->user_wm);
+                        LOG(LOG_LEVEL_DEBUG, "errno: %d, "
+                            "description: %s", g_get_errno(), g_get_strerror());
+                        LOG(LOG_LEVEL_DEBUG, "execlp3 parameter "
+                            "list:");
+                        LOG(LOG_LEVEL_DEBUG, "        argv[0] = %s",
+                            text);
+                        LOG(LOG_LEVEL_DEBUG, "        argv[1] = %s",
+                            g_cfg->user_wm);
                     }
                 }
                 /* if we're here something happened to g_execlp3
                    so we try running the default window manager */
                 g_execlp3(g_cfg->default_wm, g_cfg->default_wm, 0);
 
-                log_message(LOG_LEVEL_ALWAYS, "error starting default "
-                             "wm for user %s - pid %d", s->username, g_getpid());
+                LOG(LOG_LEVEL_ALWAYS, "error starting default "
+                    "wm for user %s - pid %d", s->username, g_getpid());
                 /* logging parameters */
-                log_message(LOG_LEVEL_DEBUG, "errno: %d, description: "
-                            "%s", g_get_errno(), g_get_strerror());
-                log_message(LOG_LEVEL_DEBUG, "execlp3 parameter list:");
-                log_message(LOG_LEVEL_DEBUG, "        argv[0] = %s",
-                            g_cfg->default_wm);
-                log_message(LOG_LEVEL_DEBUG, "        argv[1] = %s",
-                            g_cfg->default_wm);
+                LOG(LOG_LEVEL_DEBUG, "errno: %d, description: "
+                    "%s", g_get_errno(), g_get_strerror());
+                LOG(LOG_LEVEL_DEBUG, "execlp3 parameter list:");
+                LOG(LOG_LEVEL_DEBUG, "        argv[0] = %s",
+                    g_cfg->default_wm);
+                LOG(LOG_LEVEL_DEBUG, "        argv[1] = %s",
+                    g_cfg->default_wm);
 
                 /* still a problem starting window manager just start xterm */
                 g_execlp3("xterm", "xterm", 0);
 
                 /* should not get here */
-                log_message(LOG_LEVEL_ALWAYS, "error starting xterm "
-                            "for user %s - pid %d", s->username, g_getpid());
+                LOG(LOG_LEVEL_ALWAYS, "error starting xterm "
+                    "for user %s - pid %d", s->username, g_getpid());
                 /* logging parameters */
-                log_message(LOG_LEVEL_DEBUG, "errno: %d, description: "
-                            "%s", g_get_errno(), g_get_strerror());
+                LOG(LOG_LEVEL_DEBUG, "errno: %d, description: "
+                    "%s", g_get_errno(), g_get_strerror());
             }
             else
             {
-                log_message(LOG_LEVEL_ERROR, "another Xserver might "
-                            "already be active on display %d - see log", display);
+                LOG(LOG_LEVEL_ERROR, "another Xserver might "
+                    "already be active on display %d - see log", display);
             }
 
-            log_message(LOG_LEVEL_DEBUG, "aborting connection...");
+            LOG(LOG_LEVEL_DEBUG, "aborting connection...");
             g_exit(0);
         }
         else
@@ -676,9 +676,9 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
                      */
                     if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) < 0)
                     {
-                        log_message(LOG_LEVEL_WARNING,
-                                    "Failed to disable setuid on X server: %s",
-                                    g_get_strerror());
+                        LOG(LOG_LEVEL_WARNING,
+                            "Failed to disable setuid on X server: %s",
+                            g_get_strerror());
                     }
 #endif
 
@@ -702,7 +702,7 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
 
                     pp1 = (char **) xserver_params->items;
 
-                    log_message(LOG_LEVEL_INFO, "%s", dumpItemsToString(xserver_params, execvpparams, 2048));
+                    LOG(LOG_LEVEL_INFO, "%s", dumpItemsToString(xserver_params, execvpparams, 2048));
 
                     /* some args are passed via env vars */
                     g_sprintf(geometry, "%d", s->width);
@@ -747,7 +747,7 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
                     /* make sure it ends with a zero */
                     list_add_item(xserver_params, 0);
                     pp1 = (char **)xserver_params->items;
-                    log_message(LOG_LEVEL_INFO, "%s", dumpItemsToString(xserver_params, execvpparams, 2048));
+                    LOG(LOG_LEVEL_INFO, "%s", dumpItemsToString(xserver_params, execvpparams, 2048));
                     g_execvp(xserver, pp1);
                 }
                 else if (type == SESMAN_SESSION_TYPE_XRDP)
@@ -776,30 +776,30 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
                     /* make sure it ends with a zero */
                     list_add_item(xserver_params, 0);
                     pp1 = (char **)xserver_params->items;
-                    log_message(LOG_LEVEL_INFO, "%s", dumpItemsToString(xserver_params, execvpparams, 2048));
+                    LOG(LOG_LEVEL_INFO, "%s", dumpItemsToString(xserver_params, execvpparams, 2048));
                     g_execvp(xserver, pp1);
                 }
                 else
                 {
-                    log_message(LOG_LEVEL_ALWAYS, "bad session type - "
-                                "user %s - pid %d", s->username, g_getpid());
+                    LOG(LOG_LEVEL_ALWAYS, "bad session type - "
+                        "user %s - pid %d", s->username, g_getpid());
                     g_exit(1);
                 }
 
                 /* should not get here */
-                log_message(LOG_LEVEL_ALWAYS, "error starting X server "
-                            "- user %s - pid %d", s->username, g_getpid());
+                LOG(LOG_LEVEL_ALWAYS, "error starting X server "
+                    "- user %s - pid %d", s->username, g_getpid());
 
                 /* logging parameters */
-                log_message(LOG_LEVEL_DEBUG, "errno: %d, description: "
-                            "%s", g_get_errno(), g_get_strerror());
-                log_message(LOG_LEVEL_DEBUG, "execve parameter list size: "
-                            "%d", (xserver_params)->count);
+                LOG(LOG_LEVEL_DEBUG, "errno: %d, description: "
+                    "%s", g_get_errno(), g_get_strerror());
+                LOG(LOG_LEVEL_DEBUG, "execve parameter list size: "
+                    "%d", (xserver_params)->count);
 
                 for (i = 0; i < (xserver_params->count); i++)
                 {
-                    log_message(LOG_LEVEL_DEBUG, "        argv[%d] = %s",
-                                i, (char *)list_get_item(xserver_params, i));
+                    LOG(LOG_LEVEL_DEBUG, "        argv[%d] = %s",
+                        i, (char *)list_get_item(xserver_params, i));
                 }
 
                 list_delete(xserver_params);
@@ -809,13 +809,13 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
             {
                 wait_for_xserver(display);
                 chansrv_pid = session_start_chansrv(s->username, display);
-                log_message(LOG_LEVEL_ALWAYS, "waiting for window manager "
-                            "(pid %d) to exit", window_manager_pid);
+                LOG(LOG_LEVEL_ALWAYS, "waiting for window manager "
+                    "(pid %d) to exit", window_manager_pid);
                 g_waitpid(window_manager_pid);
-                log_message(LOG_LEVEL_ALWAYS, "window manager (pid %d) did "
-                            "exit, cleaning up session", window_manager_pid);
-                log_message(LOG_LEVEL_INFO, "calling auth_stop_session and "
-                            "auth_end from pid %d", g_getpid());
+                LOG(LOG_LEVEL_ALWAYS, "window manager (pid %d) did "
+                    "exit, cleaning up session", window_manager_pid);
+                LOG(LOG_LEVEL_INFO, "calling auth_stop_session and "
+                    "auth_end from pid %d", g_getpid());
                 auth_stop_session(data);
                 auth_end(data);
                 g_sigterm(display_pid);
@@ -928,8 +928,8 @@ session_kill(int pid)
     {
         if (tmp->item == 0)
         {
-            log_message(LOG_LEVEL_ERROR, "session descriptor for "
-                        "pid %d is null!", pid);
+            LOG(LOG_LEVEL_ERROR, "session descriptor for "
+                "pid %d is null!", pid);
 
             if (prev == 0)
             {
@@ -948,7 +948,7 @@ session_kill(int pid)
         if (tmp->item->pid == pid)
         {
             /* deleting the session */
-            log_message(LOG_LEVEL_INFO, "++ terminated session:  username %s, display :%d.0, session_pid %d, ip %s", tmp->item->name, tmp->item->display, tmp->item->pid, tmp->item->client_ip);
+            LOG(LOG_LEVEL_INFO, "++ terminated session:  username %s, display :%d.0, session_pid %d, ip %s", tmp->item->name, tmp->item->display, tmp->item->pid, tmp->item->client_ip);
             g_free(tmp->item);
 
             if (prev == 0)
@@ -987,8 +987,8 @@ session_sigkill_all(void)
     {
         if (tmp->item == 0)
         {
-            log_message(LOG_LEVEL_ERROR, "found null session "
-                        "descriptor!");
+            LOG(LOG_LEVEL_ERROR, "found null session "
+                "descriptor!");
         }
         else
         {
@@ -1011,7 +1011,7 @@ session_get_bypid(int pid)
 
     if (0 == dummy)
     {
-        log_message(LOG_LEVEL_ERROR, "session_get_bypid: out of memory");
+        LOG(LOG_LEVEL_ERROR, "session_get_bypid: out of memory");
         return 0;
     }
 
@@ -1021,8 +1021,8 @@ session_get_bypid(int pid)
     {
         if (tmp->item == 0)
         {
-            log_message(LOG_LEVEL_ERROR, "session descriptor for "
-                        "pid %d is null!", pid);
+            LOG(LOG_LEVEL_ERROR, "session descriptor for "
+                "pid %d is null!", pid);
             g_free(dummy);
             return 0;
         }
@@ -1061,8 +1061,8 @@ session_get_byuser(const char *user, int *cnt, unsigned char flags)
         if ((NULL == user) || (!g_strncasecmp(user, tmp->item->name, 256)))
         {
             LOG_DEVEL(LOG_LEVEL_DEBUG, "session_get_byuser: status=%d, flags=%d, "
-                    "result=%d", (tmp->item->status), flags,
-                    ((tmp->item->status) & flags));
+                      "result=%d", (tmp->item->status), flags,
+                      ((tmp->item->status) & flags));
 
             if ((tmp->item->status) & flags)
             {
@@ -1094,7 +1094,7 @@ session_get_byuser(const char *user, int *cnt, unsigned char flags)
 
     while (tmp != 0)
     {
-/* #warning FIXME: we should get only disconnected sessions! */
+        /* #warning FIXME: we should get only disconnected sessions! */
         if ((NULL == user) || (!g_strncasecmp(user, tmp->item->name, 256)))
         {
             if ((tmp->item->status) & flags)
@@ -1104,7 +1104,7 @@ session_get_byuser(const char *user, int *cnt, unsigned char flags)
                 (sess[index]).height = tmp->item->height;
                 (sess[index]).width = tmp->item->width;
                 (sess[index]).bpp = tmp->item->bpp;
-/* #warning FIXME: setting idle times and such */
+                /* #warning FIXME: setting idle times and such */
                 /*(sess[index]).connect_time.year = tmp->item->connect_time.year;
                 (sess[index]).connect_time.month = tmp->item->connect_time.month;
                 (sess[index]).connect_time.day = tmp->item->connect_time.day;
@@ -1145,7 +1145,7 @@ session_get_byuser(const char *user, int *cnt, unsigned char flags)
 int
 cleanup_sockets(int display)
 {
-    log_message(LOG_LEVEL_DEBUG, "cleanup_sockets:");
+    LOG(LOG_LEVEL_DEBUG, "cleanup_sockets:");
     char file[256];
     int error;
 
@@ -1154,11 +1154,11 @@ cleanup_sockets(int display)
     g_snprintf(file, 255, CHANSRV_PORT_OUT_STR, display);
     if (g_file_exist(file))
     {
-        log_message(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
+        LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
         if (g_file_delete(file) == 0)
         {
-            log_message(LOG_LEVEL_DEBUG,
-                       "cleanup_sockets: failed to delete %s", file);
+            LOG(LOG_LEVEL_DEBUG,
+                "cleanup_sockets: failed to delete %s", file);
             error++;
         }
     }
@@ -1166,11 +1166,11 @@ cleanup_sockets(int display)
     g_snprintf(file, 255, CHANSRV_PORT_IN_STR, display);
     if (g_file_exist(file))
     {
-        log_message(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
+        LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
         if (g_file_delete(file) == 0)
         {
-            log_message(LOG_LEVEL_DEBUG,
-                       "cleanup_sockets: failed to delete %s", file);
+            LOG(LOG_LEVEL_DEBUG,
+                "cleanup_sockets: failed to delete %s", file);
             error++;
         }
     }
@@ -1178,11 +1178,11 @@ cleanup_sockets(int display)
     g_snprintf(file, 255, XRDP_CHANSRV_STR, display);
     if (g_file_exist(file))
     {
-        log_message(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
+        LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
         if (g_file_delete(file) == 0)
         {
-            log_message(LOG_LEVEL_DEBUG,
-                       "cleanup_sockets: failed to delete %s", file);
+            LOG(LOG_LEVEL_DEBUG,
+                "cleanup_sockets: failed to delete %s", file);
             error++;
         }
     }
@@ -1190,11 +1190,11 @@ cleanup_sockets(int display)
     g_snprintf(file, 255, CHANSRV_API_STR, display);
     if (g_file_exist(file))
     {
-        log_message(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
+        LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
         if (g_file_delete(file) == 0)
         {
-            log_message(LOG_LEVEL_DEBUG,
-                       "cleanup_sockets: failed to delete %s", file);
+            LOG(LOG_LEVEL_DEBUG,
+                "cleanup_sockets: failed to delete %s", file);
             error++;
         }
     }

--- a/sesman/sig.c
+++ b/sesman/sig.c
@@ -43,7 +43,7 @@ sig_sesman_shutdown(int sig)
 {
     char pid_file[256];
 
-    log_message(LOG_LEVEL_INFO, "shutting down sesman %d", 1);
+    LOG(LOG_LEVEL_INFO, "shutting down sesman %d", 1);
 
     if (g_getpid() != g_pid)
     {
@@ -69,7 +69,7 @@ sig_sesman_reload_cfg(int sig)
     struct config_sesman *cfg;
     char cfg_file[256];
 
-    log_message(LOG_LEVEL_WARNING, "receiving SIGHUP %d", 1);
+    LOG(LOG_LEVEL_WARNING, "receiving SIGHUP %d", 1);
 
     if (g_getpid() != g_pid)
     {
@@ -81,13 +81,13 @@ sig_sesman_reload_cfg(int sig)
 
     if (0 == cfg)
     {
-        log_message(LOG_LEVEL_ERROR, "error creating new config:  - keeping old cfg");
+        LOG(LOG_LEVEL_ERROR, "error creating new config:  - keeping old cfg");
         return;
     }
 
     if (config_read(cfg) != 0)
     {
-        log_message(LOG_LEVEL_ERROR, "error reading config - keeping old cfg");
+        LOG(LOG_LEVEL_ERROR, "error reading config - keeping old cfg");
         g_free(cfg);
         return;
     }
@@ -121,7 +121,7 @@ sig_sesman_reload_cfg(int sig)
         }
     }
 
-    log_message(LOG_LEVEL_INFO, "configuration reloaded, log subsystem restarted");
+    LOG(LOG_LEVEL_INFO, "configuration reloaded, log subsystem restarted");
 }
 
 /******************************************************************************/

--- a/sesman/tools/sesrun.c
+++ b/sesman/tools/sesrun.c
@@ -85,7 +85,9 @@ main(int argc, char **argv)
 
         sck = g_tcp_socket();
         if (sck < 0)
+        {
             return 1;
+        }
 
         if (g_tcp_connect(sck, argv[1], g_cfg.listen_port) == 0)
         {

--- a/sesman/tools/sestest.c
+++ b/sesman/tools/sestest.c
@@ -56,7 +56,9 @@ int main(int argc, char **argv)
 
     sock = g_tcp_socket();
     if (sock < 0)
+    {
         return 1;
+    }
 
     s = scp_session_create();
     c = scp_connection_create(sock);

--- a/sesman/verify_user.c
+++ b/sesman/verify_user.c
@@ -78,7 +78,7 @@ auth_userpass(const char *user, const char *pass, int *errorcode)
 
         if (1 == auth_account_disabled(stp))
         {
-            log_message(LOG_LEVEL_INFO, "account %s is disabled", user);
+            LOG(LOG_LEVEL_INFO, "account %s is disabled", user);
             return 0;
         }
 
@@ -326,9 +326,9 @@ auth_account_disabled(struct spwd *stp)
     }
 
     if ((stp->sp_max >= 0) &&
-        (stp->sp_inact >= 0) &&
-        (stp->sp_lstchg > 0) &&
-        (today >= (stp->sp_lstchg + stp->sp_max + stp->sp_inact)))
+            (stp->sp_inact >= 0) &&
+            (stp->sp_lstchg > 0) &&
+            (today >= (stp->sp_lstchg + stp->sp_max + stp->sp_inact)))
     {
         return 1;
     }

--- a/sesman/verify_user_bsd.c
+++ b/sesman/verify_user_bsd.c
@@ -43,7 +43,7 @@
 #define SECS_PER_DAY (24L*3600L)
 #endif
 
-extern struct config_sesman* g_cfg; /* in sesman.c */
+extern struct config_sesman *g_cfg; /* in sesman.c */
 
 /******************************************************************************/
 /* returns boolean */
@@ -116,7 +116,7 @@ auth_crypt_pwd(const char *pwd, const char *pln, char *crp)
  *
  */
 static int
-auth_account_disabled(struct spwd* stp)
+auth_account_disabled(struct spwd *stp)
 {
     return 0;
 }

--- a/sesman/verify_user_pam.c
+++ b/sesman/verify_user_pam.c
@@ -95,7 +95,7 @@ get_service_name(char *service_name)
     service_name[0] = 0;
 
     if (g_file_exist("/etc/pam.d/xrdp-sesman") ||
-        g_file_exist(XRDP_SYSCONF_PATH "/pam.d/xrdp-sesman"))
+            g_file_exist(XRDP_SYSCONF_PATH "/pam.d/xrdp-sesman"))
     {
         g_strncpy(service_name, "xrdp-sesman", 255);
     }

--- a/sesman/xauth.c
+++ b/sesman/xauth.c
@@ -46,19 +46,19 @@ add_xauth_cookie(int display, const char *file)
     g_bytes_to_hexstr(cookie_bin, 16, cookie_str, 33);
 
     g_sprintf(xauth_str, "xauth -q -f %s add :%d . %s",
-                file, display, cookie_str);
+              file, display, cookie_str);
 
     dp = popen(xauth_str, "r");
     if (dp == NULL)
     {
-        log_message(LOG_LEVEL_ERROR, "Unable to launch xauth");
+        LOG(LOG_LEVEL_ERROR, "Unable to launch xauth");
         return 1;
     }
 
     ret = pclose(dp);
     if (ret < 0)
     {
-        log_message(LOG_LEVEL_ERROR, "An error occurred while running xauth");
+        LOG(LOG_LEVEL_ERROR, "An error occurred while running xauth");
         return 1;
     }
 


### PR DESCRIPTION
Follow-on pull request to #1633 which migrates all logging in sesman to use the `LOG()` and `LOG_DEVEL()` macros.