### PR TITLE
Remove output on stdout by default on daemon startup

### DIFF
--- a/common/log.c
+++ b/common/log.c
@@ -304,7 +304,7 @@ internal_config_read_logging(int file,
     lc->console_level = LOG_LEVEL_INFO;
     lc->enable_syslog = 0;
     lc->syslog_level = LOG_LEVEL_INFO;
-    lc->dump_on_start = 1;
+    lc->dump_on_start = 0;
     lc->enable_pid = 0;
 
     g_snprintf(section_name, 511, "%s%s", section_prefix, SESMAN_CFG_LOGGING);
@@ -616,7 +616,6 @@ log_config_init_for_console(enum logLevels lvl, const char *override_name)
         {
             config->console_level = lvl;
         }
-        config->dump_on_start = 0; /* Don't need dump for console only */
     }
     return config;
 }
@@ -721,7 +720,8 @@ log_start_from_param(const struct log_config *src_log_config)
  * @return 0 on success
  */
 enum logReturns
-log_start(const char *iniFile, const char *applicationName)
+log_start(const char *iniFile, const char *applicationName,
+          bool_t dump_on_start)
 {
     enum logReturns ret = LOG_GENERAL_ERROR;
     struct log_config *config;
@@ -730,6 +730,7 @@ log_start(const char *iniFile, const char *applicationName)
 
     if (config != NULL)
     {
+        config->dump_on_start = dump_on_start;
         ret = log_start_from_param(config);
         log_config_free(config);
 

--- a/common/log.h
+++ b/common/log.h
@@ -263,11 +263,15 @@ internal_log_location_overrides_level(const char *function_name,
  * This function initialize the log facilities according to the configuration
  * file, that is described by the in parameter.
  * @param iniFile
- * @param applicationName, the name that is used in the log for the running application
+ * @param applicationName the name that is used in the log for the running
+ *                        application
+ * @param dump_on_start Whether to dump the config on stdout before
+ *                      logging is started
  * @return LOG_STARTUP_OK on success
  */
 enum logReturns
-log_start(const char *iniFile, const char *applicationName);
+log_start(const char *iniFile, const char *applicationName,
+          bool_t dump_on_start);
 
 /**
  * An alternative log_start where the caller gives the params directly.

--- a/docs/man/xrdp-sesman.8.in
+++ b/docs/man/xrdp-sesman.8.in
@@ -13,7 +13,7 @@ xrdp\-sesman \- \fBxrdp\fR(8) session manager
 \-\-version
 .br
 .B xrdp\-sesman
-[ \-\-nodaemon ] [ --config /path/to/sesman.ini ]
+[\-\-nodaemon] [\-\-dump\-config] [\-\-config /path/to/sesman.ini]
 
 .SH "DESCRIPTION"
 \fBxrdp\-sesman\fR is \fBxrdp\fR(8) session manager.
@@ -33,6 +33,10 @@ Output version information and exit.
 .TP
 \fB\-n\fR, \fB\-\-nodaemon\fR
 Starts \fBxrdp\-sesman\fR in foreground instead of starting it as a daemon.
+.TP
+\fB\-\-dump\-config\fR
+Print the configuration on stdout before starting the daemon.
+The default is not to do this.
 .TP
 \fB\-c\fR, \fB\-\-config\fR
 Specify a path to a different \fIsesman.ini\fR file. This option is intended

--- a/docs/man/xrdp.8.in
+++ b/docs/man/xrdp.8.in
@@ -13,7 +13,7 @@
 \-\-version
 .br
 .B xrdp
-[ \-\-nodaemon ] [ --port port ] [ --fork ] [ --config /path/to/xrdp.ini ]
+[\-\-nodaemon] [\-\-port port] [\-\-fork] [\-\-dump\-config] [\-\-config /path/to/xrdp.ini]
 
 .SH "DESCRIPTION"
 \fBxrdp\fR is a Remote Desktop Protocol (RDP) Server.
@@ -44,6 +44,10 @@ Specify TCP port to listen to. This overrides \fIport\fR setting in
 Fork a new process on a new connection. If not enabled, use a new thread
 for every connection. This overrides \fIfork\fR setting in
 \fIxrdp.ini\fR file.
+.TP
+\fB\-\-dump\-config\fR
+Print the configuration on stdout before starting the daemon.
+The default is not to do this.
 .TP
 \fB\-c\fR, \fB\-\-config\fR
 Specify a path to a different \fIxrdp.ini\fR file. This option is intended

--- a/sesman/sig.c
+++ b/sesman/sig.c
@@ -92,7 +92,7 @@ sig_sesman_reload_cfg(int sig)
     g_cfg = cfg;
 
     /* start again logging subsystem */
-    error = log_start(g_cfg->sesman_ini, "xrdp-sesman");
+    error = log_start(g_cfg->sesman_ini, "xrdp-sesman", 0);
 
     if (error != LOG_STARTUP_OK)
     {

--- a/xrdp/xrdp.c
+++ b/xrdp/xrdp.c
@@ -74,13 +74,14 @@ static void
 print_help(void)
 {
     g_writeln("Usage: xrdp [options]");
-    g_writeln("   -k, --kill       shut down xrdp");
-    g_writeln("   -h, --help       show help");
-    g_writeln("   -v, --version    show version");
-    g_writeln("   -n, --nodaemon   don't fork into background");
-    g_writeln("   -p, --port       tcp listen port");
-    g_writeln("   -f, --fork       fork on new connection");
-    g_writeln("   -c, --config     Specify new path to xrdp.ini");
+    g_writeln("   -k, --kill        shut down xrdp");
+    g_writeln("   -h, --help        show help");
+    g_writeln("   -v, --version     show version");
+    g_writeln("   -n, --nodaemon    don't fork into background");
+    g_writeln("   -p, --port        tcp listen port");
+    g_writeln("   -f, --fork        fork on new connection");
+    g_writeln("   -c, --config      specify new path to xrdp.ini");
+    g_writeln("       --dump-config display config on stdout on startup");
 }
 
 /*****************************************************************************/
@@ -361,6 +362,10 @@ xrdp_process_params(int argc, char **argv,
             startup_params->fork = 1;
             g_writeln("--fork parameter found, ini override");
         }
+        else if (nocase_matches(option, "--dump-config", NULL))
+        {
+            startup_params->dump_config = 1;
+        }
         else if (nocase_matches(option, "-c", "--config", NULL))
         {
             index++;
@@ -536,7 +541,8 @@ main(int argc, char **argv)
     }
 
     /* starting logging subsystem */
-    error = log_start(startup_params.xrdp_ini, "xrdp");
+    error = log_start(startup_params.xrdp_ini, "xrdp",
+                      startup_params.dump_config);
 
     if (error != LOG_STARTUP_OK)
     {

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -539,6 +539,7 @@ struct xrdp_startup_params
   int help;
   int version;
   int fork;
+  int dump_config;
   int tcp_send_buffer_bytes;
   int tcp_recv_buffer_bytes;
   int tcp_nodelay;


### PR DESCRIPTION
Here's an initial stab at removing the logging output on stdout by default (see #1762)

It's largely what I suggested in #1762, but :-
- It was easier to retain the `dump_on_start` member and just add a parameter to `log_start()`
- I've also included the config dump which is done by sesman.
- I've also removed an `xrdp-sesman` message "starting sesman in foreground..."

Both `xrdp` and `xrdp-sesman` take a `--log-config` argument which results in the old behaviour.