### PR TITLE
Update verify_user_pam.c

### DIFF
--- a/sesman/verify_user_pam.c
+++ b/sesman/verify_user_pam.c
@@ -77,6 +77,9 @@ verify_pam_conv(int num_msg, const struct pam_message **msg,
                 reply[i].resp = g_strdup(user_pass->pass);
                 reply[i].resp_retcode = PAM_SUCCESS;
                 break;
+            case PAM_TEXT_INFO:
+                memset(&reply[i], 0, sizeof(struct pam_response));
+                break;
             default:
                 g_printf("unknown in verify_pam_conv\r\n");
                 g_free(reply);

--- a/sesman/verify_user_pam.c
+++ b/sesman/verify_user_pam.c
@@ -78,7 +78,7 @@ verify_pam_conv(int num_msg, const struct pam_message **msg,
                 reply[i].resp_retcode = PAM_SUCCESS;
                 break;
             case PAM_TEXT_INFO:
-                memset(&reply[i], 0, sizeof(struct pam_response));
+                g_memset(&reply[i], 0, sizeof(struct pam_response));
                 break;
             default:
                 g_printf("unknown in verify_pam_conv\r\n");


### PR DESCRIPTION
when a system give a tip message in function verify_pam_conv, authenticate will fail.
so it need skip this message to make sure authenticate success.