### PR TITLE
sesman: address the issue of socket file leftovers

### DIFF
--- a/sesman/session.c
+++ b/sesman/session.c
@@ -820,6 +820,11 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
                 auth_end(data);
                 g_sigterm(display_pid);
                 g_sigterm(chansrv_pid);
+
+                /* make sure socket cleanup happen after child process exit */
+                g_waitpid(display_pid);
+                g_waitpid(chansrv_pid);
+
                 cleanup_sockets(display);
                 g_deinit();
                 g_exit(0);
@@ -1188,6 +1193,33 @@ cleanup_sockets(int display)
     }
 
     g_snprintf(file, 255, CHANSRV_API_STR, display);
+    if (g_file_exist(file))
+    {
+        LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
+        if (g_file_delete(file) == 0)
+        {
+            LOG(LOG_LEVEL_DEBUG,
+                "cleanup_sockets: failed to delete %s", file);
+            error++;
+        }
+    }
+
+    /* the following files should be deleted by xorgxrdp
+     * but just in case the deletion failed */
+
+    g_snprintf(file, 255, XRDP_X11RDP_STR, display);
+    if (g_file_exist(file))
+    {
+        LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
+        if (g_file_delete(file) == 0)
+        {
+            LOG(LOG_LEVEL_DEBUG,
+                "cleanup_sockets: failed to delete %s", file);
+            error++;
+        }
+    }
+
+    g_snprintf(file, 255, XRDP_DISCONNECT_STR, display);
     if (g_file_exist(file))
     {
         LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -1162,8 +1162,9 @@ cleanup_sockets(int display)
         LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
         if (g_file_delete(file) == 0)
         {
-            LOG(LOG_LEVEL_DEBUG,
-                "cleanup_sockets: failed to delete %s", file);
+            LOG(LOG_LEVEL_WARNING,
+                "cleanup_sockets: failed to delete %s (%s)",
+                file, g_get_strerror());
             error++;
         }
     }
@@ -1174,8 +1175,9 @@ cleanup_sockets(int display)
         LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
         if (g_file_delete(file) == 0)
         {
-            LOG(LOG_LEVEL_DEBUG,
-                "cleanup_sockets: failed to delete %s", file);
+            LOG(LOG_LEVEL_WARNING,
+                "cleanup_sockets: failed to delete %s (%s)",
+                file, g_get_strerror());
             error++;
         }
     }
@@ -1186,8 +1188,9 @@ cleanup_sockets(int display)
         LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
         if (g_file_delete(file) == 0)
         {
-            LOG(LOG_LEVEL_DEBUG,
-                "cleanup_sockets: failed to delete %s", file);
+            LOG(LOG_LEVEL_WARNING,
+                "cleanup_sockets: failed to delete %s (%s)",
+                file, g_get_strerror());
             error++;
         }
     }
@@ -1198,8 +1201,9 @@ cleanup_sockets(int display)
         LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
         if (g_file_delete(file) == 0)
         {
-            LOG(LOG_LEVEL_DEBUG,
-                "cleanup_sockets: failed to delete %s", file);
+            LOG(LOG_LEVEL_WARNING,
+                "cleanup_sockets: failed to delete %s (%s)",
+                file, g_get_strerror());
             error++;
         }
     }
@@ -1213,8 +1217,9 @@ cleanup_sockets(int display)
         LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
         if (g_file_delete(file) == 0)
         {
-            LOG(LOG_LEVEL_DEBUG,
-                "cleanup_sockets: failed to delete %s", file);
+            LOG(LOG_LEVEL_WARNING,
+                "cleanup_sockets: failed to delete %s (%s)",
+                file, g_get_strerror());
             error++;
         }
     }
@@ -1225,8 +1230,9 @@ cleanup_sockets(int display)
         LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
         if (g_file_delete(file) == 0)
         {
-            LOG(LOG_LEVEL_DEBUG,
-                "cleanup_sockets: failed to delete %s", file);
+            LOG(LOG_LEVEL_WARNING,
+                "cleanup_sockets: failed to delete %s (%s)",
+                file, g_get_strerror());
             error++;
         }
     }


### PR DESCRIPTION
There are two points.

Make sure cleanup files happen after chansrv and Xserver exit. If these
child processes lock socket files, the deletion might fail.

Usually, cleanup of xorgxrdp related socket files is handled by
xorgxrdp. Just in case it failed, perform cleanup also in sesman.

Fixes #1740. Thanks to @matt335672.

Sponsored by:   Cybertrust Japan
Sponsored by:   HAW International