### PR TITLE
Add delay between exit of window manager and termination of Xvnc

### DIFF
--- a/sesman/session.c
+++ b/sesman/session.c
@@ -818,6 +818,7 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
                             "auth_end from pid %d", g_getpid());
                 auth_stop_session(data);
                 auth_end(data);
+                g_sleep(2000);
                 g_sigterm(display_pid);
                 g_sigterm(chansrv_pid);
                 cleanup_sockets(display);


### PR DESCRIPTION
kwin_x11's termination is not waited by startkde. Xvnc is closed
by sesman after sesman detects exit of startkde.
kwin_x11 runs indefinitely on getTimestamp due to the display is
closed. Thus kwin_x11 cannot process exit event from event loop.
Therefore, kwin_x11 will run a loop and consume a whole core of
CPU.

The fix adds a g_sleep(1000) to allow kwin_x11 to exit gracefully.

Fix #1712 kwin_x11 runs indefinitely because Xvnc exits too early