### PR TITLE
Unify logging in libxrdp

### DIFF
--- a/common/defines.h
+++ b/common/defines.h
@@ -40,6 +40,9 @@
 #define LOWORD(in) ((in) & 0x0000ffff)
 #undef MAKELONG
 #define MAKELONG(lo, hi) ((((hi) & 0xffff) << 16) | ((lo) & 0xffff))
+#define UNUSED_VAR(x) ((void) (x))
+
+/* graphics macros */
 #define MAKERECT(r, x, y, cx, cy) \
 { (r).left = x; (r).top = y; (r).right = (x) + (cx); (r).bottom = (y) + (cy); }
 #define ISRECTEMPTY(r) (((r).right <= (r).left) || ((r).bottom <= (r).top))

--- a/libxrdp/libxrdp.c
+++ b/libxrdp/libxrdp.c
@@ -121,7 +121,7 @@ libxrdp_get_pdu_bytes(const char *aheader)
 /******************************************************************************/
 /* only used during connection */
 struct stream *
-libxrdp_force_read(struct trans* trans)
+libxrdp_force_read(struct trans *trans)
 {
     int bytes;
     struct stream *s;
@@ -246,9 +246,9 @@ libxrdp_process_data(struct xrdp_session *session, struct stream *s)
             case 2: /* FASTPATH_INPUT_EVENT */
                 if (xrdp_fastpath_process_input_event(rdp->sec_layer->fastpath_layer, s) != 0)
                 {
-                     LOG_DEVEL(LOG_LEVEL_TRACE, "libxrdp_process_data returned non zero");
-                     cont = 0;
-                     term = 1;
+                    LOG_DEVEL(LOG_LEVEL_TRACE, "libxrdp_process_data returned non zero");
+                    cont = 0;
+                    term = 1;
                 }
                 break;
             default:
@@ -307,7 +307,8 @@ libxrdp_send_palette(struct xrdp_session *session, int *palette)
             return 1;
         }
     }
-    else {
+    else
+    {
         LOG_DEVEL(LOG_LEVEL_DEBUG, "libxrdp_send_palette: slowpath");
         xrdp_rdp_init_data((struct xrdp_rdp *)session->rdp, s);
     }
@@ -329,16 +330,16 @@ libxrdp_send_palette(struct xrdp_session *session, int *palette)
     s_mark_end(s);
     if (session->client_info->use_fast_path & 1) /* fastpath output supported */
     {
-       if (xrdp_rdp_send_fastpath((struct xrdp_rdp *)session->rdp, s,
+        if (xrdp_rdp_send_fastpath((struct xrdp_rdp *)session->rdp, s,
                                    FASTPATH_UPDATETYPE_PALETTE) != 0)
-       {
-           free_stream(s);
-           return 1;
-       }
+        {
+            free_stream(s);
+            return 1;
+        }
     }
     else
     {
-       xrdp_rdp_send_data((struct xrdp_rdp *)session->rdp, s,
+        xrdp_rdp_send_data((struct xrdp_rdp *)session->rdp, s,
                            RDP_DATA_PDU_UPDATE);
     }
     free_stream(s);
@@ -434,7 +435,7 @@ libxrdp_send_bitmap(struct xrdp_session *session, int width, int height,
     line_pad_bytes = line_bytes + e * Bpp;
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "libxrdp_send_bitmap: bpp %d Bpp %d line_bytes %d "
-           "server_line_bytes %d", bpp, Bpp, line_bytes, server_line_bytes);
+              "server_line_bytes %d", bpp, Bpp, line_bytes, server_line_bytes);
     make_stream(s);
     init_stream(s, MAX_BITMAP_BUF_SIZE);
 
@@ -479,19 +480,19 @@ libxrdp_send_bitmap(struct xrdp_session *session, int width, int height,
                     LOG_DEVEL(LOG_LEVEL_DEBUG, "libxrdp_send_bitmap: 32 bpp");
                     lines_sending = xrdp_bitmap32_compress(data, width, height,
                                                            s, 32,
-                                   (MAX_BITMAP_BUF_SIZE - 100) - total_bufsize,
+                                                           (MAX_BITMAP_BUF_SIZE - 100) - total_bufsize,
                                                            i - 1, temp_s, e, 0x10);
                     LOG_DEVEL(LOG_LEVEL_DEBUG, "libxrdp_send_bitmap: i %d lines_sending %d",
-                           i, lines_sending);
+                              i, lines_sending);
                 }
                 else
                 {
                     lines_sending = xrdp_bitmap_compress(data, width, height,
                                                          s, bpp,
-                                 (MAX_BITMAP_BUF_SIZE - 100) - total_bufsize,
+                                                         (MAX_BITMAP_BUF_SIZE - 100) - total_bufsize,
                                                          i - 1, temp_s, e);
                     LOG_DEVEL(LOG_LEVEL_DEBUG, "libxrdp_send_bitmap: i %d lines_sending %d",
-                           i, lines_sending);
+                              i, lines_sending);
                 }
 
                 if (lines_sending == 0)
@@ -535,20 +536,20 @@ libxrdp_send_bitmap(struct xrdp_session *session, int width, int height,
                 }
 
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "libxrdp_send_bitmap: decompressed pixels %d "
-                       "decompressed bytes %d compressed bytes %d",
-                       lines_sending * (width + e),
-                       line_pad_bytes * lines_sending, bufsize);
+                          "decompressed bytes %d compressed bytes %d",
+                          lines_sending * (width + e),
+                          line_pad_bytes * lines_sending, bufsize);
 
                 if (j > MAX_BITMAP_BUF_SIZE)
                 {
                     LOG_DEVEL(LOG_LEVEL_INFO, "libxrdp_send_bitmap: error, decompressed "
-                           "size too big: %d bytes", j);
+                              "size too big: %d bytes", j);
                 }
 
                 if (bufsize > MAX_BITMAP_BUF_SIZE)
                 {
                     LOG_DEVEL(LOG_LEVEL_INFO, "libxrdp_send_bitmap: error, compressed size "
-                           "too big: %d bytes", bufsize);
+                              "too big: %d bytes", bufsize);
                 }
 
                 s->p = s->end;
@@ -556,7 +557,7 @@ libxrdp_send_bitmap(struct xrdp_session *session, int width, int height,
             while (total_bufsize < MAX_BITMAP_BUF_SIZE && i > 0);
 
             LOG_DEVEL(LOG_LEVEL_DEBUG, "libxrdp_send_bitmap: num_updates %d total_bufsize %d",
-                   num_updates, total_bufsize);
+                      num_updates, total_bufsize);
 
             p_num_updates[0] = num_updates;
             p_num_updates[1] = num_updates >> 8;
@@ -566,7 +567,7 @@ libxrdp_send_bitmap(struct xrdp_session *session, int width, int height,
             if (total_bufsize > MAX_BITMAP_BUF_SIZE)
             {
                 LOG_DEVEL(LOG_LEVEL_INFO, "libxrdp_send_bitmap: error, total compressed "
-                       "size too big: %d bytes", total_bufsize);
+                          "size too big: %d bytes", total_bufsize);
             }
         }
 
@@ -629,7 +630,7 @@ libxrdp_send_bitmap(struct xrdp_session *session, int width, int height,
                             q = q - server_line_bytes;
                             for (k = 0; k < width; k++)
                             {
-                                pixel = *((tui16*)(q + k * 2));
+                                pixel = *((tui16 *)(q + k * 2));
                                 out_uint16_le(s, pixel);
                             }
                             out_uint8s(s, e * 2);
@@ -641,7 +642,7 @@ libxrdp_send_bitmap(struct xrdp_session *session, int width, int height,
                             q = q - server_line_bytes;
                             for (k = 0; k < width; k++)
                             {
-                                pixel = *((tui32*)(q + k * 4));
+                                pixel = *((tui32 *)(q + k * 4));
                                 out_uint8(s, pixel);
                                 out_uint8(s, pixel >> 8);
                                 out_uint8(s, pixel >> 16);
@@ -655,7 +656,7 @@ libxrdp_send_bitmap(struct xrdp_session *session, int width, int height,
                             q = q - server_line_bytes;
                             for (k = 0; k < width; k++)
                             {
-                                pixel = *((int*)(q + k * 4));
+                                pixel = *((int *)(q + k * 4));
                                 out_uint32_le(s, pixel);
                             }
                             out_uint8s(s, e * 4);
@@ -735,18 +736,18 @@ libxrdp_send_pointer(struct xrdp_session *session, int cache_idx,
         LOG_DEVEL(LOG_LEVEL_DEBUG, "libxrdp_send_pointer: slowpath");
         xrdp_rdp_init_data((struct xrdp_rdp *)session->rdp, s);
         if ((session->client_info->pointer_flags & 1) == 0)
-         {
-             out_uint16_le(s, RDP_POINTER_COLOR);
-             out_uint16_le(s, 0); /* pad */
-             data_bytes = 3072;
-         }
-         else
-         {
-             out_uint16_le(s, RDP_POINTER_POINTER);
-             out_uint16_le(s, 0); /* pad */
-             out_uint16_le(s, bpp);
-             data_bytes = ((bpp + 7) / 8) * 32 * 32;
-         }
+        {
+            out_uint16_le(s, RDP_POINTER_COLOR);
+            out_uint16_le(s, 0); /* pad */
+            data_bytes = 3072;
+        }
+        else
+        {
+            out_uint16_le(s, RDP_POINTER_POINTER);
+            out_uint16_le(s, 0); /* pad */
+            out_uint16_le(s, bpp);
+            data_bytes = ((bpp + 7) / 8) * 32 * 32;
+        }
     }
 
 
@@ -808,7 +809,7 @@ libxrdp_send_pointer(struct xrdp_session *session, int cache_idx,
         if ((session->client_info->pointer_flags & 1) == 0)
         {
             if (xrdp_rdp_send_fastpath((struct xrdp_rdp *)session->rdp, s,
-                                        FASTPATH_UPDATETYPE_COLOR) != 0)
+                                       FASTPATH_UPDATETYPE_COLOR) != 0)
             {
                 free_stream(s);
                 return 1;
@@ -817,7 +818,7 @@ libxrdp_send_pointer(struct xrdp_session *session, int cache_idx,
         else
         {
             if (xrdp_rdp_send_fastpath((struct xrdp_rdp *)session->rdp, s,
-                                        FASTPATH_UPDATETYPE_POINTER) != 0)
+                                       FASTPATH_UPDATETYPE_POINTER) != 0)
             {
                 free_stream(s);
                 return 1;
@@ -827,7 +828,7 @@ libxrdp_send_pointer(struct xrdp_session *session, int cache_idx,
     else
     {
         xrdp_rdp_send_data((struct xrdp_rdp *)session->rdp, s,
-                          RDP_DATA_PDU_POINTER);
+                           RDP_DATA_PDU_POINTER);
     }
     free_stream(s);
     return 0;
@@ -867,7 +868,7 @@ libxrdp_set_pointer(struct xrdp_session *session, int cache_idx)
     if (session->client_info->use_fast_path & 1) /* fastpath output supported */
     {
         if (xrdp_rdp_send_fastpath((struct xrdp_rdp *)session->rdp, s,
-                                    FASTPATH_UPDATETYPE_CACHED) != 0)
+                                   FASTPATH_UPDATETYPE_CACHED) != 0)
         {
             free_stream(s);
             return 1;
@@ -876,7 +877,7 @@ libxrdp_set_pointer(struct xrdp_session *session, int cache_idx)
     else
     {
         xrdp_rdp_send_data((struct xrdp_rdp *)session->rdp, s,
-                            RDP_DATA_PDU_POINTER);
+                           RDP_DATA_PDU_POINTER);
     }
     free_stream(s);
     return 0;
@@ -971,21 +972,21 @@ libxrdp_orders_mem_blt(struct xrdp_session *session, int cache_id,
 
 /******************************************************************************/
 int
-libxrdp_orders_composite_blt(struct xrdp_session* session, int srcidx,
+libxrdp_orders_composite_blt(struct xrdp_session *session, int srcidx,
                              int srcformat, int srcwidth, int srcrepeat,
-                             int* srctransform, int mskflags,
+                             int *srctransform, int mskflags,
                              int mskidx, int mskformat, int mskwidth,
                              int mskrepeat, int op, int srcx, int srcy,
                              int mskx, int msky, int dstx, int dsty,
                              int width, int height, int dstformat,
-                             struct xrdp_rect* rect)
+                             struct xrdp_rect *rect)
 {
-  return xrdp_orders_composite_blt((struct xrdp_orders*)session->orders,
-                                   srcidx, srcformat, srcwidth, srcrepeat,
-                                   srctransform, mskflags,
-                                   mskidx, mskformat, mskwidth, mskrepeat,
-                                   op, srcx, srcy, mskx, msky, dstx, dsty,
-                                   width, height, dstformat, rect);
+    return xrdp_orders_composite_blt((struct xrdp_orders *)session->orders,
+                                     srcidx, srcformat, srcwidth, srcrepeat,
+                                     srctransform, mskflags,
+                                     mskidx, mskformat, mskwidth, mskrepeat,
+                                     op, srcx, srcy, mskx, msky, dstx, dsty,
+                                     width, height, dstformat, rect);
 }
 
 /******************************************************************************/
@@ -1067,9 +1068,9 @@ libxrdp_reset(struct xrdp_session *session,
 
         /* if same (and only one monitor on client) don't need to do anything */
         if (client_info->width == width &&
-            client_info->height == height &&
-            client_info->bpp == bpp &&
-            (client_info->monitorCount == 0 || client_info->multimon == 0))
+                client_info->height == height &&
+                client_info->bpp == bpp &&
+                (client_info->monitorCount == 0 || client_info->multimon == 0))
         {
             return 0;
         }
@@ -1493,7 +1494,7 @@ libxrdp_codec_jpeg_compress(struct xrdp_session *session,
                             char *out_data, int *io_len)
 {
     struct xrdp_orders *orders;
-    void* jpeg_han;
+    void *jpeg_han;
 
     orders = (struct xrdp_orders *)(session->orders);
     jpeg_han = orders->jpeg_han;
@@ -1505,7 +1506,7 @@ libxrdp_codec_jpeg_compress(struct xrdp_session *session,
 /*****************************************************************************/
 int EXPORT_CC
 libxrdp_fastpath_send_surface(struct xrdp_session *session,
-                              char* data_pad, int pad_bytes,
+                              char *data_pad, int pad_bytes,
                               int data_bytes,
                               int destLeft, int destTop,
                               int destRight, int destBottom, int bpp,

--- a/libxrdp/libxrdp.c
+++ b/libxrdp/libxrdp.c
@@ -131,18 +131,18 @@ libxrdp_force_read(struct trans *trans)
 
     if (trans_force_read(trans, 4) != 0)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "libxrdp_force_read: header read error");
+        LOG(LOG_LEVEL_WARNING, "libxrdp_force_read: header read error");
         return 0;
     }
     bytes = libxrdp_get_pdu_bytes(s->data);
     if (bytes < 4 || bytes > s->size)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "libxrdp_force_read: bad header length %d", bytes);
+        LOG(LOG_LEVEL_WARNING, "libxrdp_force_read: bad header length %d", bytes);
         return 0;
     }
     if (trans_force_read(trans, bytes - 4) != 0)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "libxrdp_force_read: Can't read PDU");
+        LOG(LOG_LEVEL_WARNING, "libxrdp_force_read: Can't read PDU");
         return 0;
     }
     return s;
@@ -163,12 +163,12 @@ libxrdp_process_data(struct xrdp_session *session, struct stream *s)
     do_read = s == 0;
     if (do_read && session->up_and_running)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "libxrdp_process_data: error logic");
+        LOG(LOG_LEVEL_ERROR, "libxrdp_process_data: error logic");
         return 1;
     }
     if (session->in_process_data != 0)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "libxrdp_process_data: error reentry");
+        LOG(LOG_LEVEL_ERROR, "libxrdp_process_data: error reentry");
         return 1;
     }
     session->in_process_data++;
@@ -208,7 +208,7 @@ libxrdp_process_data(struct xrdp_session *session, struct stream *s)
             }
             if (s == 0)
             {
-                LOG_DEVEL(LOG_LEVEL_TRACE, "libxrdp_process_data: libxrdp_force_read failed");
+                LOG(LOG_LEVEL_ERROR, "libxrdp_process_data: libxrdp_force_read failed");
                 rv = 1;
                 break;
             }
@@ -216,7 +216,7 @@ libxrdp_process_data(struct xrdp_session *session, struct stream *s)
 
         if (xrdp_rdp_recv(rdp, s, &code) != 0)
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "libxrdp_process_data: xrdp_rdp_recv failed");
+            LOG(LOG_LEVEL_ERROR, "libxrdp_process_data: xrdp_rdp_recv failed");
             rv = 1;
             break;
         }
@@ -238,7 +238,7 @@ libxrdp_process_data(struct xrdp_session *session, struct stream *s)
             case PDUTYPE_DATAPDU:
                 if (xrdp_rdp_process_data(rdp, s) != 0)
                 {
-                    LOG_DEVEL(LOG_LEVEL_TRACE, "libxrdp_process_data returned non zero");
+                    LOG(LOG_LEVEL_ERROR, "libxrdp_process_data returned non zero");
                     cont = 0;
                     term = 1;
                 }
@@ -246,13 +246,13 @@ libxrdp_process_data(struct xrdp_session *session, struct stream *s)
             case 2: /* FASTPATH_INPUT_EVENT */
                 if (xrdp_fastpath_process_input_event(rdp->sec_layer->fastpath_layer, s) != 0)
                 {
-                    LOG_DEVEL(LOG_LEVEL_TRACE, "libxrdp_process_data returned non zero");
+                    LOG(LOG_LEVEL_ERROR, "libxrdp_process_data returned non zero");
                     cont = 0;
                     term = 1;
                 }
                 break;
             default:
-                LOG_DEVEL(LOG_LEVEL_TRACE, "unknown in libxrdp_process_data: code= %d", code);
+                LOG(LOG_LEVEL_ERROR, "unknown in libxrdp_process_data: code= %d", code);
                 dead_lock_counter++;
                 break;
         }
@@ -261,8 +261,8 @@ libxrdp_process_data(struct xrdp_session *session, struct stream *s)
         {
             /*This situation can happen and this is a workaround*/
             cont = 0;
-            LOG_DEVEL(LOG_LEVEL_TRACE, "Serious programming error: we were locked in a deadly loop");
-            LOG_DEVEL(LOG_LEVEL_TRACE, "Remaining: %d", (int) (s->end - s->next_packet));
+            LOG(LOG_LEVEL_ERROR, "Serious programming error: we were locked in a deadly loop");
+            LOG(LOG_LEVEL_ERROR, "Remaining: %d", (int) (s->end - s->next_packet));
             s->next_packet = 0;
         }
 
@@ -542,14 +542,14 @@ libxrdp_send_bitmap(struct xrdp_session *session, int width, int height,
 
                 if (j > MAX_BITMAP_BUF_SIZE)
                 {
-                    LOG_DEVEL(LOG_LEVEL_INFO, "libxrdp_send_bitmap: error, decompressed "
-                              "size too big: %d bytes", j);
+                    LOG(LOG_LEVEL_WARNING, "libxrdp_send_bitmap: error, decompressed "
+                        "size too big: %d bytes", j);
                 }
 
                 if (bufsize > MAX_BITMAP_BUF_SIZE)
                 {
-                    LOG_DEVEL(LOG_LEVEL_INFO, "libxrdp_send_bitmap: error, compressed size "
-                              "too big: %d bytes", bufsize);
+                    LOG(LOG_LEVEL_WARNING, "libxrdp_send_bitmap: error, compressed size "
+                        "too big: %d bytes", bufsize);
                 }
 
                 s->p = s->end;
@@ -566,8 +566,8 @@ libxrdp_send_bitmap(struct xrdp_session *session, int width, int height,
 
             if (total_bufsize > MAX_BITMAP_BUF_SIZE)
             {
-                LOG_DEVEL(LOG_LEVEL_INFO, "libxrdp_send_bitmap: error, total compressed "
-                          "size too big: %d bytes", total_bufsize);
+                LOG(LOG_LEVEL_WARNING, "libxrdp_send_bitmap: error, total compressed "
+                    "size too big: %d bytes", total_bufsize);
             }
         }
 
@@ -594,7 +594,7 @@ libxrdp_send_bitmap(struct xrdp_session *session, int width, int height,
 
                 if (lines_sending == 0)
                 {
-                    LOG_DEVEL(LOG_LEVEL_INFO, "libxrdp_send_bitmap: error, lines_sending == zero");
+                    LOG(LOG_LEVEL_WARNING, "libxrdp_send_bitmap: error, lines_sending == zero");
                     break;
                 }
 
@@ -699,14 +699,14 @@ libxrdp_send_pointer(struct xrdp_session *session, int cache_idx,
     {
         if (bpp != 24)
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "libxrdp_send_pointer: error client does not support "
-                      "new cursors and bpp is %d", bpp);
+            LOG(LOG_LEVEL_ERROR, "libxrdp_send_pointer: error client does not support "
+                "new cursors and bpp is %d", bpp);
             return 1;
         }
     }
     if ((bpp == 15) && (bpp != 16) && (bpp != 24) && (bpp != 32))
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "libxrdp_send_pointer: error");
+        LOG(LOG_LEVEL_ERROR, "libxrdp_send_pointer: error");
         return 1;
     }
     make_stream(s);
@@ -1167,7 +1167,7 @@ libxrdp_query_channel(struct xrdp_session *session, int index,
 
     if (mcs->channel_list == NULL)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "libxrdp_query_channel - No channel initialized");
+        LOG(LOG_LEVEL_ERROR, "libxrdp_query_channel - No channel initialized");
         return 1 ;
     }
 
@@ -1175,7 +1175,7 @@ libxrdp_query_channel(struct xrdp_session *session, int index,
 
     if (index < 0 || index >= count)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "libxrdp_query_channel - Channel out of range %d", index);
+        LOG(LOG_LEVEL_ERROR, "libxrdp_query_channel - Channel out of range %d", index);
         return 1;
     }
 
@@ -1185,14 +1185,14 @@ libxrdp_query_channel(struct xrdp_session *session, int index,
     if (channel_item == 0)
     {
         /* this should not happen */
-        LOG_DEVEL(LOG_LEVEL_TRACE, "libxrdp_query_channel - channel item is 0");
+        LOG(LOG_LEVEL_ERROR, "libxrdp_query_channel - channel item is 0");
         return 1;
     }
 
     if (channel_name != 0)
     {
         g_strncpy(channel_name, channel_item->name, 8);
-        LOG_DEVEL(LOG_LEVEL_TRACE, "libxrdp_query_channel - Channel %d name %s", index, channel_name);
+        LOG(LOG_LEVEL_ERROR, "libxrdp_query_channel - Channel %d name %s", index, channel_name);
     }
 
     if (channel_flags != 0)
@@ -1220,7 +1220,7 @@ libxrdp_get_channel_id(struct xrdp_session *session, const char *name)
 
     if (mcs->channel_list == NULL)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "libxrdp_get_channel_id No channel initialized");
+        LOG(LOG_LEVEL_ERROR, "libxrdp_get_channel_id No channel initialized");
         return -1 ;
     }
 
@@ -1272,7 +1272,7 @@ libxrdp_send_to_channel(struct xrdp_session *session, int channel_id,
 
     if (xrdp_channel_send(chan, s, channel_id, total_data_len, flags) != 0)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "libxrdp_send_to_channel: error, server channel data NOT sent to client channel");
+        LOG(LOG_LEVEL_ERROR, "libxrdp_send_to_channel: error, server channel data NOT sent to client channel");
         free_stream(s);
         return 1;
     }

--- a/libxrdp/libxrdp.h
+++ b/libxrdp/libxrdp.h
@@ -29,6 +29,7 @@
 #include "os_calls.h"
 #include "ssl_calls.h"
 #include "list.h"
+#include "log.h"
 #include "file.h"
 #include "libxrdpinc.h"
 #include "xrdp_client_info.h"

--- a/libxrdp/xrdp_bitmap32_compress.c
+++ b/libxrdp/xrdp_bitmap32_compress.c
@@ -33,11 +33,7 @@ http://msdn.microsoft.com/en-us/library/cc241877.aspx
 #define FLAGS_RLE     0x10
 #define FLAGS_NOALPHA 0x20
 
-#define LLOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-  do { if (_level < LLOG_LEVEL) { g_writeln _args ; } } while (0)
-#define LHEXDUMP(_level, _args) \
-  do { if (_level < LLOG_LEVEL) { g_hexdump _args ; } } while (0)
+
 
 /*****************************************************************************/
 /* split RGB */
@@ -258,7 +254,7 @@ fout(int collen, int replen, char *colptr, struct stream *s)
     int lreplen;
     int cont;
 
-    LLOGLN(10, ("fout: collen %d replen %d", collen, replen));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "fout: collen %d replen %d", collen, replen);
     cont = collen > 13;
     while (cont)
     {
@@ -285,7 +281,7 @@ fout(int collen, int replen, char *colptr, struct stream *s)
             {
                 lreplen = 47;
             }
-            LLOGLN(10, ("fout: big run lreplen %d", lreplen));
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "fout: big run lreplen %d", lreplen);
             replen -= lreplen;
             code = ((lreplen & 0xF) << 4) | ((lreplen & 0xF0) >> 4);
             out_uint8(s, code);
@@ -326,13 +322,13 @@ fpack(char *plane, int cx, int cy, struct stream *s)
     int collen;
     int replen;
 
-    LLOGLN(10, ("fpack:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "fpack:");
     holdp = s->p;
     for (jndex = 0; jndex < cy; jndex++)
     {
-        LLOGLN(10, ("line start line %d cx %d cy %d", jndex, cx, cy));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "line start line %d cx %d cy %d", jndex, cx, cy);
         ptr8 = plane + jndex * cx;
-        LHEXDUMP(10, (ptr8, cx));
+        LOG_DEVEL_HEXDUMP(LOG_LEVEL_TRACE, "line content", ptr8, cx);
         lend = ptr8 + (cx - 1);
         colptr = ptr8;
         if (colptr[0] == 0)
@@ -437,7 +433,7 @@ xrdp_bitmap32_compress(char *in_data, int width, int height,
     int total_bytes;
     int header;
 
-    LLOGLN(10, ("xrdp_bitmap32_compress:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_bitmap32_compress:");
     max_bytes = 4 * 1024;
     /* need max 8, 4K planes for work */
     if (max_bytes * 8 > temp_s->size)

--- a/libxrdp/xrdp_bitmap32_compress.c
+++ b/libxrdp/xrdp_bitmap32_compress.c
@@ -81,9 +81,9 @@ fsplit3(char *in_data, int start_line, int width, int e,
             rp |= (pixel <<  8) & 0xff000000;
             gp |= (pixel << 16) & 0xff000000;
             bp |= (pixel << 24) & 0xff000000;
-            *((int*)(r_data + out_index)) = rp;
-            *((int*)(g_data + out_index)) = gp;
-            *((int*)(b_data + out_index)) = bp;
+            *((int *)(r_data + out_index)) = rp;
+            *((int *)(g_data + out_index)) = gp;
+            *((int *)(b_data + out_index)) = bp;
             out_index += 4;
             index += 4;
         }
@@ -166,10 +166,10 @@ fsplit4(char *in_data, int start_line, int width, int e,
             rp |= (pixel <<  8) & 0xff000000;
             gp |= (pixel << 16) & 0xff000000;
             bp |= (pixel << 24) & 0xff000000;
-            *((int*)(a_data + out_index)) = ap;
-            *((int*)(r_data + out_index)) = rp;
-            *((int*)(g_data + out_index)) = gp;
-            *((int*)(b_data + out_index)) = bp;
+            *((int *)(a_data + out_index)) = ap;
+            *((int *)(r_data + out_index)) = rp;
+            *((int *)(g_data + out_index)) = gp;
+            *((int *)(b_data + out_index)) = bp;
             out_index += 4;
             index += 4;
         }
@@ -205,13 +205,13 @@ fsplit4(char *in_data, int start_line, int width, int e,
 
 /*****************************************************************************/
 #define DELTA_ONE \
-do { \
-    delta = src8[cx] - src8[0]; \
-    is_neg = (delta >> 7) & 1; \
-    dst8[cx] = (((delta ^ -is_neg) + is_neg) << 1) - is_neg; \
-    src8++; \
-    dst8++; \
-} while (0)
+    do { \
+        delta = src8[cx] - src8[0]; \
+        is_neg = (delta >> 7) & 1; \
+        dst8[cx] = (((delta ^ -is_neg) + is_neg) << 1) - is_neg; \
+        src8++; \
+        dst8++; \
+    } while (0)
 
 /*****************************************************************************/
 static int

--- a/libxrdp/xrdp_caps.c
+++ b/libxrdp/xrdp_caps.c
@@ -77,7 +77,7 @@ xrdp_caps_process_general(struct xrdp_rdp *self, struct stream *s,
 
     if (len < 10 + 2)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_general: error");
+        LOG(LOG_LEVEL_ERROR, "xrdp_caps_process_general: error");
         return 1;
     }
 
@@ -115,7 +115,7 @@ xrdp_caps_process_order(struct xrdp_rdp *self, struct stream *s,
     LOG_DEVEL(LOG_LEVEL_TRACE, "order capabilities");
     if (len < 20 + 2 + 2 + 2 + 2 + 2 + 2 + 32 + 2 + 2 + 4 + 4 + 4 + 4)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_order: error");
+        LOG(LOG_LEVEL_ERROR, "xrdp_caps_process_order: error");
         return 1;
     }
     in_uint8s(s, 20); /* Terminal desc, pad */
@@ -186,7 +186,7 @@ xrdp_caps_process_bmpcache(struct xrdp_rdp *self, struct stream *s,
 
     if (len < 24 + 2 + 2 + 2 + 2 + 2 + 2)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_bmpcache: error");
+        LOG(LOG_LEVEL_ERROR, "xrdp_caps_process_bmpcache: error");
         return 1;
     }
     self->client_info.bitmap_cache_version |= 1;
@@ -229,7 +229,7 @@ xrdp_caps_process_bmpcache2(struct xrdp_rdp *self, struct stream *s,
 
     if (len < 2 + 2 + 4 + 4 + 4)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_bmpcache2: error");
+        LOG(LOG_LEVEL_ERROR, "xrdp_caps_process_bmpcache2: error");
         return 1;
     }
     self->client_info.bitmap_cache_version |= 2;
@@ -271,7 +271,7 @@ xrdp_caps_process_cache_v3_codec_id(struct xrdp_rdp *self, struct stream *s,
 
     if (len < 1)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_cache_v3_codec_id: error");
+        LOG(LOG_LEVEL_ERROR, "xrdp_caps_process_cache_v3_codec_id: error");
         return 1;
     }
     in_uint8(s, codec_id);
@@ -293,7 +293,7 @@ xrdp_caps_process_pointer(struct xrdp_rdp *self, struct stream *s,
 
     if (len < 2 + 2 + 2)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_pointer: error");
+        LOG(LOG_LEVEL_ERROR, "xrdp_caps_process_pointer: error");
         return 1;
     }
     no_new_cursor = self->client_info.pointer_flags & 2;
@@ -304,21 +304,21 @@ xrdp_caps_process_pointer(struct xrdp_rdp *self, struct stream *s,
     self->client_info.pointer_cache_entries = i;
     if (colorPointerFlag & 1)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_pointer: client supports "
-                  "new(color) cursor");
+        LOG(LOG_LEVEL_INFO, "xrdp_caps_process_pointer: client supports "
+            "new(color) cursor");
         in_uint16_le(s, i);
         i = MIN(i, 32);
         self->client_info.pointer_cache_entries = i;
     }
     else
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_pointer: client does not support "
-                  "new(color) cursor");
+        LOG(LOG_LEVEL_INFO, "xrdp_caps_process_pointer: client does not support "
+            "new(color) cursor");
     }
     if (no_new_cursor)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_pointer: new(color) cursor is "
-                  "disabled by config");
+        LOG(LOG_LEVEL_INFO, "xrdp_caps_process_pointer: new(color) cursor is "
+            "disabled by config");
         self->client_info.pointer_flags = 0;
     }
     return 0;
@@ -352,7 +352,7 @@ xrdp_caps_process_brushcache(struct xrdp_rdp *self, struct stream *s,
 
     if (len < 4)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_brushcache: error");
+        LOG(LOG_LEVEL_ERROR, "xrdp_caps_process_brushcache: error");
         return 1;
     }
     in_uint32_le(s, code);
@@ -369,7 +369,7 @@ xrdp_caps_process_glyphcache(struct xrdp_rdp *self, struct stream *s,
 
     if (len < 40 + 4 + 2 + 2) /* MS-RDPBCGR 2.2.7.1.8 */
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_glyphcache: error");
+        LOG(LOG_LEVEL_ERROR, "xrdp_caps_process_glyphcache: error");
         return 1;
     }
 
@@ -396,7 +396,7 @@ xrdp_caps_process_offscreen_bmpcache(struct xrdp_rdp *self, struct stream *s,
 
     if (len < 4 + 2 + 2)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_offscreen_bmpcache: error");
+        LOG(LOG_LEVEL_ERROR, "xrdp_caps_process_offscreen_bmpcache: error");
         return 1;
     }
     in_uint32_le(s, i32);
@@ -405,11 +405,11 @@ xrdp_caps_process_offscreen_bmpcache(struct xrdp_rdp *self, struct stream *s,
     self->client_info.offscreen_cache_size = i32 * 1024;
     in_uint16_le(s, i32);
     self->client_info.offscreen_cache_entries = i32;
-    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_process_offscreen_bmpcache: support level %d "
-              "cache size %d MB cache entries %d",
-              self->client_info.offscreen_support_level,
-              self->client_info.offscreen_cache_size,
-              self->client_info.offscreen_cache_entries);
+    LOG(LOG_LEVEL_INFO, "xrdp_process_offscreen_bmpcache: support level %d "
+        "cache size %d MB cache entries %d",
+        self->client_info.offscreen_support_level,
+        self->client_info.offscreen_cache_size,
+        self->client_info.offscreen_cache_entries);
     return 0;
 }
 
@@ -421,13 +421,13 @@ xrdp_caps_process_rail(struct xrdp_rdp *self, struct stream *s, int len)
 
     if (len < 4)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_rail: error");
+        LOG(LOG_LEVEL_ERROR, "xrdp_caps_process_rail: error");
         return 1;
     }
     in_uint32_le(s, i32);
     self->client_info.rail_support_level = i32;
-    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_process_capset_rail: rail_support_level %d",
-              self->client_info.rail_support_level);
+    LOG(LOG_LEVEL_INFO, "xrdp_process_capset_rail: rail_support_level %d",
+        self->client_info.rail_support_level);
     return 0;
 }
 
@@ -439,7 +439,7 @@ xrdp_caps_process_window(struct xrdp_rdp *self, struct stream *s, int len)
 
     if (len < 4 + 1 + 2)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_window: error");
+        LOG(LOG_LEVEL_ERROR, "xrdp_caps_process_window: error");
         return 1;
     }
     in_uint32_le(s, i32);
@@ -448,11 +448,11 @@ xrdp_caps_process_window(struct xrdp_rdp *self, struct stream *s, int len)
     self->client_info.wnd_num_icon_caches = i32;
     in_uint16_le(s, i32);
     self->client_info.wnd_num_icon_cache_entries = i32;
-    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_process_capset_window wnd_support_level %d "
-              "wnd_num_icon_caches %d wnd_num_icon_cache_entries %d",
-              self->client_info.wnd_support_level,
-              self->client_info.wnd_num_icon_caches,
-              self->client_info.wnd_num_icon_cache_entries);
+    LOG(LOG_LEVEL_INFO, "xrdp_process_capset_window wnd_support_level %d "
+        "wnd_num_icon_caches %d wnd_num_icon_cache_entries %d",
+        self->client_info.wnd_support_level,
+        self->client_info.wnd_num_icon_caches,
+        self->client_info.wnd_num_icon_cache_entries);
     return 0;
 }
 
@@ -470,7 +470,7 @@ xrdp_caps_process_codecs(struct xrdp_rdp *self, struct stream *s, int len)
 
     if (len < 1)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_codecs: error");
+        LOG(LOG_LEVEL_ERROR, "xrdp_caps_process_codecs: error");
         return 1;
     }
     in_uint8(s, codec_count);
@@ -481,7 +481,7 @@ xrdp_caps_process_codecs(struct xrdp_rdp *self, struct stream *s, int len)
         codec_guid = s->p;
         if (len < 16 + 1 + 2)
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_codecs: error");
+            LOG(LOG_LEVEL_ERROR, "xrdp_caps_process_codecs: error");
             return 1;
         }
         in_uint8s(s, 16);
@@ -490,7 +490,7 @@ xrdp_caps_process_codecs(struct xrdp_rdp *self, struct stream *s, int len)
         len -= 16 + 1 + 2;
         if (len < codec_properties_length)
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_codecs: error");
+            LOG(LOG_LEVEL_ERROR, "xrdp_caps_process_codecs: error");
             return 1;
         }
         len -= codec_properties_length;
@@ -498,8 +498,8 @@ xrdp_caps_process_codecs(struct xrdp_rdp *self, struct stream *s, int len)
 
         if (g_memcmp(codec_guid, XR_CODEC_GUID_NSCODEC, 16) == 0)
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_codecs: nscodec, codec id %d, properties len %d",
-                      codec_id, codec_properties_length);
+            LOG(LOG_LEVEL_INFO, "xrdp_caps_process_codecs: nscodec, codec id %d, properties len %d",
+                codec_id, codec_properties_length);
             self->client_info.ns_codec_id = codec_id;
             i1 = MIN(64, codec_properties_length);
             g_memcpy(self->client_info.ns_prop, s->p, i1);
@@ -507,8 +507,8 @@ xrdp_caps_process_codecs(struct xrdp_rdp *self, struct stream *s, int len)
         }
         else if (g_memcmp(codec_guid, XR_CODEC_GUID_REMOTEFX, 16) == 0)
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_codecs: RemoteFX, codec id %d, properties len %d",
-                      codec_id, codec_properties_length);
+            LOG(LOG_LEVEL_INFO, "xrdp_caps_process_codecs: RemoteFX, codec id %d, properties len %d",
+                codec_id, codec_properties_length);
             self->client_info.rfx_codec_id = codec_id;
             i1 = MIN(64, codec_properties_length);
             g_memcpy(self->client_info.rfx_prop, s->p, i1);
