### PR TITLE
Add log_config_init_for_console() for utilities

### DIFF
--- a/common/log.h
+++ b/common/log.h
@@ -155,6 +155,7 @@ struct log_config
     int enable_syslog;
     enum logLevels syslog_level;
     struct list *per_logger_level;
+    int dump_on_start;
     int enable_pid;
     pthread_mutex_t log_lock;
     pthread_mutexattr_t log_lock_attr;
@@ -267,6 +268,16 @@ log_start(const char *iniFile, const char *applicationName);
  */
 enum logReturns
 log_start_from_param(const struct log_config *src_log_config);
+
+/**
+ * Sets up a suitable log config for writing to the console only
+ * (i.e. for a utility)
+ *
+ * The config can be customised by the caller before calling
+ * log_start_from_param()
+ */
+struct log_config*
+log_config_init_for_console(enum logLevels lvl);
 
 /**
  * Read configuration from a file and store the values in the returned 

--- a/sesman/tools/sesadmin.c
+++ b/sesman/tools/sesadmin.c
@@ -37,8 +37,6 @@ char cmnd[257];
 char serv[257];
 char port[257];
 
-struct log_config logging;
-
 void cmndList(struct SCP_CONNECTION *c);
 void cmndKill(struct SCP_CONNECTION *c, struct SCP_SESSION *s);
 void cmndHelp(void);
@@ -56,6 +54,7 @@ int main(int argc, char **argv)
     //int sel;
     int sock;
     char *pwd;
+    struct log_config *logging;
 
     user[0] = '\0';
     pass[0] = '\0';
@@ -63,11 +62,9 @@ int main(int argc, char **argv)
     serv[0] = '\0';
     port[0] = '\0';
 
-    logging.program_name = "sesadmin";
-    logging.log_file = g_strdup("xrdp-sesadmin.log");
-    logging.log_level = LOG_LEVEL_DEBUG;
-    logging.enable_syslog = 0;
-    log_start_from_param(&logging);
+    logging = log_config_init_for_console(LOG_LEVEL_INFO);
+    log_start_from_param(logging);
+    log_config_free(logging);
 
     for (idx = 0; idx < argc; idx++)
     {


### PR DESCRIPTION
This is a bit of tidy-up work for the standalone utilities in `sesman/tools`.

These utilities call library functions which use the logging facility.  Since they're utilities, they don't really need to log anywhere other than the current console. This change adds a function `log_config_init_for_console()` to the logging sub-system which allows this to be done in a straightforward manner.

The utility `sesadmin` has been modified to use the new facility.

Other changes to log.c:-
- A log file is no longer mandatory.
- A way to disable the logging config dump on startup has been added.
- The logging dump to stdout generates slightly less output for the console and syslog

@aquesnel - if you have the time, I'd be interested in any comments you have as you were the last person to make significant changes to the logging.