### PR TITLE
Fix typo in sesman.ini man page

### DIFF
--- a/docs/man/sesman.ini.5.in
+++ b/docs/man/sesman.ini.5.in
@@ -33,7 +33,7 @@ X11 server settings for supported servers
 Settings for xrdp-chansrv(8)
 
 .TP
-\fB[Chansrv_Logging]\fR
+\fB[ChansrvLogging]\fR
 Logging settings for xrdp-chansrv(8)
 
 .TP


### PR DESCRIPTION
The ChansrvLogging section name was added and changed in #1633 but this documentation line was missed when renaming the section name.