@@ -516,8 +516,8 @@ xrdp_caps_process_codecs(struct xrdp_rdp *self, struct stream *s, int len)
         }
         else if (g_memcmp(codec_guid, XR_CODEC_GUID_JPEG, 16) == 0)
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_codecs: jpeg, codec id %d, properties len %d",
-                      codec_id, codec_properties_length);
+            LOG(LOG_LEVEL_INFO, "xrdp_caps_process_codecs: jpeg, codec id %d, properties len %d",
+                codec_id, codec_properties_length);
             self->client_info.jpeg_codec_id = codec_id;
             i1 = MIN(64, codec_properties_length);
             g_memcpy(self->client_info.jpeg_prop, s->p, i1);
@@ -525,16 +525,16 @@ xrdp_caps_process_codecs(struct xrdp_rdp *self, struct stream *s, int len)
             /* make sure that requested quality is  between 0 to 100 */
             if (self->client_info.jpeg_prop[0] < 0 || self->client_info.jpeg_prop[0] > 100)
             {
-                LOG_DEVEL(LOG_LEVEL_TRACE, "  Warning: the requested jpeg quality (%d) is invalid,"
+                LOG_DEVEL(LOG_LEVEL_WARNING, "  Warning: the requested jpeg quality (%d) is invalid,"
                           " falling back to default", self->client_info.jpeg_prop[0]);
                 self->client_info.jpeg_prop[0] = 75; /* use default */
             }
-            LOG_DEVEL(LOG_LEVEL_TRACE, "  jpeg quality set to %d", self->client_info.jpeg_prop[0]);
+            LOG(LOG_LEVEL_INFO, "  jpeg quality set to %d", self->client_info.jpeg_prop[0]);
         }
         else if (g_memcmp(codec_guid, XR_CODEC_GUID_H264, 16) == 0)
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_codecs: h264, codec id %d, properties len %d",
-                      codec_id, codec_properties_length);
+            LOG(LOG_LEVEL_INFO, "xrdp_caps_process_codecs: h264, codec id %d, properties len %d",
+                codec_id, codec_properties_length);
             self->client_info.h264_codec_id = codec_id;
             i1 = MIN(64, codec_properties_length);
             g_memcpy(self->client_info.h264_prop, s->p, i1);
@@ -542,7 +542,7 @@ xrdp_caps_process_codecs(struct xrdp_rdp *self, struct stream *s, int len)
         }
         else
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_codecs: unknown codec id %d", codec_id);
+            LOG(LOG_LEVEL_WARNING, "xrdp_caps_process_codecs: unknown codec id %d", codec_id);
         }
 
         s->p = next_guid;
@@ -575,8 +575,8 @@ xrdp_caps_process_frame_ack(struct xrdp_rdp *self, struct stream *s, int len)
     in_uint32_le(s, self->client_info.max_unacknowledged_frame_count);
     if (self->client_info.max_unacknowledged_frame_count < 0)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "  invalid max_unacknowledged_frame_count value (%d), setting to 0",
-                  self->client_info.max_unacknowledged_frame_count);
+        LOG(LOG_LEVEL_WARNING, "  invalid max_unacknowledged_frame_count value (%d), setting to 0",
+            self->client_info.max_unacknowledged_frame_count);
         self->client_info.max_unacknowledged_frame_count = 0;
     }
     LOG_DEVEL(LOG_LEVEL_TRACE, "  max_unacknowledged_frame_count %d", self->client_info.max_unacknowledged_frame_count);
@@ -589,7 +589,7 @@ xrdp_caps_process_surface_cmds(struct xrdp_rdp *self, struct stream *s, int len)
 {
     int cmdFlags;
 #ifndef XRDP_DEBUG
-    /* TODO: remove UNUSED_VAR once the `cmdFlags` variable is used for more than 
+    /* TODO: remove UNUSED_VAR once the `cmdFlags` variable is used for more than
     logging in debug mode */
     UNUSED_VAR(cmdFlags);
 #endif
@@ -631,15 +631,15 @@ xrdp_caps_process_confirm_active(struct xrdp_rdp *self, struct stream *s)
         p = s->p;
         if (!s_check_rem(s, 4))
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_confirm_active: error 1");
+            LOG(LOG_LEVEL_ERROR, "xrdp_caps_process_confirm_active: error 1");
             return 1;
         }
         in_uint16_le(s, type);
         in_uint16_le(s, len);
         if ((len < 4) || !s_check_rem(s, len - 4))
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_confirm_active: error: len %d, "
-                      "remaining %d", len, (int) (s->end - s->p));
+            LOG(LOG_LEVEL_ERROR, "xrdp_caps_process_confirm_active: error: len %d, "
+                "remaining %d", len, (int) (s->end - s->p));
             return 1;
         }
         len -= 4;
@@ -731,7 +731,7 @@ xrdp_caps_process_confirm_active(struct xrdp_rdp *self, struct stream *s)
                 xrdp_caps_process_frame_ack(self, s, len);
                 break;
             default:
-                LOG_DEVEL(LOG_LEVEL_TRACE, "unknown in xrdp_caps_process_confirm_active %d", type);
+                LOG(LOG_LEVEL_WARNING, "unknown in xrdp_caps_process_confirm_active %d", type);
                 break;
         }
 
@@ -741,9 +741,9 @@ xrdp_caps_process_confirm_active(struct xrdp_rdp *self, struct stream *s)
     if (self->client_info.no_orders_supported &&
             (self->client_info.offscreen_support_level != 0))
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_confirm_active: not enough orders "
-                  "supported by client, client wants off screen bitmap but "
-                  "offscreen bitmaps disabled");
+        LOG(LOG_LEVEL_WARNING, "xrdp_caps_process_confirm_active: not enough orders "
+            "supported by client, client wants off screen bitmap but "
+            "offscreen bitmaps disabled");
         self->client_info.offscreen_support_level = 0;
         self->client_info.offscreen_cache_size = 0;
         self->client_info.offscreen_cache_entries = 0;
@@ -1047,7 +1047,7 @@ xrdp_caps_send_demand_active(struct xrdp_rdp *self)
         LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_send_demand_active: sending monitor layout pdu");
         if (xrdp_caps_send_monitorlayout(self) != 0)
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_send_demand_active: error sending monitor layout pdu");
+            LOG(LOG_LEVEL_ERROR, "xrdp_caps_send_demand_active: error sending monitor layout pdu");
         }
     }
 

--- a/libxrdp/xrdp_caps.c
+++ b/libxrdp/xrdp_caps.c
@@ -525,8 +525,8 @@ xrdp_caps_process_codecs(struct xrdp_rdp *self, struct stream *s, int len)
             /* make sure that requested quality is  between 0 to 100 */
             if (self->client_info.jpeg_prop[0] < 0 || self->client_info.jpeg_prop[0] > 100)
             {
-                LOG_DEVEL(LOG_LEVEL_WARNING, "  Warning: the requested jpeg quality (%d) is invalid,"
-                          " falling back to default", self->client_info.jpeg_prop[0]);
+                LOG(LOG_LEVEL_WARNING, "  Warning: the requested jpeg quality (%d) is invalid, "
+                    "falling back to default", self->client_info.jpeg_prop[0]);
                 self->client_info.jpeg_prop[0] = 75; /* use default */
             }
             LOG(LOG_LEVEL_INFO, "  jpeg quality set to %d", self->client_info.jpeg_prop[0]);

--- a/libxrdp/xrdp_caps.c
+++ b/libxrdp/xrdp_caps.c
@@ -77,7 +77,7 @@ xrdp_caps_process_general(struct xrdp_rdp *self, struct stream *s,
 
     if (len < 10 + 2)
     {
-        g_writeln("xrdp_caps_process_general: error");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_general: error");
         return 1;
     }
 
@@ -112,10 +112,10 @@ xrdp_caps_process_order(struct xrdp_rdp *self, struct stream *s,
     int ex_flags;
     int cap_flags;
 
-    DEBUG(("order capabilities"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "order capabilities");
     if (len < 20 + 2 + 2 + 2 + 2 + 2 + 2 + 32 + 2 + 2 + 4 + 4 + 4 + 4)
     {
-        g_writeln("xrdp_caps_process_order: error");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_order: error");
         return 1;
     }
     in_uint8s(s, 20); /* Terminal desc, pad */
@@ -127,25 +127,23 @@ xrdp_caps_process_order(struct xrdp_rdp *self, struct stream *s,
     in_uint16_le(s, cap_flags); /* Capability flags */
     in_uint8a(s, order_caps, 32); /* Orders supported */
     g_memcpy(self->client_info.orders, order_caps, 32);
-    DEBUG(("dest blt-0 %d", order_caps[0]));
-    DEBUG(("pat blt-1 %d", order_caps[1]));
-    DEBUG(("screen blt-2 %d", order_caps[2]));
-    DEBUG(("memblt-3-13 %d %d", order_caps[3], order_caps[13]));
-    DEBUG(("triblt-4-14 %d %d", order_caps[4], order_caps[14]));
-    DEBUG(("line-8 %d", order_caps[8]));
-    DEBUG(("line-9 %d", order_caps[9]));
-    DEBUG(("rect-10 %d", order_caps[10]));
-    DEBUG(("desksave-11 %d", order_caps[11]));
-    DEBUG(("polygon-20 %d", order_caps[20]));
-    DEBUG(("polygon2-21 %d", order_caps[21]));
-    DEBUG(("polyline-22 %d", order_caps[22]));
-    DEBUG(("ellipse-25 %d", order_caps[25]));
-    DEBUG(("ellipse2-26 %d", order_caps[26]));
-    DEBUG(("text2-27 %d", order_caps[27]));
-    DEBUG(("order_caps dump"));
-#if defined(XRDP_DEBUG)
-    g_hexdump(order_caps, 32);
-#endif
+    LOG_DEVEL(LOG_LEVEL_TRACE, "dest blt-0 %d", order_caps[0]);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "pat blt-1 %d", order_caps[1]);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "screen blt-2 %d", order_caps[2]);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "memblt-3-13 %d %d", order_caps[3], order_caps[13]);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "triblt-4-14 %d %d", order_caps[4], order_caps[14]);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "line-8 %d", order_caps[8]);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "line-9 %d", order_caps[9]);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "rect-10 %d", order_caps[10]);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "desksave-11 %d", order_caps[11]);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "polygon-20 %d", order_caps[20]);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "polygon2-21 %d", order_caps[21]);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "polyline-22 %d", order_caps[22]);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "ellipse-25 %d", order_caps[25]);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "ellipse2-26 %d", order_caps[26]);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "text2-27 %d", order_caps[27]);
+    LOG_DEVEL_HEXDUMP(LOG_LEVEL_TRACE, "order_caps dump", order_caps, 32);
+
     in_uint8s(s, 2); /* Text capability flags */
     /* read extended order support flags */
     in_uint16_le(s, ex_flags); /* Ex flags */
@@ -155,7 +153,7 @@ xrdp_caps_process_order(struct xrdp_rdp *self, struct stream *s,
         self->client_info.order_flags_ex = ex_flags;
         if (ex_flags & XR_ORDERFLAGS_EX_CACHE_BITMAP_REV3_SUPPORT)
         {
-            g_writeln("xrdp_caps_process_order: bitmap cache v3 supported");
+            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_order: bitmap cache v3 supported");
             self->client_info.bitmap_cache_version |= 4;
         }
     }
@@ -163,7 +161,7 @@ xrdp_caps_process_order(struct xrdp_rdp *self, struct stream *s,
 
     in_uint32_le(s, i); /* desktop cache size, usually 0x38400 */
     self->client_info.desktop_cache = i;
-    DEBUG(("desktop cache size %d", i));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "desktop cache size %d", i);
     in_uint8s(s, 4); /* Unknown */
     in_uint8s(s, 4); /* Unknown */
 
@@ -171,7 +169,7 @@ xrdp_caps_process_order(struct xrdp_rdp *self, struct stream *s,
     if (!(order_caps[TS_NEG_DSTBLT_INDEX] && order_caps[TS_NEG_PATBLT_INDEX] &&
           order_caps[TS_NEG_SCRBLT_INDEX] && order_caps[TS_NEG_MEMBLT_INDEX]))
     {
-        g_writeln("xrdp_caps_process_order: not enough orders supported by client, using painter.");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_order: not enough orders supported by client, using painter.");
         self->client_info.no_orders_supported = 1;
     }
 
@@ -188,7 +186,7 @@ xrdp_caps_process_bmpcache(struct xrdp_rdp *self, struct stream *s,
 
     if (len < 24 + 2 + 2 + 2 + 2 + 2 + 2)
     {
-        g_writeln("xrdp_caps_process_bmpcache: error");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_bmpcache: error");
         return 1;
     }
     self->client_info.bitmap_cache_version |= 1;
@@ -211,12 +209,12 @@ xrdp_caps_process_bmpcache(struct xrdp_rdp *self, struct stream *s,
     i = MAX(i, 0);
     self->client_info.cache3_entries = i;
     in_uint16_le(s, self->client_info.cache3_size);
-    DEBUG(("cache1 entries %d size %d", self->client_info.cache1_entries,
-           self->client_info.cache1_size));
-    DEBUG(("cache2 entries %d size %d", self->client_info.cache2_entries,
-           self->client_info.cache2_size));
-    DEBUG(("cache3 entries %d size %d", self->client_info.cache3_entries,
-           self->client_info.cache3_size));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "cache1 entries %d size %d", self->client_info.cache1_entries,
+           self->client_info.cache1_size);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "cache2 entries %d size %d", self->client_info.cache2_entries,
+           self->client_info.cache2_size);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "cache3 entries %d size %d", self->client_info.cache3_entries,
+           self->client_info.cache3_size);
     return 0;
 }
 
@@ -231,7 +229,7 @@ xrdp_caps_process_bmpcache2(struct xrdp_rdp *self, struct stream *s,
 
     if (len < 2 + 2 + 4 + 4 + 4)
     {
-        g_writeln("xrdp_caps_process_bmpcache2: error");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_bmpcache2: error");
         return 1;
     }
     self->client_info.bitmap_cache_version |= 2;
@@ -255,12 +253,12 @@ xrdp_caps_process_bmpcache2(struct xrdp_rdp *self, struct stream *s,
     i = MAX(i, 0);
     self->client_info.cache3_entries = i;
     self->client_info.cache3_size = 4096 * Bpp;
-    DEBUG(("cache1 entries %d size %d", self->client_info.cache1_entries,
-           self->client_info.cache1_size));
-    DEBUG(("cache2 entries %d size %d", self->client_info.cache2_entries,
-           self->client_info.cache2_size));
-    DEBUG(("cache3 entries %d size %d", self->client_info.cache3_entries,
-           self->client_info.cache3_size));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "cache1 entries %d size %d", self->client_info.cache1_entries,
+           self->client_info.cache1_size);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "cache2 entries %d size %d", self->client_info.cache2_entries,
+           self->client_info.cache2_size);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "cache3 entries %d size %d", self->client_info.cache3_entries,
+           self->client_info.cache3_size);
     return 0;
 }
 
