### PR TITLE
Add caching of cppcheck to github action CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,13 @@ jobs:
       CPPCHECK_REPO: https://github.com/danmar/cppcheck.git
     steps:
       - uses: actions/checkout@v2
+      - name: Cache cppcheck
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-cppcheck
+        with:
+          path: ~/cppcheck.local
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.CPPCHECK_VER }}
       - run: sudo scripts/install_cppcheck_dependencies_with_apt.sh
       - run: ./bootstrap
       - run: scripts/install_cppcheck.sh $CPPCHECK_REPO $CPPCHECK_VER


### PR DESCRIPTION
This pull request reduces the build time of xrdp in github actions by about 2min 30sec per build by caching the cppcheck build artifacts. Caching the cppcheck build artifacts is safe because cppcheck is a a dependency and the workflow always builds cppcheck from a git tag from the cppcheck repo.

This caching is a 10% reduction in build time across all builds (current build time is approx. 21min CPU time)

Example builds:
* without caching: https://github.com/neutrinolabs/xrdp/runs/1428776621
* with caching cppcheck build output: https://github.com/aquesnel/xrdp/runs/1440410754