@@ -273,11 +271,11 @@ xrdp_caps_process_cache_v3_codec_id(struct xrdp_rdp *self, struct stream *s,
 
     if (len < 1)
     {
-        g_writeln("xrdp_caps_process_cache_v3_codec_id: error");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_cache_v3_codec_id: error");
         return 1;
     }
     in_uint8(s, codec_id);
-    g_writeln("xrdp_caps_process_cache_v3_codec_id: cache_v3_codec_id %d",
+    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_cache_v3_codec_id: cache_v3_codec_id %d",
               codec_id);
     self->client_info.v3_codec_id = codec_id;
     return 0;
@@ -295,7 +293,7 @@ xrdp_caps_process_pointer(struct xrdp_rdp *self, struct stream *s,
 
     if (len < 2 + 2 + 2)
     {
-        g_writeln("xrdp_caps_process_pointer: error");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_pointer: error");
         return 1;
     }
     no_new_cursor = self->client_info.pointer_flags & 2;
@@ -306,7 +304,7 @@ xrdp_caps_process_pointer(struct xrdp_rdp *self, struct stream *s,
     self->client_info.pointer_cache_entries = i;
     if (colorPointerFlag & 1)
     {
-        g_writeln("xrdp_caps_process_pointer: client supports "
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_pointer: client supports "
                   "new(color) cursor");
         in_uint16_le(s, i);
         i = MIN(i, 32);
@@ -314,12 +312,12 @@ xrdp_caps_process_pointer(struct xrdp_rdp *self, struct stream *s,
     }
     else
     {
-        g_writeln("xrdp_caps_process_pointer: client does not support "
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_pointer: client does not support "
                   "new(color) cursor");
     }
     if (no_new_cursor)
     {
-        g_writeln("xrdp_caps_process_pointer: new(color) cursor is "
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_pointer: new(color) cursor is "
                   "disabled by config");
         self->client_info.pointer_flags = 0;
     }
@@ -354,7 +352,7 @@ xrdp_caps_process_brushcache(struct xrdp_rdp *self, struct stream *s,
 
     if (len < 4)
     {
-        g_writeln("xrdp_caps_process_brushcache: error");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_brushcache: error");
         return 1;
     }
     in_uint32_le(s, code);
@@ -371,7 +369,7 @@ xrdp_caps_process_glyphcache(struct xrdp_rdp *self, struct stream *s,
 
     if (len < 40 + 4 + 2 + 2) /* MS-RDPBCGR 2.2.7.1.8 */
     {
-        g_writeln("xrdp_caps_process_glyphcache: error");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_glyphcache: error");
         return 1;
     }
 
@@ -384,7 +382,7 @@ xrdp_caps_process_glyphcache(struct xrdp_rdp *self, struct stream *s,
     {
         self->client_info.use_cache_glyph_v2 = 1;
     }
-    g_writeln("xrdp_caps_process_glyphcache: support level %d ",
+    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_glyphcache: support level %d ",
               glyph_support_level);
     return 0;
 }
@@ -398,7 +396,7 @@ xrdp_caps_process_offscreen_bmpcache(struct xrdp_rdp *self, struct stream *s,
 
     if (len < 4 + 2 + 2)
     {
-        g_writeln("xrdp_caps_process_offscreen_bmpcache: error");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_offscreen_bmpcache: error");
         return 1;
     }
     in_uint32_le(s, i32);
@@ -407,7 +405,7 @@ xrdp_caps_process_offscreen_bmpcache(struct xrdp_rdp *self, struct stream *s,
     self->client_info.offscreen_cache_size = i32 * 1024;
     in_uint16_le(s, i32);
     self->client_info.offscreen_cache_entries = i32;
-    g_writeln("xrdp_process_offscreen_bmpcache: support level %d "
+    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_process_offscreen_bmpcache: support level %d "
               "cache size %d MB cache entries %d",
               self->client_info.offscreen_support_level,
               self->client_info.offscreen_cache_size,
@@ -423,12 +421,12 @@ xrdp_caps_process_rail(struct xrdp_rdp *self, struct stream *s, int len)
 
     if (len < 4)
     {
-        g_writeln("xrdp_caps_process_rail: error");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_rail: error");
         return 1;
     }
     in_uint32_le(s, i32);
     self->client_info.rail_support_level = i32;
-    g_writeln("xrdp_process_capset_rail: rail_support_level %d",
+    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_process_capset_rail: rail_support_level %d",
               self->client_info.rail_support_level);
     return 0;
 }
@@ -441,7 +439,7 @@ xrdp_caps_process_window(struct xrdp_rdp *self, struct stream *s, int len)
 
     if (len < 4 + 1 + 2)
     {
-        g_writeln("xrdp_caps_process_window: error");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_window: error");
         return 1;
     }
     in_uint32_le(s, i32);
@@ -450,7 +448,7 @@ xrdp_caps_process_window(struct xrdp_rdp *self, struct stream *s, int len)
     self->client_info.wnd_num_icon_caches = i32;
     in_uint16_le(s, i32);
     self->client_info.wnd_num_icon_cache_entries = i32;
-    g_writeln("xrdp_process_capset_window wnd_support_level %d "
+    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_process_capset_window wnd_support_level %d "
               "wnd_num_icon_caches %d wnd_num_icon_cache_entries %d",
               self->client_info.wnd_support_level,
               self->client_info.wnd_num_icon_caches,
@@ -472,7 +470,7 @@ xrdp_caps_process_codecs(struct xrdp_rdp *self, struct stream *s, int len)
 
     if (len < 1)
     {
-        g_writeln("xrdp_caps_process_codecs: error");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_codecs: error");
         return 1;
     }
     in_uint8(s, codec_count);
@@ -483,7 +481,7 @@ xrdp_caps_process_codecs(struct xrdp_rdp *self, struct stream *s, int len)
         codec_guid = s->p;
         if (len < 16 + 1 + 2)
         {
-            g_writeln("xrdp_caps_process_codecs: error");
+            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_codecs: error");
             return 1;
         }
         in_uint8s(s, 16);
@@ -492,7 +490,7 @@ xrdp_caps_process_codecs(struct xrdp_rdp *self, struct stream *s, int len)
         len -= 16 + 1 + 2;
         if (len < codec_properties_length)
         {
-            g_writeln("xrdp_caps_process_codecs: error");
+            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_codecs: error");
             return 1;
         }
         len -= codec_properties_length;
@@ -500,7 +498,7 @@ xrdp_caps_process_codecs(struct xrdp_rdp *self, struct stream *s, int len)
 
         if (g_memcmp(codec_guid, XR_CODEC_GUID_NSCODEC, 16) == 0)
         {
-            g_writeln("xrdp_caps_process_codecs: nscodec, codec id %d, properties len %d",
+            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_codecs: nscodec, codec id %d, properties len %d",
                       codec_id, codec_properties_length);
             self->client_info.ns_codec_id = codec_id;
             i1 = MIN(64, codec_properties_length);
@@ -509,7 +507,7 @@ xrdp_caps_process_codecs(struct xrdp_rdp *self, struct stream *s, int len)
         }
         else if (g_memcmp(codec_guid, XR_CODEC_GUID_REMOTEFX, 16) == 0)
         {
-            g_writeln("xrdp_caps_process_codecs: RemoteFX, codec id %d, properties len %d",
+            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_codecs: RemoteFX, codec id %d, properties len %d",
                       codec_id, codec_properties_length);
             self->client_info.rfx_codec_id = codec_id;
             i1 = MIN(64, codec_properties_length);
@@ -518,7 +516,7 @@ xrdp_caps_process_codecs(struct xrdp_rdp *self, struct stream *s, int len)
         }
         else if (g_memcmp(codec_guid, XR_CODEC_GUID_JPEG, 16) == 0)
         {
-            g_writeln("xrdp_caps_process_codecs: jpeg, codec id %d, properties len %d",
+            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_codecs: jpeg, codec id %d, properties len %d",
                       codec_id, codec_properties_length);
             self->client_info.jpeg_codec_id = codec_id;
             i1 = MIN(64, codec_properties_length);
@@ -527,15 +525,15 @@ xrdp_caps_process_codecs(struct xrdp_rdp *self, struct stream *s, int len)
             /* make sure that requested quality is  between 0 to 100 */
             if (self->client_info.jpeg_prop[0] < 0 || self->client_info.jpeg_prop[0] > 100)
             {
-                g_writeln("  Warning: the requested jpeg quality (%d) is invalid,"
+                LOG_DEVEL(LOG_LEVEL_TRACE, "  Warning: the requested jpeg quality (%d) is invalid,"
                           " falling back to default", self->client_info.jpeg_prop[0]);
                 self->client_info.jpeg_prop[0] = 75; /* use default */
             }
-            g_writeln("  jpeg quality set to %d", self->client_info.jpeg_prop[0]);
+            LOG_DEVEL(LOG_LEVEL_TRACE, "  jpeg quality set to %d", self->client_info.jpeg_prop[0]);
         }
         else if (g_memcmp(codec_guid, XR_CODEC_GUID_H264, 16) == 0)
         {
-            g_writeln("xrdp_caps_process_codecs: h264, codec id %d, properties len %d",
+            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_codecs: h264, codec id %d, properties len %d",
                       codec_id, codec_properties_length);
             self->client_info.h264_codec_id = codec_id;
             i1 = MIN(64, codec_properties_length);
@@ -544,7 +542,7 @@ xrdp_caps_process_codecs(struct xrdp_rdp *self, struct stream *s, int len)
         }
         else
         {
-            g_writeln("xrdp_caps_process_codecs: unknown codec id %d", codec_id);
+            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_codecs: unknown codec id %d", codec_id);
         }
 
         s->p = next_guid;
@@ -572,16 +570,16 @@ xrdp_caps_process_multifragmentupdate(struct xrdp_rdp *self, struct stream *s,
 static int
 xrdp_caps_process_frame_ack(struct xrdp_rdp *self, struct stream *s, int len)
 {
-    g_writeln("xrdp_caps_process_frame_ack:");
+    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_frame_ack:");
     self->client_info.use_frame_acks = 1;
     in_uint32_le(s, self->client_info.max_unacknowledged_frame_count);
     if (self->client_info.max_unacknowledged_frame_count < 0)
     {
-        g_writeln("  invalid max_unacknowledged_frame_count value (%d), setting to 0",
+        LOG_DEVEL(LOG_LEVEL_TRACE, "  invalid max_unacknowledged_frame_count value (%d), setting to 0",
                   self->client_info.max_unacknowledged_frame_count);
         self->client_info.max_unacknowledged_frame_count = 0;
     }
-    g_writeln("  max_unacknowledged_frame_count %d", self->client_info.max_unacknowledged_frame_count);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "  max_unacknowledged_frame_count %d", self->client_info.max_unacknowledged_frame_count);
     return 0;
 }
 
@@ -590,10 +588,15 @@ static int
 xrdp_caps_process_surface_cmds(struct xrdp_rdp *self, struct stream *s, int len)
 {
     int cmdFlags;
-    g_writeln("xrdp_caps_process_surface_cmds:");
+#ifndef XRDP_DEBUG
+    /* TODO: remove UNUSED_VAR once the `cmdFlags` variable is used for more than 
+    logging in debug mode */
+    UNUSED_VAR(cmdFlags);
+#endif
+    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_surface_cmds:");
     in_uint32_le(s, cmdFlags);
     in_uint8s(s, 4); /* reserved */
-    g_writeln("  cmdFlags 0x%08x", cmdFlags);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "  cmdFlags 0x%08x", cmdFlags);
     return 0;
 }
 
@@ -609,7 +612,7 @@ xrdp_caps_process_confirm_active(struct xrdp_rdp *self, struct stream *s)
     int len;
     char *p;
 
-    DEBUG(("in xrdp_caps_process_confirm_active"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "in xrdp_caps_process_confirm_active");
     in_uint8s(s, 4); /* rdp_shareid */
     in_uint8s(s, 2); /* userid */
     in_uint16_le(s, source_len); /* sizeof RDP_SOURCE */
@@ -628,14 +631,14 @@ xrdp_caps_process_confirm_active(struct xrdp_rdp *self, struct stream *s)
         p = s->p;
         if (!s_check_rem(s, 4))
         {
-            g_writeln("xrdp_caps_process_confirm_active: error 1");
+            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_confirm_active: error 1");
             return 1;
         }
         in_uint16_le(s, type);
         in_uint16_le(s, len);
         if ((len < 4) || !s_check_rem(s, len - 4))
         {
-            g_writeln("xrdp_caps_process_confirm_active: error: len %d, "
+            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_confirm_active: error: len %d, "
                       "remaining %d", len, (int) (s->end - s->p));
             return 1;
         }
@@ -643,71 +646,71 @@ xrdp_caps_process_confirm_active(struct xrdp_rdp *self, struct stream *s)
         switch (type)
         {
             case CAPSTYPE_GENERAL:
-                DEBUG(("CAPSTYPE_GENERAL"));
+                LOG_DEVEL(LOG_LEVEL_TRACE, "CAPSTYPE_GENERAL");
                 xrdp_caps_process_general(self, s, len);
                 break;
             case CAPSTYPE_BITMAP:
-                DEBUG(("CAPSTYPE_BITMAP"));
+                LOG_DEVEL(LOG_LEVEL_TRACE, "CAPSTYPE_BITMAP");
                 break;
             case CAPSTYPE_ORDER:
-                DEBUG(("CAPSTYPE_ORDER"));
+                LOG_DEVEL(LOG_LEVEL_TRACE, "CAPSTYPE_ORDER");
                 xrdp_caps_process_order(self, s, len);
                 break;
             case CAPSTYPE_BITMAPCACHE:
-                DEBUG(("CAPSTYPE_BMPCACHE"));
+                LOG_DEVEL(LOG_LEVEL_TRACE, "CAPSTYPE_BMPCACHE");
                 xrdp_caps_process_bmpcache(self, s, len);
                 break;
             case CAPSTYPE_CONTROL:
-                DEBUG(("CAPSTYPE_CONTROL"));
+                LOG_DEVEL(LOG_LEVEL_TRACE, "CAPSTYPE_CONTROL");
                 break;
             case 6:
                 xrdp_caps_process_cache_v3_codec_id(self, s, len);
                 break;
             case CAPSTYPE_ACTIVATION:
-                DEBUG(("CAPSTYPE_ACTIVAION"));
+                LOG_DEVEL(LOG_LEVEL_TRACE, "CAPSTYPE_ACTIVAION");
                 break;
             case CAPSTYPE_POINTER:
-                DEBUG(("CAPSTYPE_POINTER"));
+                LOG_DEVEL(LOG_LEVEL_TRACE, "CAPSTYPE_POINTER");
                 xrdp_caps_process_pointer(self, s, len);
                 break;
             case CAPSTYPE_SHARE:
-                DEBUG(("CAPSTYPE_SHARE"));
+                LOG_DEVEL(LOG_LEVEL_TRACE, "CAPSTYPE_SHARE");
                 break;
             case CAPSTYPE_COLORCACHE:
-                DEBUG(("CAPSTYPE_COLORCACHE"));
+                LOG_DEVEL(LOG_LEVEL_TRACE, "CAPSTYPE_COLORCACHE");
                 break;
             case CAPSTYPE_SOUND:
-                DEBUG(("CAPSTYPE_SOUND"));
+                LOG_DEVEL(LOG_LEVEL_TRACE, "CAPSTYPE_SOUND");
                 break;
             case CAPSTYPE_INPUT:
                 xrdp_caps_process_input(self, s, len);
                 break;
             case CAPSTYPE_FONT:
-                DEBUG(("CAPSTYPE_FONT"));
+                LOG_DEVEL(LOG_LEVEL_TRACE, "CAPSTYPE_FONT");
                 break;
             case CAPSTYPE_BRUSH:
                 xrdp_caps_process_brushcache(self, s, len);
                 break;
             case CAPSTYPE_GLYPHCACHE:
-                DEBUG(("CAPSTYPE_GLYPHCACHE"));
+                LOG_DEVEL(LOG_LEVEL_TRACE, "CAPSTYPE_GLYPHCACHE");
                 xrdp_caps_process_glyphcache(self, s, len);
                 break;
             case CAPSTYPE_OFFSCREENCACHE:
-                DEBUG(("CAPSTYPE_OFFSCREENCACHE"));
+                LOG_DEVEL(LOG_LEVEL_TRACE, "CAPSTYPE_OFFSCREENCACHE");
                 xrdp_caps_process_offscreen_bmpcache(self, s, len);
                 break;
             case CAPSTYPE_BITMAPCACHE_REV2:
-                DEBUG(("CAPSTYPE_BITMAPCACHE_REV2"));
+                LOG_DEVEL(LOG_LEVEL_TRACE, "CAPSTYPE_BITMAPCACHE_REV2");
                 xrdp_caps_process_bmpcache2(self, s, len);
                 break;
             case CAPSTYPE_VIRTUALCHANNEL:
-                DEBUG(("CAPSTYPE_VIRTUALCHANNEL"));
+                LOG_DEVEL(LOG_LEVEL_TRACE, "CAPSTYPE_VIRTUALCHANNEL");
                 break;
             case CAPSTYPE_DRAWNINGRIDCACHE:
-                DEBUG(("CAPSTYPE_DRAWNINGRIDCACHE"));
+                LOG_DEVEL(LOG_LEVEL_TRACE, "CAPSTYPE_DRAWNINGRIDCACHE");
                 break;
             case CAPSTYPE_DRAWGDIPLUS:
-                DEBUG(("CAPSTYPE_DRAWGDIPLUS"));
+                LOG_DEVEL(LOG_LEVEL_TRACE, "CAPSTYPE_DRAWGDIPLUS");
                 break;
             case CAPSTYPE_RAIL:
                 xrdp_caps_process_rail(self, s, len);
@@ -728,7 +731,7 @@ xrdp_caps_process_confirm_active(struct xrdp_rdp *self, struct stream *s)
                 xrdp_caps_process_frame_ack(self, s, len);
                 break;
             default:
-                g_writeln("unknown in xrdp_caps_process_confirm_active %d", type);
+                LOG_DEVEL(LOG_LEVEL_TRACE, "unknown in xrdp_caps_process_confirm_active %d", type);
                 break;
         }
 
@@ -738,7 +741,7 @@ xrdp_caps_process_confirm_active(struct xrdp_rdp *self, struct stream *s)
     if (self->client_info.no_orders_supported &&
         (self->client_info.offscreen_support_level != 0))
     {
-        g_writeln("xrdp_caps_process_confirm_active: not enough orders "
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_confirm_active: not enough orders "
                   "supported by client, client wants off screen bitmap but "
                   "offscreen bitmaps disabled");
         self->client_info.offscreen_support_level = 0;
@@ -746,7 +749,7 @@ xrdp_caps_process_confirm_active(struct xrdp_rdp *self, struct stream *s)
         self->client_info.offscreen_cache_entries = 0;
     }
 
-    DEBUG(("out xrdp_caps_process_confirm_active"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_caps_process_confirm_active");
     return 0;
 }
 /*****************************************************************************/
@@ -768,7 +771,7 @@ xrdp_caps_send_demand_active(struct xrdp_rdp *self)
     make_stream(s);
     init_stream(s, 8192);
 
-    DEBUG(("in xrdp_caps_send_demand_active"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "in xrdp_caps_send_demand_active");
 
     if (xrdp_rdp_init(self, s) != 0)
     {
@@ -1035,16 +1038,16 @@ xrdp_caps_send_demand_active(struct xrdp_rdp *self)
         free_stream(s);
         return 1;
     }
-    DEBUG(("out (1) xrdp_caps_send_demand_active"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "out (1) xrdp_caps_send_demand_active");
 
     /* send Monitor Layout PDU for dual monitor */
     if (self->client_info.monitorCount > 0 &&
         self->client_info.multimon == 1)
     {
-        DEBUG(("xrdp_caps_send_demand_active: sending monitor layout pdu"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_send_demand_active: sending monitor layout pdu");
         if (xrdp_caps_send_monitorlayout(self) != 0)
         {
-          g_writeln("xrdp_caps_send_demand_active: error sending monitor layout pdu");
+          LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_send_demand_active: error sending monitor layout pdu");
         }
     }
 

--- a/libxrdp/xrdp_caps.c
+++ b/libxrdp/xrdp_caps.c
@@ -167,7 +167,7 @@ xrdp_caps_process_order(struct xrdp_rdp *self, struct stream *s,
 
     /* check if libpainter should be used for drawing, instead of orders */
     if (!(order_caps[TS_NEG_DSTBLT_INDEX] && order_caps[TS_NEG_PATBLT_INDEX] &&
-          order_caps[TS_NEG_SCRBLT_INDEX] && order_caps[TS_NEG_MEMBLT_INDEX]))
+            order_caps[TS_NEG_SCRBLT_INDEX] && order_caps[TS_NEG_MEMBLT_INDEX]))
     {
         LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_order: not enough orders supported by client, using painter.");
         self->client_info.no_orders_supported = 1;
@@ -210,11 +210,11 @@ xrdp_caps_process_bmpcache(struct xrdp_rdp *self, struct stream *s,
     self->client_info.cache3_entries = i;
     in_uint16_le(s, self->client_info.cache3_size);
     LOG_DEVEL(LOG_LEVEL_TRACE, "cache1 entries %d size %d", self->client_info.cache1_entries,
-           self->client_info.cache1_size);
+              self->client_info.cache1_size);
     LOG_DEVEL(LOG_LEVEL_TRACE, "cache2 entries %d size %d", self->client_info.cache2_entries,
-           self->client_info.cache2_size);
+              self->client_info.cache2_size);
     LOG_DEVEL(LOG_LEVEL_TRACE, "cache3 entries %d size %d", self->client_info.cache3_entries,
-           self->client_info.cache3_size);
+              self->client_info.cache3_size);
     return 0;
 }
 
@@ -254,11 +254,11 @@ xrdp_caps_process_bmpcache2(struct xrdp_rdp *self, struct stream *s,
     self->client_info.cache3_entries = i;
     self->client_info.cache3_size = 4096 * Bpp;
     LOG_DEVEL(LOG_LEVEL_TRACE, "cache1 entries %d size %d", self->client_info.cache1_entries,
-           self->client_info.cache1_size);
+              self->client_info.cache1_size);
     LOG_DEVEL(LOG_LEVEL_TRACE, "cache2 entries %d size %d", self->client_info.cache2_entries,
-           self->client_info.cache2_size);
+              self->client_info.cache2_size);
     LOG_DEVEL(LOG_LEVEL_TRACE, "cache3 entries %d size %d", self->client_info.cache3_entries,
-           self->client_info.cache3_size);
+              self->client_info.cache3_size);
     return 0;
 }
 
@@ -566,7 +566,7 @@ xrdp_caps_process_multifragmentupdate(struct xrdp_rdp *self, struct stream *s,
     return 0;
 }
 
- /*****************************************************************************/
+/*****************************************************************************/
 static int
 xrdp_caps_process_frame_ack(struct xrdp_rdp *self, struct stream *s, int len)
 {
@@ -739,7 +739,7 @@ xrdp_caps_process_confirm_active(struct xrdp_rdp *self, struct stream *s)
     }
 
     if (self->client_info.no_orders_supported &&
-        (self->client_info.offscreen_support_level != 0))
+            (self->client_info.offscreen_support_level != 0))
     {
         LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_process_confirm_active: not enough orders "
                   "supported by client, client wants off screen bitmap but "
@@ -1042,12 +1042,12 @@ xrdp_caps_send_demand_active(struct xrdp_rdp *self)
 
     /* send Monitor Layout PDU for dual monitor */
     if (self->client_info.monitorCount > 0 &&
-        self->client_info.multimon == 1)
+            self->client_info.multimon == 1)
     {
         LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_send_demand_active: sending monitor layout pdu");
         if (xrdp_caps_send_monitorlayout(self) != 0)
         {
-          LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_send_demand_active: error sending monitor layout pdu");
+            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_send_demand_active: error sending monitor layout pdu");
         }
     }
 

--- a/libxrdp/xrdp_channel.c
+++ b/libxrdp/xrdp_channel.c
@@ -51,7 +51,7 @@ xrdp_channel_get_item(struct xrdp_channel *self, int channel_id)
 
     if (self->mcs_layer->channel_list == NULL)
     {
-        g_writeln("xrdp_channel_get_item - No channel initialized");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_channel_get_item - No channel initialized");
         return NULL ;
     }
 
@@ -114,13 +114,13 @@ xrdp_channel_send(struct xrdp_channel *self, struct stream *s, int channel_id,
 
     if (channel == NULL)
     {
-        g_writeln("xrdp_channel_send - no such channel");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_channel_send - no such channel");
         return 1;
     }
 
     if (channel->disabled)
     {
-        g_writeln("xrdp_channel_send, channel disabled");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_channel_send, channel disabled");
         return 0; /* not an error */
     }
 
@@ -147,7 +147,7 @@ xrdp_channel_send(struct xrdp_channel *self, struct stream *s, int channel_id,
 
     if (xrdp_sec_send(self->sec_layer, s, channel->chanid) != 0)
     {
-        g_writeln("xrdp_channel_send - failure sending data");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_channel_send - failure sending data");
         return 1;
     }
 
@@ -182,12 +182,12 @@ xrdp_channel_call_callback(struct xrdp_channel *self, struct stream *s,
         }
         else
         {
-            g_writeln("in xrdp_channel_call_callback, session->callback is nil");
+            LOG_DEVEL(LOG_LEVEL_TRACE, "in xrdp_channel_call_callback, session->callback is nil");
         }
     }
     else
     {
-        g_writeln("in xrdp_channel_call_callback, session is nil");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "in xrdp_channel_call_callback, session is nil");
     }
 
     return rv;
@@ -269,11 +269,11 @@ drdynvc_process_capability_response(struct xrdp_channel *self,
     in_uint16_le(s, cap_version);
     if ((cap_version != 2) && (cap_version != 3))
     {
-        g_writeln("drdynvc_process_capability_response: incompatible DVC "
+        LOG_DEVEL(LOG_LEVEL_TRACE, "drdynvc_process_capability_response: incompatible DVC "
                   "version %d detected", cap_version);
         return 1;
     }
-    g_writeln("drdynvc_process_capability_response: DVC version %d selected",
+    LOG_DEVEL(LOG_LEVEL_TRACE, "drdynvc_process_capability_response: DVC version %d selected",
               cap_version);
     self->drdynvc_state = 1;
     session = self->sec_layer->rdp_layer->session;
@@ -300,8 +300,8 @@ drdynvc_process_open_channel_response(struct xrdp_channel *self,
         return 1;
     }
     in_uint32_le(s, creation_status);
-    //g_writeln("drdynvc_process_open_channel_response: chan_id 0x%x "
-    //          "creation_status %d", chan_id, creation_status);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "drdynvc_process_open_channel_response: chan_id 0x%x "
+             "creation_status %d", chan_id, creation_status);
     session = self->sec_layer->rdp_layer->session;
     if (chan_id > 255)
     {
@@ -336,7 +336,7 @@ drdynvc_process_close_channel_response(struct xrdp_channel *self,
     {
         return 1;
     }
-    //g_writeln("drdynvc_process_close_channel_response: chan_id 0x%x", chan_id);
+      LOG_DEVEL(LOG_LEVEL_TRACE, "drdynvc_process_close_channel_response: chan_id 0x%x", chan_id);
     session = self->sec_layer->rdp_layer->session;
     if (chan_id > 255)
     {
@@ -393,7 +393,7 @@ drdynvc_process_data_first(struct xrdp_channel *self,
         in_uint32_le(s, total_bytes);
     }
     bytes = (int) (s->end - s->p);
-    //g_writeln("drdynvc_process_data_first: bytes %d total_bytes %d", bytes, total_bytes);
+      LOG_DEVEL(LOG_LEVEL_TRACE, "drdynvc_process_data_first: bytes %d total_bytes %d", bytes, total_bytes);
     session = self->sec_layer->rdp_layer->session;
     if (chan_id > 255)
     {
@@ -423,7 +423,7 @@ drdynvc_process_data(struct xrdp_channel *self,
         return 1;
     }
     bytes = (int) (s->end - s->p);
-    //g_writeln("drdynvc_process_data: bytes %d", bytes);
+      LOG_DEVEL(LOG_LEVEL_TRACE, "drdynvc_process_data: bytes %d", bytes);
     session = self->sec_layer->rdp_layer->session;
     if (chan_id > 255)
     {
@@ -456,8 +456,8 @@ xrdp_channel_process_drdynvc(struct xrdp_channel *self,
     }
     in_uint32_le(s, total_length);
     in_uint32_le(s, flags);
-    //g_writeln("xrdp_channel_process_drdynvc: total_length %d flags 0x%8.8x",
-    //          total_length, flags);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_channel_process_drdynvc: total_length %d flags 0x%8.8x",
+             total_length, flags);
     ls = NULL;
     switch (flags & 3)
     {
@@ -496,7 +496,7 @@ xrdp_channel_process_drdynvc(struct xrdp_channel *self,
             ls = s;
             break;
         default:
-            g_writeln("xrdp_channel_process_drdynvc: error");
+            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_channel_process_drdynvc: error");
             return 1;
     }
     if (ls == NULL)
@@ -504,7 +504,7 @@ xrdp_channel_process_drdynvc(struct xrdp_channel *self,
         return 1;
     }
     in_uint8(ls, cmd); /* read command */
-    //g_writeln("xrdp_channel_process_drdynvc: cmd 0x%x", cmd);
+      LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_channel_process_drdynvc: cmd 0x%x", cmd);
     rv = 1;
     switch (cmd & 0xf0)
     {
@@ -524,11 +524,11 @@ xrdp_channel_process_drdynvc(struct xrdp_channel *self,
             rv = drdynvc_process_data(self, cmd, s);
             break;
         default:
-            g_writeln("xrdp_channel_process_drdynvc: got unknown "
+            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_channel_process_drdynvc: got unknown "
                       "command 0x%x", cmd);
             break;
     }
-    //g_writeln("xrdp_channel_process_drdynvc: rv %d", rv);
+      LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_channel_process_drdynvc: rv %d", rv);
     return rv;
 }
 
@@ -556,12 +556,12 @@ xrdp_channel_process(struct xrdp_channel *self, struct stream *s,
     channel = xrdp_channel_get_item(self, channel_id);
     if (channel == NULL)
     {
-        g_writeln("xrdp_channel_process, channel not found");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_channel_process, channel not found");
         return 1;
     }
     if (channel->disabled)
     {
-        g_writeln("xrdp_channel_process, channel disabled");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_channel_process, channel disabled");
         return 0; /* not an error */
     }
     if (channel_id == self->drdynvc_channel_id)
@@ -626,7 +626,7 @@ xrdp_channel_drdynvc_start(struct xrdp_channel *self)
     struct mcs_channel_item *ci;
     struct mcs_channel_item *dci;
 
-    g_writeln("xrdp_channel_drdynvc_start:");
+    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_channel_drdynvc_start:");
     dci = NULL;
     count = self->mcs_layer->channel_list->count;
     for (index = 0; index < count; index++)

--- a/libxrdp/xrdp_channel.c
+++ b/libxrdp/xrdp_channel.c
@@ -138,10 +138,10 @@ xrdp_channel_send(struct xrdp_channel *self, struct stream *s, int channel_id,
      *
      *   That's flag makes MSTSC crash when using RAIL channel.
      */
-//    if (channel->flags & XR_CHANNEL_OPTION_SHOW_PROTOCOL)
-//    {
-//        flags |= CHANNEL_FLAG_SHOW_PROTOCOL;
-//    }
+    //    if (channel->flags & XR_CHANNEL_OPTION_SHOW_PROTOCOL)
+    //    {
+    //        flags |= CHANNEL_FLAG_SHOW_PROTOCOL;
+    //    }
 
     out_uint32_le(s, flags);
 
@@ -301,7 +301,7 @@ drdynvc_process_open_channel_response(struct xrdp_channel *self,
     }
     in_uint32_le(s, creation_status);
     LOG_DEVEL(LOG_LEVEL_TRACE, "drdynvc_process_open_channel_response: chan_id 0x%x "
-             "creation_status %d", chan_id, creation_status);
+              "creation_status %d", chan_id, creation_status);
     session = self->sec_layer->rdp_layer->session;
     if (chan_id > 255)
     {
@@ -336,7 +336,7 @@ drdynvc_process_close_channel_response(struct xrdp_channel *self,
     {
         return 1;
     }
-      LOG_DEVEL(LOG_LEVEL_TRACE, "drdynvc_process_close_channel_response: chan_id 0x%x", chan_id);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "drdynvc_process_close_channel_response: chan_id 0x%x", chan_id);
     session = self->sec_layer->rdp_layer->session;
     if (chan_id > 255)
     {
@@ -393,7 +393,7 @@ drdynvc_process_data_first(struct xrdp_channel *self,
         in_uint32_le(s, total_bytes);
     }
     bytes = (int) (s->end - s->p);
-      LOG_DEVEL(LOG_LEVEL_TRACE, "drdynvc_process_data_first: bytes %d total_bytes %d", bytes, total_bytes);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "drdynvc_process_data_first: bytes %d total_bytes %d", bytes, total_bytes);
     session = self->sec_layer->rdp_layer->session;
     if (chan_id > 255)
     {
@@ -423,7 +423,7 @@ drdynvc_process_data(struct xrdp_channel *self,
         return 1;
     }
     bytes = (int) (s->end - s->p);
-      LOG_DEVEL(LOG_LEVEL_TRACE, "drdynvc_process_data: bytes %d", bytes);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "drdynvc_process_data: bytes %d", bytes);
     session = self->sec_layer->rdp_layer->session;
     if (chan_id > 255)
     {
@@ -457,7 +457,7 @@ xrdp_channel_process_drdynvc(struct xrdp_channel *self,
     in_uint32_le(s, total_length);
     in_uint32_le(s, flags);
     LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_channel_process_drdynvc: total_length %d flags 0x%8.8x",
-             total_length, flags);
+              total_length, flags);
     ls = NULL;
     switch (flags & 3)
     {
@@ -504,7 +504,7 @@ xrdp_channel_process_drdynvc(struct xrdp_channel *self,
         return 1;
     }
     in_uint8(ls, cmd); /* read command */
-      LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_channel_process_drdynvc: cmd 0x%x", cmd);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_channel_process_drdynvc: cmd 0x%x", cmd);
     rv = 1;
     switch (cmd & 0xf0)
     {
@@ -528,7 +528,7 @@ xrdp_channel_process_drdynvc(struct xrdp_channel *self,
                       "command 0x%x", cmd);
             break;
     }
-      LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_channel_process_drdynvc: rv %d", rv);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_channel_process_drdynvc: rv %d", rv);
     return rv;
 }
 
@@ -726,7 +726,7 @@ xrdp_channel_drdynvc_close(struct xrdp_channel *self, int chan_id)
         return 1;
     }
     if ((self->drdynvcs[chan_id].status != XRDP_DRDYNVC_STATUS_OPEN) &&
-        (self->drdynvcs[chan_id].status != XRDP_DRDYNVC_STATUS_OPEN_SENT))
+            (self->drdynvcs[chan_id].status != XRDP_DRDYNVC_STATUS_OPEN_SENT))
     {
         /* not open */
         return 1;

--- a/libxrdp/xrdp_channel.c
+++ b/libxrdp/xrdp_channel.c
@@ -51,7 +51,7 @@ xrdp_channel_get_item(struct xrdp_channel *self, int channel_id)
 
     if (self->mcs_layer->channel_list == NULL)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_channel_get_item - No channel initialized");
+        LOG(LOG_LEVEL_ERROR, "xrdp_channel_get_item - No channel initialized");
         return NULL ;
     }
 
@@ -114,13 +114,13 @@ xrdp_channel_send(struct xrdp_channel *self, struct stream *s, int channel_id,
 
     if (channel == NULL)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_channel_send - no such channel");
+        LOG(LOG_LEVEL_ERROR, "xrdp_channel_send - no such channel");
         return 1;
     }
 
     if (channel->disabled)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_channel_send, channel disabled");
+        LOG(LOG_LEVEL_WARNING, "xrdp_channel_send, channel disabled");
         return 0; /* not an error */
     }
 
@@ -147,7 +147,7 @@ xrdp_channel_send(struct xrdp_channel *self, struct stream *s, int channel_id,
 
     if (xrdp_sec_send(self->sec_layer, s, channel->chanid) != 0)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_channel_send - failure sending data");
+        LOG(LOG_LEVEL_ERROR, "xrdp_channel_send - failure sending data");
         return 1;
     }
 
@@ -182,12 +182,12 @@ xrdp_channel_call_callback(struct xrdp_channel *self, struct stream *s,
         }
         else
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "in xrdp_channel_call_callback, session->callback is nil");
+            LOG(LOG_LEVEL_TRACE, "in xrdp_channel_call_callback, session->callback is nil");
         }
     }
     else
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "in xrdp_channel_call_callback, session is nil");
+        LOG(LOG_LEVEL_TRACE, "in xrdp_channel_call_callback, session is nil");
     }
 
     return rv;
@@ -269,12 +269,12 @@ drdynvc_process_capability_response(struct xrdp_channel *self,
     in_uint16_le(s, cap_version);
     if ((cap_version != 2) && (cap_version != 3))
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "drdynvc_process_capability_response: incompatible DVC "
-                  "version %d detected", cap_version);
+        LOG(LOG_LEVEL_ERROR, "drdynvc_process_capability_response: incompatible DVC "
+            "version %d detected", cap_version);
         return 1;
     }
-    LOG_DEVEL(LOG_LEVEL_TRACE, "drdynvc_process_capability_response: DVC version %d selected",
-              cap_version);
+    LOG(LOG_LEVEL_INFO, "drdynvc_process_capability_response: DVC version %d selected",
+        cap_version);
     self->drdynvc_state = 1;
     session = self->sec_layer->rdp_layer->session;
     rv = session->callback(session->id, 0x5558, 0, 0, 0, 0);
@@ -496,7 +496,7 @@ xrdp_channel_process_drdynvc(struct xrdp_channel *self,
             ls = s;
             break;
         default:
-            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_channel_process_drdynvc: error");
+            LOG(LOG_LEVEL_ERROR, "xrdp_channel_process_drdynvc: error");
             return 1;
     }
     if (ls == NULL)
@@ -556,12 +556,12 @@ xrdp_channel_process(struct xrdp_channel *self, struct stream *s,
     channel = xrdp_channel_get_item(self, channel_id);
     if (channel == NULL)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_channel_process, channel not found");
+        LOG(LOG_LEVEL_ERROR, "xrdp_channel_process, channel not found");
         return 1;
     }
     if (channel->disabled)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_channel_process, channel disabled");
+        LOG(LOG_LEVEL_WARNING, "xrdp_channel_process, channel disabled");
         return 0; /* not an error */
     }
     if (channel_id == self->drdynvc_channel_id)

--- a/libxrdp/xrdp_fastpath.c
+++ b/libxrdp/xrdp_fastpath.c
@@ -30,12 +30,12 @@ xrdp_fastpath_create(struct xrdp_sec *owner, struct trans *trans)
 {
     struct xrdp_fastpath *self;
 
-    DEBUG(("  in xrdp_fastpath_create"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "  in xrdp_fastpath_create");
     self = (struct xrdp_fastpath *)g_malloc(sizeof(struct xrdp_fastpath), 1);
     self->sec_layer = owner;
     self->trans = trans;
     self->session = owner->rdp_layer->session;
-    DEBUG(("  out xrdp_fastpath_create"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_fastpath_create");
     return self;
 }
 
@@ -67,7 +67,7 @@ xrdp_fastpath_recv(struct xrdp_fastpath *self, struct stream *s)
     int byte;
     char *holdp;
 
-    DEBUG(("   in xrdp_fastpath_recv"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "   in xrdp_fastpath_recv");
     holdp = s->p;
     if (!s_check_rem(s, 2))
     {
@@ -97,7 +97,7 @@ xrdp_fastpath_recv(struct xrdp_fastpath *self, struct stream *s)
         len = byte;
     }
     s->next_packet = holdp + len;
-    DEBUG(("  out xrdp_fastpath_recv"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_fastpath_recv");
     return 0;
 }
 
@@ -365,7 +365,7 @@ xrdp_fastpath_process_input_event(struct xrdp_fastpath *self,
                 }
                 break;
             default:
-                g_writeln("xrdp_fastpath_process_input_event: unknown "
+                LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_fastpath_process_input_event: unknown "
                           "eventCode %d", eventCode);
                 break;
         }

--- a/libxrdp/xrdp_fastpath.c
+++ b/libxrdp/xrdp_fastpath.c
@@ -179,7 +179,9 @@ xrdp_fastpath_process_EVENT_SCANCODE(struct xrdp_fastpath *self,
     }
 
     if ((eventFlags & FASTPATH_INPUT_KBDFLAGS_EXTENDED))
+    {
         flags |= KBD_FLAG_EXT;
+    }
 
     xrdp_fastpath_session_callback(self, RDP_INPUT_SCANCODE,
                                    code, 0, flags, 0);
@@ -253,13 +255,13 @@ static int
 xrdp_fastpath_process_EVENT_SYNC(struct xrdp_fastpath *self,
                                  int eventFlags, struct stream *s)
 {
-   /*
-    * The eventCode bitfield (3 bits in size) MUST be set to
-    * FASTPATH_INPUT_EVENT_SYNC (3).
-    * The eventFlags bitfield (5 bits in size) contains flags
-    * indicating the "on"
-    * status of the keyboard toggle keys.
-    */
+    /*
+     * The eventCode bitfield (3 bits in size) MUST be set to
+     * FASTPATH_INPUT_EVENT_SYNC (3).
+     * The eventFlags bitfield (5 bits in size) contains flags
+     * indicating the "on"
+     * status of the keyboard toggle keys.
+     */
 
     xrdp_fastpath_session_callback(self, RDP_INPUT_SYNCHRONIZE,
                                    eventFlags, 0, 0, 0);
@@ -326,8 +328,8 @@ xrdp_fastpath_process_input_event(struct xrdp_fastpath *self,
         {
             case FASTPATH_INPUT_EVENT_SCANCODE:
                 if (xrdp_fastpath_process_EVENT_SCANCODE(self,
-                                                         eventFlags,
-                                                         s) != 0)
+                        eventFlags,
+                        s) != 0)
                 {
                     return 1;
                 }

--- a/libxrdp/xrdp_fastpath.c
+++ b/libxrdp/xrdp_fastpath.c
@@ -367,8 +367,8 @@ xrdp_fastpath_process_input_event(struct xrdp_fastpath *self,
                 }
                 break;
             default:
-                LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_fastpath_process_input_event: unknown "
-                          "eventCode %d", eventCode);
+                LOG(LOG_LEVEL_WARNING, "xrdp_fastpath_process_input_event: unknown "
+                    "eventCode %d", eventCode);
                 break;
         }
     }

--- a/libxrdp/xrdp_iso.c
+++ b/libxrdp/xrdp_iso.c
@@ -27,13 +27,7 @@
 #include "ms-rdpbcgr.h"
 #include "log.h"
 
-#define LOG_LEVEL 1
-#define LLOG(_level, _args) \
-    do { if (_level < LOG_LEVEL) { g_write _args ; } } while (0)
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { g_writeln _args ; } } while (0)
-#define LHEXDUMP(_level, _args) \
-    do { if (_level < LOG_LEVEL) { g_hexdump _args ; } } while (0)
+
 
 
 /*****************************************************************************/
@@ -42,11 +36,11 @@ xrdp_iso_create(struct xrdp_mcs *owner, struct trans *trans)
 {
     struct xrdp_iso *self;
 
-    LLOGLN(10, ("   in xrdp_iso_create"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "   in xrdp_iso_create");
     self = (struct xrdp_iso *) g_malloc(sizeof(struct xrdp_iso), 1);
     self->mcs_layer = owner;
     self->trans = trans;
-    LLOGLN(10, ("   out xrdp_iso_create"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "   out xrdp_iso_create");
     return self;
 }
 
@@ -83,7 +77,7 @@ xrdp_iso_negotiate_security(struct xrdp_iso *self)
                     !g_file_readable(client_info->key_file))
                 {
                     /* certificate or privkey is not readable */
-                    log_message(LOG_LEVEL_DEBUG, "No readable certificates or "
+                    LOG(LOG_LEVEL_DEBUG, "No readable certificates or "
                                 "private keys, cannot accept TLS connections");
                     self->failureCode = SSL_CERT_NOT_ON_SERVER;
                     rv = 1; /* error */
@@ -116,7 +110,7 @@ xrdp_iso_negotiate_security(struct xrdp_iso *self)
             break;
     }
 
-    log_message(LOG_LEVEL_DEBUG, "Security layer: requested %d, selected %d",
+    LOG(LOG_LEVEL_DEBUG, "Security layer: requested %d, selected %d",
                 self->requestedProtocol, self->selectedProtocol);
     return rv;
 }
@@ -131,29 +125,29 @@ xrdp_iso_process_rdp_neg_req(struct xrdp_iso *self, struct stream *s)
 
     if (!s_check_rem(s, 7))
     {
-        LLOGLN(10, ("xrdp_iso_process_rdpNegReq: unexpected end-of-record"));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_iso_process_rdpNegReq: unexpected end-of-record");
         return 1;
     }
 
     in_uint8(s, flags);
     if (flags != 0x0 && flags != 0x8 && flags != 0x1)
     {
-        LLOGLN(10, ("xrdp_iso_process_rdpNegReq: error, flags: %x",flags));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_iso_process_rdpNegReq: error, flags: %x",flags);
         return 1;
     }
 
     in_uint16_le(s, len);
     if (len != 8)
     {
-        LLOGLN(10, ("xrdp_iso_process_rdpNegReq: error, length: %x",len));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_iso_process_rdpNegReq: error, length: %x",len);
         return 1;
     }
 
     in_uint32_le(s, self->requestedProtocol);
     if (self->requestedProtocol > 0xb)
     {
-        LLOGLN(10, ("xrdp_iso_process_rdpNegReq: error, requestedProtocol: %x",
-                self->requestedProtocol));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_iso_process_rdpNegReq: error, requestedProtocol: %x",
+                self->requestedProtocol);
         return 1;
     }
 
@@ -181,7 +175,7 @@ xrdp_iso_recv_msg(struct xrdp_iso *self, struct stream *s, int *code, int *len)
 
     if (s != self->trans->in_s)
     {
-        LLOGLN(10, ("xrdp_iso_recv_msg error logic"));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_iso_recv_msg error logic");
     }
 
     /* TPKT header is 4 bytes, then first 2 bytes of the X.224 CR-TPDU */
@@ -197,16 +191,16 @@ xrdp_iso_recv_msg(struct xrdp_iso *self, struct stream *s, int *code, int *len)
 
     if (ver != 3)
     {
-        LLOGLN(10, ("xrdp_iso_recv_msg: bad ver"));
-        LHEXDUMP(10, (s->data, 4));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_iso_recv_msg: bad ver");
+        LOG_DEVEL_HEXDUMP(LOG_LEVEL_TRACE, "header", s->data, 4);
         return 1;
     }
 
     if (*len == 255)
     {
         /* X.224 13.2.1 - reserved value */
-        LLOGLN(10, ("xrdp_iso_recv_msg: reserved length encountered"));
-        LHEXDUMP(10, (s->data, 4));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_iso_recv_msg: reserved length encountered");
+        LOG_DEVEL_HEXDUMP(LOG_LEVEL_TRACE, "header", s->data, 4);
         return 1;
     }
 
@@ -240,21 +234,21 @@ xrdp_iso_recv(struct xrdp_iso *self, struct stream *s)
     int code;
     int len;
 
-    LLOGLN(10, ("   in xrdp_iso_recv"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "   in xrdp_iso_recv");
 
     if (xrdp_iso_recv_msg(self, s, &code, &len) != 0)
     {
-        LLOGLN(10, ("   out xrdp_iso_recv xrdp_iso_recv_msg return non zero"));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "   out xrdp_iso_recv xrdp_iso_recv_msg return non zero");
         return 1;
     }
 
     if (code != ISO_PDU_DT || len != 2)
     {
-        LLOGLN(10, ("   out xrdp_iso_recv code != ISO_PDU_DT or length != 2"));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "   out xrdp_iso_recv code != ISO_PDU_DT or length != 2");
         return 1;
     }
 
-    LLOGLN(10, ("   out xrdp_iso_recv"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "   out xrdp_iso_recv");
     return 0;
 }
 /*****************************************************************************/
@@ -345,7 +339,7 @@ xrdp_iso_incoming(struct xrdp_iso *self)
     struct stream *s;
     int expected_pdu_len;
 
-    LLOGLN(10, ("   in xrdp_iso_incoming"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "   in xrdp_iso_incoming");
 
     s = libxrdp_force_read(self->trans);
     if (s == NULL)
@@ -355,7 +349,7 @@ xrdp_iso_incoming(struct xrdp_iso *self)
 
     if (xrdp_iso_recv_msg(self, s, &code, &len) != 0)
     {
-        LLOGLN(0, ("xrdp_iso_incoming: xrdp_iso_recv_msg returned non zero"));
+        LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_iso_incoming: xrdp_iso_recv_msg returned non zero");
         return 1;
     }
 
@@ -375,8 +369,8 @@ xrdp_iso_incoming(struct xrdp_iso *self)
     expected_pdu_len = (s->end - s->p) + 6;
     if (len != expected_pdu_len)
     {
-        LLOGLN(0, ("xrdp_iso_incoming: X.224 CR-TPDU length exp %d got %d",
-                   expected_pdu_len, len));
+        LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_iso_incoming: X.224 CR-TPDU length exp %d got %d",
+                   expected_pdu_len, len);
         return 1;
     }
 
@@ -392,7 +386,7 @@ xrdp_iso_incoming(struct xrdp_iso *self)
                 self->rdpNegData = 1;
                 if (xrdp_iso_process_rdp_neg_req(self, s) != 0)
                 {
-                    LLOGLN(0, ("xrdp_iso_incoming: xrdp_iso_process_rdpNegReq returned non zero"));
+                    LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_iso_incoming: xrdp_iso_process_rdpNegReq returned non zero");
                     return 1;
                 }
                 break;
@@ -400,7 +394,7 @@ xrdp_iso_incoming(struct xrdp_iso *self)
                 // TODO
                 if (!s_check_rem(s, 1 + 2 + 16 + 16))
                 {
-                    LLOGLN(0, ("xrdp_iso_incoming: short correlation info"));
+                    LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_iso_incoming: short correlation info");
                     return 1;
                 }
 
@@ -433,11 +427,11 @@ xrdp_iso_incoming(struct xrdp_iso *self)
     /* send connection confirm back to client */
     if (xrdp_iso_send_cc(self) != 0)
     {
-        LLOGLN(0, ("xrdp_iso_incoming: xrdp_iso_send_cc returned non zero"));
+        LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_iso_incoming: xrdp_iso_send_cc returned non zero");
         return 1;
     }
 
-    LLOGLN(10, ("   out xrdp_iso_incoming"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "   out xrdp_iso_incoming");
     return rv;
 }
 
@@ -458,7 +452,7 @@ xrdp_iso_send(struct xrdp_iso *self, struct stream *s)
 {
     int len;
 
-    LLOGLN(10, ("   in xrdp_iso_send"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "   in xrdp_iso_send");
     s_pop_layer(s, iso_hdr);
     len = (int) (s->end - s->p);
     out_uint8(s, 3);
@@ -473,6 +467,6 @@ xrdp_iso_send(struct xrdp_iso *self, struct stream *s)
         return 1;
     }
 
-    LLOGLN(10, ("   out xrdp_iso_send"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "   out xrdp_iso_send");
     return 0;
 }

--- a/libxrdp/xrdp_iso.c
+++ b/libxrdp/xrdp_iso.c
@@ -74,11 +74,11 @@ xrdp_iso_negotiate_security(struct xrdp_iso *self)
             if (self->requestedProtocol & PROTOCOL_SSL)
             {
                 if (!g_file_readable(client_info->certificate) ||
-                    !g_file_readable(client_info->key_file))
+                        !g_file_readable(client_info->key_file))
                 {
                     /* certificate or privkey is not readable */
                     LOG(LOG_LEVEL_DEBUG, "No readable certificates or "
-                                "private keys, cannot accept TLS connections");
+                        "private keys, cannot accept TLS connections");
                     self->failureCode = SSL_CERT_NOT_ON_SERVER;
                     rv = 1; /* error */
                 }
@@ -97,8 +97,8 @@ xrdp_iso_negotiate_security(struct xrdp_iso *self)
         case PROTOCOL_HYBRID_EX:
         default:
             if ((self->requestedProtocol & PROTOCOL_SSL) &&
-                g_file_readable(client_info->certificate) &&
-                g_file_readable(client_info->key_file))
+                    g_file_readable(client_info->certificate) &&
+                    g_file_readable(client_info->key_file))
             {
                 /* that's a patch since we don't support CredSSP for now */
                 self->selectedProtocol = PROTOCOL_SSL;
@@ -111,7 +111,7 @@ xrdp_iso_negotiate_security(struct xrdp_iso *self)
     }
 
     LOG(LOG_LEVEL_DEBUG, "Security layer: requested %d, selected %d",
-                self->requestedProtocol, self->selectedProtocol);
+        self->requestedProtocol, self->selectedProtocol);
     return rv;
 }
 
@@ -132,14 +132,14 @@ xrdp_iso_process_rdp_neg_req(struct xrdp_iso *self, struct stream *s)
     in_uint8(s, flags);
     if (flags != 0x0 && flags != 0x8 && flags != 0x1)
     {
-        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_iso_process_rdpNegReq: error, flags: %x",flags);
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_iso_process_rdpNegReq: error, flags: %x", flags);
         return 1;
     }
 
     in_uint16_le(s, len);
     if (len != 8)
     {
-        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_iso_process_rdpNegReq: error, length: %x",len);
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_iso_process_rdpNegReq: error, length: %x", len);
         return 1;
     }
 
@@ -147,7 +147,7 @@ xrdp_iso_process_rdp_neg_req(struct xrdp_iso *self, struct stream *s)
     if (self->requestedProtocol > 0xb)
     {
         LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_iso_process_rdpNegReq: error, requestedProtocol: %x",
-                self->requestedProtocol);
+                  self->requestedProtocol);
         return 1;
     }
 
@@ -370,7 +370,7 @@ xrdp_iso_incoming(struct xrdp_iso *self)
     if (len != expected_pdu_len)
     {
         LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_iso_incoming: X.224 CR-TPDU length exp %d got %d",
-                   expected_pdu_len, len);
+                  expected_pdu_len, len);
         return 1;
     }
 
@@ -401,10 +401,10 @@ xrdp_iso_incoming(struct xrdp_iso *self)
                 in_uint8s(s, 1 + 2 + 16 + 16);
                 break;
             case 'C': /* Cookie */
-                 /* The routingToken and cookie fields are both ASCII
-                  * strings starting with the word 'Cookie: ' and
-                  * ending with CR+LF. We ignore both, so we do
-                  * not need to distinguish them  */
+                /* The routingToken and cookie fields are both ASCII
+                 * strings starting with the word 'Cookie: ' and
+                 * ending with CR+LF. We ignore both, so we do
+                 * not need to distinguish them  */
                 while (s_check_rem(s, 1))
                 {
                     in_uint8(s, cc_type);

--- a/libxrdp/xrdp_jpeg_compress.c
+++ b/libxrdp/xrdp_jpeg_compress.c
@@ -55,12 +55,12 @@ xrdp_jpeg_compress(void *handle, char *in_data, int width, int height,
 
     if (bpp != 24)
     {
-        g_writeln("xrdp_jpeg_compress: bpp wrong %d", bpp);
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_jpeg_compress: bpp wrong %d", bpp);
         return height;
     }
     if (handle == 0)
     {
-        g_writeln("xrdp_jpeg_compress: handle is nil");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_jpeg_compress: handle is nil");
         return height;
     }
     tj_han = (tjhandle) handle;
@@ -103,7 +103,7 @@ xrdp_jpeg_compress(void *handle, char *in_data, int width, int height,
                        TJSAMP_420, quality, 0);
     if (error != 0)
     {
-        log_message(LOG_LEVEL_ERROR,
+        LOG(LOG_LEVEL_ERROR,
                     "xrdp_jpeg_compress: tjCompress error: %s",
                     tjGetErrorStr());
     }
@@ -147,7 +147,7 @@ xrdp_codec_jpeg_compress(void *handle,
 
     if (handle == 0)
     {
-        g_writeln("xrdp_codec_jpeg_compress: handle is nil");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_codec_jpeg_compress: handle is nil");
         return height;
     }
 
@@ -188,7 +188,7 @@ xrdp_codec_jpeg_compress(void *handle,
                        );
     if (error != 0)
     {
-        log_message(LOG_LEVEL_ERROR,
+        LOG(LOG_LEVEL_ERROR,
                     "xrdp_codec_jpeg_compress: tjCompress error: %s",
                     tjGetErrorStr());
     }
@@ -400,7 +400,7 @@ jpeg_compress(char *in_data, int width, int height,
     }
     else
     {
-        g_writeln("bpp wrong %d", bpp);
+        LOG_DEVEL(LOG_LEVEL_TRACE, "bpp wrong %d", bpp);
     }
 
     cdata_bytes = byte_limit;

--- a/libxrdp/xrdp_jpeg_compress.c
+++ b/libxrdp/xrdp_jpeg_compress.c
@@ -55,12 +55,12 @@ xrdp_jpeg_compress(void *handle, char *in_data, int width, int height,
 
     if (bpp != 24)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_jpeg_compress: bpp wrong %d", bpp);
+        LOG(LOG_LEVEL_WARNING, "xrdp_jpeg_compress: bpp wrong %d", bpp);
         return height;
     }
     if (handle == 0)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_jpeg_compress: handle is nil");
+        LOG(LOG_LEVEL_WARNING, "xrdp_jpeg_compress: handle is nil");
         return height;
     }
     tj_han = (tjhandle) handle;
@@ -147,7 +147,7 @@ xrdp_codec_jpeg_compress(void *handle,
 
     if (handle == 0)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_codec_jpeg_compress: handle is nil");
+        LOG(LOG_LEVEL_WARNING, "xrdp_codec_jpeg_compress: handle is nil");
         return height;
     }
 
@@ -400,7 +400,7 @@ jpeg_compress(char *in_data, int width, int height,
     }
     else
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "bpp wrong %d", bpp);
+        LOG(LOG_LEVEL_WARNING, "bpp wrong %d", bpp);
     }
 
     cdata_bytes = byte_limit;

--- a/libxrdp/xrdp_jpeg_compress.c
+++ b/libxrdp/xrdp_jpeg_compress.c
@@ -70,7 +70,7 @@ xrdp_jpeg_compress(void *handle, char *in_data, int width, int height,
     temp_buf = 0;
     if (e == 0)
     {
-        src_buf = (unsigned char*)in_data;
+        src_buf = (unsigned char *)in_data;
     }
     else
     {
@@ -97,15 +97,15 @@ xrdp_jpeg_compress(void *handle, char *in_data, int width, int height,
         }
         src_buf = (unsigned char *) temp_buf;
     }
-    dst_buf = (unsigned char*)(s->p);
+    dst_buf = (unsigned char *)(s->p);
     error = tjCompress(tj_han, src_buf, width + e, (width + e) * 4, height,
                        TJPF_XBGR, dst_buf, &cdata_bytes,
                        TJSAMP_420, quality, 0);
     if (error != 0)
     {
         LOG(LOG_LEVEL_ERROR,
-                    "xrdp_jpeg_compress: tjCompress error: %s",
-                    tjGetErrorStr());
+            "xrdp_jpeg_compress: tjCompress error: %s",
+            tjGetErrorStr());
     }
 
     s->p += cdata_bytes;
@@ -132,8 +132,8 @@ xrdp_codec_jpeg_compress(void *handle,
                          int   quality,  /* higher numbers compress less */
                          char *out_data, /* dest for jpg image */
                          int  *io_len    /* length of out_data and on return */
-                                         /* len of compressed data */
-                         )
+                         /* len of compressed data */
+                        )
 {
     tjhandle       tj_han;
     int            error;
@@ -185,12 +185,12 @@ xrdp_codec_jpeg_compress(void *handle,
                        TJSAMP_420, /* jpeg sub sample */
                        quality,    /* jpeg quality */
                        0           /* flags */
-                       );
+                      );
     if (error != 0)
     {
         LOG(LOG_LEVEL_ERROR,
-                    "xrdp_codec_jpeg_compress: tjCompress error: %s",
-                    tjGetErrorStr());
+            "xrdp_codec_jpeg_compress: tjCompress error: %s",
+            tjGetErrorStr());
     }
 
     *io_len = lio_len;
@@ -303,7 +303,7 @@ jp_do_compress(JOCTET *data, int width, int height, int bpp, int quality,
     jpeg_create_compress(&cinfo);
     memset(&md, 0, sizeof(md));
     md.cb = comp_data,
-       md.cb_bytes = *comp_data_bytes;
+    md.cb_bytes = *comp_data_bytes;
     cinfo.client_data = &md;
     memset(&dst_mgr, 0, sizeof(dst_mgr));
     dst_mgr.init_destination = my_init_destination;

--- a/libxrdp/xrdp_mcs.c
+++ b/libxrdp/xrdp_mcs.c
@@ -34,7 +34,7 @@ xrdp_mcs_create(struct xrdp_sec *owner, struct trans *trans,
 {
     struct xrdp_mcs *self;
 
-    DEBUG(("  in xrdp_mcs_create"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "  in xrdp_mcs_create");
     self = (struct xrdp_mcs *)g_malloc(sizeof(struct xrdp_mcs), 1);
     self->sec_layer = owner;
     self->userid = 1;
@@ -43,7 +43,7 @@ xrdp_mcs_create(struct xrdp_sec *owner, struct trans *trans,
     self->server_mcs_data = server_mcs_data;
     self->iso_layer = xrdp_iso_create(self, trans);
     self->channel_list = list_create();
-    DEBUG(("  out xrdp_mcs_create"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_create");
     return self;
 }
 
@@ -74,7 +74,7 @@ xrdp_mcs_delete(struct xrdp_mcs *self)
 
     xrdp_iso_delete(self->iso_layer);
     /* make sure we get null pointer exception if struct is used again. */
-    DEBUG(("xrdp_mcs_delete processed"))
+    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_mcs_delete processed");
     g_memset(self, 0, sizeof(struct xrdp_mcs)) ;
     g_free(self);
 }
@@ -87,14 +87,14 @@ xrdp_mcs_send_cjcf(struct xrdp_mcs *self, int userid, int chanid)
 {
     struct stream *s;
 
-    DEBUG(("  in xrdp_mcs_send_cjcf"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "  in xrdp_mcs_send_cjcf");
     make_stream(s);
     init_stream(s, 8192);
 
     if (xrdp_iso_init(self->iso_layer, s) != 0)
     {
         free_stream(s);
-        DEBUG(("  out xrdp_mcs_send_cjcf error"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_send_cjcf error");
         return 1;
     }
 
@@ -108,12 +108,12 @@ xrdp_mcs_send_cjcf(struct xrdp_mcs *self, int userid, int chanid)
     if (xrdp_iso_send(self->iso_layer, s) != 0)
     {
         free_stream(s);
-        DEBUG(("  out xrdp_mcs_send_cjcf error"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_send_cjcf error");
         return 1;
     }
 
     free_stream(s);
-    DEBUG(("  out xrdp_mcs_send_cjcf"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_send_cjcf");
     return 0;
 }
 
@@ -127,14 +127,14 @@ xrdp_mcs_recv(struct xrdp_mcs *self, struct stream *s, int *chan)
     int len;
     int userid;
     int chanid;
-    DEBUG(("  in xrdp_mcs_recv"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "  in xrdp_mcs_recv");
 
     while (1)
     {
         if (xrdp_iso_recv(self->iso_layer, s) != 0)
         {
-            DEBUG(("   out xrdp_mcs_recv, xrdp_iso_recv return non zero"));
-            g_writeln("xrdp_mcs_recv: xrdp_iso_recv failed");
+            LOG_DEVEL(LOG_LEVEL_TRACE, "   out xrdp_mcs_recv, xrdp_iso_recv return non zero");
+            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_mcs_recv: xrdp_iso_recv failed");
             return 1;
         }
 
@@ -148,8 +148,8 @@ xrdp_mcs_recv(struct xrdp_mcs *self, struct stream *s, int *chan)
 
         if (appid == MCS_DPUM) /* Disconnect Provider Ultimatum */
         {
-            g_writeln("received Disconnect Provider Ultimatum");
-            DEBUG(("  out xrdp_mcs_recv appid != MCS_DPUM"));
+            LOG_DEVEL(LOG_LEVEL_TRACE, "received Disconnect Provider Ultimatum");
+            LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_recv appid != MCS_DPUM");
             return 1;
         }
 
@@ -164,18 +164,18 @@ xrdp_mcs_recv(struct xrdp_mcs *self, struct stream *s, int *chan)
 
             in_uint16_be(s, userid);
             in_uint16_be(s, chanid);
-            log_message(LOG_LEVEL_DEBUG,"MCS_CJRQ - channel join request received");
-            DEBUG(("xrdp_mcs_recv  adding channel %4.4x", chanid));
+            LOG(LOG_LEVEL_DEBUG,"MCS_CJRQ - channel join request received");
+            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_mcs_recv  adding channel %4.4x", chanid);
 
             if (xrdp_mcs_send_cjcf(self, userid, chanid) != 0)
             {
-                log_message(LOG_LEVEL_ERROR,"Non handled error from xrdp_mcs_send_cjcf") ;
+                LOG(LOG_LEVEL_ERROR,"Non handled error from xrdp_mcs_send_cjcf") ;
             }
 
             s = libxrdp_force_read(self->iso_layer->trans);
             if (s == 0)
             {
-                g_writeln("xrdp_mcs_recv: libxrdp_force_read failed");
+                LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_mcs_recv: libxrdp_force_read failed");
                 return 1;
             }
 
@@ -188,7 +188,7 @@ xrdp_mcs_recv(struct xrdp_mcs *self, struct stream *s, int *chan)
         }
         else
         {
-            log_message(LOG_LEVEL_DEBUG,"Received an unhandled appid:%d",appid);
+            LOG(LOG_LEVEL_DEBUG,"Received an unhandled appid:%d",appid);
         }
 
         break;
@@ -196,7 +196,7 @@ xrdp_mcs_recv(struct xrdp_mcs *self, struct stream *s, int *chan)
 
     if (appid != MCS_SDRQ)
     {
-        DEBUG(("  out xrdp_mcs_recv err got 0x%x need MCS_SDRQ", appid));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_recv err got 0x%x need MCS_SDRQ", appid);
         return 1;
     }
 
@@ -219,7 +219,7 @@ xrdp_mcs_recv(struct xrdp_mcs *self, struct stream *s, int *chan)
         in_uint8s(s, 1);
     }
 
-    DEBUG(("  out xrdp_mcs_recv"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_recv");
     return 0;
 }
 
@@ -437,7 +437,7 @@ xrdp_mcs_recv_edrq(struct xrdp_mcs *self)
     int opcode;
     struct stream *s;
 
-    DEBUG(("    in xrdp_mcs_recv_edrq"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "    in xrdp_mcs_recv_edrq");
 
     s = libxrdp_force_read(self->iso_layer->trans);
     if (s == 0)
@@ -484,7 +484,7 @@ xrdp_mcs_recv_edrq(struct xrdp_mcs *self)
         return 1;
     }
 
-    DEBUG(("    out xrdp_mcs_recv_edrq"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "    out xrdp_mcs_recv_edrq");
     return 0;
 }
 
@@ -496,7 +496,7 @@ xrdp_mcs_recv_aurq(struct xrdp_mcs *self)
     int opcode;
     struct stream *s;
 
-    DEBUG(("    in xrdp_mcs_recv_aurq"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "    in xrdp_mcs_recv_aurq");
 
     s = libxrdp_force_read(self->iso_layer->trans);
     if (s == 0)
@@ -535,7 +535,7 @@ xrdp_mcs_recv_aurq(struct xrdp_mcs *self)
         return 1;
     }
 
-    DEBUG(("    out xrdp_mcs_recv_aurq"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "    out xrdp_mcs_recv_aurq");
     return 0;
 }
 
@@ -546,14 +546,14 @@ xrdp_mcs_send_aucf(struct xrdp_mcs *self)
 {
     struct stream *s;
 
-    DEBUG(("  in xrdp_mcs_send_aucf"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "  in xrdp_mcs_send_aucf");
     make_stream(s);
     init_stream(s, 8192);
 
     if (xrdp_iso_init(self->iso_layer, s) != 0)
     {
         free_stream(s);
-        DEBUG(("  out xrdp_mcs_send_aucf error"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_send_aucf error");
         return 1;
     }
 
@@ -565,12 +565,12 @@ xrdp_mcs_send_aucf(struct xrdp_mcs *self)
     if (xrdp_iso_send(self->iso_layer, s) != 0)
     {
         free_stream(s);
-        DEBUG(("  out xrdp_mcs_send_aucf error"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_send_aucf error");
         return 1;
     }
 
     free_stream(s);
-    DEBUG(("  out xrdp_mcs_send_aucf"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_send_aucf");
     return 0;
 }
 
@@ -789,7 +789,7 @@ xrdp_mcs_out_gcc_data(struct xrdp_sec *self)
 
     if (self->rsa_key_bytes == 64)
     {
-        g_writeln("xrdp_sec_out_mcs_data: using 512 bit RSA key");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_out_mcs_data: using 512 bit RSA key");
         out_uint16_le(s, SEC_TAG_SRV_CRYPT);
         out_uint16_le(s, 0x00ec); /* len is 236 */
         out_uint32_le(s, self->crypt_method);
@@ -819,7 +819,7 @@ xrdp_mcs_out_gcc_data(struct xrdp_sec *self)
     }
     else if (self->rsa_key_bytes == 256)
     {
-        g_writeln("xrdp_sec_out_mcs_data: using 2048 bit RSA key");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_out_mcs_data: using 2048 bit RSA key");
         out_uint16_le(s, SEC_TAG_SRV_CRYPT);
         out_uint16_le(s, 0x01ac); /* len is 428 */
         out_uint32_le(s, self->crypt_method);
@@ -849,7 +849,7 @@ xrdp_mcs_out_gcc_data(struct xrdp_sec *self)
     }
     else if (self->rsa_key_bytes == 0) /* no security */
     {
-        g_writeln("xrdp_sec_out_mcs_data: using no security");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_out_mcs_data: using no security");
         out_uint16_le(s, SEC_TAG_SRV_CRYPT);
         out_uint16_le(s, 12); /* len is 12 */
         out_uint32_le(s, self->crypt_method);
@@ -857,7 +857,7 @@ xrdp_mcs_out_gcc_data(struct xrdp_sec *self)
     }
     else
     {
-        g_writeln("xrdp_sec_out_mcs_data: error");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_out_mcs_data: error");
     }
     /* end certificate */
     s_mark_end(s);
@@ -876,7 +876,7 @@ xrdp_mcs_send_connect_response(struct xrdp_mcs *self)
     int data_len;
     struct stream *s;
 
-    DEBUG(("  in xrdp_mcs_send_connect_response"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "  in xrdp_mcs_send_connect_response");
     make_stream(s);
     init_stream(s, 8192);
     data_len = (int) (self->server_mcs_data->end - self->server_mcs_data->data);
@@ -897,12 +897,12 @@ xrdp_mcs_send_connect_response(struct xrdp_mcs *self)
     if (xrdp_iso_send(self->iso_layer, s) != 0)
     {
         free_stream(s);
-        DEBUG(("  out xrdp_mcs_send_connect_response error"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_send_connect_response error");
         return 1;
     }
 
     free_stream(s);
-    DEBUG(("  out xrdp_mcs_send_connect_response"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_send_connect_response");
     return 0;
 }
 
@@ -913,7 +913,7 @@ xrdp_mcs_incoming(struct xrdp_mcs *self)
 {
     int index;
 
-    DEBUG(("  in xrdp_mcs_incoming"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "  in xrdp_mcs_incoming");
 
     if (xrdp_mcs_recv_connect_initial(self) != 0)
     {
@@ -965,7 +965,7 @@ xrdp_mcs_incoming(struct xrdp_mcs *self)
         }
     }
 
-    DEBUG(("  out xrdp_mcs_incoming"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_incoming");
     return 0;
 }
 
@@ -1005,12 +1005,12 @@ xrdp_mcs_call_callback(struct xrdp_mcs *self)
         }
         else
         {
-            g_writeln("in xrdp_mcs_send, session->callback is nil");
+            LOG_DEVEL(LOG_LEVEL_TRACE, "in xrdp_mcs_send, session->callback is nil");
         }
     }
     else
     {
-        g_writeln("in xrdp_mcs_send, session is nil");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "in xrdp_mcs_send, session is nil");
     }
 
     return rv;
@@ -1025,13 +1025,13 @@ xrdp_mcs_send(struct xrdp_mcs *self, struct stream *s, int chan)
     char *lp;
     //static int max_len = 0;
 
-    DEBUG(("  in xrdp_mcs_send"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "  in xrdp_mcs_send");
     s_pop_layer(s, mcs_hdr);
     len = (s->end - s->p) - 8;
 
     if (len > 8192 * 2)
     {
-        g_writeln("error in xrdp_mcs_send, size too big: %d bytes", len);
+        LOG_DEVEL(LOG_LEVEL_TRACE, "error in xrdp_mcs_send, size too big: %d bytes", len);
     }
 
     //if (len > max_len)
@@ -1068,7 +1068,7 @@ xrdp_mcs_send(struct xrdp_mcs *self, struct stream *s, int chan)
 
     if (xrdp_iso_send(self->iso_layer, s) != 0)
     {
-        DEBUG(("  out xrdp_mcs_send error"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_send error");
         return 1;
     }
 
@@ -1079,7 +1079,7 @@ xrdp_mcs_send(struct xrdp_mcs *self, struct stream *s, int chan)
         xrdp_mcs_call_callback(self);
     }
 
-    DEBUG(("  out xrdp_mcs_send"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_send");
     return 0;
 }
 
@@ -1097,11 +1097,11 @@ close_rdp_socket(struct xrdp_mcs *self)
             trans_shutdown_tls_mode(self->iso_layer->trans);
             g_tcp_close(self->iso_layer->trans->sck);
             self->iso_layer->trans->sck = 0 ;
-            g_writeln("xrdp_mcs_disconnect - socket closed");
+            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_mcs_disconnect - socket closed");
             return;
         }
     }
-    g_writeln("Failed to close socket");
+    LOG_DEVEL(LOG_LEVEL_TRACE, "Failed to close socket");
 }
 
 /*****************************************************************************/
@@ -1111,7 +1111,7 @@ xrdp_mcs_disconnect(struct xrdp_mcs *self)
 {
     struct stream *s;
 
-    DEBUG(("  in xrdp_mcs_disconnect"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "  in xrdp_mcs_disconnect");
     make_stream(s);
     init_stream(s, 8192);
 
@@ -1119,7 +1119,7 @@ xrdp_mcs_disconnect(struct xrdp_mcs *self)
     {
         free_stream(s);
         close_rdp_socket(self);
-        DEBUG(("  out xrdp_mcs_disconnect error - 1"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_disconnect error - 1");
         return 1;
     }
 
@@ -1131,12 +1131,12 @@ xrdp_mcs_disconnect(struct xrdp_mcs *self)
     {
         free_stream(s);
         close_rdp_socket(self);
-        DEBUG(("  out xrdp_mcs_disconnect error - 2"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_disconnect error - 2");
         return 1;
     }
 
     free_stream(s);
     close_rdp_socket(self);
-    DEBUG(("xrdp_mcs_disconnect - close sent"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_mcs_disconnect - close sent");
     return 0;
 }

--- a/libxrdp/xrdp_mcs.c
+++ b/libxrdp/xrdp_mcs.c
@@ -94,7 +94,7 @@ xrdp_mcs_send_cjcf(struct xrdp_mcs *self, int userid, int chanid)
     if (xrdp_iso_init(self->iso_layer, s) != 0)
     {
         free_stream(s);
-        LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_send_cjcf error");
+        LOG(LOG_LEVEL_ERROR, "  out xrdp_mcs_send_cjcf error");
         return 1;
     }
 
@@ -108,7 +108,7 @@ xrdp_mcs_send_cjcf(struct xrdp_mcs *self, int userid, int chanid)
     if (xrdp_iso_send(self->iso_layer, s) != 0)
     {
         free_stream(s);
-        LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_send_cjcf error");
+        LOG(LOG_LEVEL_ERROR, "  out xrdp_mcs_send_cjcf error");
         return 1;
     }
 
@@ -133,8 +133,8 @@ xrdp_mcs_recv(struct xrdp_mcs *self, struct stream *s, int *chan)
     {
         if (xrdp_iso_recv(self->iso_layer, s) != 0)
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "   out xrdp_mcs_recv, xrdp_iso_recv return non zero");
-            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_mcs_recv: xrdp_iso_recv failed");
+            LOG(LOG_LEVEL_ERROR, "   out xrdp_mcs_recv, xrdp_iso_recv return non zero");
+            LOG(LOG_LEVEL_ERROR, "xrdp_mcs_recv: xrdp_iso_recv failed");
             return 1;
         }
 
@@ -148,8 +148,8 @@ xrdp_mcs_recv(struct xrdp_mcs *self, struct stream *s, int *chan)
 
         if (appid == MCS_DPUM) /* Disconnect Provider Ultimatum */
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "received Disconnect Provider Ultimatum");
-            LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_recv appid != MCS_DPUM");
+            LOG(LOG_LEVEL_ERROR, "received Disconnect Provider Ultimatum");
+            LOG(LOG_LEVEL_ERROR, "  out xrdp_mcs_recv appid != MCS_DPUM");
             return 1;
         }
 
@@ -175,7 +175,7 @@ xrdp_mcs_recv(struct xrdp_mcs *self, struct stream *s, int *chan)
             s = libxrdp_force_read(self->iso_layer->trans);
             if (s == 0)
             {
-                LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_mcs_recv: libxrdp_force_read failed");
+                LOG(LOG_LEVEL_ERROR, "xrdp_mcs_recv: libxrdp_force_read failed");
                 return 1;
             }
 
@@ -196,7 +196,7 @@ xrdp_mcs_recv(struct xrdp_mcs *self, struct stream *s, int *chan)
 
     if (appid != MCS_SDRQ)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_recv err got 0x%x need MCS_SDRQ", appid);
+        LOG(LOG_LEVEL_ERROR, "  out xrdp_mcs_recv err got 0x%x need MCS_SDRQ", appid);
         return 1;
     }
 
@@ -553,7 +553,7 @@ xrdp_mcs_send_aucf(struct xrdp_mcs *self)
     if (xrdp_iso_init(self->iso_layer, s) != 0)
     {
         free_stream(s);
-        LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_send_aucf error");
+        LOG(LOG_LEVEL_ERROR, "  out xrdp_mcs_send_aucf error");
         return 1;
     }
 
@@ -565,7 +565,7 @@ xrdp_mcs_send_aucf(struct xrdp_mcs *self)
     if (xrdp_iso_send(self->iso_layer, s) != 0)
     {
         free_stream(s);
-        LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_send_aucf error");
+        LOG(LOG_LEVEL_ERROR, "  out xrdp_mcs_send_aucf error");
         return 1;
     }
 
@@ -789,7 +789,7 @@ xrdp_mcs_out_gcc_data(struct xrdp_sec *self)
 
     if (self->rsa_key_bytes == 64)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_out_mcs_data: using 512 bit RSA key");
+        LOG(LOG_LEVEL_DEBUG, "xrdp_sec_out_mcs_data: using 512 bit RSA key");
         out_uint16_le(s, SEC_TAG_SRV_CRYPT);
         out_uint16_le(s, 0x00ec); /* len is 236 */
         out_uint32_le(s, self->crypt_method);
@@ -819,7 +819,7 @@ xrdp_mcs_out_gcc_data(struct xrdp_sec *self)
     }
     else if (self->rsa_key_bytes == 256)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_out_mcs_data: using 2048 bit RSA key");
+        LOG(LOG_LEVEL_DEBUG, "xrdp_sec_out_mcs_data: using 2048 bit RSA key");
         out_uint16_le(s, SEC_TAG_SRV_CRYPT);
         out_uint16_le(s, 0x01ac); /* len is 428 */
         out_uint32_le(s, self->crypt_method);
@@ -849,7 +849,7 @@ xrdp_mcs_out_gcc_data(struct xrdp_sec *self)
     }
     else if (self->rsa_key_bytes == 0) /* no security */
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_out_mcs_data: using no security");
+        LOG(LOG_LEVEL_DEBUG, "xrdp_sec_out_mcs_data: using no security");
         out_uint16_le(s, SEC_TAG_SRV_CRYPT);
         out_uint16_le(s, 12); /* len is 12 */
         out_uint32_le(s, self->crypt_method);
@@ -857,7 +857,7 @@ xrdp_mcs_out_gcc_data(struct xrdp_sec *self)
     }
     else
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_out_mcs_data: error");
+        LOG(LOG_LEVEL_ERROR, "xrdp_sec_out_mcs_data: error");
     }
     /* end certificate */
     s_mark_end(s);
@@ -897,7 +897,7 @@ xrdp_mcs_send_connect_response(struct xrdp_mcs *self)
     if (xrdp_iso_send(self->iso_layer, s) != 0)
     {
         free_stream(s);
-        LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_send_connect_response error");
+        LOG(LOG_LEVEL_ERROR, "  out xrdp_mcs_send_connect_response error");
         return 1;
     }
 
@@ -1031,7 +1031,7 @@ xrdp_mcs_send(struct xrdp_mcs *self, struct stream *s, int chan)
 
     if (len > 8192 * 2)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "error in xrdp_mcs_send, size too big: %d bytes", len);
+        LOG(LOG_LEVEL_WARNING, "error in xrdp_mcs_send, size too big: %d bytes", len);
     }
 
     //if (len > max_len)
@@ -1068,7 +1068,7 @@ xrdp_mcs_send(struct xrdp_mcs *self, struct stream *s, int chan)
 
     if (xrdp_iso_send(self->iso_layer, s) != 0)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_send error");
+        LOG(LOG_LEVEL_ERROR, "  out xrdp_mcs_send error");
         return 1;
     }
 
@@ -1119,7 +1119,7 @@ xrdp_mcs_disconnect(struct xrdp_mcs *self)
     {
         free_stream(s);
         close_rdp_socket(self);
-        LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_disconnect error - 1");
+        LOG(LOG_LEVEL_ERROR, "  out xrdp_mcs_disconnect error - 1");
         return 1;
     }
 
@@ -1131,7 +1131,7 @@ xrdp_mcs_disconnect(struct xrdp_mcs *self)
     {
         free_stream(s);
         close_rdp_socket(self);
-        LOG_DEVEL(LOG_LEVEL_TRACE, "  out xrdp_mcs_disconnect error - 2");
+        LOG(LOG_LEVEL_ERROR, "  out xrdp_mcs_disconnect error - 2");
         return 1;
     }
 

--- a/libxrdp/xrdp_mcs.c
+++ b/libxrdp/xrdp_mcs.c
@@ -164,12 +164,12 @@ xrdp_mcs_recv(struct xrdp_mcs *self, struct stream *s, int *chan)
 
             in_uint16_be(s, userid);
             in_uint16_be(s, chanid);
-            LOG(LOG_LEVEL_DEBUG,"MCS_CJRQ - channel join request received");
+            LOG(LOG_LEVEL_DEBUG, "MCS_CJRQ - channel join request received");
             LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_mcs_recv  adding channel %4.4x", chanid);
 
             if (xrdp_mcs_send_cjcf(self, userid, chanid) != 0)
             {
-                LOG(LOG_LEVEL_ERROR,"Non handled error from xrdp_mcs_send_cjcf") ;
+                LOG(LOG_LEVEL_ERROR, "Non handled error from xrdp_mcs_send_cjcf") ;
             }
 
             s = libxrdp_force_read(self->iso_layer->trans);
@@ -188,7 +188,7 @@ xrdp_mcs_recv(struct xrdp_mcs *self, struct stream *s, int *chan)
         }
         else
         {
-            LOG(LOG_LEVEL_DEBUG,"Received an unhandled appid:%d",appid);
+            LOG(LOG_LEVEL_DEBUG, "Received an unhandled appid:%d", appid);
         }
 
         break;
@@ -722,8 +722,8 @@ xrdp_mcs_out_gcc_data(struct xrdp_sec *self)
     int index;
     int channel;
     int gcc_size;
-    char* gcc_size_ptr;
-    char* ud_ptr;
+    char *gcc_size_ptr;
+    char *ud_ptr;
 
     num_channels = self->mcs_layer->channel_list->count;
     num_channels_even = num_channels + (num_channels & 1);
@@ -766,7 +766,7 @@ xrdp_mcs_out_gcc_data(struct xrdp_sec *self)
     out_uint8(s, 0);
     if (self->mcs_layer->iso_layer->rdpNegData)
     {
-         /* RequestedProtocol */
+        /* RequestedProtocol */
         out_uint32_le(s, self->mcs_layer->iso_layer->requestedProtocol);
     }
     out_uint16_le(s, SEC_TAG_SRV_CHANNELS);
@@ -883,7 +883,7 @@ xrdp_mcs_send_connect_response(struct xrdp_mcs *self)
     xrdp_iso_init(self->iso_layer, s);
     //TODO: we should calculate the whole length include MCS_CONNECT_RESPONSE
     xrdp_mcs_ber_out_header(self, s, MCS_CONNECT_RESPONSE,
-            data_len > 0x80 ? data_len + 38 : data_len + 36);
+                            data_len > 0x80 ? data_len + 38 : data_len + 36);
     xrdp_mcs_ber_out_header(self, s, BER_TAG_RESULT, 1);
     out_uint8(s, 0);
     xrdp_mcs_ber_out_header(self, s, BER_TAG_INTEGER, 1);
@@ -959,7 +959,7 @@ xrdp_mcs_incoming(struct xrdp_mcs *self)
         }
 
         if (xrdp_mcs_send_cjcf(self, self->userid,
-                      self->userid + MCS_USERCHANNEL_BASE + index) != 0)
+                               self->userid + MCS_USERCHANNEL_BASE + index) != 0)
         {
             return 1;
         }

--- a/libxrdp/xrdp_mppc_enc.c
+++ b/libxrdp/xrdp_mppc_enc.c
@@ -41,7 +41,7 @@
 
 #define CRC_INIT 0xFFFF
 #define CRC(_crcval, _newchar) _crcval = \
-    ((_crcval) >> 8) ^ g_crc_table[((_crcval) ^ (_newchar)) & 0x00ff]
+        ((_crcval) >> 8) ^ g_crc_table[((_crcval) ^ (_newchar)) & 0x00ff]
 
 /* CRC16 defs */
 static const tui16 g_crc_table[256] =
@@ -84,336 +84,336 @@ static const tui16 g_crc_table[256] =
                      insert 2 bits into outputBuffer
 ******************************************************************************/
 #define insert_2_bits(_data) \
-do \
-{ \
-    if ((bits_left >= 3) && (bits_left <= 8)) \
+    do \
     { \
-        i = bits_left - 2; \
-        outputBuffer[opb_index] |= _data << i; \
-        bits_left = i; \
-    } \
-    else \
-    { \
-        i = 2 - bits_left; \
-        j = 8 - i; \
-        outputBuffer[opb_index++] |= _data >> i; \
-        outputBuffer[opb_index] |= _data << j; \
-        bits_left = j; \
-    } \
-} while (0)
+        if ((bits_left >= 3) && (bits_left <= 8)) \
+        { \
+            i = bits_left - 2; \
+            outputBuffer[opb_index] |= _data << i; \
+            bits_left = i; \
+        } \
+        else \
+        { \
+            i = 2 - bits_left; \
+            j = 8 - i; \
+            outputBuffer[opb_index++] |= _data >> i; \
+            outputBuffer[opb_index] |= _data << j; \
+            bits_left = j; \
+        } \
+    } while (0)
 
 /*****************************************************************************
                      insert 3 bits into outputBuffer
 ******************************************************************************/
 #define insert_3_bits(_data) \
-do \
-{ \
-    if ((bits_left >= 4) && (bits_left <= 8)) \
+    do \
     { \
-        i = bits_left - 3; \
-        outputBuffer[opb_index] |= _data << i; \
-        bits_left = i; \
-    } \
-    else \
-    { \
-        i = 3 - bits_left; \
-        j = 8 - i; \
-        outputBuffer[opb_index++] |= _data >> i; \
-        outputBuffer[opb_index] |= _data << j; \
-        bits_left = j; \
-    } \
-} while (0)
+        if ((bits_left >= 4) && (bits_left <= 8)) \
+        { \
+            i = bits_left - 3; \
+            outputBuffer[opb_index] |= _data << i; \
+            bits_left = i; \
+        } \
+        else \
+        { \
+            i = 3 - bits_left; \
+            j = 8 - i; \
+            outputBuffer[opb_index++] |= _data >> i; \
+            outputBuffer[opb_index] |= _data << j; \
+            bits_left = j; \
+        } \
+    } while (0)
 
 /*****************************************************************************
                      insert 4 bits into outputBuffer
 ******************************************************************************/
 #define insert_4_bits(_data) \
-do \
-{ \
-    if ((bits_left >= 5) && (bits_left <= 8)) \
+    do \
     { \
-        i = bits_left - 4; \
-        outputBuffer[opb_index] |= _data << i; \
-        bits_left = i; \
-    } \
-    else \
-    { \
-        i = 4 - bits_left; \
-        j = 8 - i; \
-        outputBuffer[opb_index++] |= _data >> i; \
-        outputBuffer[opb_index] |= _data << j; \
-        bits_left = j; \
-    } \
-} while (0)
+        if ((bits_left >= 5) && (bits_left <= 8)) \
+        { \
+            i = bits_left - 4; \
+            outputBuffer[opb_index] |= _data << i; \
+            bits_left = i; \
+        } \
+        else \
+        { \
+            i = 4 - bits_left; \
+            j = 8 - i; \
+            outputBuffer[opb_index++] |= _data >> i; \
+            outputBuffer[opb_index] |= _data << j; \
+            bits_left = j; \
+        } \
+    } while (0)
 
 /*****************************************************************************
                      insert 5 bits into outputBuffer
 ******************************************************************************/
 #define insert_5_bits(_data) \
-do \
-{ \
-    if ((bits_left >= 6) && (bits_left <= 8)) \
+    do \
     { \
-        i = bits_left - 5; \
-        outputBuffer[opb_index] |= _data << i; \
-        bits_left = i; \
-    } \
-    else \
-    { \
-        i = 5 - bits_left; \
-        j = 8 - i; \
-        outputBuffer[opb_index++] |= _data >> i; \
-        outputBuffer[opb_index] |= _data << j; \
-        bits_left = j; \
-    } \
-} while (0)
+        if ((bits_left >= 6) && (bits_left <= 8)) \
+        { \
+            i = bits_left - 5; \
+            outputBuffer[opb_index] |= _data << i; \
+            bits_left = i; \
+        } \
+        else \
+        { \
+            i = 5 - bits_left; \
+            j = 8 - i; \
+            outputBuffer[opb_index++] |= _data >> i; \
+            outputBuffer[opb_index] |= _data << j; \
+            bits_left = j; \
+        } \
+    } while (0)
 
 /*****************************************************************************
                      insert 6 bits into outputBuffer
 ******************************************************************************/
 #define insert_6_bits(_data) \
-do \
-{ \
-    if ((bits_left >= 7) && (bits_left <= 8)) \
+    do \
     { \
-        i = bits_left - 6; \
-        outputBuffer[opb_index] |= (_data << i); \
-        bits_left = i; \
-    } \
-    else \
-    { \
-        i = 6 - bits_left; \
-        j = 8 - i; \
-        outputBuffer[opb_index++] |= (_data >> i); \
-        outputBuffer[opb_index] |= (_data << j); \
-        bits_left = j; \
-    } \
-} while (0)
+        if ((bits_left >= 7) && (bits_left <= 8)) \
+        { \
+            i = bits_left - 6; \
+            outputBuffer[opb_index] |= (_data << i); \
+            bits_left = i; \
+        } \
+        else \
+        { \
+            i = 6 - bits_left; \
+            j = 8 - i; \
+            outputBuffer[opb_index++] |= (_data >> i); \
+            outputBuffer[opb_index] |= (_data << j); \
+            bits_left = j; \
+        } \
+    } while (0)
 
 /*****************************************************************************
                      insert 7 bits into outputBuffer
 ******************************************************************************/
 #define insert_7_bits(_data) \
-do \
-{ \
-    if (bits_left == 8) \
+    do \
     { \
-        outputBuffer[opb_index] |= _data << 1; \
-        bits_left = 1; \
-    } \
-    else \
-    { \
-        i = 7 - bits_left; \
-        j = 8 - i; \
-        outputBuffer[opb_index++] |= _data >> i; \
-        outputBuffer[opb_index] |= _data << j; \
-        bits_left = j; \
-    } \
-} while (0)
+        if (bits_left == 8) \
+        { \
+            outputBuffer[opb_index] |= _data << 1; \
+            bits_left = 1; \
+        } \
+        else \
+        { \
+            i = 7 - bits_left; \
+            j = 8 - i; \
+            outputBuffer[opb_index++] |= _data >> i; \
+            outputBuffer[opb_index] |= _data << j; \
+            bits_left = j; \
+        } \
+    } while (0)
 
 /*****************************************************************************
                      insert 8 bits into outputBuffer
 ******************************************************************************/
 #define insert_8_bits(_data) \
-do \
-{ \
-    if (bits_left == 8) \
+    do \
     { \
-        outputBuffer[opb_index++] |= _data; \
-        bits_left = 8; \
-    } \
-    else \
-    { \
-        i = 8 - bits_left; \
-        j = 8 - i; \
-        outputBuffer[opb_index++] |= _data >> i; \
-        outputBuffer[opb_index] |= _data << j; \
-        bits_left = j; \
-    } \
-} while (0)
+        if (bits_left == 8) \
+        { \
+            outputBuffer[opb_index++] |= _data; \
+            bits_left = 8; \
+        } \
+        else \
+        { \
+            i = 8 - bits_left; \
+            j = 8 - i; \
+            outputBuffer[opb_index++] |= _data >> i; \
+            outputBuffer[opb_index] |= _data << j; \
+            bits_left = j; \
+        } \
+    } while (0)
 
 /*****************************************************************************
                      insert 9 bits into outputBuffer
 ******************************************************************************/
 #define insert_9_bits(_data16) \
-do \
-{ \
-    i = 9 - bits_left; \
-    j = 8 - i; \
-    outputBuffer[opb_index++] |= (char) (_data16 >> i); \
-    outputBuffer[opb_index] |= (char) (_data16 << j); \
-    bits_left = j; \
-    if (bits_left == 0) \
+    do \
     { \
-        opb_index++; \
-        bits_left = 8; \
-    } \
-} while (0)
+        i = 9 - bits_left; \
+        j = 8 - i; \
+        outputBuffer[opb_index++] |= (char) (_data16 >> i); \
+        outputBuffer[opb_index] |= (char) (_data16 << j); \
+        bits_left = j; \
+        if (bits_left == 0) \
+        { \
+            opb_index++; \
+            bits_left = 8; \
+        } \
+    } while (0)
 
 /*****************************************************************************
                      insert 10 bits into outputBuffer
 ******************************************************************************/
 #define insert_10_bits(_data16) \
-do \
-{ \
-    i = 10 - bits_left; \
-    if ((bits_left >= 3) && (bits_left <= 8)) \
+    do \
     { \
-        j = 8 - i; \
-        outputBuffer[opb_index++] |= (char) (_data16 >> i); \
-        outputBuffer[opb_index] |= (char) (_data16 << j); \
-        bits_left = j; \
-    } \
-    else \
-    { \
-        j = i - 8; \
-        k = 8 - j; \
-        outputBuffer[opb_index++] |= (char) (_data16 >> i); \
-        outputBuffer[opb_index++] |= (char) (_data16 >> j); \
-        outputBuffer[opb_index] |= (char) (_data16 << k); \
-        bits_left = k; \
-    } \
-} while (0)
+        i = 10 - bits_left; \
+        if ((bits_left >= 3) && (bits_left <= 8)) \
+        { \
+            j = 8 - i; \
+            outputBuffer[opb_index++] |= (char) (_data16 >> i); \
+            outputBuffer[opb_index] |= (char) (_data16 << j); \
+            bits_left = j; \
+        } \
+        else \
+        { \
+            j = i - 8; \
+            k = 8 - j; \
+            outputBuffer[opb_index++] |= (char) (_data16 >> i); \
+            outputBuffer[opb_index++] |= (char) (_data16 >> j); \
+            outputBuffer[opb_index] |= (char) (_data16 << k); \
+            bits_left = k; \
+        } \
+    } while (0)
 
 /*****************************************************************************
                      insert 11 bits into outputBuffer
 ******************************************************************************/
 #define insert_11_bits(_data16) \
-do \
-{ \
-    i = 11 - bits_left; \
-    if ((bits_left >= 4) && (bits_left <= 8)) \
+    do \
     { \
-        j = 8 - i; \
-        outputBuffer[opb_index++] |= (char) (_data16 >> i); \
-        outputBuffer[opb_index] |= (char) (_data16 << j); \
-        bits_left = j; \
-    } \
-    else \
-    { \
-        j = i - 8;                                \
-        k = 8 - j; \
-        outputBuffer[opb_index++] |= (char) (_data16 >> i); \
-        outputBuffer[opb_index++] |= (char) (_data16 >> j); \
-        outputBuffer[opb_index] |= (char) (_data16 << k); \
-        bits_left = k; \
-    } \
-} while (0)
+        i = 11 - bits_left; \
+        if ((bits_left >= 4) && (bits_left <= 8)) \
+        { \
+            j = 8 - i; \
+            outputBuffer[opb_index++] |= (char) (_data16 >> i); \
+            outputBuffer[opb_index] |= (char) (_data16 << j); \
+            bits_left = j; \
+        } \
+        else \
+        { \
+            j = i - 8;                                \
+            k = 8 - j; \
+            outputBuffer[opb_index++] |= (char) (_data16 >> i); \
+            outputBuffer[opb_index++] |= (char) (_data16 >> j); \
+            outputBuffer[opb_index] |= (char) (_data16 << k); \
+            bits_left = k; \
+        } \
+    } while (0)
 
 /*****************************************************************************
                      insert 12 bits into outputBuffer
 ******************************************************************************/
 #define insert_12_bits(_data16) \
-do \
-{ \
-    i = 12 - bits_left; \
-    if ((bits_left >= 5) && (bits_left <= 8)) \
+    do \
     { \
-        j = 8 - i; \
-        outputBuffer[opb_index++] |= (char) (_data16 >> i); \
-        outputBuffer[opb_index] |= (char) (_data16 << j); \
-        bits_left = j; \
-    } \
-    else \
-    { \
-        j = i - 8; \
-        k = 8 - j; \
-        outputBuffer[opb_index++] |= (char) (_data16 >> i); \
-        outputBuffer[opb_index++] |= (char) (_data16 >> j); \
-        outputBuffer[opb_index] |= (char) (_data16 << k); \
-        bits_left = k; \
-    } \
-} while (0)
+        i = 12 - bits_left; \
+        if ((bits_left >= 5) && (bits_left <= 8)) \
+        { \
+            j = 8 - i; \
+            outputBuffer[opb_index++] |= (char) (_data16 >> i); \
+            outputBuffer[opb_index] |= (char) (_data16 << j); \
+            bits_left = j; \
+        } \
+        else \
+        { \
+            j = i - 8; \
+            k = 8 - j; \
+            outputBuffer[opb_index++] |= (char) (_data16 >> i); \
+            outputBuffer[opb_index++] |= (char) (_data16 >> j); \
+            outputBuffer[opb_index] |= (char) (_data16 << k); \
+            bits_left = k; \
+        } \
+    } while (0)
 
 /*****************************************************************************
                      insert 13 bits into outputBuffer
 ******************************************************************************/
 #define insert_13_bits(_data16) \
-do \
-{ \
-    i = 13 - bits_left; \
-    if ((bits_left >= 6) && (bits_left <= 8)) \
+    do \
     { \
-        j = 8 - i; \
-        outputBuffer[opb_index++] |= (char) (_data16 >> i); \
-        outputBuffer[opb_index] |= (char) (_data16 << j); \
-        bits_left = j; \
-    } \
-    else \
-    { \
-        j = i - 8; \
-        k = 8 - j; \
-        outputBuffer[opb_index++] |= (char) (_data16 >> i); \
-        outputBuffer[opb_index++] |= (char) (_data16 >> j); \
-        outputBuffer[opb_index] |= (char) (_data16 << k); \
-        bits_left = k; \
-    } \
-} while (0)
+        i = 13 - bits_left; \
+        if ((bits_left >= 6) && (bits_left <= 8)) \
+        { \
+            j = 8 - i; \
+            outputBuffer[opb_index++] |= (char) (_data16 >> i); \
+            outputBuffer[opb_index] |= (char) (_data16 << j); \
+            bits_left = j; \
+        } \
+        else \
+        { \
+            j = i - 8; \
+            k = 8 - j; \
+            outputBuffer[opb_index++] |= (char) (_data16 >> i); \
+            outputBuffer[opb_index++] |= (char) (_data16 >> j); \
+            outputBuffer[opb_index] |= (char) (_data16 << k); \
+            bits_left = k; \
+        } \
+    } while (0)
 
 /*****************************************************************************
                      insert 14 bits into outputBuffer
 ******************************************************************************/
 #define insert_14_bits(_data16) \
-do \
-{ \
-    i = 14 - bits_left; \
-    if ((bits_left >= 7) && (bits_left <= 8)) \
+    do \
     { \
-        j = 8 - i; \
-        outputBuffer[opb_index++] |= (char) (_data16 >> i); \
-        outputBuffer[opb_index] |= (char) (_data16 << j); \
-        bits_left = j; \
-    } \
-    else \
-    { \
-        j = i - 8; \
-        k = 8 - j; \
-        outputBuffer[opb_index++] |= (char) (_data16 >> i); \
-        outputBuffer[opb_index++] |= (char) (_data16 >> j); \
-        outputBuffer[opb_index] |= (char) (_data16 << k); \
-        bits_left = k; \
-    } \
-} while (0)
+        i = 14 - bits_left; \
+        if ((bits_left >= 7) && (bits_left <= 8)) \
+        { \
+            j = 8 - i; \
+            outputBuffer[opb_index++] |= (char) (_data16 >> i); \
+            outputBuffer[opb_index] |= (char) (_data16 << j); \
+            bits_left = j; \
+        } \
+        else \
+        { \
+            j = i - 8; \
+            k = 8 - j; \
+            outputBuffer[opb_index++] |= (char) (_data16 >> i); \
+            outputBuffer[opb_index++] |= (char) (_data16 >> j); \
+            outputBuffer[opb_index] |= (char) (_data16 << k); \
+            bits_left = k; \
+        } \
+    } while (0)
 
 /*****************************************************************************
                      insert 15 bits into outputBuffer
 ******************************************************************************/
 #define insert_15_bits(_data16) \
-do \
-{ \
-    i = 15 - bits_left; \
-    if (bits_left == 8) \
+    do \
     { \
-        j = 8 - i; \
-        outputBuffer[opb_index++] |= (char) (_data16 >> i); \
-        outputBuffer[opb_index] |= (char) (_data16 << j); \
-        bits_left = j; \
-    } \
-    else \
+        i = 15 - bits_left; \
+        if (bits_left == 8) \
+        { \
+            j = 8 - i; \
+            outputBuffer[opb_index++] |= (char) (_data16 >> i); \
+            outputBuffer[opb_index] |= (char) (_data16 << j); \
+            bits_left = j; \
+        } \
+        else \
+        { \
+            j = i - 8; \
+            k = 8 - j; \
+            outputBuffer[opb_index++] |= (char) (_data16 >> i); \
+            outputBuffer[opb_index++] |= (char) (_data16 >> j); \
+            outputBuffer[opb_index] |= (char) (_data16 << k); \
+            bits_left = k; \
+        } \
+    } while (0)
+
+/*****************************************************************************
+                     insert 16 bits into outputBuffer
+******************************************************************************/
+#define insert_16_bits(_data16) \
+    do \
     { \
+        i = 16 - bits_left; \
         j = i - 8; \
         k = 8 - j; \
         outputBuffer[opb_index++] |= (char) (_data16 >> i); \
         outputBuffer[opb_index++] |= (char) (_data16 >> j); \
         outputBuffer[opb_index] |= (char) (_data16 << k); \
         bits_left = k; \
-    } \
-} while (0)
-
-/*****************************************************************************
-                     insert 16 bits into outputBuffer
-******************************************************************************/
-#define insert_16_bits(_data16) \
-do \
-{ \
-    i = 16 - bits_left; \
-    j = i - 8; \
-    k = 8 - j; \
-    outputBuffer[opb_index++] |= (char) (_data16 >> i); \
-    outputBuffer[opb_index++] |= (char) (_data16 >> j); \
-    outputBuffer[opb_index] |= (char) (_data16 << k); \
-    bits_left = k; \
-} while (0)
+    } while (0)
 
 /**
  * Initialize mppc_enc structure
@@ -670,8 +670,8 @@ compress_rdp_5(struct xrdp_mppc_enc *enc, tui8 *srcData, int len)
 
         /* double check that we have a pattern match */
         if ((*cptr1 != *cptr2) ||
-            (*(cptr1 + 1) != *(cptr2 + 1)) ||
-            (*(cptr1 + 2) != *(cptr2 + 2)))
+                (*(cptr1 + 1) != *(cptr2 + 1)) ||
+                (*(cptr1 + 2) != *(cptr2 + 2)))
         {
             /* no match found; encode literal byte */
             data = *cptr1;
@@ -703,7 +703,7 @@ compress_rdp_5(struct xrdp_mppc_enc *enc, tui8 *srcData, int len)
         }
         saved_ctr = ctr + lom;
         LOG_DEVEL(LOG_LEVEL_TRACE, "<%ld: %u,%d> ",  (historyPointer + ctr) - hbuf_start,
-              copy_offset, lom);
+                  copy_offset, lom);
 
         /* compute CRC for matching segment and store in hash table */
 
@@ -984,7 +984,7 @@ compress_rdp_5(struct xrdp_mppc_enc *enc, tui8 *srcData, int len)
 
     LOG_DEVEL(LOG_LEVEL_TRACE, "\n");
 
-      LOG_DEVEL(LOG_LEVEL_TRACE, "compression ratio: %f", (float) len / (float) enc->bytes_in_opb);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "compression ratio: %f", (float) len / (float) enc->bytes_in_opb);
 
     return 1;
 }

--- a/libxrdp/xrdp_mppc_enc.c
+++ b/libxrdp/xrdp_mppc_enc.c
@@ -24,14 +24,6 @@
 
 #include "libxrdp.h"
 
-#define MPPC_ENC_DEBUG 0
-
-#if MPPC_ENC_DEBUG
-#define DLOG(_args) g_printf _args
-#else
-#define DLOG(_args) do { } while (0)
-#endif
-
 /* local defines */
 
 #define RDP_40_HIST_BUF_LEN (1024 * 8) /* RDP 4.0 uses 8K history buf */
@@ -606,7 +598,7 @@ compress_rdp_5(struct xrdp_mppc_enc *enc, tui8 *srcData, int len)
         for (x = 0; x < 2; x++)
         {
             data = *(historyPointer + x);
-            DLOG(("%.2x ", (tui8) data));
+            LOG_DEVEL(LOG_LEVEL_TRACE, "%.2x ", (tui8) data);
             if (data & 0x80)
             {
                 /* insert encoded literal */
@@ -684,7 +676,7 @@ compress_rdp_5(struct xrdp_mppc_enc *enc, tui8 *srcData, int len)
             /* no match found; encode literal byte */
             data = *cptr1;
 
-            DLOG(("%.2x ", data));
+            LOG_DEVEL(LOG_LEVEL_TRACE, "%.2x ", data);
             if (data < 0x80)
             {
                 /* literal byte < 0x80 */
@@ -710,8 +702,8 @@ compress_rdp_5(struct xrdp_mppc_enc *enc, tui8 *srcData, int len)
             lom++;
         }
         saved_ctr = ctr + lom;
-        DLOG(("<%d: %ld,%d> ",  (historyPointer + ctr) - hbuf_start,
-              copy_offset, lom));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "<%ld: %u,%d> ",  (historyPointer + ctr) - hbuf_start,
+              copy_offset, lom);
 
         /* compute CRC for matching segment and store in hash table */
 
@@ -951,7 +943,7 @@ compress_rdp_5(struct xrdp_mppc_enc *enc, tui8 *srcData, int len)
     while (len - ctr > 0)
     {
         data = srcData[ctr];
-        DLOG(("%.2x ", data));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "%.2x ", data);
         if (data < 0x80)
         {
             /* literal byte < 0x80 */
@@ -990,9 +982,9 @@ compress_rdp_5(struct xrdp_mppc_enc *enc, tui8 *srcData, int len)
     enc->flags |= enc->flagsHold;
     enc->flagsHold = 0;
 
-    DLOG(("\n"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "\n");
 
-    //g_writeln("compression ratio: %f", (float) len / (float) enc->bytes_in_opb);
+      LOG_DEVEL(LOG_LEVEL_TRACE, "compression ratio: %f", (float) len / (float) enc->bytes_in_opb);
 
     return 1;
 }

--- a/libxrdp/xrdp_orders.c
+++ b/libxrdp/xrdp_orders.c
@@ -1640,20 +1640,20 @@ xrdp_orders_mem_blt(struct xrdp_orders *self, int cache_id,
 /*****************************************************************************/
 /* returns error */
 int
-xrdp_orders_composite_blt(struct xrdp_orders* self, int srcidx, int srcformat,
-                          int srcwidth, int srcrepeat, int* srctransform,
+xrdp_orders_composite_blt(struct xrdp_orders *self, int srcidx, int srcformat,
+                          int srcwidth, int srcrepeat, int *srctransform,
                           int mskflags, int mskidx, int mskformat,
                           int mskwidth, int mskrepeat, int op,
                           int srcx, int srcy, int mskx, int msky,
                           int dstx, int dsty, int width, int height,
                           int dstformat,
-                          struct xrdp_rect* rect)
+                          struct xrdp_rect *rect)
 {
     int order_flags;
     int vals[20];
     int present;
-    char* present_ptr;
-    char* order_flags_ptr;
+    char *present_ptr;
+    char *order_flags_ptr;
 
     if (xrdp_orders_check(self, 80) != 0)
     {
@@ -1670,7 +1670,7 @@ xrdp_orders_composite_blt(struct xrdp_orders* self, int srcidx, int srcformat,
     {
         /* if clip is present, still check if it's needed */
         if (dstx < rect->left || dsty < rect->top ||
-            dstx + width > rect->right || dsty + height > rect->bottom)
+                dstx + width > rect->right || dsty + height > rect->bottom)
         {
             order_flags |= TS_BOUNDS;
             if (xrdp_orders_last_bounds(self, rect))
@@ -1717,7 +1717,7 @@ xrdp_orders_composite_blt(struct xrdp_orders* self, int srcidx, int srcformat,
     present_ptr = self->out_s->p;
     out_uint8s(self->out_s, 3);
     if ((order_flags & TS_BOUNDS) &&
-        !(order_flags & TS_ZERO_BOUNDS_DELTAS))
+            !(order_flags & TS_ZERO_BOUNDS_DELTAS))
     {
         xrdp_orders_out_bounds(self, rect);
     }
@@ -2482,7 +2482,7 @@ xrdp_orders_cache_glyph(struct xrdp_orders *self,
 
 /*****************************************************************************/
 /* returns error */
-static int write_2byte_signed(struct stream * s, int value)
+static int write_2byte_signed(struct stream *s, int value)
 {
     unsigned char byte;
     int negative = 0;
@@ -2528,7 +2528,7 @@ static int write_2byte_signed(struct stream * s, int value)
 
 /*****************************************************************************/
 /* returns error */
-static int write_2byte_unsigned(struct stream * s, unsigned int value)
+static int write_2byte_unsigned(struct stream *s, unsigned int value)
 {
     unsigned char byte;
 
@@ -2594,9 +2594,9 @@ xrdp_orders_cache_glyph_v2(struct xrdp_orders *self,
 
     out_uint8(self->out_s, char_index);
     if (write_2byte_signed(self->out_s, font_char->offset) ||
-        write_2byte_signed(self->out_s, font_char->baseline) ||
-        write_2byte_unsigned(self->out_s, font_char->width) ||
-        write_2byte_unsigned(self->out_s, font_char->height))
+            write_2byte_signed(self->out_s, font_char->baseline) ||
+            write_2byte_unsigned(self->out_s, font_char->width) ||
+            write_2byte_unsigned(self->out_s, font_char->height))
     {
         return 1;
     }
@@ -2887,7 +2887,7 @@ xrdp_orders_send_as_rfx(struct xrdp_orders *self,
     }
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "width %d height %d rfx_min_pixel %d", width, height,
-                self->rfx_min_pixel);
+              self->rfx_min_pixel);
     if (width * height < self->rfx_min_pixel)
     {
         return 0;

--- a/libxrdp/xrdp_orders.c
+++ b/libxrdp/xrdp_orders.c
@@ -30,15 +30,7 @@
 #include <freerdp/codec/rfx.h>
 #endif
 
-#define LLOG_LEVEL 2
-#define LLOGLN(_log_level, _params) \
-    { \
-        if (_log_level < LLOG_LEVEL) \
-        { \
-            g_write("xrdp_orders.c [%10.10u]: ", g_time3()); \
-            g_writeln _params ; \
-        } \
-    }
+
 
 #define MAX_ORDERS_SIZE(_client_info) \
     (MAX((_client_info)->max_fastpath_frag_bytes, 16 * 1024) - 256);
@@ -114,7 +106,7 @@ xrdp_orders_init(struct xrdp_orders *self)
         self->order_count = 0;
         if (self->rdp_layer->client_info.use_fast_path & 1)
         {
-            LLOGLN(10, ("xrdp_orders_init: fastpath"));
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_orders_init: fastpath");
             if (xrdp_rdp_init_fastpath(self->rdp_layer, self->out_s) != 0)
             {
                 return 1;
@@ -124,7 +116,7 @@ xrdp_orders_init(struct xrdp_orders *self)
         }
         else
         {
-            LLOGLN(10, ("xrdp_orders_init: slowpath"));
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_orders_init: slowpath");
             if (xrdp_rdp_init_data(self->rdp_layer, self->out_s) != 0)
             {
                 return 1;
@@ -153,7 +145,7 @@ xrdp_orders_send(struct xrdp_orders *self)
         if ((self->order_level == 0) && (self->order_count > 0))
         {
             s_mark_end(self->out_s);
-            DEBUG(("xrdp_orders_send sending %d orders", self->order_count));
+            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_orders_send sending %d orders", self->order_count);
             self->order_count_ptr[0] = self->order_count;
             self->order_count_ptr[1] = self->order_count >> 8;
             self->order_count = 0;
@@ -190,7 +182,7 @@ xrdp_orders_force_send(struct xrdp_orders *self)
     if ((self->order_level > 0) && (self->order_count > 0))
     {
         s_mark_end(self->out_s);
-        DEBUG(("xrdp_orders_force_send sending %d orders", self->order_count));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_orders_force_send sending %d orders", self->order_count);
         self->order_count_ptr[0] = self->order_count;
         self->order_count_ptr[1] = self->order_count >> 8;
         if (self->rdp_layer->client_info.use_fast_path & 1)
@@ -245,7 +237,7 @@ xrdp_orders_check(struct xrdp_orders *self, int max_size)
     size = (int)(self->out_s->p - self->order_count_ptr);
     if (size < 0)
     {
-        g_writeln("error in xrdp_orders_check, size too small: %d bytes", size);
+        LOG_DEVEL(LOG_LEVEL_TRACE, "error in xrdp_orders_check, size too small: %d bytes", size);
         return 1;
     }
     if (size > max_order_size)
@@ -253,7 +245,7 @@ xrdp_orders_check(struct xrdp_orders *self, int max_size)
         /* this suggests someone calls this function without passing the
            correct max_size so we end up putting more into the buffer
            than we indicate we can */
-        g_writeln("error in xrdp_orders_check, size too big: %d bytes", size);
+        LOG_DEVEL(LOG_LEVEL_TRACE, "error in xrdp_orders_check, size too big: %d bytes", size);
         /* We where getting called with size already greater than
            max_order_size
            Which I suspect was because the sending of text did not include
@@ -2227,13 +2219,13 @@ xrdp_orders_send_raw_bitmap(struct xrdp_orders *self,
 
     if (width > 64)
     {
-        g_writeln("error, width > 64");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "error, width > 64");
         return 1;
     }
 
     if (height > 64)
     {
-        g_writeln("error, height > 64");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "error, height > 64");
         return 1;
     }
 
@@ -2353,13 +2345,13 @@ xrdp_orders_send_bitmap(struct xrdp_orders *self,
 
     if (width > 64)
     {
-        g_writeln("error, width > 64");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "error, width > 64");
         return 1;
     }
 
     if (height > 64)
     {
-        g_writeln("error, height > 64");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "error, height > 64");
         return 1;
     }
 
@@ -2653,13 +2645,13 @@ xrdp_orders_send_raw_bitmap2(struct xrdp_orders *self,
 
     if (width > 64)
     {
-        g_writeln("error, width > 64");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "error, width > 64");
         return 1;
     }
 
     if (height > 64)
     {
-        g_writeln("error, height > 64");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "error, height > 64");
         return 1;
     }
 
@@ -2781,13 +2773,13 @@ xrdp_orders_send_bitmap2(struct xrdp_orders *self,
 
     if (width > 64)
     {
-        g_writeln("error, width > 64");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "error, width > 64");
         return 1;
     }
 
     if (height > 64)
     {
-        g_writeln("error, height > 64");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "error, height > 64");
         return 1;
     }
 
@@ -2894,8 +2886,8 @@ xrdp_orders_send_as_rfx(struct xrdp_orders *self,
         return 0;
     }
 
-    LLOGLN(10, ("width %d height %d rfx_min_pixel %d", width, height,
-                self->rfx_min_pixel));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "width %d height %d rfx_min_pixel %d", width, height,
+                self->rfx_min_pixel);
     if (width * height < self->rfx_min_pixel)
     {
         return 0;
@@ -2987,7 +2979,7 @@ xrdp_orders_send_bitmap3(struct xrdp_orders *self,
             return 2;
         }
 
-        LLOGLN(10, ("xrdp_orders_send_bitmap3: rfx"));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_orders_send_bitmap3: rfx");
         context = (RFX_CONTEXT *)(self->rdp_layer->rfx_enc);
         make_stream(xr_s);
         init_stream(xr_s, 16384);
@@ -3016,11 +3008,11 @@ xrdp_orders_send_bitmap3(struct xrdp_orders *self,
 
         if (!xrdp_orders_send_as_jpeg(self, width, height, bpp, hints))
         {
-            LLOGLN(10, ("xrdp_orders_send_bitmap3: jpeg skipped"));
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_orders_send_bitmap3: jpeg skipped");
             return 2;
         }
 
-        LLOGLN(10, ("xrdp_orders_send_bitmap3: jpeg"));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_orders_send_bitmap3: jpeg");
         e = width % 4;
 
         if (e != 0)
@@ -3048,7 +3040,7 @@ xrdp_orders_send_bitmap3(struct xrdp_orders *self,
     }
     else
     {
-        g_writeln("xrdp_orders_send_bitmap3: todo unknown codec");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_orders_send_bitmap3: todo unknown codec");
         return 1;
     }
 
@@ -3119,7 +3111,7 @@ xrdp_orders_send_create_os_surface(struct xrdp_orders *self, int id,
     order_flags |= 1 << 2; /* type RDP_ORDER_ALTSEC_CREATE_OFFSCR_BITMAP */
     out_uint8(self->out_s, order_flags);
     cache_id = id & 0x7fff;
-    LLOGLN(10, ("xrdp_orders_send_create_os_surface: cache_id %d", cache_id));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_orders_send_create_os_surface: cache_id %d", cache_id);
     flags = cache_id;
 
     if (num_del_list > 0)

--- a/libxrdp/xrdp_orders.c
+++ b/libxrdp/xrdp_orders.c
@@ -237,7 +237,7 @@ xrdp_orders_check(struct xrdp_orders *self, int max_size)
     size = (int)(self->out_s->p - self->order_count_ptr);
     if (size < 0)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "error in xrdp_orders_check, size too small: %d bytes", size);
+        LOG(LOG_LEVEL_ERROR, "error in xrdp_orders_check, size too small: %d bytes", size);
         return 1;
     }
     if (size > max_order_size)
@@ -245,7 +245,7 @@ xrdp_orders_check(struct xrdp_orders *self, int max_size)
         /* this suggests someone calls this function without passing the
            correct max_size so we end up putting more into the buffer
            than we indicate we can */
-        LOG_DEVEL(LOG_LEVEL_TRACE, "error in xrdp_orders_check, size too big: %d bytes", size);
+        LOG(LOG_LEVEL_WARNING, "error in xrdp_orders_check, size too big: %d bytes", size);
         /* We where getting called with size already greater than
            max_order_size
            Which I suspect was because the sending of text did not include
@@ -2219,13 +2219,13 @@ xrdp_orders_send_raw_bitmap(struct xrdp_orders *self,
 
     if (width > 64)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "error, width > 64");
+        LOG(LOG_LEVEL_ERROR, "error, width > 64");
         return 1;
     }
 
     if (height > 64)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "error, height > 64");
+        LOG(LOG_LEVEL_ERROR, "error, height > 64");
         return 1;
     }
 
@@ -2345,13 +2345,13 @@ xrdp_orders_send_bitmap(struct xrdp_orders *self,
 
     if (width > 64)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "error, width > 64");
+        LOG(LOG_LEVEL_ERROR, "error, width > 64");
         return 1;
     }
 
     if (height > 64)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "error, height > 64");
+        LOG(LOG_LEVEL_ERROR, "error, height > 64");
         return 1;
     }
 
@@ -2645,13 +2645,13 @@ xrdp_orders_send_raw_bitmap2(struct xrdp_orders *self,
 
     if (width > 64)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "error, width > 64");
+        LOG(LOG_LEVEL_ERROR, "error, width > 64");
         return 1;
     }
 
     if (height > 64)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "error, height > 64");
+        LOG(LOG_LEVEL_ERROR, "error, height > 64");
         return 1;
     }
 
@@ -2773,13 +2773,13 @@ xrdp_orders_send_bitmap2(struct xrdp_orders *self,
 
     if (width > 64)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "error, width > 64");
+        LOG(LOG_LEVEL_ERROR, "error, width > 64");
         return 1;
     }
 
     if (height > 64)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "error, height > 64");
+        LOG(LOG_LEVEL_ERROR, "error, height > 64");
         return 1;
     }
 
@@ -3008,7 +3008,7 @@ xrdp_orders_send_bitmap3(struct xrdp_orders *self,
 
         if (!xrdp_orders_send_as_jpeg(self, width, height, bpp, hints))
         {
-            LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_orders_send_bitmap3: jpeg skipped");
+            LOG(LOG_LEVEL_ERROR, "xrdp_orders_send_bitmap3: jpeg skipped");
             return 2;
         }
 
@@ -3040,7 +3040,7 @@ xrdp_orders_send_bitmap3(struct xrdp_orders *self,
     }
     else
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_orders_send_bitmap3: todo unknown codec");
+        LOG(LOG_LEVEL_ERROR, "xrdp_orders_send_bitmap3: todo unknown codec");
         return 1;
     }
 

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -459,8 +459,8 @@ xrdp_rdp_recv(struct xrdp_rdp *self, struct stream *s, int *code)
 
         if (error != 0)
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_rdp_recv error");
-            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_rdp_recv: xrdp_sec_recv failed");
+            LOG(LOG_LEVEL_ERROR, "out xrdp_rdp_recv error");
+            LOG(LOG_LEVEL_ERROR, "xrdp_rdp_recv: xrdp_sec_recv failed");
             return 1;
         }
 
@@ -470,14 +470,14 @@ xrdp_rdp_recv(struct xrdp_rdp *self, struct stream *s, int *code)
             {
                 if (xrdp_channel_process(self->sec_layer->chan_layer, s, chan) != 0)
                 {
-                    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_channel_process returned unhandled error") ;
+                    LOG(LOG_LEVEL_ERROR, "xrdp_channel_process returned unhandled error") ;
                 }
             }
             else
             {
                 if (chan != 1)
                 {
-                    LOG_DEVEL(LOG_LEVEL_TRACE, "Wrong channel Id to be handled by xrdp_channel_process %d", chan);
+                    LOG(LOG_LEVEL_ERROR, "Wrong channel Id to be handled by xrdp_channel_process %d", chan);
                 }
             }
 
@@ -532,7 +532,7 @@ xrdp_rdp_send(struct xrdp_rdp *self, struct stream *s, int pdu_type)
 
     if (xrdp_sec_send(self->sec_layer, s, MCS_GLOBAL_CHANNEL) != 0)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_rdp_send error");
+        LOG(LOG_LEVEL_ERROR, "out xrdp_rdp_send error");
         return 1;
     }
 
@@ -620,7 +620,7 @@ xrdp_rdp_send_data(struct xrdp_rdp *self, struct stream *s,
 
     if (xrdp_sec_send(self->sec_layer, s, MCS_GLOBAL_CHANNEL) != 0)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_rdp_send_data error");
+        LOG(LOG_LEVEL_ERROR, "out xrdp_rdp_send_data error");
         return 1;
     }
 
@@ -775,7 +775,7 @@ xrdp_rdp_send_fastpath(struct xrdp_rdp *self, struct stream *s,
         send_s.end = send_s.p + send_len;
         if (xrdp_sec_send_fastpath(self->sec_layer, &send_s) != 0)
         {
-            LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_rdp_send_fastpath: xrdp_fastpath_send failed");
+            LOG(LOG_LEVEL_ERROR, "xrdp_rdp_send_fastpath: xrdp_fastpath_send failed");
             return 1;
         }
         frag_s.p += no_comp_len;
@@ -810,7 +810,7 @@ xrdp_rdp_send_data_update_sync(struct xrdp_rdp *self)
     {
         if (xrdp_rdp_init_data(self, s) != 0)
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_rdp_send_data_update_sync error");
+            LOG(LOG_LEVEL_ERROR, "out xrdp_rdp_send_data_update_sync error");
             free_stream(s);
             return 1;
         }
@@ -833,7 +833,7 @@ xrdp_rdp_send_data_update_sync(struct xrdp_rdp *self)
     {
         if (xrdp_rdp_send_data(self, s, RDP_DATA_PDU_UPDATE) != 0)
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_rdp_send_data_update_sync error");
+            LOG(LOG_LEVEL_ERROR, "out xrdp_rdp_send_data_update_sync error");
             free_stream(s);
             return 1;
         }
@@ -1375,7 +1375,7 @@ xrdp_rdp_send_deactivate(struct xrdp_rdp *self)
     if (xrdp_rdp_init(self, s) != 0)
     {
         free_stream(s);
-        LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_rdp_send_deactivate error");
+        LOG(LOG_LEVEL_ERROR, "out xrdp_rdp_send_deactivate error");
         return 1;
     }
 
@@ -1384,7 +1384,7 @@ xrdp_rdp_send_deactivate(struct xrdp_rdp *self)
     if (xrdp_rdp_send(self, s, PDUTYPE_DEACTIVATEALLPDU) != 0)
     {
         free_stream(s);
-        LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_rdp_send_deactivate error");
+        LOG(LOG_LEVEL_ERROR, "out xrdp_rdp_send_deactivate error");
         return 1;
     }
 

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -460,7 +460,6 @@ xrdp_rdp_recv(struct xrdp_rdp *self, struct stream *s, int *code)
         if (error != 0)
         {
             LOG(LOG_LEVEL_ERROR, "out xrdp_rdp_recv error");
-            LOG(LOG_LEVEL_ERROR, "xrdp_rdp_recv: xrdp_sec_recv failed");
             return 1;
         }
 
@@ -499,9 +498,8 @@ xrdp_rdp_recv(struct xrdp_rdp *self, struct stream *s, int *code)
     {
         s->next_packet = 0;
         *code = 0;
-        LOG_DEVEL(LOG_LEVEL_TRACE, "out (3) xrdp_rdp_recv");
         len = (int)(s->end - s->p);
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_rdp_recv: bad RDP packet, length [%d]", len);
+        LOG_DEVEL(LOG_LEVEL_TRACE, "out (3) xrdp_rdp_recv: bad RDP packet, length [%d]", len);
         return 0;
     }
     else

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -99,8 +99,8 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
             }
             else
             {
-                LOG(LOG_LEVEL_ALWAYS,"Warning: Your configured crypt level is "
-                          "undefined, 'high' will be used");
+                LOG(LOG_LEVEL_ALWAYS, "Warning: Your configured crypt level is "
+                    "undefined, 'high' will be used");
                 client_info->crypt_level = 3;
             }
         }
@@ -109,17 +109,17 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
             client_info->channels_allowed = g_text2bool(value);
             if (client_info->channels_allowed == 0)
             {
-                LOG(LOG_LEVEL_DEBUG,"Info - All channels are disabled");
+                LOG(LOG_LEVEL_DEBUG, "Info - All channels are disabled");
             }
         }
         else if (g_strcasecmp(item, "allow_multimon") == 0)
-                {
-                    client_info->multimon = g_text2bool(value);
-                    if (client_info->multimon == 0)
-                    {
-                        LOG(LOG_LEVEL_DEBUG,"Info - Multi monitor server support disabled");
-                    }
-                }
+        {
+            client_info->multimon = g_text2bool(value);
+            if (client_info->multimon == 0)
+            {
+                LOG(LOG_LEVEL_DEBUG, "Info - Multi monitor server support disabled");
+            }
+        }
         else if (g_strcasecmp(item, "max_bpp") == 0)
         {
             client_info->max_bpp = g_atoi(value);
@@ -160,8 +160,8 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
             }
             else
             {
-                LOG(LOG_LEVEL_ALWAYS,"Warning: Your configured fastpath level is "
-                          "undefined, fastpath will not be used");
+                LOG(LOG_LEVEL_ALWAYS, "Warning: Your configured fastpath level is "
+                    "undefined, fastpath will not be used");
                 client_info->use_fast_path = 0;
             }
         }
@@ -205,8 +205,8 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
             else
             {
                 LOG(LOG_LEVEL_ERROR, "security_layer=%s is not "
-                            "recognized, will use security_layer=negotiate",
-                            value);
+                    "recognized, will use security_layer=negotiate",
+                    value);
                 client_info->security_layer = PROTOCOL_SSL | PROTOCOL_HYBRID | PROTOCOL_HYBRID_EX;
             }
         }
@@ -218,8 +218,8 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
                 /* default certificate path */
                 g_snprintf(client_info->certificate, 1023, "%s/cert.pem", XRDP_CFG_PATH);
                 LOG(LOG_LEVEL_INFO,
-                            "Using default X.509 certificate: %s",
-                            client_info->certificate);
+                    "Using default X.509 certificate: %s",
+                    client_info->certificate);
 
             }
             else if (value[0] != '/')
@@ -227,8 +227,8 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
                 /* default certificate path */
                 g_snprintf(client_info->certificate, 1023, "%s/cert.pem", XRDP_CFG_PATH);
                 LOG(LOG_LEVEL_WARNING,
-                            "X.509 certificate should use absolute path, using "
-                            "default instead: %s", client_info->certificate);
+                    "X.509 certificate should use absolute path, using "
+                    "default instead: %s", client_info->certificate);
             }
             else
             {
@@ -236,10 +236,10 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
                 g_strncpy(client_info->certificate, value, 1023);
             }
 
-	    if (!g_file_readable(client_info->certificate))
+            if (!g_file_readable(client_info->certificate))
             {
                 LOG(LOG_LEVEL_ERROR, "Cannot read certificate file %s: %s",
-                            client_info->certificate, g_get_strerror());
+                    client_info->certificate, g_get_strerror());
             }
         }
         else if (g_strcasecmp(item, "key_file") == 0)
@@ -250,15 +250,15 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
                 /* default key_file path */
                 g_snprintf(client_info->key_file, 1023, "%s/key.pem", XRDP_CFG_PATH);
                 LOG(LOG_LEVEL_INFO, "Using default X.509 key file: %s",
-                            client_info->key_file);
+                    client_info->key_file);
             }
             else if (value[0] != '/')
             {
                 /* default key_file path */
                 g_snprintf(client_info->key_file, 1023, "%s/key.pem", XRDP_CFG_PATH);
                 LOG(LOG_LEVEL_WARNING,
-                            "X.509 key file should use absolute path, using "
-                            "default instead: %s", client_info->key_file);
+                    "X.509 key file should use absolute path, using "
+                    "default instead: %s", client_info->key_file);
             }
             else
             {
@@ -269,7 +269,7 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
             if (!g_file_readable(client_info->key_file))
             {
                 LOG(LOG_LEVEL_ERROR, "Cannot read private key file %s: %s",
-                            client_info->key_file, g_get_strerror());
+                    client_info->key_file, g_get_strerror());
             }
         }
         else if (g_strcasecmp(item, "domain_user_separator") == 0
@@ -304,9 +304,9 @@ cpuid(tui32 info, tui32 *eax, tui32 *ebx, tui32 *ecx, tui32 *edx)
         "cpuid;"
         "xchg %%rbx, %%rsi;"
 #endif
-    : "=a" (*eax), "=S" (*ebx), "=c" (*ecx), "=d" (*edx)
-            : "0" (info)
-        );
+        : "=a" (*eax), "=S" (*ebx), "=c" (*ecx), "=d" (*edx)
+        : "0" (info)
+    );
 #endif
 #endif
 }
@@ -575,8 +575,8 @@ xrdp_rdp_send_data(struct xrdp_rdp *self, struct stream *s,
         if (compress_rdp(mppc_enc, (tui8 *)(s->p + 18), tocomplen))
         {
             LOG_DEVEL(LOG_LEVEL_TRACE, "mppc_encode ok flags 0x%x bytes_in_opb %d historyOffset %d "
-                   "tocomplen %d", mppc_enc->flags, mppc_enc->bytes_in_opb,
-                   mppc_enc->historyOffset, tocomplen);
+                      "tocomplen %d", mppc_enc->flags, mppc_enc->bytes_in_opb,
+                      mppc_enc->historyOffset, tocomplen);
 
             clen = mppc_enc->bytes_in_opb + 18;
             pdulen = clen;
@@ -602,8 +602,8 @@ xrdp_rdp_send_data(struct xrdp_rdp *self, struct stream *s,
         else
         {
             LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_rdp_send_data: mppc_encode not ok "
-                   "type %d flags %d", mppc_enc->protocol_type,
-                   mppc_enc->flags);
+                      "type %d flags %d", mppc_enc->protocol_type,
+                      mppc_enc->flags);
         }
     }
 
@@ -731,7 +731,7 @@ xrdp_rdp_send_fastpath(struct xrdp_rdp *self, struct stream *s,
         }
         send_len = no_comp_len;
         LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_rdp_send_fastpath: no_comp_len %d fragmentation %d",
-               no_comp_len, fragmentation);
+                  no_comp_len, fragmentation);
         if ((compression != 0) && (no_comp_len > header_bytes + 16))
         {
             to_comp_len = no_comp_len - header_bytes;
@@ -741,13 +741,13 @@ xrdp_rdp_send_fastpath(struct xrdp_rdp *self, struct stream *s,
             {
                 comp_len = mppc_enc->bytes_in_opb + header_bytes;
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_rdp_send_fastpath: no_comp_len %d "
-                       "comp_len %d", no_comp_len, comp_len);
+                          "comp_len %d", no_comp_len, comp_len);
                 send_len = comp_len;
                 comp_type = mppc_enc->flags;
                 /* outputBuffer has 64 bytes preceding it */
                 g_memset(&comp_s, 0, sizeof(comp_s));
                 comp_s.data = mppc_enc->outputBuffer -
-                                         (rdp_offset + header_bytes);
+                              (rdp_offset + header_bytes);
                 comp_s.p = comp_s.data + rdp_offset;
                 comp_s.end = comp_s.p + send_len;
                 comp_s.size = send_len;
@@ -758,13 +758,13 @@ xrdp_rdp_send_fastpath(struct xrdp_rdp *self, struct stream *s,
             else
             {
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_rdp_send_fastpath: mppc_encode not ok "
-                       "type %d flags %d", mppc_enc->protocol_type,
-                       mppc_enc->flags);
+                          "type %d flags %d", mppc_enc->protocol_type,
+                          mppc_enc->flags);
             }
         }
         updateHeader = (updateCode & 15) |
-                      ((fragmentation & 3) << 4) |
-                      ((compression & 3) << 6);
+                       ((fragmentation & 3) << 4) |
+                       ((compression & 3) << 6);
         out_uint8(&send_s, updateHeader);
         if (compression != 0)
         {
@@ -870,20 +870,20 @@ xrdp_rdp_incoming(struct xrdp_rdp *self)
     if (iso->selectedProtocol > PROTOCOL_RDP)
     {
         LOG(LOG_LEVEL_INFO,
-                    "TLS connection established from %s port %s: %s with cipher %s",
-                    self->client_info.client_addr,
-                    self->client_info.client_port,
-                    iso->trans->ssl_protocol,
-                    iso->trans->cipher_name);
+            "TLS connection established from %s port %s: %s with cipher %s",
+            self->client_info.client_addr,
+            self->client_info.client_port,
+            iso->trans->ssl_protocol,
+            iso->trans->cipher_name);
     }
     /* log non-TLS connections */
     else
     {
         LOG(LOG_LEVEL_INFO,
-                    "Non-TLS connection established from %s port %s: "
-                    "encrypted with standard RDP security",
-                    self->client_info.client_addr,
-                    self->client_info.client_port);
+            "Non-TLS connection established from %s port %s: "
+            "encrypted with standard RDP security",
+            self->client_info.client_addr,
+            self->client_info.client_port);
     }
 
     return 0;
@@ -929,7 +929,7 @@ xrdp_rdp_process_data_input(struct xrdp_rdp *self, struct stream *s)
         in_sint16_le(s, param1);
         in_sint16_le(s, param2);
         LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_rdp_process_data_input event %4.4x flags %4.4x param1 %d "
-               "param2 %d time %d", msg_type, device_flags, param1, param2, time);
+                  "param2 %d time %d", msg_type, device_flags, param1, param2, time);
 
         if (self->session->callback != 0)
         {
@@ -1216,9 +1216,9 @@ xrdp_rdp_process_frame_ack(struct xrdp_rdp *self, struct stream *s)
 {
     int frame_id;
 
-      LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_rdp_process_frame_ack:");
+    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_rdp_process_frame_ack:");
     in_uint32_le(s, frame_id);
-      LOG_DEVEL(LOG_LEVEL_TRACE, "  frame_id %d", frame_id);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "  frame_id %d", frame_id);
     if (self->session->callback != 0)
     {
         /* call to xrdp_wm.c : callback */
@@ -1412,7 +1412,7 @@ xrdp_rdp_send_session_info(struct xrdp_rdp *self, const char *data,
 
     if (s_check_rem_out(s, data_bytes))
     {
-        out_uint8a(s, data, data_bytes); 
+        out_uint8a(s, data, data_bytes);
     }
     else
     {

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -32,11 +32,7 @@
 #include <freerdp/constants.h>
 #endif
 
-#define LOG_LEVEL 1
-#define LLOG(_level, _args) \
-    do { if (_level < LOG_LEVEL) { g_write _args ; } } while (0)
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { g_writeln _args ; } } while (0)
+
 
 #define FASTPATH_FRAG_SIZE (16 * 1024 - 128)
 
@@ -58,14 +54,14 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
     items->auto_free = 1;
     values = list_create();
     values->auto_free = 1;
-    DEBUG(("xrdp_ini %s", xrdp_ini));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "cfg_file %s", xrdp_ini);
     file_by_name_read_section(xrdp_ini, "globals", items, values);
 
     for (index = 0; index < items->count; index++)
     {
         item = (char *)list_get_item(items, index);
         value = (char *)list_get_item(values, index);
-        DEBUG(("item %s value %s", item, value));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "item %s value %s", item, value);
 
         if (g_strcasecmp(item, "bitmap_cache") == 0)
         {
@@ -103,7 +99,7 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
             }
             else
             {
-                log_message(LOG_LEVEL_ALWAYS,"Warning: Your configured crypt level is "
+                LOG(LOG_LEVEL_ALWAYS,"Warning: Your configured crypt level is "
                           "undefined, 'high' will be used");
                 client_info->crypt_level = 3;
             }
@@ -113,7 +109,7 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
             client_info->channels_allowed = g_text2bool(value);
             if (client_info->channels_allowed == 0)
             {
-                log_message(LOG_LEVEL_DEBUG,"Info - All channels are disabled");
+                LOG(LOG_LEVEL_DEBUG,"Info - All channels are disabled");
             }
         }
         else if (g_strcasecmp(item, "allow_multimon") == 0)
@@ -121,7 +117,7 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
                     client_info->multimon = g_text2bool(value);
                     if (client_info->multimon == 0)
                     {
-                        log_message(LOG_LEVEL_DEBUG,"Info - Multi monitor server support disabled");
+                        LOG(LOG_LEVEL_DEBUG,"Info - Multi monitor server support disabled");
                     }
                 }
         else if (g_strcasecmp(item, "max_bpp") == 0)
@@ -164,7 +160,7 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
             }
             else
             {
-                log_message(LOG_LEVEL_ALWAYS,"Warning: Your configured fastpath level is "
+                LOG(LOG_LEVEL_ALWAYS,"Warning: Your configured fastpath level is "
                           "undefined, fastpath will not be used");
                 client_info->use_fast_path = 0;
             }
@@ -208,7 +204,7 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
             }
             else
             {
-                log_message(LOG_LEVEL_ERROR, "security_layer=%s is not "
+                LOG(LOG_LEVEL_ERROR, "security_layer=%s is not "
                             "recognized, will use security_layer=negotiate",
                             value);
                 client_info->security_layer = PROTOCOL_SSL | PROTOCOL_HYBRID | PROTOCOL_HYBRID_EX;
@@ -221,7 +217,7 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
             {
                 /* default certificate path */
                 g_snprintf(client_info->certificate, 1023, "%s/cert.pem", XRDP_CFG_PATH);
-                log_message(LOG_LEVEL_INFO,
+                LOG(LOG_LEVEL_INFO,
                             "Using default X.509 certificate: %s",
                             client_info->certificate);
 
@@ -230,7 +226,7 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
             {
                 /* default certificate path */
                 g_snprintf(client_info->certificate, 1023, "%s/cert.pem", XRDP_CFG_PATH);
-                log_message(LOG_LEVEL_WARNING,
+                LOG(LOG_LEVEL_WARNING,
                             "X.509 certificate should use absolute path, using "
                             "default instead: %s", client_info->certificate);
             }
@@ -242,7 +238,7 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
 
 	    if (!g_file_readable(client_info->certificate))
             {
-                log_message(LOG_LEVEL_ERROR, "Cannot read certificate file %s: %s",
+                LOG(LOG_LEVEL_ERROR, "Cannot read certificate file %s: %s",
                             client_info->certificate, g_get_strerror());
             }
         }
@@ -253,14 +249,14 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
             {
                 /* default key_file path */
                 g_snprintf(client_info->key_file, 1023, "%s/key.pem", XRDP_CFG_PATH);
-                log_message(LOG_LEVEL_INFO, "Using default X.509 key file: %s",
+                LOG(LOG_LEVEL_INFO, "Using default X.509 key file: %s",
                             client_info->key_file);
             }
             else if (value[0] != '/')
             {
                 /* default key_file path */
                 g_snprintf(client_info->key_file, 1023, "%s/key.pem", XRDP_CFG_PATH);
-                log_message(LOG_LEVEL_WARNING,
+                LOG(LOG_LEVEL_WARNING,
                             "X.509 key file should use absolute path, using "
                             "default instead: %s", client_info->key_file);
             }
@@ -272,7 +268,7 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
 
             if (!g_file_readable(client_info->key_file))
             {
-                log_message(LOG_LEVEL_ERROR, "Cannot read private key file %s: %s",
+                LOG(LOG_LEVEL_ERROR, "Cannot read private key file %s: %s",
                             client_info->key_file, g_get_strerror());
             }
         }
@@ -334,7 +330,7 @@ xrdp_rdp_detect_cpu(void)
 
     if (edx & (1 << 26))
     {
-        DEBUG(("SSE2 detected"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "SSE2 detected");
         cpu_opt |= CPU_SSE2;
     }
 
@@ -349,7 +345,7 @@ xrdp_rdp_create(struct xrdp_session *session, struct trans *trans)
     struct xrdp_rdp *self = (struct xrdp_rdp *)NULL;
     int bytes;
 
-    DEBUG(("in xrdp_rdp_create"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "in xrdp_rdp_create");
     self = (struct xrdp_rdp *)g_malloc(sizeof(struct xrdp_rdp), 1);
     self->session = session;
     self->share_id = 66538;
@@ -373,7 +369,7 @@ xrdp_rdp_create(struct xrdp_session *session, struct trans *trans)
     rfx_context_set_cpu_opt(self->rfx_enc, xrdp_rdp_detect_cpu());
 #endif
     self->client_info.size = sizeof(self->client_info);
-    DEBUG(("out xrdp_rdp_create"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_rdp_create");
     return self;
 }
 
@@ -432,7 +428,7 @@ xrdp_rdp_recv(struct xrdp_rdp *self, struct stream *s, int *code)
     int chan = 0;
     const tui8 *header;
 
-    DEBUG(("in xrdp_rdp_recv"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "in xrdp_rdp_recv");
     if (s->next_packet == 0 || s->next_packet >= s->end)
     {
         /* check for fastpath first */
@@ -445,7 +441,7 @@ xrdp_rdp_recv(struct xrdp_rdp *self, struct stream *s, int *code)
             }
             /* next_packet gets set in xrdp_sec_recv_fastpath */
             *code = 2; // special code for fastpath input
-            DEBUG(("out (fastpath) xrdp_rdp_recv"));
+            LOG_DEVEL(LOG_LEVEL_TRACE, "out (fastpath) xrdp_rdp_recv");
             return 0;
         }
 
@@ -457,14 +453,14 @@ xrdp_rdp_recv(struct xrdp_rdp *self, struct stream *s, int *code)
         {
             s->next_packet = 0;
             *code = -1;
-            DEBUG(("out (1) xrdp_rdp_recv"));
+            LOG_DEVEL(LOG_LEVEL_TRACE, "out (1) xrdp_rdp_recv");
             return 0;
         }
 
         if (error != 0)
         {
-            DEBUG(("out xrdp_rdp_recv error"));
-            g_writeln("xrdp_rdp_recv: xrdp_sec_recv failed");
+            LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_rdp_recv error");
+            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_rdp_recv: xrdp_sec_recv failed");
             return 1;
         }
 
@@ -474,20 +470,20 @@ xrdp_rdp_recv(struct xrdp_rdp *self, struct stream *s, int *code)
             {
                 if (xrdp_channel_process(self->sec_layer->chan_layer, s, chan) != 0)
                 {
-                    g_writeln("xrdp_channel_process returned unhandled error") ;
+                    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_channel_process returned unhandled error") ;
                 }
             }
             else
             {
                 if (chan != 1)
                 {
-                    g_writeln("Wrong channel Id to be handled by xrdp_channel_process %d", chan);
+                    LOG_DEVEL(LOG_LEVEL_TRACE, "Wrong channel Id to be handled by xrdp_channel_process %d", chan);
                 }
             }
 
             s->next_packet = 0;
             *code = 0;
-            DEBUG(("out (2) xrdp_rdp_recv"));
+            LOG_DEVEL(LOG_LEVEL_TRACE, "out (2) xrdp_rdp_recv");
             return 0;
         }
 
@@ -495,7 +491,7 @@ xrdp_rdp_recv(struct xrdp_rdp *self, struct stream *s, int *code)
     }
     else
     {
-        DEBUG(("xrdp_rdp_recv stream not touched"))
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_rdp_recv stream not touched");
         s->p = s->next_packet;
     }
 
@@ -503,20 +499,20 @@ xrdp_rdp_recv(struct xrdp_rdp *self, struct stream *s, int *code)
     {
         s->next_packet = 0;
         *code = 0;
-        DEBUG(("out (3) xrdp_rdp_recv"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "out (3) xrdp_rdp_recv");
         len = (int)(s->end - s->p);
-        g_writeln("xrdp_rdp_recv: bad RDP packet, length [%d]", len);
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_rdp_recv: bad RDP packet, length [%d]", len);
         return 0;
     }
     else
     {
         in_uint16_le(s, len);
-        /*g_writeln("New len received : %d next packet: %d s_end: %d",len,s->next_packet,s->end); */
+        /*LOG_DEVEL(LOG_LEVEL_TRACE, "New len received : %d next packet: %d s_end: %d",len,s->next_packet,s->end); */
         in_uint16_le(s, pdu_code);
         *code = pdu_code & 0xf;
         in_uint8s(s, 2); /* mcs user id */
         s->next_packet += len;
-        DEBUG(("out (4) xrdp_rdp_recv"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "out (4) xrdp_rdp_recv");
         return 0;
     }
 }
@@ -527,7 +523,7 @@ xrdp_rdp_send(struct xrdp_rdp *self, struct stream *s, int pdu_type)
 {
     int len = 0;
 
-    DEBUG(("in xrdp_rdp_send"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "in xrdp_rdp_send");
     s_pop_layer(s, rdp_hdr);
     len = s->end - s->p;
     out_uint16_le(s, len);
@@ -536,11 +532,11 @@ xrdp_rdp_send(struct xrdp_rdp *self, struct stream *s, int pdu_type)
 
     if (xrdp_sec_send(self->sec_layer, s, MCS_GLOBAL_CHANNEL) != 0)
     {
-        DEBUG(("out xrdp_rdp_send error"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_rdp_send error");
         return 1;
     }
 
-    DEBUG(("out xrdp_rdp_send"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_rdp_send");
     return 0;
 }
 
@@ -563,7 +559,7 @@ xrdp_rdp_send_data(struct xrdp_rdp *self, struct stream *s,
     struct stream ls;
     struct xrdp_mppc_enc *mppc_enc;
 
-    DEBUG(("in xrdp_rdp_send_data"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "in xrdp_rdp_send_data");
     s_pop_layer(s, rdp_hdr);
     len = (int)(s->end - s->p);
     pdutype = 0x10 | PDUTYPE_DATAPDU;
@@ -578,9 +574,9 @@ xrdp_rdp_send_data(struct xrdp_rdp *self, struct stream *s,
         mppc_enc = self->mppc_enc;
         if (compress_rdp(mppc_enc, (tui8 *)(s->p + 18), tocomplen))
         {
-            DEBUG(("mppc_encode ok flags 0x%x bytes_in_opb %d historyOffset %d "
+            LOG_DEVEL(LOG_LEVEL_TRACE, "mppc_encode ok flags 0x%x bytes_in_opb %d historyOffset %d "
                    "tocomplen %d", mppc_enc->flags, mppc_enc->bytes_in_opb,
-                   mppc_enc->historyOffset, tocomplen));
+                   mppc_enc->historyOffset, tocomplen);
 
             clen = mppc_enc->bytes_in_opb + 18;
             pdulen = clen;
@@ -605,9 +601,9 @@ xrdp_rdp_send_data(struct xrdp_rdp *self, struct stream *s,
         }
         else
         {
-            LLOGLN(10, ("xrdp_rdp_send_data: mppc_encode not ok "
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_rdp_send_data: mppc_encode not ok "
                    "type %d flags %d", mppc_enc->protocol_type,
-                   mppc_enc->flags));
+                   mppc_enc->flags);
         }
     }
 
@@ -624,11 +620,11 @@ xrdp_rdp_send_data(struct xrdp_rdp *self, struct stream *s,
 
     if (xrdp_sec_send(self->sec_layer, s, MCS_GLOBAL_CHANNEL) != 0)
     {
-        DEBUG(("out xrdp_rdp_send_data error"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_rdp_send_data error");
         return 1;
     }
 
-    DEBUG(("out xrdp_rdp_send_data"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_rdp_send_data");
     return 0;
 }
 
@@ -690,7 +686,7 @@ xrdp_rdp_send_fastpath(struct xrdp_rdp *self, struct stream *s,
     struct stream send_s;
     struct xrdp_mppc_enc *mppc_enc;
 
-    LLOGLN(10, ("xrdp_rdp_send_fastpath:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_rdp_send_fastpath:");
     s_pop_layer(s, rdp_hdr);
     updateCode = data_pdu_type;
     if (self->client_info.rdp_compression)
@@ -734,8 +730,8 @@ xrdp_rdp_send_fastpath(struct xrdp_rdp *self, struct stream *s,
             }
         }
         send_len = no_comp_len;
-        LLOGLN(10, ("xrdp_rdp_send_fastpath: no_comp_len %d fragmentation %d",
-               no_comp_len, fragmentation));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_rdp_send_fastpath: no_comp_len %d fragmentation %d",
+               no_comp_len, fragmentation);
         if ((compression != 0) && (no_comp_len > header_bytes + 16))
         {
             to_comp_len = no_comp_len - header_bytes;
@@ -744,8 +740,8 @@ xrdp_rdp_send_fastpath(struct xrdp_rdp *self, struct stream *s,
                              to_comp_len))
             {
                 comp_len = mppc_enc->bytes_in_opb + header_bytes;
-                LLOGLN(10, ("xrdp_rdp_send_fastpath: no_comp_len %d "
-                       "comp_len %d", no_comp_len, comp_len));
+                LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_rdp_send_fastpath: no_comp_len %d "
+                       "comp_len %d", no_comp_len, comp_len);
                 send_len = comp_len;
                 comp_type = mppc_enc->flags;
                 /* outputBuffer has 64 bytes preceding it */
@@ -761,9 +757,9 @@ xrdp_rdp_send_fastpath(struct xrdp_rdp *self, struct stream *s,
             }
             else
             {
-                LLOGLN(10, ("xrdp_rdp_send_fastpath: mppc_encode not ok "
+                LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_rdp_send_fastpath: mppc_encode not ok "
                        "type %d flags %d", mppc_enc->protocol_type,
-                       mppc_enc->flags));
+                       mppc_enc->flags);
             }
         }
         updateHeader = (updateCode & 15) |
@@ -779,7 +775,7 @@ xrdp_rdp_send_fastpath(struct xrdp_rdp *self, struct stream *s,
         send_s.end = send_s.p + send_len;
         if (xrdp_sec_send_fastpath(self->sec_layer, &send_s) != 0)
         {
-            LLOGLN(0, ("xrdp_rdp_send_fastpath: xrdp_fastpath_send failed"));
+            LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_rdp_send_fastpath: xrdp_fastpath_send failed");
             return 1;
         }
         frag_s.p += no_comp_len;
@@ -799,11 +795,11 @@ xrdp_rdp_send_data_update_sync(struct xrdp_rdp *self)
 
     make_stream(s);
     init_stream(s, 8192);
-    DEBUG(("in xrdp_rdp_send_data_update_sync"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "in xrdp_rdp_send_data_update_sync");
 
     if (self->client_info.use_fast_path & 1) /* fastpath output supported */
     {
-        LLOGLN(10, ("xrdp_rdp_send_data_update_sync: fastpath"));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_rdp_send_data_update_sync: fastpath");
         if (xrdp_rdp_init_fastpath(self, s) != 0)
         {
             free_stream(s);
@@ -814,7 +810,7 @@ xrdp_rdp_send_data_update_sync(struct xrdp_rdp *self)
     {
         if (xrdp_rdp_init_data(self, s) != 0)
         {
-            DEBUG(("out xrdp_rdp_send_data_update_sync error"));
+            LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_rdp_send_data_update_sync error");
             free_stream(s);
             return 1;
         }
@@ -837,14 +833,14 @@ xrdp_rdp_send_data_update_sync(struct xrdp_rdp *self)
     {
         if (xrdp_rdp_send_data(self, s, RDP_DATA_PDU_UPDATE) != 0)
         {
-            DEBUG(("out xrdp_rdp_send_data_update_sync error"));
+            LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_rdp_send_data_update_sync error");
             free_stream(s);
             return 1;
         }
     }
 
 
-    DEBUG(("out xrdp_rdp_send_data_update_sync"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_rdp_send_data_update_sync");
     free_stream(s);
     return 0;
 }
@@ -856,7 +852,7 @@ xrdp_rdp_incoming(struct xrdp_rdp *self)
     struct xrdp_iso *iso;
     iso = self->sec_layer->mcs_layer->iso_layer;
 
-    DEBUG(("in xrdp_rdp_incoming"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "in xrdp_rdp_incoming");
 
     if (xrdp_sec_incoming(self->sec_layer) != 0)
     {
@@ -864,7 +860,7 @@ xrdp_rdp_incoming(struct xrdp_rdp *self)
     }
     self->mcs_channel = self->sec_layer->mcs_layer->userid +
                         MCS_USERCHANNEL_BASE;
-    DEBUG(("out xrdp_rdp_incoming mcs channel %d", self->mcs_channel));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_rdp_incoming mcs channel %d", self->mcs_channel);
     g_strncpy(self->client_info.client_addr, iso->trans->addr,
               sizeof(self->client_info.client_addr) - 1);
     g_strncpy(self->client_info.client_port, iso->trans->port,
@@ -873,7 +869,7 @@ xrdp_rdp_incoming(struct xrdp_rdp *self)
     /* log TLS version and cipher of TLS connections */
     if (iso->selectedProtocol > PROTOCOL_RDP)
     {
-        log_message(LOG_LEVEL_INFO,
+        LOG(LOG_LEVEL_INFO,
                     "TLS connection established from %s port %s: %s with cipher %s",
                     self->client_info.client_addr,
                     self->client_info.client_port,
@@ -883,7 +879,7 @@ xrdp_rdp_incoming(struct xrdp_rdp *self)
     /* log non-TLS connections */
     else
     {
-        log_message(LOG_LEVEL_INFO,
+        LOG(LOG_LEVEL_INFO,
                     "Non-TLS connection established from %s port %s: "
                     "encrypted with standard RDP security",
                     self->client_info.client_addr,
@@ -919,7 +915,7 @@ xrdp_rdp_process_data_input(struct xrdp_rdp *self, struct stream *s)
     }
     in_uint16_le(s, num_events);
     in_uint8s(s, 2); /* pad */
-    DEBUG(("in xrdp_rdp_process_data_input %d events", num_events));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "in xrdp_rdp_process_data_input %d events", num_events);
 
     for (index = 0; index < num_events; index++)
     {
@@ -932,8 +928,8 @@ xrdp_rdp_process_data_input(struct xrdp_rdp *self, struct stream *s)
         in_uint16_le(s, device_flags);
         in_sint16_le(s, param1);
         in_sint16_le(s, param2);
-        DEBUG(("xrdp_rdp_process_data_input event %4.4x flags %4.4x param1 %d "
-               "param2 %d time %d", msg_type, device_flags, param1, param2, time));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_rdp_process_data_input event %4.4x flags %4.4x param1 %d "
+               "param2 %d time %d", msg_type, device_flags, param1, param2, time);
 
         if (self->session->callback != 0)
         {
@@ -948,7 +944,7 @@ xrdp_rdp_process_data_input(struct xrdp_rdp *self, struct stream *s)
         }
     }
 
-    DEBUG(("out xrdp_rdp_process_data_input"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_rdp_process_data_input");
     return 0;
 }
 
@@ -1017,24 +1013,24 @@ xrdp_rdp_process_data_control(struct xrdp_rdp *self, struct stream *s)
 {
     int action;
 
-    DEBUG(("xrdp_rdp_process_data_control"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_rdp_process_data_control");
     in_uint16_le(s, action);
     in_uint8s(s, 2); /* user id */
     in_uint8s(s, 4); /* control id */
 
     if (action == RDP_CTL_REQUEST_CONTROL)
     {
-        DEBUG(("xrdp_rdp_process_data_control got RDP_CTL_REQUEST_CONTROL"));
-        DEBUG(("xrdp_rdp_process_data_control calling xrdp_rdp_send_synchronise"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_rdp_process_data_control got RDP_CTL_REQUEST_CONTROL");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_rdp_process_data_control calling xrdp_rdp_send_synchronise");
         xrdp_rdp_send_synchronise(self);
-        DEBUG(("xrdp_rdp_process_data_control sending RDP_CTL_COOPERATE"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_rdp_process_data_control sending RDP_CTL_COOPERATE");
         xrdp_rdp_send_control(self, RDP_CTL_COOPERATE);
-        DEBUG(("xrdp_rdp_process_data_control sending RDP_CTL_GRANT_CONTROL"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_rdp_process_data_control sending RDP_CTL_GRANT_CONTROL");
         xrdp_rdp_send_control(self, RDP_CTL_GRANT_CONTROL);
     }
     else
     {
-        DEBUG(("xrdp_rdp_process_data_control unknown action"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_rdp_process_data_control unknown action");
     }
 
     return 0;
@@ -1044,7 +1040,7 @@ xrdp_rdp_process_data_control(struct xrdp_rdp *self, struct stream *s)
 static int
 xrdp_rdp_process_data_sync(struct xrdp_rdp *self)
 {
-    DEBUG(("xrdp_rdp_process_data_sync"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_rdp_process_data_sync");
     return 0;
 }
 
@@ -1068,7 +1064,7 @@ xrdp_rdp_process_screen_update(struct xrdp_rdp *self, struct stream *s)
     }
     in_uint8(s, num_rects);
     in_uint8s(s, 3); /* pad */
-    g_writeln("xrdp_rdp_process_screen_update: num_rects %d", num_rects);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_rdp_process_screen_update: num_rects %d", num_rects);
     for (index = 0; index < num_rects; index++)
     {
         if (!s_check_rem(s, 8))
@@ -1080,7 +1076,7 @@ xrdp_rdp_process_screen_update(struct xrdp_rdp *self, struct stream *s)
         in_uint16_le(s, top);
         in_uint16_le(s, right);
         in_uint16_le(s, bottom);
-        g_writeln("  left %d top %d right %d bottom %d",
+        LOG_DEVEL(LOG_LEVEL_TRACE, "  left %d top %d right %d bottom %d",
                   left, top, right, bottom);
         cx = (right - left) + 1;
         cy = (bottom - top) + 1;
@@ -1131,7 +1127,7 @@ xrdp_rdp_process_data_font(struct xrdp_rdp *self, struct stream *s)
 {
     int seq;
 
-    DEBUG(("in xrdp_rdp_process_data_font"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "in xrdp_rdp_process_data_font");
     in_uint8s(s, 2); /* NumberFonts: 0x0, SHOULD be set to 0 */
     in_uint8s(s, 2); /* TotalNumberFonts: 0x0, SHOULD be set to 0 */
     in_uint16_le(s, seq); /* ListFlags */
@@ -1141,17 +1137,17 @@ xrdp_rdp_process_data_font(struct xrdp_rdp *self, struct stream *s)
     if (seq == 2 || seq == 3) /* after second font message, we are up and */
     {
         /* running */
-        DEBUG(("sending fontmap"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "sending fontmap");
         xrdp_rdp_send_fontmap(self);
 
         self->session->up_and_running = 1;
-        g_writeln("yeah, up_and_running");
-        DEBUG(("up_and_running set"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "yeah, up_and_running");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "up_and_running set");
         xrdp_rdp_send_data_update_sync(self);
         xrdp_channel_drdynvc_start(self->sec_layer->chan_layer);
     }
 
-    DEBUG(("out xrdp_rdp_process_data_font"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_rdp_process_data_font");
     return 0;
 }
 
@@ -1220,9 +1216,9 @@ xrdp_rdp_process_frame_ack(struct xrdp_rdp *self, struct stream *s)
 {
     int frame_id;
 
-    //g_writeln("xrdp_rdp_process_frame_ack:");
+      LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_rdp_process_frame_ack:");
     in_uint32_le(s, frame_id);
-    //g_writeln("  frame_id %d", frame_id);
+      LOG_DEVEL(LOG_LEVEL_TRACE, "  frame_id %d", frame_id);
     if (self->session->callback != 0)
     {
         /* call to xrdp_wm.c : callback */
@@ -1247,13 +1243,13 @@ xrdp_rdp_process_suppress(struct xrdp_rdp *self, struct stream *s)
         return 1;
     }
     in_uint8(s, allowDisplayUpdates);
-    g_writeln("xrdp_rdp_process_suppress: allowDisplayUpdates %d bytes "
+    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_rdp_process_suppress: allowDisplayUpdates %d bytes "
               "left %d", allowDisplayUpdates, (int) (s->end - s->p));
     switch (allowDisplayUpdates)
     {
         case 0: /* SUPPRESS_DISPLAY_UPDATES */
             self->client_info.suppress_output = 1;
-            g_writeln("xrdp_rdp_process_suppress: suppress_output %d",
+            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_rdp_process_suppress: suppress_output %d",
                       self->client_info.suppress_output);
             if (self->session->callback != 0)
             {
@@ -1272,7 +1268,7 @@ xrdp_rdp_process_suppress(struct xrdp_rdp *self, struct stream *s)
             in_uint16_le(s, top);
             in_uint16_le(s, right);
             in_uint16_le(s, bottom);
-            g_writeln("xrdp_rdp_process_suppress: suppress_output %d "
+            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_rdp_process_suppress: suppress_output %d "
                       "left %d top %d right %d bottom %d",
                       self->client_info.suppress_output,
                       left, top, right, bottom);
@@ -1315,7 +1311,7 @@ xrdp_rdp_process_data(struct xrdp_rdp *self, struct stream *s)
     {
         return 1;
     }
-    DEBUG(("xrdp_rdp_process_data pduType2 %d", pduType2));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_rdp_process_data pduType2 %d", pduType2);
     switch (pduType2)
     {
         case RDP_DATA_PDU_POINTER: /* 27(0x1b) */
@@ -1349,7 +1345,7 @@ xrdp_rdp_process_data(struct xrdp_rdp *self, struct stream *s)
             xrdp_rdp_process_frame_ack(self, s);
             break;
         default:
-            g_writeln("unknown in xrdp_rdp_process_data pduType2 %d", pduType2);
+            LOG_DEVEL(LOG_LEVEL_TRACE, "unknown in xrdp_rdp_process_data pduType2 %d", pduType2);
             break;
     }
     return 0;
@@ -1360,9 +1356,9 @@ xrdp_rdp_disconnect(struct xrdp_rdp *self)
 {
     int rv;
 
-    DEBUG(("in xrdp_rdp_disconnect"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "in xrdp_rdp_disconnect");
     rv = xrdp_sec_disconnect(self->sec_layer);
-    DEBUG(("out xrdp_rdp_disconnect"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_rdp_disconnect");
     return rv;
 }
 
@@ -1372,14 +1368,14 @@ xrdp_rdp_send_deactivate(struct xrdp_rdp *self)
 {
     struct stream *s;
 
-    DEBUG(("in xrdp_rdp_send_deactivate"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "in xrdp_rdp_send_deactivate");
     make_stream(s);
     init_stream(s, 8192);
 
     if (xrdp_rdp_init(self, s) != 0)
     {
         free_stream(s);
-        DEBUG(("out xrdp_rdp_send_deactivate error"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_rdp_send_deactivate error");
         return 1;
     }
 
@@ -1388,12 +1384,12 @@ xrdp_rdp_send_deactivate(struct xrdp_rdp *self)
     if (xrdp_rdp_send(self, s, PDUTYPE_DEACTIVATEALLPDU) != 0)
     {
         free_stream(s);
-        DEBUG(("out xrdp_rdp_send_deactivate error"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_rdp_send_deactivate error");
         return 1;
     }
 
     free_stream(s);
-    DEBUG(("out xrdp_rdp_send_deactivate"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_rdp_send_deactivate");
     return 0;
 }
 
@@ -1404,7 +1400,7 @@ xrdp_rdp_send_session_info(struct xrdp_rdp *self, const char *data,
 {
     struct stream *s;
 
-    LLOGLN(0, ("xrdp_rdp_send_session_info: data_bytes %d", data_bytes));
+    LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_rdp_send_session_info: data_bytes %d", data_bytes);
     make_stream(s);
     init_stream(s, 8192);
 

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -236,7 +236,7 @@ xrdp_load_keyboard_layout(struct xrdp_client_info *client_info)
     char rdp_layout[256] = { 0 };
 
     LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_load_keyboard_layout: keyboard_type [%d] keyboard_subtype [%d]",
-               client_info->keyboard_type, client_info->keyboard_subtype);
+              client_info->keyboard_type, client_info->keyboard_subtype);
 
     /* infer model/variant */
     /* TODO specify different X11 keyboard models/variants */
@@ -288,7 +288,7 @@ xrdp_load_keyboard_layout(struct xrdp_client_info *client_info)
                     item = (char *)list_get_item(items, i);
                     value = (char *)list_get_item(values, i);
                     LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_load_keyboard_layout: item %s value %s",
-                           item, value);
+                              item, value);
                     if (g_strcasecmp(item, "keyboard_type") == 0)
                     {
                         int v = g_atoi(value);
@@ -301,7 +301,7 @@ xrdp_load_keyboard_layout(struct xrdp_client_info *client_info)
                     {
                         int v = g_atoi(value);
                         if (v != client_info->keyboard_subtype &&
-                            section_found == index)
+                                section_found == index)
                         {
                             section_found = -1;
                             break;
@@ -355,8 +355,8 @@ xrdp_load_keyboard_layout(struct xrdp_client_info *client_info)
                          * skipping over current section.
                          */
                         LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_load_keyboard_layout: skipping "
-                               "configuration item - %s, continuing to next "
-                               "section", item);
+                                  "configuration item - %s, continuing to next "
+                                  "section", item);
                         break;
                     }
                 }
@@ -423,14 +423,14 @@ xrdp_load_keyboard_layout(struct xrdp_client_info *client_info)
         list_delete(values);
 
         LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_load_keyboard_layout: model [%s] variant [%s] "
-               "layout [%s] options [%s]", client_info->model,
-               client_info->variant, client_info->layout, client_info->options);
+                  "layout [%s] options [%s]", client_info->model,
+                  client_info->variant, client_info->layout, client_info->options);
         g_file_close(fd);
     }
     else
     {
         LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_load_keyboard_layout: error opening %s",
-               keyboard_cfg_file);
+                  keyboard_cfg_file);
     }
 }
 
@@ -687,7 +687,7 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
         /* must be or error */
         LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_process_logon_info: flags wrong, major error");
         LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_sec_process_logon_info: flags wrong, likely decrypt "
-               "not working");
+                  "not working");
         return 1;
     }
 
@@ -838,7 +838,7 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
         }
     }
     if (self->rdp_layer->client_info.domain_user_separator[0] != '\0'
-        && self->rdp_layer->client_info.domain[0] != '\0')
+            && self->rdp_layer->client_info.domain[0] != '\0')
     {
         int size = sizeof(self->rdp_layer->client_info.username);
         g_strncat(self->rdp_layer->client_info.username, self->rdp_layer->client_info.domain_user_separator, size - 1 - g_strlen(self->rdp_layer->client_info.domain_user_separator));
@@ -1124,9 +1124,9 @@ xrdp_sec_fips_establish_keys(struct xrdp_sec *self)
 
     fips_ivec = (const char *) g_fips_ivec;
     self->encrypt_fips_info =
-          ssl_des3_encrypt_info_create(self->fips_encrypt_key, fips_ivec);
+        ssl_des3_encrypt_info_create(self->fips_encrypt_key, fips_ivec);
     self->decrypt_fips_info =
-          ssl_des3_decrypt_info_create(self->fips_decrypt_key, fips_ivec);
+        ssl_des3_decrypt_info_create(self->fips_decrypt_key, fips_ivec);
     self->sign_fips_info = ssl_hmac_info_create();
 }
 
@@ -1619,7 +1619,7 @@ xrdp_sec_send_fastpath(struct xrdp_sec *self, struct stream *s)
 /* http://msdn.microsoft.com/en-us/library/cc240510.aspx
    2.2.1.3.2 Client Core Data (TS_UD_CS_CORE) */
 static int
-xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec* self, struct stream* s)
+xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec *self, struct stream *s)
 {
     int colorDepth;
     int postBeta2ColorDepth;
@@ -1764,7 +1764,7 @@ xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec* self, struct stream* s)
 
 /*****************************************************************************/
 static int
-xrdp_sec_process_mcs_data_CS_SECURITY(struct xrdp_sec *self, struct stream* s)
+xrdp_sec_process_mcs_data_CS_SECURITY(struct xrdp_sec *self, struct stream *s)
 {
     int crypt_method;
     int found;
@@ -1789,8 +1789,8 @@ xrdp_sec_process_mcs_data_CS_SECURITY(struct xrdp_sec *self, struct stream* s)
     }
     found = 0;
     if ((found == 0) &&
-        (self->crypt_method & CRYPT_METHOD_FIPS) &&
-        (self->crypt_level == CRYPT_LEVEL_FIPS))
+            (self->crypt_method & CRYPT_METHOD_FIPS) &&
+            (self->crypt_level == CRYPT_LEVEL_FIPS))
     {
         if (crypt_method & CRYPT_METHOD_FIPS)
         {
@@ -1801,8 +1801,8 @@ xrdp_sec_process_mcs_data_CS_SECURITY(struct xrdp_sec *self, struct stream* s)
         }
     }
     if ((found == 0) &&
-        (self->crypt_method & CRYPT_METHOD_128BIT) &&
-        (self->crypt_level == CRYPT_LEVEL_HIGH))
+            (self->crypt_method & CRYPT_METHOD_128BIT) &&
+            (self->crypt_level == CRYPT_LEVEL_HIGH))
     {
         if (crypt_method & CRYPT_METHOD_128BIT)
         {
@@ -1814,8 +1814,8 @@ xrdp_sec_process_mcs_data_CS_SECURITY(struct xrdp_sec *self, struct stream* s)
         }
     }
     if ((found == 0) &&
-        (self->crypt_method & CRYPT_METHOD_40BIT) &&
-        (self->crypt_level == CRYPT_LEVEL_CLIENT_COMPATIBLE))
+            (self->crypt_method & CRYPT_METHOD_40BIT) &&
+            (self->crypt_level == CRYPT_LEVEL_CLIENT_COMPATIBLE))
     {
         if (crypt_method & CRYPT_METHOD_40BIT)
         {
@@ -1827,8 +1827,8 @@ xrdp_sec_process_mcs_data_CS_SECURITY(struct xrdp_sec *self, struct stream* s)
         }
     }
     if ((found == 0) &&
-        (self->crypt_method & CRYPT_METHOD_40BIT) &&
-        (self->crypt_level == CRYPT_LEVEL_LOW))
+            (self->crypt_method & CRYPT_METHOD_40BIT) &&
+            (self->crypt_level == CRYPT_LEVEL_LOW))
     {
         if (crypt_method & CRYPT_METHOD_40BIT)
         {
@@ -1840,7 +1840,7 @@ xrdp_sec_process_mcs_data_CS_SECURITY(struct xrdp_sec *self, struct stream* s)
         }
     }
     if ((found == 0) &&
-        (self->crypt_level == CRYPT_LEVEL_NONE))
+            (self->crypt_level == CRYPT_LEVEL_NONE))
     {
         if (crypt_method == CRYPT_METHOD_NONE)
         {
@@ -1851,11 +1851,11 @@ xrdp_sec_process_mcs_data_CS_SECURITY(struct xrdp_sec *self, struct stream* s)
             found = 1;
         }
     }
-//    if (found == 0)
-//    {
-//        LOG_DEVEL(LOG_LEVEL_TRACE, "  can not find client / server agreed encryption method");
-//        return 1;
-//    }
+    //    if (found == 0)
+    //    {
+    //        LOG_DEVEL(LOG_LEVEL_TRACE, "  can not find client / server agreed encryption method");
+    //        return 1;
+    //    }
     return 0;
 }
 
@@ -1872,12 +1872,12 @@ xrdp_sec_process_mcs_data_channels(struct xrdp_sec *self, struct stream *s)
 
     client_info = &(self->rdp_layer->client_info);
     LOG_DEVEL(LOG_LEVEL_TRACE, "processing channels, channels_allowed is %d",
-           client_info->channels_allowed);
+              client_info->channels_allowed);
     /* this is an option set in xrdp.ini */
     if (client_info->channels_allowed == 0) /* are channels on? */
     {
         LOG(LOG_LEVEL_INFO, "all channels are disabled by "
-                    "configuration");
+            "configuration");
         return 0;
     }
     if (!s_check_rem(s, 4))
@@ -1903,12 +1903,12 @@ xrdp_sec_process_mcs_data_channels(struct xrdp_sec *self, struct stream *s)
         {
             channel_item->chanid = MCS_GLOBAL_CHANNEL + (index + 1);
             LOG(LOG_LEVEL_INFO, "adding channel item name %s chan_id "
-                        "%d flags 0x%8.8x", channel_item->name,
-                        channel_item->chanid, channel_item->flags);
+                "%d flags 0x%8.8x", channel_item->name,
+                channel_item->chanid, channel_item->flags);
             list_add_item(self->mcs_layer->channel_list,
                           (intptr_t) channel_item);
             LOG_DEVEL(LOG_LEVEL_TRACE, "got channel flags %8.8x name %s", channel_item->flags,
-                   channel_item->name);
+                      channel_item->name);
         }
         else
         {
@@ -1940,7 +1940,7 @@ xrdp_sec_process_mcs_data_monitors(struct xrdp_sec *self, struct stream *s)
     if (client_info->multimon != 1) /* are multi-monitors allowed ? */
     {
         LOG_DEVEL(LOG_LEVEL_INFO, "[INFO] xrdp_sec_process_mcs_data_monitors: multimon is not "
-               "allowed, skipping");
+                  "allowed, skipping");
         return 0;
     }
     in_uint32_le(s, flags); /* flags */
@@ -1948,7 +1948,7 @@ xrdp_sec_process_mcs_data_monitors(struct xrdp_sec *self, struct stream *s)
     if (flags != 0)
     {
         LOG_DEVEL(LOG_LEVEL_INFO, "[ERROR] xrdp_sec_process_mcs_data_monitors: flags MUST be "
-               "zero, detected: %d", flags);
+                  "zero, detected: %d", flags);
         return 1;
     }
     in_uint32_le(s, monitorCount);
@@ -1956,7 +1956,7 @@ xrdp_sec_process_mcs_data_monitors(struct xrdp_sec *self, struct stream *s)
     if (monitorCount > 16)
     {
         LOG_DEVEL(LOG_LEVEL_INFO, "[ERROR] xrdp_sec_process_mcs_data_monitors: max allowed "
-               "monitors is 16, detected: %d", monitorCount);
+                  "monitors is 16, detected: %d", monitorCount);
         return 1;
     }
 
@@ -1998,12 +1998,12 @@ xrdp_sec_process_mcs_data_monitors(struct xrdp_sec *self, struct stream *s)
         }
 
         LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_sec_process_mcs_data_monitors: got a monitor [%d]: left= %d, top= %d, right= %d, bottom= %d, is_primary?= %d",
-                index,
-                client_info->minfo[index].left,
-                client_info->minfo[index].top,
-                client_info->minfo[index].right,
-                client_info->minfo[index].bottom,
-                client_info->minfo[index].is_primary);
+                  index,
+                  client_info->minfo[index].left,
+                  client_info->minfo[index].top,
+                  client_info->minfo[index].right,
+                  client_info->minfo[index].bottom,
+                  client_info->minfo[index].is_primary);
     }
 
     if (!got_primary)
@@ -2028,7 +2028,7 @@ xrdp_sec_process_mcs_data_monitors(struct xrdp_sec *self, struct stream *s)
     }
     /* make sure virtual desktop size is ok */
     if (client_info->width > 0x7FFE || client_info->width < 0xC8 ||
-        client_info->height > 0x7FFE || client_info->height < 0xC8)
+            client_info->height > 0x7FFE || client_info->height < 0xC8)
     {
         LOG_DEVEL(LOG_LEVEL_INFO, "[ERROR] xrdp_sec_process_mcs_data_monitors: error, virtual desktop width / height is too large");
         return 1; /* error */
@@ -2077,7 +2077,7 @@ xrdp_sec_process_mcs_data(struct xrdp_sec *self)
         if ((size < 4) || (!s_check_rem(s, size - 4)))
         {
             LOG_DEVEL(LOG_LEVEL_INFO, "error in xrdp_sec_process_mcs_data tag %d size %d",
-                   tag, size);
+                      tag, size);
             break;
         }
 
@@ -2110,17 +2110,17 @@ xrdp_sec_process_mcs_data(struct xrdp_sec *self)
                     return 1;
                 }
                 break;
-                                       /* CS_MCS_MSGCHANNEL 0xC006
-                                          CS_MONITOR_EX     0xC008
-                                          CS_MULTITRANSPORT 0xC00A
-                                          SC_CORE           0x0C01
-                                          SC_SECURITY       0x0C02
-                                          SC_NET            0x0C03
-                                          SC_MCS_MSGCHANNEL 0x0C04
-                                          SC_MULTITRANSPORT 0x0C08 */
+            /* CS_MCS_MSGCHANNEL 0xC006
+               CS_MONITOR_EX     0xC008
+               CS_MULTITRANSPORT 0xC00A
+               SC_CORE           0x0C01
+               SC_SECURITY       0x0C02
+               SC_NET            0x0C03
+               SC_MCS_MSGCHANNEL 0x0C04
+               SC_MULTITRANSPORT 0x0C08 */
             default:
                 LOG_DEVEL(LOG_LEVEL_INFO, "error unknown xrdp_sec_process_mcs_data "
-                       "tag 0x%4.4x size %d", tag, size);
+                          "tag 0x%4.4x size %d", tag, size);
                 break;
         }
 
@@ -2130,14 +2130,14 @@ xrdp_sec_process_mcs_data(struct xrdp_sec *self)
     if (self->rdp_layer->client_info.max_bpp > 0)
     {
         if (self->rdp_layer->client_info.bpp >
-            self->rdp_layer->client_info.max_bpp)
+                self->rdp_layer->client_info.max_bpp)
         {
             LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_rdp_parse_client_mcs_data: client asked "
-                   "for %dbpp connection but configuration is limited "
-                   "to %dbpp", self->rdp_layer->client_info.bpp,
-                   self->rdp_layer->client_info.max_bpp);
+                      "for %dbpp connection but configuration is limited "
+                      "to %dbpp", self->rdp_layer->client_info.bpp,
+                      self->rdp_layer->client_info.max_bpp);
             self->rdp_layer->client_info.bpp =
-                         self->rdp_layer->client_info.max_bpp;
+                self->rdp_layer->client_info.max_bpp;
         }
     }
 
@@ -2292,10 +2292,10 @@ xrdp_sec_incoming(struct xrdp_sec *self)
         LOG_DEVEL(LOG_LEVEL_TRACE, " in xrdp_sec_incoming: init tls security");
 
         if (trans_set_tls_mode(self->mcs_layer->iso_layer->trans,
-                self->rdp_layer->client_info.key_file,
-                self->rdp_layer->client_info.certificate,
-                self->rdp_layer->client_info.ssl_protocols,
-                self->rdp_layer->client_info.tls_ciphers) != 0)
+                               self->rdp_layer->client_info.key_file,
+                               self->rdp_layer->client_info.certificate,
+                               self->rdp_layer->client_info.ssl_protocols,
+                               self->rdp_layer->client_info.tls_ciphers) != 0)
         {
             LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_incoming: trans_set_tls_mode failed");
             return 1;
@@ -2329,7 +2329,7 @@ xrdp_sec_incoming(struct xrdp_sec *self)
             {
                 /* this is a show stopper */
                 LOG(LOG_LEVEL_ALWAYS, "XRDP cannot read file: %s "
-                            "(check permissions)", key_file);
+                    "(check permissions)", key_file);
                 list_delete(items);
                 list_delete(values);
                 return 1;
@@ -2367,7 +2367,7 @@ xrdp_sec_incoming(struct xrdp_sec *self)
                 LOG_DEVEL(LOG_LEVEL_TRACE, "warning, RSA key len 512 "
                           "bits or less, consider creating a 2048 bit key");
                 LOG(LOG_LEVEL_WARNING, "warning, RSA key len 512 "
-                            "bits or less, consider creating a 2048 bit key");
+                    "bits or less, consider creating a 2048 bit key");
             }
 
             list_delete(items);
@@ -2382,9 +2382,9 @@ xrdp_sec_incoming(struct xrdp_sec *self)
     }
 
     LOG_DEVEL_HEXDUMP(LOG_LEVEL_TRACE, "client mcs data received", self->client_mcs_data.data,
-              (int)(self->client_mcs_data.end - self->client_mcs_data.data));
+                      (int)(self->client_mcs_data.end - self->client_mcs_data.data));
     LOG_DEVEL_HEXDUMP(LOG_LEVEL_TRACE, "server mcs data sent", self->server_mcs_data.data,
-              (int)(self->server_mcs_data.end - self->server_mcs_data.data));
+                      (int)(self->server_mcs_data.end - self->server_mcs_data.data));
     LOG_DEVEL(LOG_LEVEL_TRACE, " out xrdp_sec_incoming");
     if (xrdp_sec_in_mcs_data(self) != 0)
     {

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -26,13 +26,7 @@
 #include "ms-rdpbcgr.h"
 #include "log.h"
 
-#define LOG_LEVEL 1
-#define LLOG(_level, _args) \
-    do { if (_level < LOG_LEVEL) { g_write _args ; } } while (0)
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { g_writeln _args ; } } while (0)
-#define LHEXDUMP(_level, _args) \
-    do { if (_level < LOG_LEVEL) { g_hexdump _args ; } } while (0)
+
 
 /* some compilers need unsigned char to avoid warnings */
 static tui8 g_pad_54[40] =
@@ -241,8 +235,8 @@ xrdp_load_keyboard_layout(struct xrdp_client_info *client_info)
     char keyboard_cfg_file[256] = { 0 };
     char rdp_layout[256] = { 0 };
 
-    LLOGLN(0, ("xrdp_load_keyboard_layout: keyboard_type [%d] keyboard_subtype [%d]",
-               client_info->keyboard_type, client_info->keyboard_subtype));
+    LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_load_keyboard_layout: keyboard_type [%d] keyboard_subtype [%d]",
+               client_info->keyboard_type, client_info->keyboard_subtype);
 
     /* infer model/variant */
     /* TODO specify different X11 keyboard models/variants */
@@ -262,7 +256,7 @@ xrdp_load_keyboard_layout(struct xrdp_client_info *client_info)
     }
 
     g_snprintf(keyboard_cfg_file, 255, "%s/xrdp_keyboard.ini", XRDP_CFG_PATH);
-    LLOGLN(10, ("keyboard_cfg_file %s", keyboard_cfg_file));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "keyboard_cfg_file %s", keyboard_cfg_file);
 
     fd = g_file_open(keyboard_cfg_file);
 
@@ -293,8 +287,8 @@ xrdp_load_keyboard_layout(struct xrdp_client_info *client_info)
                 {
                     item = (char *)list_get_item(items, i);
                     value = (char *)list_get_item(values, i);
-                    LLOGLN(10, ("xrdp_load_keyboard_layout: item %s value %s",
-                           item, value));
+                    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_load_keyboard_layout: item %s value %s",
+                           item, value);
                     if (g_strcasecmp(item, "keyboard_type") == 0)
                     {
                         int v = g_atoi(value);
@@ -360,9 +354,9 @@ xrdp_load_keyboard_layout(struct xrdp_client_info *client_info)
                          * mixing items from different sections will result in
                          * skipping over current section.
                          */
-                        LLOGLN(10, ("xrdp_load_keyboard_layout: skipping "
+                        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_load_keyboard_layout: skipping "
                                "configuration item - %s, continuing to next "
-                               "section", item));
+                               "section", item);
                         break;
                     }
                 }
@@ -428,15 +422,15 @@ xrdp_load_keyboard_layout(struct xrdp_client_info *client_info)
         list_delete(items);
         list_delete(values);
 
-        LLOGLN(0, ("xrdp_load_keyboard_layout: model [%s] variant [%s] "
+        LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_load_keyboard_layout: model [%s] variant [%s] "
                "layout [%s] options [%s]", client_info->model,
-               client_info->variant, client_info->layout, client_info->options));
+               client_info->variant, client_info->layout, client_info->options);
         g_file_close(fd);
     }
     else
     {
-        LLOGLN(0, ("xrdp_load_keyboard_layout: error opening %s",
-               keyboard_cfg_file));
+        LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_load_keyboard_layout: error opening %s",
+               keyboard_cfg_file);
     }
 }
 
@@ -446,7 +440,7 @@ xrdp_sec_create(struct xrdp_rdp *owner, struct trans *trans)
 {
     struct xrdp_sec *self;
 
-    DEBUG((" in xrdp_sec_create"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, " in xrdp_sec_create");
     self = (struct xrdp_sec *) g_malloc(sizeof(struct xrdp_sec), 1);
     self->rdp_layer = owner;
     self->crypt_method = CRYPT_METHOD_NONE; /* set later */
@@ -456,7 +450,7 @@ xrdp_sec_create(struct xrdp_rdp *owner, struct trans *trans)
     self->fastpath_layer = xrdp_fastpath_create(self, trans);
     self->chan_layer = xrdp_channel_create(self, self->mcs_layer);
     self->is_security_header_present = 1;
-    DEBUG((" out xrdp_sec_create"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, " out xrdp_sec_create");
 
     return self;
 }
@@ -467,7 +461,7 @@ xrdp_sec_delete(struct xrdp_sec *self)
 {
     if (self == 0)
     {
-        g_writeln("xrdp_sec_delete: self is null");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_delete: self is null");
         return;
     }
 
@@ -567,7 +561,7 @@ xrdp_sec_update(char *key, char *update_key, int key_len)
 static void
 xrdp_sec_fips_decrypt(struct xrdp_sec *self, char *data, int len)
 {
-    LLOGLN(10, ("xrdp_sec_fips_decrypt:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_sec_fips_decrypt:");
     ssl_des3_decrypt(self->decrypt_fips_info, len, data, data);
     self->decrypt_use_count++;
 }
@@ -576,7 +570,7 @@ xrdp_sec_fips_decrypt(struct xrdp_sec *self, char *data, int len)
 static void
 xrdp_sec_decrypt(struct xrdp_sec *self, char *data, int len)
 {
-    LLOGLN(10, ("xrdp_sec_decrypt:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_sec_decrypt:");
     if (self->decrypt_use_count == 4096)
     {
         xrdp_sec_update(self->decrypt_key, self->decrypt_update_key,
@@ -593,7 +587,7 @@ xrdp_sec_decrypt(struct xrdp_sec *self, char *data, int len)
 static void
 xrdp_sec_fips_encrypt(struct xrdp_sec *self, char *data, int len)
 {
-    LLOGLN(10, ("xrdp_sec_fips_encrypt:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_sec_fips_encrypt:");
     ssl_des3_encrypt(self->encrypt_fips_info, len, data, data);
     self->encrypt_use_count++;
 }
@@ -602,7 +596,7 @@ xrdp_sec_fips_encrypt(struct xrdp_sec *self, char *data, int len)
 static void
 xrdp_sec_encrypt(struct xrdp_sec *self, char *data, int len)
 {
-    LLOGLN(10, ("xrdp_sec_encrypt:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_sec_encrypt:");
     if (self->encrypt_use_count == 4096)
     {
         xrdp_sec_update(self->encrypt_key, self->encrypt_update_key,
@@ -628,7 +622,7 @@ unicode_utf16_in(struct stream *s, int src_bytes, char *dst, int dst_len)
     int i;
     int bytes;
 
-    LLOGLN(10, ("unicode_utf16_in: uni_len %d, dst_len %d", src_bytes, dst_len));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "unicode_utf16_in: uni_len %d, dst_len %d", src_bytes, dst_len);
     if (src_bytes == 0)
     {
         if (!s_check_rem(s, 2))
@@ -655,7 +649,7 @@ unicode_utf16_in(struct stream *s, int src_bytes, char *dst, int dst_len)
     {
         g_memset(dst, '\0', dst_len);
     }
-    LLOGLN(10, ("unicode_utf16_in: num_chars %d, dst %s", num_chars, dst));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "unicode_utf16_in: num_chars %d, dst %s", num_chars, dst);
     g_free(src);
 
     return 0;
@@ -685,48 +679,48 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
     }
     in_uint8s(s, 4);
     in_uint32_le(s, flags);
-    DEBUG(("in xrdp_sec_process_logon_info flags $%x", flags));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "in xrdp_sec_process_logon_info flags $%x", flags);
 
     /* this is the first test that the decrypt is working */
     if ((flags & RDP_LOGON_NORMAL) != RDP_LOGON_NORMAL) /* 0x33 */
     {
         /* must be or error */
-        DEBUG(("xrdp_sec_process_logon_info: flags wrong, major error"));
-        LLOGLN(0, ("xrdp_sec_process_logon_info: flags wrong, likely decrypt "
-               "not working"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_process_logon_info: flags wrong, major error");
+        LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_sec_process_logon_info: flags wrong, likely decrypt "
+               "not working");
         return 1;
     }
 
     if (flags & RDP_LOGON_LEAVE_AUDIO)
     {
         self->rdp_layer->client_info.sound_code = 1;
-        DEBUG(("flag RDP_LOGON_LEAVE_AUDIO found"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "flag RDP_LOGON_LEAVE_AUDIO found");
     }
 
     if (flags & RDP_LOGON_RAIL)
     {
         self->rdp_layer->client_info.rail_enable = 1;
-        DEBUG(("flag RDP_LOGON_RAIL found"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "flag RDP_LOGON_RAIL found");
     }
 
     if ((flags & RDP_LOGON_AUTO) && (!self->rdp_layer->client_info.is_mce))
         /* todo, for now not allowing autologon and mce both */
     {
         self->rdp_layer->client_info.rdp_autologin = 1;
-        DEBUG(("flag RDP_LOGON_AUTO found"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "flag RDP_LOGON_AUTO found");
     }
 
     if (flags & RDP_COMPRESSION)
     {
-        DEBUG(("flag RDP_COMPRESSION found"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "flag RDP_COMPRESSION found");
         if (self->rdp_layer->client_info.use_bulk_comp)
         {
-            DEBUG(("flag RDP_COMPRESSION set"));
+            LOG_DEVEL(LOG_LEVEL_TRACE, "flag RDP_COMPRESSION set");
             self->rdp_layer->client_info.rdp_compression = 1;
         }
         else
         {
-            DEBUG(("flag RDP_COMPRESSION not set"));
+            LOG_DEVEL(LOG_LEVEL_TRACE, "flag RDP_COMPRESSION not set");
         }
     }
 
@@ -738,7 +732,7 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
 
     if (len_domain >= INFO_CLIENT_MAX_CB_LEN)
     {
-        DEBUG(("ERROR [xrdp_sec_process_logon_info()]: len_domain >= %d", INFO_CLIENT_MAX_CB_LEN));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "ERROR [xrdp_sec_process_logon_info()]: len_domain >= %d", INFO_CLIENT_MAX_CB_LEN);
         return 1;
     }
 
@@ -760,7 +754,7 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
 
     if (len_user >= INFO_CLIENT_MAX_CB_LEN)
     {
-        DEBUG(("ERROR [xrdp_sec_process_logon_info()]: len_user >= %d", INFO_CLIENT_MAX_CB_LEN));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "ERROR [xrdp_sec_process_logon_info()]: len_user >= %d", INFO_CLIENT_MAX_CB_LEN);
         return 1;
     }
 
@@ -772,7 +766,7 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
 
     if (len_password >= INFO_CLIENT_MAX_CB_LEN)
     {
-        DEBUG(("ERROR [xrdp_sec_process_logon_info()]: len_password >= %d", INFO_CLIENT_MAX_CB_LEN));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "ERROR [xrdp_sec_process_logon_info()]: len_password >= %d", INFO_CLIENT_MAX_CB_LEN);
         return 1;
     }
 
@@ -784,7 +778,7 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
 
     if (len_program >= INFO_CLIENT_MAX_CB_LEN)
     {
-        DEBUG(("ERROR [xrdp_sec_process_logon_info()]: len_program >= %d", INFO_CLIENT_MAX_CB_LEN));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "ERROR [xrdp_sec_process_logon_info()]: len_program >= %d", INFO_CLIENT_MAX_CB_LEN);
         return 1;
     }
 
@@ -796,7 +790,7 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
 
     if (len_directory >= INFO_CLIENT_MAX_CB_LEN)
     {
-        DEBUG(("ERROR [xrdp_sec_process_logon_info()]: len_directory >= %d", INFO_CLIENT_MAX_CB_LEN));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "ERROR [xrdp_sec_process_logon_info()]: len_directory >= %d", INFO_CLIENT_MAX_CB_LEN);
         return 1;
     }
 
@@ -804,11 +798,12 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
     {
         return 1;
     }
-    DEBUG(("domain %s", self->rdp_layer->client_info.domain));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "domain %s", self->rdp_layer->client_info.domain);
     if (unicode_utf16_in(s, len_user, self->rdp_layer->client_info.username, sizeof(self->rdp_layer->client_info.username) - 1) != 0)
     {
         return 1;
     }
+
 
     if (flags & RDP_LOGON_AUTO)
     {
@@ -816,14 +811,14 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
         {
             return 1;
         }
-        DEBUG(("flag RDP_LOGON_AUTO found"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "flag RDP_LOGON_AUTO found");
     }
     else if (self->rdp_layer->client_info.enable_token_login
              && len_user > 0
              && len_password == 0
              && (sep = g_strchr(self->rdp_layer->client_info.username, '\x1f')) != NULL)
     {
-        DEBUG(("Logon token detected"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "Logon token detected");
         g_strncpy(self->rdp_layer->client_info.password, sep + 1,
                   sizeof(self->rdp_layer->client_info.password) - 1);
         self->rdp_layer->client_info.username[sep - self->rdp_layer->client_info.username] = '\0';
@@ -838,7 +833,7 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
         in_uint8s(s, len_password + 2);
         if (self->rdp_layer->client_info.require_credentials)
         {
-            g_writeln("xrdp_sec_process_logon_info: credentials on cmd line is mandatory");
+            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_process_logon_info: credentials on cmd line is mandatory");
             return 1; /* credentials on cmd line is mandatory */
         }
     }
@@ -849,18 +844,18 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
         g_strncat(self->rdp_layer->client_info.username, self->rdp_layer->client_info.domain_user_separator, size - 1 - g_strlen(self->rdp_layer->client_info.domain_user_separator));
         g_strncat(self->rdp_layer->client_info.username, self->rdp_layer->client_info.domain, size - 1 - g_strlen(self->rdp_layer->client_info.domain));
     }
-    DEBUG(("username %s", self->rdp_layer->client_info.username));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "username %s", self->rdp_layer->client_info.username);
 
     if (unicode_utf16_in(s, len_program, self->rdp_layer->client_info.program, sizeof(self->rdp_layer->client_info.program) - 1) != 0)
     {
         return 1;
     }
-    DEBUG(("program %s", self->rdp_layer->client_info.program));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "program %s", self->rdp_layer->client_info.program);
     if (unicode_utf16_in(s, len_directory, self->rdp_layer->client_info.directory, sizeof(self->rdp_layer->client_info.directory) - 1) != 0)
     {
         return 1;
     }
-    DEBUG(("directory %s", self->rdp_layer->client_info.directory));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "directory %s", self->rdp_layer->client_info.directory);
 
     if (flags & RDP_LOGON_BLOB)
     {
@@ -895,7 +890,7 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
         in_uint32_le(s, self->rdp_layer->client_info.rdp5_performanceflags);
     }
 
-    DEBUG(("out xrdp_sec_process_logon_info"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_sec_process_logon_info");
     return 0;
 }
 
@@ -906,7 +901,7 @@ xrdp_sec_send_lic_initial(struct xrdp_sec *self)
 {
     struct stream *s;
 
-    LLOGLN(10, ("xrdp_sec_send_lic_initial:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_sec_send_lic_initial:");
     make_stream(s);
     init_stream(s, 8192);
 
@@ -1099,7 +1094,7 @@ xrdp_sec_fips_establish_keys(struct xrdp_sec *self)
     const char *fips_ivec;
     void *sha1;
 
-    LLOGLN(0, ("xrdp_sec_fips_establish_keys:"));
+    LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_sec_fips_establish_keys:");
 
     sha1 = ssl_sha1_info_create();
     ssl_sha1_clear(sha1);
@@ -1143,7 +1138,7 @@ xrdp_sec_establish_keys(struct xrdp_sec *self)
     char temp_hash[48];
     char input[48];
 
-    LLOGLN(0, ("xrdp_sec_establish_keys:"));
+    LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_sec_establish_keys:");
 
     g_memcpy(input, self->client_random, 24);
     g_memcpy(input + 24, self->server_random, 24);
@@ -1184,7 +1179,13 @@ xrdp_sec_recv_fastpath(struct xrdp_sec *self, struct stream *s)
     int len;
     int pad;
 
-    LLOGLN(10, ("xrdp_sec_recv_fastpath:"));
+#ifndef XRDP_DEBUG
+    /* TODO: remove UNUSED_VAR once the `var` variable is used for more than 
+    logging in debug mode */
+    UNUSED_VAR(ver);
+#endif
+
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_sec_recv_fastpath:");
     if (xrdp_fastpath_recv(self->fastpath_layer, s) != 0)
     {
         return 1;
@@ -1205,9 +1206,9 @@ xrdp_sec_recv_fastpath(struct xrdp_sec *self, struct stream *s)
                 return 1;
             }
             in_uint8(s, pad);
-            LLOGLN(10, ("xrdp_sec_recv_fastpath: len %d ver %d pad %d", len, ver, pad));
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_sec_recv_fastpath: len %d ver %d pad %d", len, ver, pad);
             in_uint8s(s, 8);  /* dataSignature (8 bytes), skip for now */
-            LLOGLN(10, ("xrdp_sec_recv_fastpath: data len %d", (int)(s->end - s->p)));
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_sec_recv_fastpath: data len %d", (int)(s->end - s->p));
             xrdp_sec_fips_decrypt(self, s->p, (int)(s->end - s->p));
             s->end -= pad;
         }
@@ -1247,12 +1248,12 @@ xrdp_sec_recv(struct xrdp_sec *self, struct stream *s, int *chan)
     int ver;
     int pad;
 
-    DEBUG((" in xrdp_sec_recv"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, " in xrdp_sec_recv");
 
     if (xrdp_mcs_recv(self->mcs_layer, s, chan) != 0)
     {
-        DEBUG((" out xrdp_sec_recv : error"));
-        g_writeln("xrdp_sec_recv: xrdp_mcs_recv failed");
+        LOG_DEVEL(LOG_LEVEL_TRACE, " out xrdp_sec_recv : error");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_recv: xrdp_mcs_recv failed");
         return 1;
     }
 
@@ -1268,7 +1269,7 @@ xrdp_sec_recv(struct xrdp_sec *self, struct stream *s, int *chan)
     }
 
     in_uint32_le(s, flags);
-    DEBUG((" in xrdp_sec_recv flags $%x", flags));
+    LOG_DEVEL(LOG_LEVEL_TRACE, " in xrdp_sec_recv flags $%x", flags);
 
     if (flags & SEC_ENCRYPT) /* 0x08 */
     {
@@ -1285,9 +1286,9 @@ xrdp_sec_recv(struct xrdp_sec *self, struct stream *s, int *chan)
                 return 1;
             }
             in_uint8(s, pad);
-            LLOGLN(10, ("xrdp_sec_recv: len %d ver %d pad %d", len, ver, pad));
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_sec_recv: len %d ver %d pad %d", len, ver, pad);
             in_uint8s(s, 8); /* signature(8) */
-            LLOGLN(10, ("xrdp_sec_recv: data len %d", (int)(s->end - s->p)));
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_sec_recv: data len %d", (int)(s->end - s->p));
             xrdp_sec_fips_decrypt(self, s->p, (int)(s->end - s->p));
             s->end -= pad;
         }
@@ -1321,9 +1322,9 @@ xrdp_sec_recv(struct xrdp_sec *self, struct stream *s, int *chan)
         in_uint8a(s, self->client_crypt_random, len - 8);
         xrdp_sec_rsa_op(self, self->client_random, self->client_crypt_random,
                         len - 8, self->pub_mod, self->pri_exp);
-        LLOGLN(10, ("xrdp_sec_recv: client random - len %d", len));
-        LHEXDUMP(10, (self->client_random, 256));
-        LHEXDUMP(10, (self->client_crypt_random, len - 8));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_sec_recv: client random - len %d", len);
+        LOG_DEVEL_HEXDUMP(LOG_LEVEL_TRACE, "client random", self->client_random, 256);
+        LOG_DEVEL_HEXDUMP(LOG_LEVEL_TRACE, "client crypt random", self->client_crypt_random, len - 8);
         if (self->crypt_level == CRYPT_LEVEL_FIPS)
         {
             xrdp_sec_fips_establish_keys(self);
@@ -1333,7 +1334,7 @@ xrdp_sec_recv(struct xrdp_sec *self, struct stream *s, int *chan)
             xrdp_sec_establish_keys(self);
         }
         *chan = 1; /* just set a non existing channel and exit */
-        DEBUG((" out xrdp_sec_recv"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, " out xrdp_sec_recv");
         return 0;
     }
 
@@ -1341,7 +1342,7 @@ xrdp_sec_recv(struct xrdp_sec *self, struct stream *s, int *chan)
     {
         if (xrdp_sec_process_logon_info(self, s) != 0)
         {
-            DEBUG((" out xrdp_sec_recv error"));
+            LOG_DEVEL(LOG_LEVEL_TRACE, " out xrdp_sec_recv error");
             return 1;
         }
 
@@ -1349,22 +1350,22 @@ xrdp_sec_recv(struct xrdp_sec *self, struct stream *s, int *chan)
         {
             if (xrdp_sec_send_media_lic_response(self) != 0)
             {
-                DEBUG((" out xrdp_sec_recv error"));
+                LOG_DEVEL(LOG_LEVEL_TRACE, " out xrdp_sec_recv error");
                 return 1;
             }
 
-            DEBUG((" out xrdp_sec_recv"));
+            LOG_DEVEL(LOG_LEVEL_TRACE, " out xrdp_sec_recv");
             return -1; /* special error that means send demand active */
         }
 
         if (xrdp_sec_send_lic_initial(self) != 0)
         {
-            DEBUG((" out xrdp_sec_recv error"));
+            LOG_DEVEL(LOG_LEVEL_TRACE, " out xrdp_sec_recv error");
             return 1;
         }
 
         *chan = 1; /* just set a non existing channel and exit */
-        DEBUG((" out xrdp_sec_recv"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, " out xrdp_sec_recv");
         return 0;
     }
 
@@ -1372,7 +1373,7 @@ xrdp_sec_recv(struct xrdp_sec *self, struct stream *s, int *chan)
     {
         if (xrdp_sec_send_lic_response(self) != 0)
         {
-            DEBUG((" out xrdp_sec_recv error"));
+            LOG_DEVEL(LOG_LEVEL_TRACE, " out xrdp_sec_recv error");
             return 1;
         }
 
@@ -1383,11 +1384,11 @@ xrdp_sec_recv(struct xrdp_sec *self, struct stream *s, int *chan)
             self->is_security_header_present = 0;
         }
 
-        DEBUG((" out xrdp_sec_recv"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, " out xrdp_sec_recv");
         return -1; /* special error that means send demand active */
     }
 
-    DEBUG((" out xrdp_sec_recv"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, " out xrdp_sec_recv");
     return 0;
 }
 
@@ -1458,15 +1459,15 @@ xrdp_sec_send(struct xrdp_sec *self, struct stream *s, int chan)
     int datalen;
     int pad;
 
-    LLOGLN(10, ("xrdp_sec_send:"));
-    DEBUG((" in xrdp_sec_send"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_sec_send:");
+    LOG_DEVEL(LOG_LEVEL_TRACE, " in xrdp_sec_send");
     s_pop_layer(s, sec_hdr);
 
     if (self->crypt_level > CRYPT_LEVEL_NONE)
     {
         if (self->crypt_level == CRYPT_LEVEL_FIPS)
         {
-            LLOGLN(10, ("xrdp_sec_send: fips"));
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_sec_send: fips");
             out_uint32_le(s, SEC_ENCRYPT);
             datalen = (int)((s->end - s->p) - 12);
             out_uint16_le(s, 16); /* crypto header size */
@@ -1496,7 +1497,7 @@ xrdp_sec_send(struct xrdp_sec *self, struct stream *s, int chan)
         return 1;
     }
 
-    DEBUG((" out xrdp_sec_send"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, " out xrdp_sec_send");
     return 0;
 }
 
@@ -1555,12 +1556,12 @@ xrdp_sec_send_fastpath(struct xrdp_sec *self, struct stream *s)
     int error;
     char save[8];
 
-    LLOGLN(10, ("xrdp_sec_send_fastpath:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_sec_send_fastpath:");
     error = 0;
     s_pop_layer(s, sec_hdr);
     if (self->crypt_level == CRYPT_LEVEL_FIPS)
     {
-        LLOGLN(10, ("xrdp_sec_send_fastpath: fips"));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_sec_send_fastpath: fips");
         pdulen = (int)(s->end - s->p);
         datalen = pdulen - 15;
         pad = (8 - (datalen % 8)) & 7;
@@ -1583,7 +1584,7 @@ xrdp_sec_send_fastpath(struct xrdp_sec *self, struct stream *s)
     }
     else if (self->crypt_level > CRYPT_LEVEL_LOW)
     {
-        LLOGLN(10, ("xrdp_sec_send_fastpath: crypt"));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_sec_send_fastpath: crypt");
         pdulen = (int)(s->end - s->p);
         datalen = pdulen - 11;
         secFlags = 0x2;
@@ -1597,9 +1598,9 @@ xrdp_sec_send_fastpath(struct xrdp_sec *self, struct stream *s)
     }
     else
     {
-        LLOGLN(10, ("xrdp_sec_send_fastpath: no crypt"));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_sec_send_fastpath: no crypt");
         pdulen = (int)(s->end - s->p);
-        LLOGLN(10, ("xrdp_sec_send_fastpath: pdulen %d", pdulen));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_sec_send_fastpath: pdulen %d", pdulen);
         secFlags = 0x0;
         fpOutputHeader = secFlags << 6;
         out_uint8(s, fpOutputHeader);
@@ -1631,7 +1632,7 @@ xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec* self, struct stream* s)
     in_uint16_le(s, self->rdp_layer->client_info.width);
     in_uint16_le(s, self->rdp_layer->client_info.height);
     in_uint16_le(s, colorDepth);
-    g_writeln("colorDepth 0x%4.4x (0xca00 4bpp 0xca01 8bpp)", colorDepth);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "colorDepth 0x%4.4x (0xca00 4bpp 0xca01 8bpp)", colorDepth);
     switch (colorDepth)
     {
         case RNS_UD_COLOR_4BPP:
@@ -1645,13 +1646,13 @@ xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec* self, struct stream* s)
     in_uint8s(s, 4); /* keyboardLayout */
     in_uint8s(s, 4); /* clientBuild */
     unicode_utf16_in(s, INFO_CLIENT_NAME_BYTES - 2, clientName, sizeof(clientName) - 1);  /* clientName */
-    log_message(LOG_LEVEL_INFO, "connected client computer name: %s", clientName);
+    LOG(LOG_LEVEL_INFO, "connected client computer name: %s", clientName);
     in_uint8s(s, 4); /* keyboardType */
     in_uint8s(s, 4); /* keyboardSubType */
     in_uint8s(s, 4); /* keyboardFunctionKey */
     in_uint8s(s, 64); /* imeFileName */
     in_uint16_le(s, postBeta2ColorDepth);
-    g_writeln("postBeta2ColorDepth 0x%4.4x (0xca00 4bpp 0xca01 8bpp "
+    LOG_DEVEL(LOG_LEVEL_TRACE, "postBeta2ColorDepth 0x%4.4x (0xca00 4bpp 0xca01 8bpp "
               "0xca02 15bpp 0xca03 16bpp 0xca04 24bpp)", postBeta2ColorDepth);
 
     switch (postBeta2ColorDepth)
@@ -1689,7 +1690,7 @@ xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec* self, struct stream* s)
         return 0;
     }
     in_uint16_le(s, highColorDepth);
-    g_writeln("highColorDepth 0x%4.4x (0x0004 4bpp 0x0008 8bpp 0x000f 15bpp "
+    LOG_DEVEL(LOG_LEVEL_TRACE, "highColorDepth 0x%4.4x (0x0004 4bpp 0x0008 8bpp 0x000f 15bpp "
               "0x0010 16 bpp 0x0018 24bpp)", highColorDepth);
     self->rdp_layer->client_info.bpp = highColorDepth;
 
@@ -1698,7 +1699,7 @@ xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec* self, struct stream* s)
         return 0;
     }
     in_uint16_le(s, supportedColorDepths);
-    g_writeln("supportedColorDepths 0x%4.4x (0x0001 24bpp 0x0002 16bpp "
+    LOG_DEVEL(LOG_LEVEL_TRACE, "supportedColorDepths 0x%4.4x (0x0001 24bpp 0x0002 16bpp "
               "0x0004 15bpp 0x0008 32bpp)", supportedColorDepths);
 
     if (!s_check_rem(s, 2))
@@ -1707,7 +1708,7 @@ xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec* self, struct stream* s)
     }
     in_uint16_le(s, earlyCapabilityFlags);
     self->rdp_layer->client_info.mcs_early_capability_flags = earlyCapabilityFlags;
-    g_writeln("earlyCapabilityFlags 0x%4.4x (0x0002 want32)",
+    LOG_DEVEL(LOG_LEVEL_TRACE, "earlyCapabilityFlags 0x%4.4x (0x0002 want32)",
               earlyCapabilityFlags);
     if ((earlyCapabilityFlags & 0x0002) && (supportedColorDepths & 0x0008))
     {
@@ -1725,7 +1726,7 @@ xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec* self, struct stream* s)
         return 0;
     }
     in_uint8(s, self->rdp_layer->client_info.mcs_connection_type); /* connectionType */
-    g_writeln("got client client connection type 0x%8.8x",
+    LOG_DEVEL(LOG_LEVEL_TRACE, "got client client connection type 0x%8.8x",
               self->rdp_layer->client_info.mcs_connection_type);
 
     if (!s_check_rem(s, 1))
@@ -1768,23 +1769,23 @@ xrdp_sec_process_mcs_data_CS_SECURITY(struct xrdp_sec *self, struct stream* s)
     int crypt_method;
     int found;
 
-    g_writeln("xrdp_sec_process_mcs_data_CS_SECURITY:");
+    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_process_mcs_data_CS_SECURITY:");
     in_uint32_le(s, crypt_method);
     if (crypt_method & CRYPT_METHOD_40BIT)
     {
-        g_writeln("  client supports 40 bit encryption");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "  client supports 40 bit encryption");
     }
     if (crypt_method & CRYPT_METHOD_128BIT)
     {
-        g_writeln("  client supports 128 bit encryption");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "  client supports 128 bit encryption");
     }
     if (crypt_method & CRYPT_METHOD_56BIT)
     {
-        g_writeln("  client supports 56 bit encryption");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "  client supports 56 bit encryption");
     }
     if (crypt_method & CRYPT_METHOD_FIPS)
     {
-        g_writeln("  client supports fips encryption");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "  client supports fips encryption");
     }
     found = 0;
     if ((found == 0) &&
@@ -1793,7 +1794,7 @@ xrdp_sec_process_mcs_data_CS_SECURITY(struct xrdp_sec *self, struct stream* s)
     {
         if (crypt_method & CRYPT_METHOD_FIPS)
         {
-            g_writeln("  client and server support fips, using fips");
+            LOG_DEVEL(LOG_LEVEL_TRACE, "  client and server support fips, using fips");
             self->crypt_method = CRYPT_METHOD_FIPS;
             self->crypt_level = CRYPT_LEVEL_FIPS;
             found = 1;
@@ -1805,7 +1806,7 @@ xrdp_sec_process_mcs_data_CS_SECURITY(struct xrdp_sec *self, struct stream* s)
     {
         if (crypt_method & CRYPT_METHOD_128BIT)
         {
-            g_writeln("  client and server support high crypt, using "
+            LOG_DEVEL(LOG_LEVEL_TRACE, "  client and server support high crypt, using "
                       "high crypt");
             self->crypt_method = CRYPT_METHOD_128BIT;
             self->crypt_level = CRYPT_LEVEL_HIGH;
@@ -1818,7 +1819,7 @@ xrdp_sec_process_mcs_data_CS_SECURITY(struct xrdp_sec *self, struct stream* s)
     {
         if (crypt_method & CRYPT_METHOD_40BIT)
         {
-            g_writeln("  client and server support medium crypt, using "
+            LOG_DEVEL(LOG_LEVEL_TRACE, "  client and server support medium crypt, using "
                       "medium crypt");
             self->crypt_method = CRYPT_METHOD_40BIT;
             self->crypt_level = CRYPT_LEVEL_CLIENT_COMPATIBLE;
@@ -1831,7 +1832,7 @@ xrdp_sec_process_mcs_data_CS_SECURITY(struct xrdp_sec *self, struct stream* s)
     {
         if (crypt_method & CRYPT_METHOD_40BIT)
         {
-            g_writeln("  client and server support low crypt, using "
+            LOG_DEVEL(LOG_LEVEL_TRACE, "  client and server support low crypt, using "
                       "low crypt");
             self->crypt_method = CRYPT_METHOD_40BIT;
             self->crypt_level = CRYPT_LEVEL_LOW;
@@ -1843,7 +1844,7 @@ xrdp_sec_process_mcs_data_CS_SECURITY(struct xrdp_sec *self, struct stream* s)
     {
         if (crypt_method == CRYPT_METHOD_NONE)
         {
-            g_writeln("  client and server support none crypt, using "
+            LOG_DEVEL(LOG_LEVEL_TRACE, "  client and server support none crypt, using "
                       "none crypt");
             self->crypt_method = CRYPT_METHOD_NONE;
             self->crypt_level = CRYPT_LEVEL_NONE;
@@ -1852,7 +1853,7 @@ xrdp_sec_process_mcs_data_CS_SECURITY(struct xrdp_sec *self, struct stream* s)
     }
 //    if (found == 0)
 //    {
-//        g_writeln("  can not find client / server agreed encryption method");
+//        LOG_DEVEL(LOG_LEVEL_TRACE, "  can not find client / server agreed encryption method");
 //        return 1;
 //    }
     return 0;
@@ -1870,12 +1871,12 @@ xrdp_sec_process_mcs_data_channels(struct xrdp_sec *self, struct stream *s)
     struct mcs_channel_item *channel_item;
 
     client_info = &(self->rdp_layer->client_info);
-    DEBUG(("processing channels, channels_allowed is %d",
-           client_info->channels_allowed));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "processing channels, channels_allowed is %d",
+           client_info->channels_allowed);
     /* this is an option set in xrdp.ini */
     if (client_info->channels_allowed == 0) /* are channels on? */
     {
-        log_message(LOG_LEVEL_INFO, "all channels are disabled by "
+        LOG(LOG_LEVEL_INFO, "all channels are disabled by "
                     "configuration");
         return 0;
     }
@@ -1901,13 +1902,13 @@ xrdp_sec_process_mcs_data_channels(struct xrdp_sec *self, struct stream *s)
         if (g_strlen(channel_item->name) > 0)
         {
             channel_item->chanid = MCS_GLOBAL_CHANNEL + (index + 1);
-            log_message(LOG_LEVEL_INFO, "adding channel item name %s chan_id "
+            LOG(LOG_LEVEL_INFO, "adding channel item name %s chan_id "
                         "%d flags 0x%8.8x", channel_item->name,
                         channel_item->chanid, channel_item->flags);
             list_add_item(self->mcs_layer->channel_list,
                           (intptr_t) channel_item);
-            DEBUG(("got channel flags %8.8x name %s", channel_item->flags,
-                   channel_item->name));
+            LOG_DEVEL(LOG_LEVEL_TRACE, "got channel flags %8.8x name %s", channel_item->flags,
+                   channel_item->name);
         }
         else
         {
@@ -1934,32 +1935,32 @@ xrdp_sec_process_mcs_data_monitors(struct xrdp_sec *self, struct stream *s)
 
     client_info = &(self->rdp_layer->client_info);
 
-    LLOGLN(10, ("xrdp_sec_process_mcs_data_monitors: processing monitors data, allow_multimon is %d", client_info->multimon));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_sec_process_mcs_data_monitors: processing monitors data, allow_multimon is %d", client_info->multimon);
     /* this is an option set in xrdp.ini */
     if (client_info->multimon != 1) /* are multi-monitors allowed ? */
     {
-        LLOGLN(0, ("[INFO] xrdp_sec_process_mcs_data_monitors: multimon is not "
-               "allowed, skipping"));
+        LOG_DEVEL(LOG_LEVEL_INFO, "[INFO] xrdp_sec_process_mcs_data_monitors: multimon is not "
+               "allowed, skipping");
         return 0;
     }
     in_uint32_le(s, flags); /* flags */
     //verify flags - must be 0x0
     if (flags != 0)
     {
-        LLOGLN(0, ("[ERROR] xrdp_sec_process_mcs_data_monitors: flags MUST be "
-               "zero, detected: %d", flags));
+        LOG_DEVEL(LOG_LEVEL_INFO, "[ERROR] xrdp_sec_process_mcs_data_monitors: flags MUST be "
+               "zero, detected: %d", flags);
         return 1;
     }
     in_uint32_le(s, monitorCount);
     //verify monitorCount - max 16
     if (monitorCount > 16)
     {
-        LLOGLN(0, ("[ERROR] xrdp_sec_process_mcs_data_monitors: max allowed "
-               "monitors is 16, detected: %d", monitorCount));
+        LOG_DEVEL(LOG_LEVEL_INFO, "[ERROR] xrdp_sec_process_mcs_data_monitors: max allowed "
+               "monitors is 16, detected: %d", monitorCount);
         return 1;
     }
 
-    LLOGLN(10, ("xrdp_sec_process_mcs_data_monitors: monitorCount= %d", monitorCount));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_sec_process_mcs_data_monitors: monitorCount= %d", monitorCount);
 
     client_info->monitorCount = monitorCount;
 
@@ -1996,13 +1997,13 @@ xrdp_sec_process_mcs_data_monitors(struct xrdp_sec *self, struct stream *s)
             got_primary = 1;
         }
 
-        LLOGLN(10, ("xrdp_sec_process_mcs_data_monitors: got a monitor [%d]: left= %d, top= %d, right= %d, bottom= %d, is_primary?= %d",
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_sec_process_mcs_data_monitors: got a monitor [%d]: left= %d, top= %d, right= %d, bottom= %d, is_primary?= %d",
                 index,
                 client_info->minfo[index].left,
                 client_info->minfo[index].top,
                 client_info->minfo[index].right,
                 client_info->minfo[index].bottom,
-                client_info->minfo[index].is_primary));
+                client_info->minfo[index].is_primary);
     }
 
     if (!got_primary)
@@ -2029,7 +2030,7 @@ xrdp_sec_process_mcs_data_monitors(struct xrdp_sec *self, struct stream *s)
     if (client_info->width > 0x7FFE || client_info->width < 0xC8 ||
         client_info->height > 0x7FFE || client_info->height < 0xC8)
     {
-        LLOGLN(0, ("[ERROR] xrdp_sec_process_mcs_data_monitors: error, virtual desktop width / height is too large"));
+        LOG_DEVEL(LOG_LEVEL_INFO, "[ERROR] xrdp_sec_process_mcs_data_monitors: error, virtual desktop width / height is too large");
         return 1; /* error */
     }
 
@@ -2075,12 +2076,12 @@ xrdp_sec_process_mcs_data(struct xrdp_sec *self)
 
         if ((size < 4) || (!s_check_rem(s, size - 4)))
         {
-            LLOGLN(0, ("error in xrdp_sec_process_mcs_data tag %d size %d",
-                   tag, size));
+            LOG_DEVEL(LOG_LEVEL_INFO, "error in xrdp_sec_process_mcs_data tag %d size %d",
+                   tag, size);
             break;
         }
 
-        LLOGLN(10, ("xrdp_sec_process_mcs_data: 0x%8.8x", tag));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_sec_process_mcs_data: 0x%8.8x", tag);
         switch (tag)
         {
             case SEC_TAG_CLI_INFO:     /* CS_CORE           0xC001 */
@@ -2118,8 +2119,8 @@ xrdp_sec_process_mcs_data(struct xrdp_sec *self)
                                           SC_MCS_MSGCHANNEL 0x0C04
                                           SC_MULTITRANSPORT 0x0C08 */
             default:
-                LLOGLN(0, ("error unknown xrdp_sec_process_mcs_data "
-                       "tag 0x%4.4x size %d", tag, size));
+                LOG_DEVEL(LOG_LEVEL_INFO, "error unknown xrdp_sec_process_mcs_data "
+                       "tag 0x%4.4x size %d", tag, size);
                 break;
         }
 
@@ -2131,10 +2132,10 @@ xrdp_sec_process_mcs_data(struct xrdp_sec *self)
         if (self->rdp_layer->client_info.bpp >
             self->rdp_layer->client_info.max_bpp)
         {
-            LLOGLN(0, ("xrdp_rdp_parse_client_mcs_data: client asked "
+            LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_rdp_parse_client_mcs_data: client asked "
                    "for %dbpp connection but configuration is limited "
                    "to %dbpp", self->rdp_layer->client_info.bpp,
-                   self->rdp_layer->client_info.max_bpp));
+                   self->rdp_layer->client_info.max_bpp);
             self->rdp_layer->client_info.bpp =
                          self->rdp_layer->client_info.max_bpp;
         }
@@ -2237,13 +2238,13 @@ xrdp_sec_init_rdp_security(struct xrdp_sec *self)
             self->crypt_level = CRYPT_LEVEL_FIPS;
             break;
         default:
-            g_writeln("Fatal : Illegal crypt_level");
+            LOG_DEVEL(LOG_LEVEL_TRACE, "Fatal : Illegal crypt_level");
             break ;
     }
 
     if (self->decrypt_rc4_info != NULL)
     {
-        g_writeln("xrdp_sec_init_rdp_security: decrypt_rc4_info already created !!!");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_init_rdp_security: decrypt_rc4_info already created !!!");
     }
     else
     {
@@ -2252,7 +2253,7 @@ xrdp_sec_init_rdp_security(struct xrdp_sec *self)
 
     if (self->encrypt_rc4_info != NULL)
     {
-        g_writeln("xrdp_sec_init_rdp_security: encrypt_rc4_info already created !!!");
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_init_rdp_security: encrypt_rc4_info already created !!!");
     }
     else
     {
@@ -2274,13 +2275,13 @@ xrdp_sec_incoming(struct xrdp_sec *self)
     char *value = NULL;
     char key_file[256];
 
-    DEBUG((" in xrdp_sec_incoming:"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, " in xrdp_sec_incoming:");
     iso = self->mcs_layer->iso_layer;
 
     /* negotiate security layer */
     if (xrdp_iso_incoming(iso) != 0)
     {
-        DEBUG(("xrdp_sec_incoming: xrdp_iso_incoming failed"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_incoming: xrdp_iso_incoming failed");
         return 1;
     }
 
@@ -2288,7 +2289,7 @@ xrdp_sec_incoming(struct xrdp_sec *self)
     if (iso->selectedProtocol > PROTOCOL_RDP)
     {
         /* init tls security */
-        DEBUG((" in xrdp_sec_incoming: init tls security"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, " in xrdp_sec_incoming: init tls security");
 
         if (trans_set_tls_mode(self->mcs_layer->iso_layer->trans,
                 self->rdp_layer->client_info.key_file,
@@ -2296,7 +2297,7 @@ xrdp_sec_incoming(struct xrdp_sec *self)
                 self->rdp_layer->client_info.ssl_protocols,
                 self->rdp_layer->client_info.tls_ciphers) != 0)
         {
-            g_writeln("xrdp_sec_incoming: trans_set_tls_mode failed");
+            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_incoming: trans_set_tls_mode failed");
             return 1;
         }
 
@@ -2308,10 +2309,10 @@ xrdp_sec_incoming(struct xrdp_sec *self)
     else
     {
         /* init rdp security */
-        DEBUG((" in xrdp_sec_incoming: init rdp security"));
+        LOG_DEVEL(LOG_LEVEL_TRACE, " in xrdp_sec_incoming: init rdp security");
         if (xrdp_sec_init_rdp_security(self) != 0)
         {
-            DEBUG(("xrdp_sec_incoming: xrdp_sec_init_rdp_security failed"));
+            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_incoming: xrdp_sec_init_rdp_security failed");
             return 1;
         }
         if (self->crypt_method != CRYPT_METHOD_NONE)
@@ -2327,7 +2328,7 @@ xrdp_sec_incoming(struct xrdp_sec *self)
             if (file_by_name_read_section(key_file, "keys", items, values) != 0)
             {
                 /* this is a show stopper */
-                log_message(LOG_LEVEL_ALWAYS, "XRDP cannot read file: %s "
+                LOG(LOG_LEVEL_ALWAYS, "XRDP cannot read file: %s "
                             "(check permissions)", key_file);
                 list_delete(items);
                 list_delete(values);
@@ -2346,7 +2347,7 @@ xrdp_sec_incoming(struct xrdp_sec *self)
                 else if (g_strcasecmp(item, "pub_mod") == 0)
                 {
                     self->rsa_key_bytes = (g_strlen(value) + 1) / 5;
-                    g_writeln("pub_mod bytes %d", self->rsa_key_bytes);
+                    LOG_DEVEL(LOG_LEVEL_TRACE, "pub_mod bytes %d", self->rsa_key_bytes);
                     hex_str_to_bin(value, self->pub_mod, self->rsa_key_bytes);
                 }
                 else if (g_strcasecmp(item, "pub_sig") == 0)
@@ -2356,16 +2357,16 @@ xrdp_sec_incoming(struct xrdp_sec *self)
                 else if (g_strcasecmp(item, "pri_exp") == 0)
                 {
                     self->rsa_key_bytes = (g_strlen(value) + 1) / 5;
-                    g_writeln("pri_exp %d", self->rsa_key_bytes);
+                    LOG_DEVEL(LOG_LEVEL_TRACE, "pri_exp %d", self->rsa_key_bytes);
                     hex_str_to_bin(value, self->pri_exp, self->rsa_key_bytes);
                 }
             }
 
             if (self->rsa_key_bytes <= 64)
             {
-                g_writeln("warning, RSA key len 512 "
+                LOG_DEVEL(LOG_LEVEL_TRACE, "warning, RSA key len 512 "
                           "bits or less, consider creating a 2048 bit key");
-                log_message(LOG_LEVEL_WARNING, "warning, RSA key len 512 "
+                LOG(LOG_LEVEL_WARNING, "warning, RSA key len 512 "
                             "bits or less, consider creating a 2048 bit key");
             }
 
@@ -2380,21 +2381,17 @@ xrdp_sec_incoming(struct xrdp_sec *self)
         return 1;
     }
 
-#ifdef XRDP_DEBUG
-    g_writeln("client mcs data received");
-    g_hexdump(self->client_mcs_data.data,
+    LOG_DEVEL_HEXDUMP(LOG_LEVEL_TRACE, "client mcs data received", self->client_mcs_data.data,
               (int)(self->client_mcs_data.end - self->client_mcs_data.data));
-    g_writeln("server mcs data sent");
-    g_hexdump(self->server_mcs_data.data,
+    LOG_DEVEL_HEXDUMP(LOG_LEVEL_TRACE, "server mcs data sent", self->server_mcs_data.data,
               (int)(self->server_mcs_data.end - self->server_mcs_data.data));
-#endif
-    DEBUG((" out xrdp_sec_incoming"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, " out xrdp_sec_incoming");
     if (xrdp_sec_in_mcs_data(self) != 0)
     {
         return 1;
     }
 
-    LLOGLN(10, ("xrdp_sec_incoming: out"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_sec_incoming: out");
     return 0;
 }
 
@@ -2404,8 +2401,8 @@ xrdp_sec_disconnect(struct xrdp_sec *self)
 {
     int rv;
 
-    DEBUG((" in xrdp_sec_disconnect"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, " in xrdp_sec_disconnect");
     rv = xrdp_mcs_disconnect(self->mcs_layer);
-    DEBUG((" out xrdp_sec_disconnect"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, " out xrdp_sec_disconnect");
     return rv;
 }

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -235,8 +235,8 @@ xrdp_load_keyboard_layout(struct xrdp_client_info *client_info)
     char keyboard_cfg_file[256] = { 0 };
     char rdp_layout[256] = { 0 };
 
-    LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_load_keyboard_layout: keyboard_type [%d] keyboard_subtype [%d]",
-              client_info->keyboard_type, client_info->keyboard_subtype);
+    LOG(LOG_LEVEL_INFO, "xrdp_load_keyboard_layout: keyboard_type [%d] keyboard_subtype [%d]",
+        client_info->keyboard_type, client_info->keyboard_subtype);
 
     /* infer model/variant */
     /* TODO specify different X11 keyboard models/variants */
@@ -256,7 +256,7 @@ xrdp_load_keyboard_layout(struct xrdp_client_info *client_info)
     }
 
     g_snprintf(keyboard_cfg_file, 255, "%s/xrdp_keyboard.ini", XRDP_CFG_PATH);
-    LOG_DEVEL(LOG_LEVEL_DEBUG, "keyboard_cfg_file %s", keyboard_cfg_file);
+    LOG(LOG_LEVEL_DEBUG, "keyboard_cfg_file %s", keyboard_cfg_file);
 
     fd = g_file_open(keyboard_cfg_file);
 
@@ -287,8 +287,8 @@ xrdp_load_keyboard_layout(struct xrdp_client_info *client_info)
                 {
                     item = (char *)list_get_item(items, i);
                     value = (char *)list_get_item(values, i);
-                    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_load_keyboard_layout: item %s value %s",
-                              item, value);
+                    LOG(LOG_LEVEL_DEBUG, "xrdp_load_keyboard_layout: item %s value %s",
+                        item, value);
                     if (g_strcasecmp(item, "keyboard_type") == 0)
                     {
                         int v = g_atoi(value);
@@ -354,9 +354,9 @@ xrdp_load_keyboard_layout(struct xrdp_client_info *client_info)
                          * mixing items from different sections will result in
                          * skipping over current section.
                          */
-                        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_load_keyboard_layout: skipping "
-                                  "configuration item - %s, continuing to next "
-                                  "section", item);
+                        LOG(LOG_LEVEL_DEBUG, "xrdp_load_keyboard_layout: skipping "
+                            "configuration item - %s, continuing to next "
+                            "section", item);
                         break;
                     }
                 }
@@ -422,15 +422,15 @@ xrdp_load_keyboard_layout(struct xrdp_client_info *client_info)
         list_delete(items);
         list_delete(values);
 
-        LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_load_keyboard_layout: model [%s] variant [%s] "
-                  "layout [%s] options [%s]", client_info->model,
-                  client_info->variant, client_info->layout, client_info->options);
+        LOG(LOG_LEVEL_INFO, "xrdp_load_keyboard_layout: model [%s] variant [%s] "
+            "layout [%s] options [%s]", client_info->model,
+            client_info->variant, client_info->layout, client_info->options);
         g_file_close(fd);
     }
     else
     {
-        LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_load_keyboard_layout: error opening %s",
-                  keyboard_cfg_file);
+        LOG(LOG_LEVEL_ERROR, "xrdp_load_keyboard_layout: error opening %s",
+            keyboard_cfg_file);
     }
 }
 
@@ -461,7 +461,7 @@ xrdp_sec_delete(struct xrdp_sec *self)
 {
     if (self == 0)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_delete: self is null");
+        LOG(LOG_LEVEL_ERROR, "xrdp_sec_delete: self is null");
         return;
     }
 
@@ -685,9 +685,9 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
     if ((flags & RDP_LOGON_NORMAL) != RDP_LOGON_NORMAL) /* 0x33 */
     {
         /* must be or error */
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_process_logon_info: flags wrong, major error");
-        LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_sec_process_logon_info: flags wrong, likely decrypt "
-                  "not working");
+        LOG(LOG_LEVEL_ERROR, "xrdp_sec_process_logon_info: flags wrong, major error");
+        LOG(LOG_LEVEL_ERROR, "xrdp_sec_process_logon_info: flags wrong, likely decrypt "
+            "not working");
         return 1;
     }
 
@@ -732,7 +732,7 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
 
     if (len_domain >= INFO_CLIENT_MAX_CB_LEN)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "ERROR [xrdp_sec_process_logon_info()]: len_domain >= %d", INFO_CLIENT_MAX_CB_LEN);
+        LOG(LOG_LEVEL_ERROR, "ERROR [xrdp_sec_process_logon_info()]: len_domain >= %d", INFO_CLIENT_MAX_CB_LEN);
         return 1;
     }
 
@@ -754,7 +754,7 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
 
     if (len_user >= INFO_CLIENT_MAX_CB_LEN)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "ERROR [xrdp_sec_process_logon_info()]: len_user >= %d", INFO_CLIENT_MAX_CB_LEN);
+        LOG(LOG_LEVEL_ERROR, "ERROR [xrdp_sec_process_logon_info()]: len_user >= %d", INFO_CLIENT_MAX_CB_LEN);
         return 1;
     }
 
@@ -766,7 +766,7 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
 
     if (len_password >= INFO_CLIENT_MAX_CB_LEN)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "ERROR [xrdp_sec_process_logon_info()]: len_password >= %d", INFO_CLIENT_MAX_CB_LEN);
+        LOG(LOG_LEVEL_ERROR, "ERROR [xrdp_sec_process_logon_info()]: len_password >= %d", INFO_CLIENT_MAX_CB_LEN);
         return 1;
     }
 
@@ -778,7 +778,7 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
 
     if (len_program >= INFO_CLIENT_MAX_CB_LEN)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "ERROR [xrdp_sec_process_logon_info()]: len_program >= %d", INFO_CLIENT_MAX_CB_LEN);
+        LOG(LOG_LEVEL_ERROR, "ERROR [xrdp_sec_process_logon_info()]: len_program >= %d", INFO_CLIENT_MAX_CB_LEN);
         return 1;
     }
 
@@ -790,7 +790,7 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
 
     if (len_directory >= INFO_CLIENT_MAX_CB_LEN)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "ERROR [xrdp_sec_process_logon_info()]: len_directory >= %d", INFO_CLIENT_MAX_CB_LEN);
+        LOG(LOG_LEVEL_ERROR, "ERROR [xrdp_sec_process_logon_info()]: len_directory >= %d", INFO_CLIENT_MAX_CB_LEN);
         return 1;
     }
 
@@ -833,7 +833,7 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
         in_uint8s(s, len_password + 2);
         if (self->rdp_layer->client_info.require_credentials)
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_process_logon_info: credentials on cmd line is mandatory");
+            LOG(LOG_LEVEL_ERROR, "xrdp_sec_process_logon_info: credentials on cmd line is mandatory");
             return 1; /* credentials on cmd line is mandatory */
         }
     }
@@ -1180,7 +1180,7 @@ xrdp_sec_recv_fastpath(struct xrdp_sec *self, struct stream *s)
     int pad;
 
 #ifndef XRDP_DEBUG
-    /* TODO: remove UNUSED_VAR once the `var` variable is used for more than 
+    /* TODO: remove UNUSED_VAR once the `var` variable is used for more than
     logging in debug mode */
     UNUSED_VAR(ver);
 #endif
@@ -1252,8 +1252,8 @@ xrdp_sec_recv(struct xrdp_sec *self, struct stream *s, int *chan)
 
     if (xrdp_mcs_recv(self->mcs_layer, s, chan) != 0)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, " out xrdp_sec_recv : error");
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_recv: xrdp_mcs_recv failed");
+        LOG(LOG_LEVEL_ERROR, " out xrdp_sec_recv : error");
+        LOG(LOG_LEVEL_ERROR, "xrdp_sec_recv: xrdp_mcs_recv failed");
         return 1;
     }
 
@@ -1342,7 +1342,7 @@ xrdp_sec_recv(struct xrdp_sec *self, struct stream *s, int *chan)
     {
         if (xrdp_sec_process_logon_info(self, s) != 0)
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, " out xrdp_sec_recv error");
+            LOG(LOG_LEVEL_ERROR, " out xrdp_sec_recv error");
             return 1;
         }
 
@@ -1350,7 +1350,7 @@ xrdp_sec_recv(struct xrdp_sec *self, struct stream *s, int *chan)
         {
             if (xrdp_sec_send_media_lic_response(self) != 0)
             {
-                LOG_DEVEL(LOG_LEVEL_TRACE, " out xrdp_sec_recv error");
+                LOG(LOG_LEVEL_ERROR, " out xrdp_sec_recv error");
                 return 1;
             }
 
@@ -1360,7 +1360,7 @@ xrdp_sec_recv(struct xrdp_sec *self, struct stream *s, int *chan)
 
         if (xrdp_sec_send_lic_initial(self) != 0)
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, " out xrdp_sec_recv error");
+            LOG(LOG_LEVEL_ERROR, " out xrdp_sec_recv error");
             return 1;
         }
 
@@ -1373,7 +1373,7 @@ xrdp_sec_recv(struct xrdp_sec *self, struct stream *s, int *chan)
     {
         if (xrdp_sec_send_lic_response(self) != 0)
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, " out xrdp_sec_recv error");
+            LOG(LOG_LEVEL_ERROR, " out xrdp_sec_recv error");
             return 1;
         }
 
@@ -1773,19 +1773,19 @@ xrdp_sec_process_mcs_data_CS_SECURITY(struct xrdp_sec *self, struct stream *s)
     in_uint32_le(s, crypt_method);
     if (crypt_method & CRYPT_METHOD_40BIT)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "  client supports 40 bit encryption");
+        LOG(LOG_LEVEL_INFO, "  client supports 40 bit encryption");
     }
     if (crypt_method & CRYPT_METHOD_128BIT)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "  client supports 128 bit encryption");
+        LOG(LOG_LEVEL_INFO, "  client supports 128 bit encryption");
     }
     if (crypt_method & CRYPT_METHOD_56BIT)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "  client supports 56 bit encryption");
+        LOG(LOG_LEVEL_INFO, "  client supports 56 bit encryption");
     }
     if (crypt_method & CRYPT_METHOD_FIPS)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "  client supports fips encryption");
+        LOG(LOG_LEVEL_INFO, "  client supports fips encryption");
     }
     found = 0;
     if ((found == 0) &&
@@ -1794,7 +1794,7 @@ xrdp_sec_process_mcs_data_CS_SECURITY(struct xrdp_sec *self, struct stream *s)
     {
         if (crypt_method & CRYPT_METHOD_FIPS)
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "  client and server support fips, using fips");
+            LOG(LOG_LEVEL_INFO, "  client and server support fips, using fips");
             self->crypt_method = CRYPT_METHOD_FIPS;
             self->crypt_level = CRYPT_LEVEL_FIPS;
             found = 1;
@@ -1806,8 +1806,8 @@ xrdp_sec_process_mcs_data_CS_SECURITY(struct xrdp_sec *self, struct stream *s)
     {
         if (crypt_method & CRYPT_METHOD_128BIT)
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "  client and server support high crypt, using "
-                      "high crypt");
+            LOG(LOG_LEVEL_INFO, "  client and server support high crypt, using "
+                "high crypt");
             self->crypt_method = CRYPT_METHOD_128BIT;
             self->crypt_level = CRYPT_LEVEL_HIGH;
             found = 1;
@@ -1819,8 +1819,8 @@ xrdp_sec_process_mcs_data_CS_SECURITY(struct xrdp_sec *self, struct stream *s)
     {
         if (crypt_method & CRYPT_METHOD_40BIT)
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "  client and server support medium crypt, using "
-                      "medium crypt");
+            LOG(LOG_LEVEL_INFO, "  client and server support medium crypt, using "
+                "medium crypt");
             self->crypt_method = CRYPT_METHOD_40BIT;
             self->crypt_level = CRYPT_LEVEL_CLIENT_COMPATIBLE;
             found = 1;
@@ -1832,8 +1832,8 @@ xrdp_sec_process_mcs_data_CS_SECURITY(struct xrdp_sec *self, struct stream *s)
     {
         if (crypt_method & CRYPT_METHOD_40BIT)
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "  client and server support low crypt, using "
-                      "low crypt");
+            LOG(LOG_LEVEL_INFO, "  client and server support low crypt, using "
+                "low crypt");
             self->crypt_method = CRYPT_METHOD_40BIT;
             self->crypt_level = CRYPT_LEVEL_LOW;
             found = 1;
@@ -1844,8 +1844,8 @@ xrdp_sec_process_mcs_data_CS_SECURITY(struct xrdp_sec *self, struct stream *s)
     {
         if (crypt_method == CRYPT_METHOD_NONE)
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "  client and server support none crypt, using "
-                      "none crypt");
+            LOG(LOG_LEVEL_INFO, "  client and server support none crypt, using "
+                "none crypt");
             self->crypt_method = CRYPT_METHOD_NONE;
             self->crypt_level = CRYPT_LEVEL_NONE;
             found = 1;
@@ -1947,16 +1947,16 @@ xrdp_sec_process_mcs_data_monitors(struct xrdp_sec *self, struct stream *s)
     //verify flags - must be 0x0
     if (flags != 0)
     {
-        LOG_DEVEL(LOG_LEVEL_INFO, "[ERROR] xrdp_sec_process_mcs_data_monitors: flags MUST be "
-                  "zero, detected: %d", flags);
+        LOG(LOG_LEVEL_ERROR, "[ERROR] xrdp_sec_process_mcs_data_monitors: flags MUST be "
+            "zero, detected: %d", flags);
         return 1;
     }
     in_uint32_le(s, monitorCount);
     //verify monitorCount - max 16
     if (monitorCount > 16)
     {
-        LOG_DEVEL(LOG_LEVEL_INFO, "[ERROR] xrdp_sec_process_mcs_data_monitors: max allowed "
-                  "monitors is 16, detected: %d", monitorCount);
+        LOG(LOG_LEVEL_ERROR, "[ERROR] xrdp_sec_process_mcs_data_monitors: max allowed "
+            "monitors is 16, detected: %d", monitorCount);
         return 1;
     }
 
@@ -2030,7 +2030,7 @@ xrdp_sec_process_mcs_data_monitors(struct xrdp_sec *self, struct stream *s)
     if (client_info->width > 0x7FFE || client_info->width < 0xC8 ||
             client_info->height > 0x7FFE || client_info->height < 0xC8)
     {
-        LOG_DEVEL(LOG_LEVEL_INFO, "[ERROR] xrdp_sec_process_mcs_data_monitors: error, virtual desktop width / height is too large");
+        LOG(LOG_LEVEL_ERROR, "[ERROR] xrdp_sec_process_mcs_data_monitors: error, virtual desktop width / height is too large");
         return 1; /* error */
     }
 
@@ -2076,8 +2076,8 @@ xrdp_sec_process_mcs_data(struct xrdp_sec *self)
 
         if ((size < 4) || (!s_check_rem(s, size - 4)))
         {
-            LOG_DEVEL(LOG_LEVEL_INFO, "error in xrdp_sec_process_mcs_data tag %d size %d",
-                      tag, size);
+            LOG(LOG_LEVEL_ERROR, "error in xrdp_sec_process_mcs_data tag %d size %d",
+                tag, size);
             break;
         }
 
@@ -2119,8 +2119,8 @@ xrdp_sec_process_mcs_data(struct xrdp_sec *self)
                SC_MCS_MSGCHANNEL 0x0C04
                SC_MULTITRANSPORT 0x0C08 */
             default:
-                LOG_DEVEL(LOG_LEVEL_INFO, "error unknown xrdp_sec_process_mcs_data "
-                          "tag 0x%4.4x size %d", tag, size);
+                LOG(LOG_LEVEL_ERROR, "error unknown xrdp_sec_process_mcs_data "
+                    "tag 0x%4.4x size %d", tag, size);
                 break;
         }
 
@@ -2132,10 +2132,10 @@ xrdp_sec_process_mcs_data(struct xrdp_sec *self)
         if (self->rdp_layer->client_info.bpp >
                 self->rdp_layer->client_info.max_bpp)
         {
-            LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_rdp_parse_client_mcs_data: client asked "
-                      "for %dbpp connection but configuration is limited "
-                      "to %dbpp", self->rdp_layer->client_info.bpp,
-                      self->rdp_layer->client_info.max_bpp);
+            LOG(LOG_LEVEL_INFO, "xrdp_rdp_parse_client_mcs_data: client asked "
+                "for %dbpp connection but configuration is limited "
+                "to %dbpp", self->rdp_layer->client_info.bpp,
+                self->rdp_layer->client_info.max_bpp);
             self->rdp_layer->client_info.bpp =
                 self->rdp_layer->client_info.max_bpp;
         }
@@ -2281,7 +2281,7 @@ xrdp_sec_incoming(struct xrdp_sec *self)
     /* negotiate security layer */
     if (xrdp_iso_incoming(iso) != 0)
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_incoming: xrdp_iso_incoming failed");
+        LOG(LOG_LEVEL_ERROR, "xrdp_sec_incoming: xrdp_iso_incoming failed");
         return 1;
     }
 

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -685,7 +685,6 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
     if ((flags & RDP_LOGON_NORMAL) != RDP_LOGON_NORMAL) /* 0x33 */
     {
         /* must be or error */
-        LOG(LOG_LEVEL_ERROR, "xrdp_sec_process_logon_info: flags wrong, major error");
         LOG(LOG_LEVEL_ERROR, "xrdp_sec_process_logon_info: flags wrong, likely decrypt "
             "not working");
         return 1;
@@ -1253,7 +1252,6 @@ xrdp_sec_recv(struct xrdp_sec *self, struct stream *s, int *chan)
     if (xrdp_mcs_recv(self->mcs_layer, s, chan) != 0)
     {
         LOG(LOG_LEVEL_ERROR, " out xrdp_sec_recv : error");
-        LOG(LOG_LEVEL_ERROR, "xrdp_sec_recv: xrdp_mcs_recv failed");
         return 1;
     }
 

--- a/libxrdp/xrdp_surface.c
+++ b/libxrdp/xrdp_surface.c
@@ -111,7 +111,7 @@ xrdp_surface_send_surface_bits(struct xrdp_surface *self, int bpp, char *data,
     }
     else
     {
-        g_writeln("bpp = %d is not supported\n", bpp);
+        LOG_DEVEL(LOG_LEVEL_TRACE, "bpp = %d is not supported\n", bpp);
         return 1;
     }
 

--- a/libxrdp/xrdp_surface.c
+++ b/libxrdp/xrdp_surface.c
@@ -111,7 +111,7 @@ xrdp_surface_send_surface_bits(struct xrdp_surface *self, int bpp, char *data,
     }
     else
     {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "bpp = %d is not supported\n", bpp);
+        LOG(LOG_LEVEL_ERROR, "bpp = %d is not supported\n", bpp);
         return 1;
     }
 


### PR DESCRIPTION
Follow-on pull request to #1633 which migrates all logging in the **libxrdp** directory to use the LOG() and LOG_DEVEL() macros.