### PR TITLE
Unify logging in xrdp/*

### DIFF
--- a/xrdp/lang.c
+++ b/xrdp/lang.c
@@ -244,7 +244,7 @@ get_keymaps(int keylayout, struct xrdp_keymap *keymap)
     /* if the file does not exist, use only lower 16 bits instead */
     if (!g_file_exist(filename))
     {
-        log_message(LOG_LEVEL_INFO, "Cannot find keymap file %s", filename);
+        LOG(LOG_LEVEL_WARNING, "Cannot find keymap file %s", filename);
         /* e.g. km-00000411.ini */
         g_snprintf(filename, 255, "%s/km-%08x.ini", XRDP_CFG_PATH, basic_key_layout);
     }
@@ -252,14 +252,14 @@ get_keymaps(int keylayout, struct xrdp_keymap *keymap)
     /* finally, use 'en-us' */
     if (!g_file_exist(filename))
     {
-        log_message(LOG_LEVEL_INFO, "Cannot find keymap file %s", filename);
+        LOG(LOG_LEVEL_WARNING, "Cannot find keymap file %s", filename);
         g_snprintf(filename, 255, "%s/km-00000409.ini", XRDP_CFG_PATH);
     }
 
     if (g_file_exist(filename))
     {
         fd = g_file_open(filename);
-        log_message(LOG_LEVEL_INFO, "Loading keymap file %s", filename);
+        LOG(LOG_LEVEL_INFO, "Loading keymap file %s", filename);
 
         if (fd != -1)
         {
@@ -280,9 +280,9 @@ get_keymaps(int keylayout, struct xrdp_keymap *keymap)
 
             if (g_memcmp(lkeymap, keymap, sizeof(struct xrdp_keymap)) != 0)
             {
-                log_message(LOG_LEVEL_WARNING,
-                            "local keymap file for 0x%08x found and doesn't match "
-                            "built in keymap, using local keymap file", keylayout);
+                LOG(LOG_LEVEL_WARNING,
+                    "local keymap file for 0x%08x found and doesn't match "
+                    "built in keymap, using local keymap file", keylayout);
             }
 
             g_free(lkeymap);
@@ -291,7 +291,7 @@ get_keymaps(int keylayout, struct xrdp_keymap *keymap)
     }
     else
     {
-        log_message(LOG_LEVEL_WARNING, "File does not exist: %s", filename);
+        LOG(LOG_LEVEL_WARNING, "File does not exist: %s", filename);
     }
 
     g_free(filename);

--- a/xrdp/lang.c
+++ b/xrdp/lang.c
@@ -108,7 +108,7 @@ get_key_info_from_scan_code(int device_flags, int scan_code, int *keys,
     {
         rv = &(keymap->keys_shiftaltgr[index]);
     }
-     else if (shift)
+    else if (shift)
     {
         rv = &(keymap->keys_shift[index]);
     }

--- a/xrdp/xrdp.c
+++ b/xrdp/xrdp.c
@@ -548,20 +548,20 @@ main(int argc, char **argv)
     {
         switch (error)
         {
-        case LOG_ERROR_MALLOC:
-            g_writeln("error on malloc. cannot start logging. quitting.");
-            break;
-        case LOG_ERROR_FILE_OPEN:
-            g_writeln("error opening log file [%s]. quitting.",
-                      getLogFile(text, 255));
-            break;
-        case LOG_ERROR_NO_CFG:
-            g_writeln("config file %s unreadable or missing",
-                      startup_params.xrdp_ini);
-            break;
-        default:
-            g_writeln("log_start error");
-            break;
+            case LOG_ERROR_MALLOC:
+                g_writeln("error on malloc. cannot start logging. quitting.");
+                break;
+            case LOG_ERROR_FILE_OPEN:
+                g_writeln("error opening log file [%s]. quitting.",
+                          getLogFile(text, 255));
+                break;
+            case LOG_ERROR_NO_CFG:
+                g_writeln("config file %s unreadable or missing",
+                          startup_params.xrdp_ini);
+                break;
+            default:
+                g_writeln("log_start error");
+                break;
         }
 
         g_deinit();

--- a/xrdp/xrdp.c
+++ b/xrdp/xrdp.c
@@ -102,7 +102,7 @@ g_xrdp_sync(long (*sync_func)(long param1, long param2), long sync_param1,
         /* this is the main thread, call the function directly */
         /* in fork mode, this always happens too */
         sync_result = sync_func(sync_param1, sync_param2);
-        /*g_writeln("g_xrdp_sync processed IN main thread -> continue");*/
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "g_xrdp_sync processed IN main thread -> continue");
     }
     else
     {
@@ -133,10 +133,9 @@ g_xrdp_sync(long (*sync_func)(long param1, long param2), long sync_param1,
             tc_mutex_unlock(g_sync_mutex);
         }
         while (sync_command != 0); /* loop until g_process_waiting_function()
-
                                 * has processed the request */
         tc_mutex_unlock(g_sync1_mutex);
-        /*g_writeln("g_xrdp_sync processed BY main thread -> continue");*/
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "g_xrdp_sync processed BY main thread -> continue");
     }
 
     return sync_result;
@@ -149,8 +148,8 @@ xrdp_shutdown(int sig)
     tbus threadid;
 
     threadid = tc_get_threadid();
-    g_writeln("shutting down");
-    g_writeln("signal %d threadid %lld", sig, (long long)threadid);
+    LOG(LOG_LEVEL_INFO, "shutting down");
+    LOG(LOG_LEVEL_INFO, "signal %d threadid %lld", sig, (long long)threadid);
 
     if (!g_is_wait_obj_set(g_term_event))
     {
@@ -173,7 +172,7 @@ xrdp_child(int sig)
 static void
 xrdp_hang_up(int sig)
 {
-    log_message(LOG_LEVEL_INFO, "caught SIGHUP, noop...");
+    LOG(LOG_LEVEL_INFO, "caught SIGHUP, noop...");
 }
 
 /*****************************************************************************/
@@ -235,7 +234,7 @@ static void
 pipe_sig(int sig_num)
 {
     /* do nothing */
-    g_writeln("got XRDP SIGPIPE(%d)", sig_num);
+    LOG(LOG_LEVEL_INFO, "got XRDP SIGPIPE(%d)", sig_num);
 }
 
 /*****************************************************************************/
@@ -613,8 +612,8 @@ main(int argc, char **argv)
         /* if can't listen, exit with failure status */
         if (xrdp_listen_test(&startup_params) != 0)
         {
-            log_message(LOG_LEVEL_ERROR, "Failed to start xrdp daemon, "
-                        "possibly address already in use.");
+            LOG(LOG_LEVEL_ERROR, "Failed to start xrdp daemon, "
+                "possibly address already in use.");
             g_deinit();
             /* must exit with failure status,
                or systemd cannot detect xrdp daemon couldn't start properly */
@@ -686,13 +685,13 @@ main(int argc, char **argv)
     g_sync_mutex = tc_mutex_create();
     g_sync1_mutex = tc_mutex_create();
     pid = g_getpid();
-    log_message(LOG_LEVEL_INFO, "starting xrdp with pid %d", pid);
+    LOG(LOG_LEVEL_INFO, "starting xrdp with pid %d", pid);
     g_snprintf(text, 255, "xrdp_%8.8x_main_term", pid);
     g_term_event = g_create_wait_obj(text);
 
     if (g_term_event == 0)
     {
-        g_writeln("error creating g_term_event");
+        LOG(LOG_LEVEL_WARNING, "error creating g_term_event");
     }
 
     g_snprintf(text, 255, "xrdp_%8.8x_main_sync", pid);
@@ -700,7 +699,7 @@ main(int argc, char **argv)
 
     if (g_sync_event == 0)
     {
-        g_writeln("error creating g_sync_event");
+        LOG(LOG_LEVEL_WARNING, "error creating g_sync_event");
     }
 
     g_listen->startup_params = &startup_params;

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -53,84 +53,84 @@ void
 g_process_waiting_function(void);
 
 /* xrdp_cache.c */
-struct xrdp_cache*
-xrdp_cache_create(struct xrdp_wm* owner, struct xrdp_session* session,
-                  struct xrdp_client_info* client_info);
+struct xrdp_cache *
+xrdp_cache_create(struct xrdp_wm *owner, struct xrdp_session *session,
+                  struct xrdp_client_info *client_info);
 void
-xrdp_cache_delete(struct xrdp_cache* self);
+xrdp_cache_delete(struct xrdp_cache *self);
 int
-xrdp_cache_reset(struct xrdp_cache* self,
-                 struct xrdp_client_info* client_info);
+xrdp_cache_reset(struct xrdp_cache *self,
+                 struct xrdp_client_info *client_info);
 int
-xrdp_cache_add_bitmap(struct xrdp_cache* self, struct xrdp_bitmap* bitmap,
+xrdp_cache_add_bitmap(struct xrdp_cache *self, struct xrdp_bitmap *bitmap,
                       int hints);
 int
-xrdp_cache_add_palette(struct xrdp_cache* self, int* palette);
+xrdp_cache_add_palette(struct xrdp_cache *self, int *palette);
 int
-xrdp_cache_add_char(struct xrdp_cache* self,
-                    struct xrdp_font_char* font_item);
+xrdp_cache_add_char(struct xrdp_cache *self,
+                    struct xrdp_font_char *font_item);
 int
-xrdp_cache_add_pointer(struct xrdp_cache* self,
-                       struct xrdp_pointer_item* pointer_item);
+xrdp_cache_add_pointer(struct xrdp_cache *self,
+                       struct xrdp_pointer_item *pointer_item);
 int
-xrdp_cache_add_pointer_static(struct xrdp_cache* self,
-                              struct xrdp_pointer_item* pointer_item,
+xrdp_cache_add_pointer_static(struct xrdp_cache *self,
+                              struct xrdp_pointer_item *pointer_item,
                               int index);
 int
-xrdp_cache_add_brush(struct xrdp_cache* self,
-                     char* brush_item_data);
+xrdp_cache_add_brush(struct xrdp_cache *self,
+                     char *brush_item_data);
 int
-xrdp_cache_add_os_bitmap(struct xrdp_cache* self, struct xrdp_bitmap* bitmap,
+xrdp_cache_add_os_bitmap(struct xrdp_cache *self, struct xrdp_bitmap *bitmap,
                          int rdpindex);
 int
-xrdp_cache_remove_os_bitmap(struct xrdp_cache* self, int rdpindex);
-struct xrdp_os_bitmap_item*
-xrdp_cache_get_os_bitmap(struct xrdp_cache* self, int rdpindex);
+xrdp_cache_remove_os_bitmap(struct xrdp_cache *self, int rdpindex);
+struct xrdp_os_bitmap_item *
+xrdp_cache_get_os_bitmap(struct xrdp_cache *self, int rdpindex);
 
 /* xrdp_wm.c */
-struct xrdp_wm*
-xrdp_wm_create(struct xrdp_process* owner,
-               struct xrdp_client_info* client_info);
+struct xrdp_wm *
+xrdp_wm_create(struct xrdp_process *owner,
+               struct xrdp_client_info *client_info);
 void
-xrdp_wm_delete(struct xrdp_wm* self);
+xrdp_wm_delete(struct xrdp_wm *self);
 int
-xrdp_wm_send_palette(struct xrdp_wm* self);
+xrdp_wm_send_palette(struct xrdp_wm *self);
 int
-xrdp_wm_send_bell(struct xrdp_wm* self);
+xrdp_wm_send_bell(struct xrdp_wm *self);
 int
-xrdp_wm_load_static_colors_plus(struct xrdp_wm* self, char* autorun_name);
+xrdp_wm_load_static_colors_plus(struct xrdp_wm *self, char *autorun_name);
 int
-xrdp_wm_load_static_pointers(struct xrdp_wm* self);
+xrdp_wm_load_static_pointers(struct xrdp_wm *self);
 int
-xrdp_wm_init(struct xrdp_wm* self);
+xrdp_wm_init(struct xrdp_wm *self);
 int
-xrdp_wm_send_bitmap(struct xrdp_wm* self, struct xrdp_bitmap* bitmap,
+xrdp_wm_send_bitmap(struct xrdp_wm *self, struct xrdp_bitmap *bitmap,
                     int x, int y, int cx, int cy);
 int
-xrdp_wm_set_pointer(struct xrdp_wm* self, int cache_idx);
+xrdp_wm_set_pointer(struct xrdp_wm *self, int cache_idx);
 unsigned int
 xrdp_wm_htoi (const char *ptr);
 int
-xrdp_wm_set_focused(struct xrdp_wm* self, struct xrdp_bitmap* wnd);
+xrdp_wm_set_focused(struct xrdp_wm *self, struct xrdp_bitmap *wnd);
 int
-xrdp_wm_get_vis_region(struct xrdp_wm* self, struct xrdp_bitmap* bitmap,
+xrdp_wm_get_vis_region(struct xrdp_wm *self, struct xrdp_bitmap *bitmap,
                        int x, int y, int cx, int cy,
-                       struct xrdp_region* region, int clip_children);
+                       struct xrdp_region *region, int clip_children);
 int
-xrdp_wm_mouse_move(struct xrdp_wm* self, int x, int y);
+xrdp_wm_mouse_move(struct xrdp_wm *self, int x, int y);
 int
-xrdp_wm_mouse_click(struct xrdp_wm* self, int x, int y, int but, int down);
+xrdp_wm_mouse_click(struct xrdp_wm *self, int x, int y, int but, int down);
 int
-xrdp_wm_key(struct xrdp_wm* self, int device_flags, int scan_code);
+xrdp_wm_key(struct xrdp_wm *self, int device_flags, int scan_code);
 int
-xrdp_wm_key_sync(struct xrdp_wm* self, int device_flags, int key_flags);
+xrdp_wm_key_sync(struct xrdp_wm *self, int device_flags, int key_flags);
 int
-xrdp_wm_pu(struct xrdp_wm* self, struct xrdp_bitmap* control);
+xrdp_wm_pu(struct xrdp_wm *self, struct xrdp_bitmap *control);
 int
-xrdp_wm_send_pointer(struct xrdp_wm* self, int cache_idx,
-                     char* data, char* mask, int x, int y, int bpp);
+xrdp_wm_send_pointer(struct xrdp_wm *self, int cache_idx,
+                     char *data, char *mask, int x, int y, int bpp);
 int
-xrdp_wm_pointer(struct xrdp_wm* self, char* data, char* mask, int x, int y,
+xrdp_wm_pointer(struct xrdp_wm *self, char *data, char *mask, int x, int y,
                 int bpp);
 int
 callback(intptr_t id, int msg, intptr_t param1, intptr_t param2,
@@ -138,388 +138,388 @@ callback(intptr_t id, int msg, intptr_t param1, intptr_t param2,
 int
 xrdp_wm_drdynvc_up(intptr_t id);
 int
-xrdp_wm_delete_all_children(struct xrdp_wm* self);
+xrdp_wm_delete_all_children(struct xrdp_wm *self);
 int
 xrdp_wm_show_log(struct xrdp_wm *self);
 int
 xrdp_wm_log_msg(struct xrdp_wm *self, enum logLevels loglevel,
                 const char *fmt, ...) printflike(3, 4);
 int
-xrdp_wm_get_wait_objs(struct xrdp_wm* self, tbus* robjs, int* rc,
-                      tbus* wobjs, int* wc, int* timeout);
+xrdp_wm_get_wait_objs(struct xrdp_wm *self, tbus *robjs, int *rc,
+                      tbus *wobjs, int *wc, int *timeout);
 int
-xrdp_wm_check_wait_objs(struct xrdp_wm* self);
+xrdp_wm_check_wait_objs(struct xrdp_wm *self);
 int
-xrdp_wm_set_login_state(struct xrdp_wm* self, enum wm_login_state login_state);
+xrdp_wm_set_login_state(struct xrdp_wm *self, enum wm_login_state login_state);
 
 /* xrdp_process.c */
-struct xrdp_process*
-xrdp_process_create(struct xrdp_listen* owner, tbus done_event);
+struct xrdp_process *
+xrdp_process_create(struct xrdp_listen *owner, tbus done_event);
 void
-xrdp_process_delete(struct xrdp_process* self);
+xrdp_process_delete(struct xrdp_process *self);
 int
-xrdp_process_main_loop(struct xrdp_process* self);
+xrdp_process_main_loop(struct xrdp_process *self);
 
 /* xrdp_listen.c */
-struct xrdp_listen*
+struct xrdp_listen *
 xrdp_listen_create(void);
 void
-xrdp_listen_delete(struct xrdp_listen* self);
+xrdp_listen_delete(struct xrdp_listen *self);
 int
-xrdp_listen_main_loop(struct xrdp_listen* self);
+xrdp_listen_main_loop(struct xrdp_listen *self);
 int
 xrdp_listen_test(struct xrdp_startup_params *startup_params);
 
 /* xrdp_region.c */
-struct xrdp_region*
-xrdp_region_create(struct xrdp_wm* wm);
+struct xrdp_region *
+xrdp_region_create(struct xrdp_wm *wm);
 void
-xrdp_region_delete(struct xrdp_region* self);
+xrdp_region_delete(struct xrdp_region *self);
 int
-xrdp_region_add_rect(struct xrdp_region* self, struct xrdp_rect* rect);
+xrdp_region_add_rect(struct xrdp_region *self, struct xrdp_rect *rect);
 int
-xrdp_region_subtract_rect(struct xrdp_region* self, struct xrdp_rect* rect);
+xrdp_region_subtract_rect(struct xrdp_region *self, struct xrdp_rect *rect);
 int
-xrdp_region_intersect_rect(struct xrdp_region* self, struct xrdp_rect* rect);
+xrdp_region_intersect_rect(struct xrdp_region *self, struct xrdp_rect *rect);
 int
-xrdp_region_get_rect(struct xrdp_region* self, int index,
-                     struct xrdp_rect* rect);
+xrdp_region_get_rect(struct xrdp_region *self, int index,
+                     struct xrdp_rect *rect);
 
 /* xrdp_bitmap.c */
-struct xrdp_bitmap*
+struct xrdp_bitmap *
 xrdp_bitmap_create(int width, int height, int bpp,
-                   int type, struct xrdp_wm* wm);
-struct xrdp_bitmap*
+                   int type, struct xrdp_wm *wm);
+struct xrdp_bitmap *
 xrdp_bitmap_create_with_data(int width, int height,
-                             int bpp, char* data,
-                             struct xrdp_wm* wm);
+                             int bpp, char *data,
+                             struct xrdp_wm *wm);
 void
-xrdp_bitmap_delete(struct xrdp_bitmap* self);
-struct xrdp_bitmap*
-xrdp_bitmap_get_child_by_id(struct xrdp_bitmap* self, int id);
+xrdp_bitmap_delete(struct xrdp_bitmap *self);
+struct xrdp_bitmap *
+xrdp_bitmap_get_child_by_id(struct xrdp_bitmap *self, int id);
 int
-xrdp_bitmap_set_focus(struct xrdp_bitmap* self, int focused);
+xrdp_bitmap_set_focus(struct xrdp_bitmap *self, int focused);
 int
-xrdp_bitmap_resize(struct xrdp_bitmap* self, int width, int height);
+xrdp_bitmap_resize(struct xrdp_bitmap *self, int width, int height);
 int
-xrdp_bitmap_load(struct xrdp_bitmap* self, const char* filename, int* palette);
+xrdp_bitmap_load(struct xrdp_bitmap *self, const char *filename, int *palette);
 int
-xrdp_bitmap_get_pixel(struct xrdp_bitmap* self, int x, int y);
+xrdp_bitmap_get_pixel(struct xrdp_bitmap *self, int x, int y);
 int
-xrdp_bitmap_set_pixel(struct xrdp_bitmap* self, int x, int y, int pixel);
+xrdp_bitmap_set_pixel(struct xrdp_bitmap *self, int x, int y, int pixel);
 int
-xrdp_bitmap_copy_box(struct xrdp_bitmap* self,
-                     struct xrdp_bitmap* dest,
+xrdp_bitmap_copy_box(struct xrdp_bitmap *self,
+                     struct xrdp_bitmap *dest,
                      int x, int y, int cx, int cy);
 int
 xrdp_bitmap_hash_crc(struct xrdp_bitmap *self);
 int
-xrdp_bitmap_copy_box_with_crc(struct xrdp_bitmap* self,
-                              struct xrdp_bitmap* dest,
+xrdp_bitmap_copy_box_with_crc(struct xrdp_bitmap *self,
+                              struct xrdp_bitmap *dest,
                               int x, int y, int cx, int cy);
 int
-xrdp_bitmap_compare(struct xrdp_bitmap* self,
-                    struct xrdp_bitmap* b);
+xrdp_bitmap_compare(struct xrdp_bitmap *self,
+                    struct xrdp_bitmap *b);
 int
-xrdp_bitmap_invalidate(struct xrdp_bitmap* self, struct xrdp_rect* rect);
+xrdp_bitmap_invalidate(struct xrdp_bitmap *self, struct xrdp_rect *rect);
 int
-xrdp_bitmap_def_proc(struct xrdp_bitmap* self, int msg,
+xrdp_bitmap_def_proc(struct xrdp_bitmap *self, int msg,
                      int param1, int param2);
 int
-xrdp_bitmap_to_screenx(struct xrdp_bitmap* self, int x);
+xrdp_bitmap_to_screenx(struct xrdp_bitmap *self, int x);
 int
-xrdp_bitmap_to_screeny(struct xrdp_bitmap* self, int y);
+xrdp_bitmap_to_screeny(struct xrdp_bitmap *self, int y);
 int
-xrdp_bitmap_from_screenx(struct xrdp_bitmap* self, int x);
+xrdp_bitmap_from_screenx(struct xrdp_bitmap *self, int x);
 int
-xrdp_bitmap_from_screeny(struct xrdp_bitmap* self, int y);
+xrdp_bitmap_from_screeny(struct xrdp_bitmap *self, int y);
 int
-xrdp_bitmap_get_screen_clip(struct xrdp_bitmap* self,
-                            struct xrdp_painter* painter,
-                            struct xrdp_rect* rect,
-                            int* dx, int* dy);
+xrdp_bitmap_get_screen_clip(struct xrdp_bitmap *self,
+                            struct xrdp_painter *painter,
+                            struct xrdp_rect *rect,
+                            int *dx, int *dy);
 
 /* xrdp_painter.c */
-struct xrdp_painter*
-xrdp_painter_create(struct xrdp_wm* wm, struct xrdp_session* session);
+struct xrdp_painter *
+xrdp_painter_create(struct xrdp_wm *wm, struct xrdp_session *session);
 void
-xrdp_painter_delete(struct xrdp_painter* self);
+xrdp_painter_delete(struct xrdp_painter *self);
 int
-wm_painter_set_target(struct xrdp_painter* self);
+wm_painter_set_target(struct xrdp_painter *self);
 int
-xrdp_painter_begin_update(struct xrdp_painter* self);
+xrdp_painter_begin_update(struct xrdp_painter *self);
 int
-xrdp_painter_end_update(struct xrdp_painter* self);
+xrdp_painter_end_update(struct xrdp_painter *self);
 int
-xrdp_painter_font_needed(struct xrdp_painter* self);
+xrdp_painter_font_needed(struct xrdp_painter *self);
 int
-xrdp_painter_set_clip(struct xrdp_painter* self,
+xrdp_painter_set_clip(struct xrdp_painter *self,
                       int x, int y, int cx, int cy);
 int
-xrdp_painter_clr_clip(struct xrdp_painter* self);
+xrdp_painter_clr_clip(struct xrdp_painter *self);
 int
-xrdp_painter_fill_rect(struct xrdp_painter* self,
-                       struct xrdp_bitmap* bitmap,
+xrdp_painter_fill_rect(struct xrdp_painter *self,
+                       struct xrdp_bitmap *bitmap,
                        int x, int y, int cx, int cy);
 int
-xrdp_painter_draw_bitmap(struct xrdp_painter* self,
-                         struct xrdp_bitmap* bitmap,
-                         struct xrdp_bitmap* to_draw,
+xrdp_painter_draw_bitmap(struct xrdp_painter *self,
+                         struct xrdp_bitmap *bitmap,
+                         struct xrdp_bitmap *to_draw,
                          int x, int y, int cx, int cy);
 int
-xrdp_painter_text_width(struct xrdp_painter* self, const char *text);
+xrdp_painter_text_width(struct xrdp_painter *self, const char *text);
 int
-xrdp_painter_text_height(struct xrdp_painter* self, const char *text);
+xrdp_painter_text_height(struct xrdp_painter *self, const char *text);
 int
-xrdp_painter_draw_text(struct xrdp_painter* self,
-                       struct xrdp_bitmap* bitmap,
-                       int x, int y, const char* text);
+xrdp_painter_draw_text(struct xrdp_painter *self,
+                       struct xrdp_bitmap *bitmap,
+                       int x, int y, const char *text);
 int
-xrdp_painter_draw_text2(struct xrdp_painter* self,
-                        struct xrdp_bitmap* bitmap,
+xrdp_painter_draw_text2(struct xrdp_painter *self,
+                        struct xrdp_bitmap *bitmap,
                         int font, int flags, int mixmode,
                         int clip_left, int clip_top,
                         int clip_right, int clip_bottom,
                         int box_left, int box_top,
                         int box_right, int box_bottom,
-                        int x, int y, char* data, int data_len);
+                        int x, int y, char *data, int data_len);
 int
-xrdp_painter_copy(struct xrdp_painter* self,
-                  struct xrdp_bitmap* src,
-                  struct xrdp_bitmap* dst,
+xrdp_painter_copy(struct xrdp_painter *self,
+                  struct xrdp_bitmap *src,
+                  struct xrdp_bitmap *dst,
                   int x, int y, int cx, int cy,
                   int srcx, int srcy);
 int
-xrdp_painter_composite(struct xrdp_painter* self,
-                       struct xrdp_bitmap* src,
+xrdp_painter_composite(struct xrdp_painter *self,
+                       struct xrdp_bitmap *src,
                        int srcformat,
                        int srcwidth,
                        int srcrepeat,
-                       struct xrdp_bitmap* dst,
-                       int* srctransform,
+                       struct xrdp_bitmap *dst,
+                       int *srctransform,
                        int mskflags,
-                       struct xrdp_bitmap* msk,
+                       struct xrdp_bitmap *msk,
                        int mskformat, int mskwidth, int mskrepeat, int op,
                        int srcx, int srcy, int mskx, int msky,
                        int dstx, int dsty, int width, int height,
                        int dstformat);
 int
-xrdp_painter_line(struct xrdp_painter* self,
-                  struct xrdp_bitmap* bitmap,
+xrdp_painter_line(struct xrdp_painter *self,
+                  struct xrdp_bitmap *bitmap,
                   int x1, int y1, int x2, int y2);
 
 /* xrdp_font.c */
-struct xrdp_font*
-xrdp_font_create(struct xrdp_wm* wm);
+struct xrdp_font *
+xrdp_font_create(struct xrdp_wm *wm);
 void
-xrdp_font_delete(struct xrdp_font* self);
+xrdp_font_delete(struct xrdp_font *self);
 int
-xrdp_font_item_compare(struct xrdp_font_char* font1,
-                       struct xrdp_font_char* font2);
+xrdp_font_item_compare(struct xrdp_font_char *font1,
+                       struct xrdp_font_char *font2);
 
 /* funcs.c */
 int
-rect_contains_pt(struct xrdp_rect* in, int x, int y);
+rect_contains_pt(struct xrdp_rect *in, int x, int y);
 int
-rect_intersect(struct xrdp_rect* in1, struct xrdp_rect* in2,
-               struct xrdp_rect* out);
+rect_intersect(struct xrdp_rect *in1, struct xrdp_rect *in2,
+               struct xrdp_rect *out);
 int
-rect_contained_by(struct xrdp_rect* in1, int left, int top,
+rect_contained_by(struct xrdp_rect *in1, int left, int top,
                   int right, int bottom);
 int
-check_bounds(struct xrdp_bitmap* b, int* x, int* y, int* cx, int* cy);
+check_bounds(struct xrdp_bitmap *b, int *x, int *y, int *cx, int *cy);
 int
-add_char_at(char* text, int text_size, twchar ch, int index);
+add_char_at(char *text, int text_size, twchar ch, int index);
 int
-remove_char_at(char* text, int text_size, int index);
+remove_char_at(char *text, int text_size, int index);
 int
-set_string(char** in_str, const char* in);
+set_string(char **in_str, const char *in);
 int
-wchar_repeat(twchar* dest, int dest_size_in_wchars, twchar ch, int repeat);
+wchar_repeat(twchar *dest, int dest_size_in_wchars, twchar ch, int repeat);
 
 /* in lang.c */
-struct xrdp_key_info*
-get_key_info_from_scan_code(int device_flags, int scan_code, int* keys,
+struct xrdp_key_info *
+get_key_info_from_scan_code(int device_flags, int scan_code, int *keys,
                             int caps_lock, int num_lock, int scroll_lock,
-                            struct xrdp_keymap* keymap);
+                            struct xrdp_keymap *keymap);
 int
-get_keysym_from_scan_code(int device_flags, int scan_code, int* keys,
+get_keysym_from_scan_code(int device_flags, int scan_code, int *keys,
                           int caps_lock, int num_lock, int scroll_lock,
-                          struct xrdp_keymap* keymap);
+                          struct xrdp_keymap *keymap);
 twchar
-get_char_from_scan_code(int device_flags, int scan_code, int* keys,
+get_char_from_scan_code(int device_flags, int scan_code, int *keys,
                         int caps_lock, int num_lock, int scroll_lock,
-                        struct xrdp_keymap* keymap);
+                        struct xrdp_keymap *keymap);
 int
-get_keymaps(int keylayout, struct xrdp_keymap* keymap);
+get_keymaps(int keylayout, struct xrdp_keymap *keymap);
 
 /* xrdp_login_wnd.c */
 int
-xrdp_login_wnd_create(struct xrdp_wm* self);
+xrdp_login_wnd_create(struct xrdp_wm *self);
 int
 load_xrdp_config(struct xrdp_config *config, const char *xrdp_ini, int bpp);
 
 /* xrdp_bitmap_compress.c */
 int
-xrdp_bitmap_compress(char* in_data, int width, int height,
-                     struct stream* s, int bpp, int byte_limit,
-                     int start_line, struct stream* temp,
+xrdp_bitmap_compress(char *in_data, int width, int height,
+                     struct stream *s, int bpp, int byte_limit,
+                     int start_line, struct stream *temp,
                      int e);
 
 /* xrdp_mm.c */
 int
-xrdp_mm_drdynvc_up(struct xrdp_mm* self);
+xrdp_mm_drdynvc_up(struct xrdp_mm *self);
 int
-xrdp_mm_suppress_output(struct xrdp_mm* self, int suppress,
+xrdp_mm_suppress_output(struct xrdp_mm *self, int suppress,
                         int left, int top, int right, int bottom);
-struct xrdp_mm*
-xrdp_mm_create(struct xrdp_wm* owner);
+struct xrdp_mm *
+xrdp_mm_create(struct xrdp_wm *owner);
 void
-xrdp_mm_delete(struct xrdp_mm* self);
+xrdp_mm_delete(struct xrdp_mm *self);
 int
-xrdp_mm_connect(struct xrdp_mm* self);
+xrdp_mm_connect(struct xrdp_mm *self);
 int
-xrdp_mm_process_channel_data(struct xrdp_mm* self, tbus param1, tbus param2,
+xrdp_mm_process_channel_data(struct xrdp_mm *self, tbus param1, tbus param2,
                              tbus param3, tbus param4);
 int
-xrdp_mm_get_wait_objs(struct xrdp_mm* self,
-                      tbus* read_objs, int* rcount,
-                      tbus* write_objs, int* wcount, int* timeout);
+xrdp_mm_get_wait_objs(struct xrdp_mm *self,
+                      tbus *read_objs, int *rcount,
+                      tbus *write_objs, int *wcount, int *timeout);
 int
 xrdp_mm_check_chan(struct xrdp_mm *self);
 int
-xrdp_mm_check_wait_objs(struct xrdp_mm* self);
+xrdp_mm_check_wait_objs(struct xrdp_mm *self);
 int
 xrdp_mm_frame_ack(struct xrdp_mm *self, int frame_id);
 int
-server_begin_update(struct xrdp_mod* mod);
+server_begin_update(struct xrdp_mod *mod);
 int
-server_end_update(struct xrdp_mod* mod);
+server_end_update(struct xrdp_mod *mod);
 int
-server_bell_trigger(struct xrdp_mod* mod);
+server_bell_trigger(struct xrdp_mod *mod);
 int
-server_fill_rect(struct xrdp_mod* mod, int x, int y, int cx, int cy);
+server_fill_rect(struct xrdp_mod *mod, int x, int y, int cx, int cy);
 int
-server_screen_blt(struct xrdp_mod* mod, int x, int y, int cx, int cy,
+server_screen_blt(struct xrdp_mod *mod, int x, int y, int cx, int cy,
                   int srcx, int srcy);
 int
-server_paint_rect(struct xrdp_mod* mod, int x, int y, int cx, int cy,
-                  char* data, int width, int height, int srcx, int srcy);
+server_paint_rect(struct xrdp_mod *mod, int x, int y, int cx, int cy,
+                  char *data, int width, int height, int srcx, int srcy);
 int
-server_paint_rect_bpp(struct xrdp_mod* mod, int x, int y, int cx, int cy,
-                      char* data, int width, int height, int srcx, int srcy,
+server_paint_rect_bpp(struct xrdp_mod *mod, int x, int y, int cx, int cy,
+                      char *data, int width, int height, int srcx, int srcy,
                       int bpp);
 int
-server_composite(struct xrdp_mod* mod, int srcidx, int srcformat, int srcwidth,
-                 int srcrepeat, int* srctransform, int mskflags, int mskidx,
+server_composite(struct xrdp_mod *mod, int srcidx, int srcformat, int srcwidth,
+                 int srcrepeat, int *srctransform, int mskflags, int mskidx,
                  int mskformat, int mskwidth, int mskrepeat, int op,
                  int srcx, int srcy, int mskx, int msky,
                  int dstx, int dsty, int width, int height, int dstformat);
 int
-server_paint_rects(struct xrdp_mod* mod, int num_drects, short *drects,
+server_paint_rects(struct xrdp_mod *mod, int num_drects, short *drects,
                    int num_crects, short *crects,
                    char *data, int width, int height,
                    int flags, int frame_id);
 int
-server_set_pointer(struct xrdp_mod* mod, int x, int y,
-                   char* data, char* mask);
+server_set_pointer(struct xrdp_mod *mod, int x, int y,
+                   char *data, char *mask);
 int
-server_set_pointer_ex(struct xrdp_mod* mod, int x, int y,
-                      char* data, char* mask, int bpp);
+server_set_pointer_ex(struct xrdp_mod *mod, int x, int y,
+                      char *data, char *mask, int bpp);
 int
-server_palette(struct xrdp_mod* mod, int* palette);
+server_palette(struct xrdp_mod *mod, int *palette);
 int
-server_msg(struct xrdp_mod* mod, char* msg, int code);
+server_msg(struct xrdp_mod *mod, char *msg, int code);
 int
-server_is_term(struct xrdp_mod* mod);
+server_is_term(struct xrdp_mod *mod);
 int
-server_set_clip(struct xrdp_mod* mod, int x, int y, int cx, int cy);
+server_set_clip(struct xrdp_mod *mod, int x, int y, int cx, int cy);
 int
-server_reset_clip(struct xrdp_mod* mod);
+server_reset_clip(struct xrdp_mod *mod);
 int
-server_set_fgcolor(struct xrdp_mod* mod, int fgcolor);
+server_set_fgcolor(struct xrdp_mod *mod, int fgcolor);
 int
-server_set_bgcolor(struct xrdp_mod* mod, int bgcolor);
+server_set_bgcolor(struct xrdp_mod *mod, int bgcolor);
 int
-server_set_opcode(struct xrdp_mod* mod, int opcode);
+server_set_opcode(struct xrdp_mod *mod, int opcode);
 int
-server_set_mixmode(struct xrdp_mod* mod, int mixmode);
+server_set_mixmode(struct xrdp_mod *mod, int mixmode);
 int
-server_set_brush(struct xrdp_mod* mod, int x_origin, int y_origin,
-                 int style, char* pattern);
+server_set_brush(struct xrdp_mod *mod, int x_origin, int y_origin,
+                 int style, char *pattern);
 int
-server_set_pen(struct xrdp_mod* mod, int style, int width);
+server_set_pen(struct xrdp_mod *mod, int style, int width);
 int
-server_draw_line(struct xrdp_mod* mod, int x1, int y1, int x2, int y2);
+server_draw_line(struct xrdp_mod *mod, int x1, int y1, int x2, int y2);
 int
-server_add_char(struct xrdp_mod* mod, int font, int character,
+server_add_char(struct xrdp_mod *mod, int font, int character,
                 int offset, int baseline,
-                int width, int height, char* data);
+                int width, int height, char *data);
 int
-server_draw_text(struct xrdp_mod* mod, int font,
+server_draw_text(struct xrdp_mod *mod, int font,
                  int flags, int mixmode, int clip_left, int clip_top,
                  int clip_right, int clip_bottom,
                  int box_left, int box_top,
                  int box_right, int box_bottom,
-                 int x, int y, char* data, int data_len);
+                 int x, int y, char *data, int data_len);
 int
-server_reset(struct xrdp_mod* mod, int width, int height, int bpp);
+server_reset(struct xrdp_mod *mod, int width, int height, int bpp);
 int
-is_channel_allowed(struct xrdp_wm* wm, int channel_id);
+is_channel_allowed(struct xrdp_wm *wm, int channel_id);
 int
-server_query_channel(struct xrdp_mod* mod, int index, char* channel_name,
-                     int* channel_flags);
+server_query_channel(struct xrdp_mod *mod, int index, char *channel_name,
+                     int *channel_flags);
 int
-server_get_channel_id(struct xrdp_mod* mod, const char *name);
+server_get_channel_id(struct xrdp_mod *mod, const char *name);
 int
-server_send_to_channel(struct xrdp_mod* mod, int channel_id,
-                       char* data, int data_len,
+server_send_to_channel(struct xrdp_mod *mod, int channel_id,
+                       char *data, int data_len,
                        int total_data_len, int flags);
 int
-server_create_os_surface(struct xrdp_mod* mod, int id,
+server_create_os_surface(struct xrdp_mod *mod, int id,
                          int width, int height);
 int
-server_create_os_surface_bpp(struct xrdp_mod* mod, int id,
+server_create_os_surface_bpp(struct xrdp_mod *mod, int id,
                              int width, int height, int bpp);
 int
-server_switch_os_surface(struct xrdp_mod* mod, int id);
+server_switch_os_surface(struct xrdp_mod *mod, int id);
 int
-server_delete_os_surface(struct xrdp_mod* mod, int id);
+server_delete_os_surface(struct xrdp_mod *mod, int id);
 int
-server_paint_rect_os(struct xrdp_mod* mod, int x, int y, int cx, int cy,
+server_paint_rect_os(struct xrdp_mod *mod, int x, int y, int cx, int cy,
                      int id, int srcx, int srcy);
 int
-server_set_hints(struct xrdp_mod* mod, int hints, int mask);
+server_set_hints(struct xrdp_mod *mod, int hints, int mask);
 int
-server_window_new_update(struct xrdp_mod* mod, int window_id,
-                         struct rail_window_state_order* window_state,
+server_window_new_update(struct xrdp_mod *mod, int window_id,
+                         struct rail_window_state_order *window_state,
                          int flags);
 int
-server_window_delete(struct xrdp_mod* mod, int window_id);
+server_window_delete(struct xrdp_mod *mod, int window_id);
 int
-server_window_icon(struct xrdp_mod* mod, int window_id, int cache_entry,
-                   int cache_id, struct rail_icon_info* icon_info,
+server_window_icon(struct xrdp_mod *mod, int window_id, int cache_entry,
+                   int cache_id, struct rail_icon_info *icon_info,
                    int flags);
 int
-server_window_cached_icon(struct xrdp_mod* mod,
+server_window_cached_icon(struct xrdp_mod *mod,
                           int window_id, int cache_entry,
                           int cache_id, int flags);
 int
-server_notify_new_update(struct xrdp_mod* mod,
+server_notify_new_update(struct xrdp_mod *mod,
                          int window_id, int notify_id,
-                         struct rail_notify_state_order* notify_state,
+                         struct rail_notify_state_order *notify_state,
                          int flags);
 int
-server_notify_delete(struct xrdp_mod* mod, int window_id,
+server_notify_delete(struct xrdp_mod *mod, int window_id,
                      int notify_id);
 int
-server_monitored_desktop(struct xrdp_mod* mod,
-                         struct rail_monitored_desktop_order* mdo,
+server_monitored_desktop(struct xrdp_mod *mod,
+                         struct rail_monitored_desktop_order *mdo,
                          int flags);
 int
-server_add_char_alpha(struct xrdp_mod* mod, int font, int character,
+server_add_char_alpha(struct xrdp_mod *mod, int font, int character,
                       int offset, int baseline,
-                      int width, int height, char* data);
+                      int width, int height, char *data);
 int
 server_session_info(struct xrdp_mod *mod, const char *data, int data_bytes);
 

--- a/xrdp/xrdp_bitmap.c
+++ b/xrdp/xrdp_bitmap.c
@@ -31,17 +31,7 @@
 #include "log.h"
 #include "string_calls.h"
 
-#define LLOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do \
-    { \
-        if (_level < LLOG_LEVEL) \
-        { \
-            g_write("xrdp:xrdp_bitmap [%10.10u]: ", g_time3()); \
-            g_writeln _args ; \
-        } \
-    } \
-    while (0)
+
 
 
 static const unsigned int g_crc_table[256] =
@@ -153,8 +143,8 @@ xrdp_bitmap_create(int width, int height, int bpp,
         self->data = alloc_bitmap_data(width, height, Bpp);
         if (self->data == NULL)
         {
-            LLOGLN(0, ("xrdp_bitmap_create: size overflow %dx%dx%d",
-                       width, height, Bpp));
+            LOG(LOG_LEVEL_ERROR, "xrdp_bitmap_create: size overflow %dx%dx%d",
+                width, height, Bpp);
             g_free(self);
             return NULL;
         }
@@ -163,12 +153,12 @@ xrdp_bitmap_create(int width, int height, int bpp,
 #if defined(XRDP_PAINTER)
     if (self->type == WND_TYPE_SCREEN) /* noorders */
     {
-        LLOGLN(0, ("xrdp_bitmap_create: noorders"));
+        LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_bitmap_create: noorders");
         self->data = alloc_bitmap_data(width, height, Bpp);
         if (self->data == NULL)
         {
-            LLOGLN(0, ("xrdp_bitmap_create: size overflow %dx%dx%d",
-                       width, height, Bpp));
+            LOG(LOG_LEVEL_ERROR, "xrdp_bitmap_create: size overflow %dx%dx%d",
+                width, height, Bpp);
             g_free(self);
             return NULL;
         }
@@ -492,8 +482,8 @@ xrdp_bitmap_load(struct xrdp_bitmap *self, const char *filename, int *palette)
 
     if (!g_file_exist(filename))
     {
-        log_message(LOG_LEVEL_ERROR, "xrdp_bitmap_load: error bitmap file [%s] "
-                    "does not exist", filename);
+        LOG(LOG_LEVEL_ERROR, "xrdp_bitmap_load: error bitmap file [%s] "
+            "does not exist", filename);
         return 1;
     }
 
@@ -504,16 +494,16 @@ xrdp_bitmap_load(struct xrdp_bitmap *self, const char *filename, int *palette)
         /* read file type */
         if (g_file_read(fd, type1, 2) != 2)
         {
-            log_message(LOG_LEVEL_ERROR, "xrdp_bitmap_load: error bitmap file [%s] "
-                        "read error", filename);
+            LOG(LOG_LEVEL_ERROR, "xrdp_bitmap_load: error bitmap file [%s] "
+                "read error", filename);
             g_file_close(fd);
             return 1;
         }
 
         if ((type1[0] != 'B') || (type1[1] != 'M'))
         {
-            log_message(LOG_LEVEL_ERROR, "xrdp_bitmap_load: error bitmap file [%s] "
-                        "not BMP file", filename);
+            LOG(LOG_LEVEL_ERROR, "xrdp_bitmap_load: error bitmap file [%s] "
+                "not BMP file", filename);
             g_file_close(fd);
             return 1;
         }
@@ -526,8 +516,8 @@ xrdp_bitmap_load(struct xrdp_bitmap *self, const char *filename, int *palette)
         /* read bmp header */
         if (g_file_seek(fd, 14) < 0)
         {
-            log_message(LOG_LEVEL_ERROR, "xrdp_bitmap_load: seek error in file %s",
-                        filename);
+            LOG(LOG_LEVEL_ERROR, "xrdp_bitmap_load: seek error in file %s",
+                filename);
             free_stream(s);
             g_file_close(fd);
             return 1;
@@ -549,8 +539,8 @@ xrdp_bitmap_load(struct xrdp_bitmap *self, const char *filename, int *palette)
         if ((header.bit_count != 4) && (header.bit_count != 8) &&
                 (header.bit_count != 24))
         {
-            log_message(LOG_LEVEL_ERROR, "xrdp_bitmap_load: error bitmap file [%s] "
-                        "bad bpp %d", filename, header.bit_count);
+            LOG(LOG_LEVEL_ERROR, "xrdp_bitmap_load: error bitmap file [%s] "
+                "bad bpp %d", filename, header.bit_count);
             free_stream(s);
             g_file_close(fd);
             return 1;
@@ -560,8 +550,8 @@ xrdp_bitmap_load(struct xrdp_bitmap *self, const char *filename, int *palette)
         {
             if (g_file_seek(fd, 14 + header.size) < 0)
             {
-                log_message(LOG_LEVEL_ERROR, "xrdp_bitmap_load: seek error in file %s",
-                            filename);
+                LOG(LOG_LEVEL_WARNING, "xrdp_bitmap_load: seek error in file %s",
+                    filename);
             }
             xrdp_bitmap_resize(self, header.image_width, header.image_height);
             size = header.image_width * header.image_height * 3;
@@ -575,8 +565,8 @@ xrdp_bitmap_load(struct xrdp_bitmap *self, const char *filename, int *palette)
 
                 if (k != size)
                 {
-                    log_message(LOG_LEVEL_ERROR, "xrdp_bitmap_load: error bitmap "
-                                "file [%s] read", filename);
+                    LOG(LOG_LEVEL_WARNING, "xrdp_bitmap_load: error bitmap "
+                        "file [%s] read", filename);
                 }
             }
 
@@ -617,8 +607,8 @@ xrdp_bitmap_load(struct xrdp_bitmap *self, const char *filename, int *palette)
             /* read palette */
             if (g_file_seek(fd, 14 + header.size) < 0)
             {
-                log_message(LOG_LEVEL_ERROR, "xrdp_bitmap_load: seek error in file %s",
-                            filename);
+                LOG(LOG_LEVEL_WARNING, "xrdp_bitmap_load: seek error in file %s",
+                    filename);
             }
             init_stream(s, 8192);
             g_file_read(fd, s->data, header.clr_used * sizeof(int));
@@ -640,8 +630,8 @@ xrdp_bitmap_load(struct xrdp_bitmap *self, const char *filename, int *palette)
 
                 if (k != size)
                 {
-                    log_message(LOG_LEVEL_ERROR, "xrdp_bitmap_load: error bitmap "
-                                "file [%s] read", filename);
+                    LOG(LOG_LEVEL_WARNING, "xrdp_bitmap_load: error bitmap "
+                        "file [%s] read", filename);
                 }
             }
 
@@ -678,8 +668,8 @@ xrdp_bitmap_load(struct xrdp_bitmap *self, const char *filename, int *palette)
             /* read palette */
             if (g_file_seek(fd, 14 + header.size) < 0)
             {
-                log_message(LOG_LEVEL_ERROR, "xrdp_bitmap_load: seek error in file %s",
-                            filename);
+                LOG(LOG_LEVEL_WARNING, "xrdp_bitmap_load: seek error in file %s",
+                    filename);
             }
             init_stream(s, 8192);
             g_file_read(fd, s->data, header.clr_used * sizeof(int));
@@ -701,8 +691,8 @@ xrdp_bitmap_load(struct xrdp_bitmap *self, const char *filename, int *palette)
 
                 if (k != size)
                 {
-                    log_message(LOG_LEVEL_ERROR, "xrdp_bitmap_load: error bitmap "
-                                "file [%s] read", filename);
+                    LOG(LOG_LEVEL_WARNING, "xrdp_bitmap_load: error bitmap "
+                        "file [%s] read", filename);
                 }
             }
 
@@ -749,8 +739,8 @@ xrdp_bitmap_load(struct xrdp_bitmap *self, const char *filename, int *palette)
     }
     else
     {
-        log_message(LOG_LEVEL_ERROR, "xrdp_bitmap_load: error loading bitmap "
-                    "from file [%s]", filename);
+        LOG(LOG_LEVEL_ERROR, "xrdp_bitmap_load: error loading bitmap "
+            "from file [%s]", filename);
         return 1;
     }
 
@@ -1242,10 +1232,10 @@ xrdp_bitmap_copy_box_with_crc(struct xrdp_bitmap *self,
     dest->crc32 = crc;
     dest->crc16 = dest->crc32 & 0xffff;
 
-    LLOGLN(10, ("xrdp_bitmap_copy_box_with_crc: crc16 0x%4.4x",
-                dest->crc16));
-    LLOGLN(10, ("xrdp_bitmap_copy_box_with_crc: width %d height %d",
-                dest->width, dest->height));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_bitmap_copy_box_with_crc: crc16 0x%4.4x",
+              dest->crc16);
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_bitmap_copy_box_with_crc: width %d height %d",
+              dest->width, dest->height);
 
     return 0;
 }
@@ -1256,7 +1246,7 @@ int
 xrdp_bitmap_compare(struct xrdp_bitmap *self,
                     struct xrdp_bitmap *b)
 {
-    LLOGLN(10, ("xrdp_bitmap_compare:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_bitmap_compare:");
 
     if (self == 0)
     {

--- a/xrdp/xrdp_bitmap.c
+++ b/xrdp/xrdp_bitmap.c
@@ -33,15 +33,15 @@
 
 #define LLOG_LEVEL 1
 #define LLOGLN(_level, _args) \
-  do \
-  { \
-    if (_level < LLOG_LEVEL) \
+    do \
     { \
-        g_write("xrdp:xrdp_bitmap [%10.10u]: ", g_time3()); \
-        g_writeln _args ; \
+        if (_level < LLOG_LEVEL) \
+        { \
+            g_write("xrdp:xrdp_bitmap [%10.10u]: ", g_time3()); \
+            g_writeln _args ; \
+        } \
     } \
-  } \
-  while (0)
+    while (0)
 
 
 static const unsigned int g_crc_table[256] =
@@ -231,7 +231,7 @@ xrdp_bitmap_create_with_data(int width, int height,
 #if defined(NEED_ALIGN)
     data_as_int = (tintptr) data;
     if (((bpp >= 24) && (data_as_int & 3)) ||
-        (((bpp == 15) || (bpp == 16)) && (data_as_int & 1)))
+            (((bpp == 15) || (bpp == 16)) && (data_as_int & 1)))
     {
         /* got to copy data here, it's not aligned
            other calls in this file assume alignment */
@@ -240,7 +240,7 @@ xrdp_bitmap_create_with_data(int width, int height,
         return self;
     }
 #endif
-    self->data = data; 
+    self->data = data;
     self->do_not_free_data = 1;
     return self;
 }
@@ -527,7 +527,7 @@ xrdp_bitmap_load(struct xrdp_bitmap *self, const char *filename, int *palette)
         if (g_file_seek(fd, 14) < 0)
         {
             log_message(LOG_LEVEL_ERROR, "xrdp_bitmap_load: seek error in file %s",
-                filename);
+                        filename);
             free_stream(s);
             g_file_close(fd);
             return 1;
@@ -561,7 +561,7 @@ xrdp_bitmap_load(struct xrdp_bitmap *self, const char *filename, int *palette)
             if (g_file_seek(fd, 14 + header.size) < 0)
             {
                 log_message(LOG_LEVEL_ERROR, "xrdp_bitmap_load: seek error in file %s",
-                    filename);
+                            filename);
             }
             xrdp_bitmap_resize(self, header.image_width, header.image_height);
             size = header.image_width * header.image_height * 3;
@@ -618,7 +618,7 @@ xrdp_bitmap_load(struct xrdp_bitmap *self, const char *filename, int *palette)
             if (g_file_seek(fd, 14 + header.size) < 0)
             {
                 log_message(LOG_LEVEL_ERROR, "xrdp_bitmap_load: seek error in file %s",
-                    filename);
+                            filename);
             }
             init_stream(s, 8192);
             g_file_read(fd, s->data, header.clr_used * sizeof(int));
@@ -679,7 +679,7 @@ xrdp_bitmap_load(struct xrdp_bitmap *self, const char *filename, int *palette)
             if (g_file_seek(fd, 14 + header.size) < 0)
             {
                 log_message(LOG_LEVEL_ERROR, "xrdp_bitmap_load: seek error in file %s",
-                    filename);
+                            filename);
             }
             init_stream(s, 8192);
             g_file_read(fd, s->data, header.clr_used * sizeof(int));
@@ -1243,9 +1243,9 @@ xrdp_bitmap_copy_box_with_crc(struct xrdp_bitmap *self,
     dest->crc16 = dest->crc32 & 0xffff;
 
     LLOGLN(10, ("xrdp_bitmap_copy_box_with_crc: crc16 0x%4.4x",
-           dest->crc16));
+                dest->crc16));
     LLOGLN(10, ("xrdp_bitmap_copy_box_with_crc: width %d height %d",
-           dest->width, dest->height));
+                dest->width, dest->height));
 
     return 0;
 }

--- a/xrdp/xrdp_cache.c
+++ b/xrdp/xrdp_cache.c
@@ -27,15 +27,15 @@
 
 #define LLOG_LEVEL 1
 #define LLOGLN(_level, _args) \
-  do \
-  { \
-    if (_level < LLOG_LEVEL) \
+    do \
     { \
-        g_write("xrdp:xrdp_cache [%10.10u]: ", g_time3()); \
-        g_writeln _args ; \
+        if (_level < LLOG_LEVEL) \
+        { \
+            g_write("xrdp:xrdp_cache [%10.10u]: ", g_time3()); \
+            g_writeln _args ; \
+        } \
     } \
-  } \
-  while (0)
+    while (0)
 
 /*****************************************************************************/
 static int
@@ -231,9 +231,9 @@ xrdp_cache_reset(struct xrdp_cache *self,
 }
 
 #define COMPARE_WITH_CRC32(_b1, _b2) \
- ((_b1->crc32 == _b2->crc32) && \
-  (_b1->bpp == _b2->bpp) && \
-  (_b1->width == _b2->width) && (_b1->height == _b2->height))
+    ((_b1->crc32 == _b2->crc32) && \
+     (_b1->bpp == _b2->bpp) && \
+     (_b1->width == _b2->width) && (_b1->height == _b2->height))
 
 /*****************************************************************************/
 static int
@@ -329,7 +329,7 @@ xrdp_cache_add_bitmap(struct xrdp_cache *self, struct xrdp_bitmap *bitmap,
 
     LLOGLN(10, ("xrdp_cache_add_bitmap:"));
     LLOGLN(10, ("xrdp_cache_add_bitmap: crc16 0x%4.4x",
-           bitmap->crc16));
+                bitmap->crc16));
 
     e = (4 - (bitmap->width % 4)) & 3;
     found = 0;
@@ -395,7 +395,7 @@ xrdp_cache_add_bitmap(struct xrdp_cache *self, struct xrdp_bitmap *bitmap,
     {
         self->lru_reset[cache_id] = 0;
         LLOGLN(0, ("xrdp_cache_add_bitmap: reset detected cache_id %d",
-               cache_id));
+                   cache_id));
         self->lru_tail[cache_id] = cache_entries - 1;
         index = self->lru_tail[cache_id];
         llru = &(self->bitmap_lrus[cache_id][index]);
@@ -412,9 +412,9 @@ xrdp_cache_add_bitmap(struct xrdp_cache *self, struct xrdp_bitmap *bitmap,
     LLOGLN(10, ("xrdp_cache_add_bitmap: oldest %d %d", cache_id, cache_idx));
 
     LLOGLN(10, ("adding bitmap at %d %d old ptr %p new ptr %p",
-           cache_id, cache_idx,
-           self->bitmap_items[cache_id][cache_idx].bitmap,
-           bitmap));
+                cache_id, cache_idx,
+                self->bitmap_items[cache_id][cache_idx].bitmap,
+                bitmap));
 
     /* remove old, about to be deleted, from crc16 list */
     lbm = self->bitmap_items[cache_id][cache_idx].bitmap;
@@ -428,7 +428,7 @@ xrdp_cache_add_bitmap(struct xrdp_cache *self, struct xrdp_bitmap *bitmap,
             LLOGLN(0, ("xrdp_cache_add_bitmap: error removing cache_idx"));
         }
         LLOGLN(10, ("xrdp_cache_add_bitmap: removing index %d from crc16 %d",
-               iig, crc16));
+                    iig, crc16));
         list16_remove_item(ll, iig);
         xrdp_bitmap_delete(lbm);
     }

--- a/xrdp/xrdp_cache.c
+++ b/xrdp/xrdp_cache.c
@@ -25,17 +25,7 @@
 #include "xrdp.h"
 #include "log.h"
 
-#define LLOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do \
-    { \
-        if (_level < LLOG_LEVEL) \
-        { \
-            g_write("xrdp:xrdp_cache [%10.10u]: ", g_time3()); \
-            g_writeln _args ; \
-        } \
-    } \
-    while (0)
+
 
 /*****************************************************************************/
 static int
@@ -124,8 +114,8 @@ xrdp_cache_create(struct xrdp_wm *owner,
     self->xrdp_os_del_list = list_create();
     xrdp_cache_reset_lru(self);
     xrdp_cache_reset_crc(self);
-    LLOGLN(10, ("xrdp_cache_create: 0 %d 1 %d 2 %d",
-                self->cache1_entries, self->cache2_entries, self->cache3_entries));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_cache_create: 0 %d 1 %d 2 %d",
+              self->cache1_entries, self->cache2_entries, self->cache3_entries);
     return self;
 }
 
@@ -245,10 +235,10 @@ xrdp_cache_update_lru(struct xrdp_cache *self, int cache_id, int lru_index)
     struct xrdp_lru_item *thislru;
     struct xrdp_lru_item *taillru;
 
-    LLOGLN(10, ("xrdp_cache_update_lru: lru_index %d", lru_index));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_cache_update_lru: lru_index %d", lru_index);
     if ((lru_index < 0) || (lru_index >= XRDP_MAX_BITMAP_CACHE_IDX))
     {
-        LLOGLN(0, ("xrdp_cache_update_lru: error"));
+        LOG(LOG_LEVEL_ERROR, "xrdp_cache_update_lru: error");
         return 1;
     }
     if (self->lru_tail[cache_id] == lru_index)
@@ -327,9 +317,9 @@ xrdp_cache_add_bitmap(struct xrdp_cache *self, struct xrdp_bitmap *bitmap,
     struct xrdp_bitmap *lbm;
     struct xrdp_lru_item *llru;
 
-    LLOGLN(10, ("xrdp_cache_add_bitmap:"));
-    LLOGLN(10, ("xrdp_cache_add_bitmap: crc16 0x%4.4x",
-                bitmap->crc16));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_cache_add_bitmap:");
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_cache_add_bitmap: crc16 0x%4.4x",
+              bitmap->crc16);
 
     e = (4 - (bitmap->width % 4)) & 3;
     found = 0;
@@ -358,8 +348,8 @@ xrdp_cache_add_bitmap(struct xrdp_cache *self, struct xrdp_bitmap *bitmap,
     }
     else
     {
-        log_message(LOG_LEVEL_ERROR, "error in xrdp_cache_add_bitmap, "
-                    "too big(%d) bpp %d", bmp_size, bitmap->bpp);
+        LOG(LOG_LEVEL_ERROR, "error in xrdp_cache_add_bitmap, "
+            "too big(%d) bpp %d", bmp_size, bitmap->bpp);
         return 0;
     }
 
@@ -371,7 +361,7 @@ xrdp_cache_add_bitmap(struct xrdp_cache *self, struct xrdp_bitmap *bitmap,
         lbm = self->bitmap_items[cache_id][cache_idx].bitmap;
         if ((lbm != NULL) && COMPARE_WITH_CRC32(lbm, bitmap))
         {
-            LLOGLN(10, ("found bitmap at %d %d", index, jndex));
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "found bitmap at %d %d", cache_idx, jndex);
             found = 1;
             break;
         }
@@ -394,8 +384,8 @@ xrdp_cache_add_bitmap(struct xrdp_cache *self, struct xrdp_bitmap *bitmap,
     if (self->lru_reset[cache_id])
     {
         self->lru_reset[cache_id] = 0;
-        LLOGLN(0, ("xrdp_cache_add_bitmap: reset detected cache_id %d",
-                   cache_id));
+        LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_cache_add_bitmap: reset detected cache_id %d",
+                  cache_id);
         self->lru_tail[cache_id] = cache_entries - 1;
         index = self->lru_tail[cache_id];
         llru = &(self->bitmap_lrus[cache_id][index]);
@@ -409,12 +399,12 @@ xrdp_cache_add_bitmap(struct xrdp_cache *self, struct xrdp_bitmap *bitmap,
     /* update lru to end */
     xrdp_cache_update_lru(self, cache_id, lru_index);
 
-    LLOGLN(10, ("xrdp_cache_add_bitmap: oldest %d %d", cache_id, cache_idx));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_cache_add_bitmap: oldest %d %d", cache_id, cache_idx);
 
-    LLOGLN(10, ("adding bitmap at %d %d old ptr %p new ptr %p",
-                cache_id, cache_idx,
-                self->bitmap_items[cache_id][cache_idx].bitmap,
-                bitmap));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "adding bitmap at %d %d old ptr %p new ptr %p",
+              cache_id, cache_idx,
+              self->bitmap_items[cache_id][cache_idx].bitmap,
+              bitmap);
 
     /* remove old, about to be deleted, from crc16 list */
     lbm = self->bitmap_items[cache_id][cache_idx].bitmap;
@@ -425,10 +415,10 @@ xrdp_cache_add_bitmap(struct xrdp_cache *self, struct xrdp_bitmap *bitmap,
         iig = list16_index_of(ll, cache_idx);
         if (iig == -1)
         {
-            LLOGLN(0, ("xrdp_cache_add_bitmap: error removing cache_idx"));
+            LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_cache_add_bitmap: error removing cache_idx");
         }
-        LLOGLN(10, ("xrdp_cache_add_bitmap: removing index %d from crc16 %d",
-                    iig, crc16));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_cache_add_bitmap: removing index %d from crc16 %d",
+                  iig, crc16);
         list16_remove_item(ll, iig);
         xrdp_bitmap_delete(lbm);
     }
@@ -445,7 +435,7 @@ xrdp_cache_add_bitmap(struct xrdp_cache *self, struct xrdp_bitmap *bitmap,
     list16_add_item(ll, cache_idx);
     if (ll->count > 1)
     {
-        LLOGLN(10, ("xrdp_cache_add_bitmap: count %d", ll->count));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_cache_add_bitmap: count %d", ll->count);
     }
 
     if (self->use_bitmap_comp)
@@ -575,7 +565,7 @@ xrdp_cache_add_char(struct xrdp_cache *self,
             if (xrdp_font_item_compare(&self->char_items[i][j].font_item, font_item))
             {
                 self->char_items[i][j].stamp = self->char_stamp;
-                DEBUG(("found font at %d %d", i, j));
+                LOG_DEVEL(LOG_LEVEL_TRACE, "found font at %d %d", i, j);
                 return MAKELONG(j, i);
             }
         }
@@ -599,7 +589,7 @@ xrdp_cache_add_char(struct xrdp_cache *self,
         }
     }
 
-    DEBUG(("adding char at %d %d", f, c));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "adding char at %d %d", f, c);
     /* set, send char and return */
     fi = &self->char_items[f][c].font_item;
     g_free(fi->data);
@@ -649,7 +639,7 @@ xrdp_cache_add_pointer(struct xrdp_cache *self,
             self->pointer_items[i].stamp = self->pointer_stamp;
             xrdp_wm_set_pointer(self->wm, i);
             self->wm->current_pointer = i;
-            DEBUG(("found pointer at %d", i));
+            LOG_DEVEL(LOG_LEVEL_TRACE, "found pointer at %d", i);
             return i;
         }
     }
@@ -682,7 +672,7 @@ xrdp_cache_add_pointer(struct xrdp_cache *self,
                          self->pointer_items[index].y,
                          self->pointer_items[index].bpp);
     self->wm->current_pointer = index;
-    DEBUG(("adding pointer at %d", index));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "adding pointer at %d", index);
     return index;
 }
 
@@ -714,7 +704,7 @@ xrdp_cache_add_pointer_static(struct xrdp_cache *self,
                          self->pointer_items[index].y,
                          self->pointer_items[index].bpp);
     self->wm->current_pointer = index;
-    DEBUG(("adding pointer at %d", index));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "adding pointer at %d", index);
     return index;
 }
 
@@ -742,7 +732,7 @@ xrdp_cache_add_brush(struct xrdp_cache *self,
                      brush_item_data, 8) == 0)
         {
             self->brush_items[i].stamp = self->brush_stamp;
-            DEBUG(("found brush at %d", i));
+            LOG_DEVEL(LOG_LEVEL_TRACE, "found brush at %d", i);
             return i;
         }
     }
@@ -765,7 +755,7 @@ xrdp_cache_add_brush(struct xrdp_cache *self,
     self->brush_items[index].stamp = self->brush_stamp;
     libxrdp_orders_send_brush(self->session, 8, 8, 1, 0x81, 8,
                               self->brush_items[index].pattern, index);
-    DEBUG(("adding brush at %d", index));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "adding brush at %d", index);
     return index;
 }
 

--- a/xrdp/xrdp_encoder.c
+++ b/xrdp/xrdp_encoder.c
@@ -482,7 +482,8 @@ proc_enc_msg(void *arg)
 
         if (g_is_wait_obj_set(term_obj)) /* global term */
         {
-            LOG_DEVEL(LOG_LEVEL_DEBUG, "proc_enc_msg: global term");
+            LOG(LOG_LEVEL_DEBUG,
+                "Received termination signal, stopping the encoder thread");
             break;
         }
 

--- a/xrdp/xrdp_encoder.c
+++ b/xrdp/xrdp_encoder.c
@@ -32,17 +32,7 @@
 #include "rfxcodec_encode.h"
 #endif
 
-#define LLOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do \
-    { \
-        if (_level < LLOG_LEVEL) \
-        { \
-            g_write("xrdp:xrdp_encoder [%10.10u]: ", g_time3()); \
-            g_writeln _args ; \
-        } \
-    } \
-    while (0)
+
 
 #define XRDP_SURCMD_PREFIX_BYTES 256
 
@@ -81,7 +71,7 @@ xrdp_encoder_create(struct xrdp_mm *mm)
 
     if (client_info->jpeg_codec_id != 0)
     {
-        LLOGLN(0, ("xrdp_encoder_create: starting jpeg codec session"));
+        LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_encoder_create: starting jpeg codec session");
         self->codec_id = client_info->jpeg_codec_id;
         self->in_codec_mode = 1;
         self->codec_quality = client_info->jpeg_prop[0];
@@ -94,7 +84,7 @@ xrdp_encoder_create(struct xrdp_mm *mm)
 #ifdef XRDP_RFXCODEC
     else if (client_info->rfx_codec_id != 0)
     {
-        LLOGLN(0, ("xrdp_encoder_create: starting rfx codec session"));
+        LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_encoder_create: starting rfx codec session");
         self->codec_id = client_info->rfx_codec_id;
         self->in_codec_mode = 1;
         client_info->capture_code = 2;
@@ -106,7 +96,7 @@ xrdp_encoder_create(struct xrdp_mm *mm)
 #endif
     else if (client_info->h264_codec_id != 0)
     {
-        LLOGLN(0, ("xrdp_encoder_create: starting h264 codec session"));
+        LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_encoder_create: starting h264 codec session");
         self->codec_id = client_info->h264_codec_id;
         self->in_codec_mode = 1;
         client_info->capture_code = 3;
@@ -121,7 +111,7 @@ xrdp_encoder_create(struct xrdp_mm *mm)
         return 0;
     }
 
-    LLOGLN(0, ("init_xrdp_encoder: initializing encoder codec_id %d", self->codec_id));
+    LOG_DEVEL(LOG_LEVEL_INFO, "init_xrdp_encoder: initializing encoder codec_id %d", self->codec_id);
 
     /* setup required FIFOs */
     self->fifo_to_proc = fifo_create();
@@ -155,7 +145,7 @@ xrdp_encoder_delete(struct xrdp_encoder *self)
     XRDP_ENC_DATA_DONE *enc_done;
     FIFO *fifo;
 
-    LLOGLN(0, ("xrdp_encoder_delete:"));
+    LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_encoder_delete:");
     if (self == 0)
     {
         return;
@@ -243,7 +233,7 @@ process_enc_jpg(struct xrdp_encoder *self, XRDP_ENC_DATA *enc)
     tbus mutex;
     tbus event_processed;
 
-    LLOGLN(10, ("process_enc_jpg:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "process_enc_jpg:");
     quality = self->codec_quality;
     fifo_processed = self->fifo_processed;
     mutex = self->mutex;
@@ -257,22 +247,22 @@ process_enc_jpg(struct xrdp_encoder *self, XRDP_ENC_DATA *enc)
         cy = enc->crects[index * 4 + 3];
         if (cx < 1 || cy < 1)
         {
-            LLOGLN(0, ("process_enc_jpg: error 1"));
+            LOG_DEVEL(LOG_LEVEL_WARNING, "process_enc_jpg: error 1");
             continue;
         }
 
-        LLOGLN(10, ("process_enc_jpg: x %d y %d cx %d cy %d", x, y, cx, cy));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "process_enc_jpg: x %d y %d cx %d cy %d", x, y, cx, cy);
 
         out_data_bytes = MAX((cx + 4) * cy * 4, 8192);
         if ((out_data_bytes < 1) || (out_data_bytes > 16 * 1024 * 1024))
         {
-            LLOGLN(0, ("process_enc_jpg: error 2"));
+            LOG_DEVEL(LOG_LEVEL_ERROR, "process_enc_jpg: error 2");
             return 1;
         }
         out_data = (char *) g_malloc(out_data_bytes + 256 + 2, 0);
         if (out_data == 0)
         {
-            LLOGLN(0, ("process_enc_jpg: error 3"));
+            LOG_DEVEL(LOG_LEVEL_ERROR, "process_enc_jpg: error 3");
             return 1;
         }
 
@@ -285,12 +275,12 @@ process_enc_jpg(struct xrdp_encoder *self, XRDP_ENC_DATA *enc)
                                             out_data + 256 + 2, &out_data_bytes);
         if (error < 0)
         {
-            LLOGLN(0, ("process_enc_jpg: jpeg error %d bytes %d",
-                       error, out_data_bytes));
+            LOG_DEVEL(LOG_LEVEL_ERROR, "process_enc_jpg: jpeg error %d bytes %d",
+                      error, out_data_bytes);
             g_free(out_data);
             return 1;
         }
-        LLOGLN(10, ("jpeg error %d bytes %d", error, out_data_bytes));
+        LOG_DEVEL(LOG_LEVEL_WARNING, "jpeg error %d bytes %d", error, out_data_bytes);
         enc_done = (XRDP_ENC_DATA_DONE *)
                    g_malloc(sizeof(XRDP_ENC_DATA_DONE), 1);
         enc_done->comp_bytes = out_data_bytes + 2;
@@ -336,9 +326,9 @@ process_enc_rfx(struct xrdp_encoder *self, XRDP_ENC_DATA *enc)
     struct rfx_rect *rfxrects;
     int alloc_bytes;
 
-    LLOGLN(10, ("process_enc_rfx:"));
-    LLOGLN(10, ("process_enc_rfx: num_crects %d num_drects %d",
-                enc->num_crects, enc->num_drects));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "process_enc_rfx:");
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "process_enc_rfx: num_crects %d num_drects %d",
+              enc->num_crects, enc->num_drects);
     fifo_processed = self->fifo_processed;
     mutex = self->mutex;
     event_processed = self->xrdp_encoder_event_processed;
@@ -400,7 +390,7 @@ process_enc_rfx(struct xrdp_encoder *self, XRDP_ENC_DATA *enc)
         }
     }
 
-    LLOGLN(10, ("process_enc_rfx: rfxcodec_encode rv %d", error));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "process_enc_rfx: rfxcodec_encode rv %d", error);
     /* only if enc_done->comp_bytes is not zero is something sent
        to the client but you must always send something back even
        on error so Xorg can get ack */
@@ -434,7 +424,7 @@ process_enc_rfx(struct xrdp_encoder *self, XRDP_ENC_DATA *enc)
 static int
 process_enc_h264(struct xrdp_encoder *self, XRDP_ENC_DATA *enc)
 {
-    LLOGLN(0, ("process_enc_x264:"));
+    LOG_DEVEL(LOG_LEVEL_INFO, "process_enc_x264:");
     return 0;
 }
 
@@ -458,12 +448,12 @@ proc_enc_msg(void *arg)
     tbus wobjs[32];
     struct xrdp_encoder *self;
 
-    LLOGLN(0, ("proc_enc_msg: thread is running"));
+    LOG_DEVEL(LOG_LEVEL_INFO, "proc_enc_msg: thread is running");
 
     self = (struct xrdp_encoder *) arg;
     if (self == 0)
     {
-        LLOGLN(0, ("proc_enc_msg: self nil"));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "proc_enc_msg: self nil");
         return 0;
     }
 
@@ -492,13 +482,13 @@ proc_enc_msg(void *arg)
 
         if (g_is_wait_obj_set(term_obj)) /* global term */
         {
-            LLOGLN(0, ("proc_enc_msg: global term"));
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "proc_enc_msg: global term");
             break;
         }
 
         if (g_is_wait_obj_set(lterm_obj)) /* xrdp_mm term */
         {
-            LLOGLN(0, ("proc_enc_msg: xrdp_mm term"));
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "proc_enc_msg: xrdp_mm term");
             break;
         }
 
@@ -522,6 +512,6 @@ proc_enc_msg(void *arg)
         }
 
     } /* end while (cont) */
-    LLOGLN(0, ("proc_enc_msg: thread exit"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "proc_enc_msg: thread exit");
     return 0;
 }

--- a/xrdp/xrdp_encoder.c
+++ b/xrdp/xrdp_encoder.c
@@ -34,15 +34,15 @@
 
 #define LLOG_LEVEL 1
 #define LLOGLN(_level, _args) \
-  do \
-  { \
-    if (_level < LLOG_LEVEL) \
+    do \
     { \
-        g_write("xrdp:xrdp_encoder [%10.10u]: ", g_time3()); \
-        g_writeln _args ; \
+        if (_level < LLOG_LEVEL) \
+        { \
+            g_write("xrdp:xrdp_encoder [%10.10u]: ", g_time3()); \
+            g_writeln _args ; \
+        } \
     } \
-  } \
-  while (0)
+    while (0)
 
 #define XRDP_SURCMD_PREFIX_BYTES 256
 
@@ -100,8 +100,8 @@ xrdp_encoder_create(struct xrdp_mm *mm)
         client_info->capture_code = 2;
         self->process_enc = process_enc_rfx;
         self->codec_handle = rfxcodec_encode_create(mm->wm->screen->width,
-                                                    mm->wm->screen->height,
-                                                    RFX_FORMAT_YUV, 0);
+                             mm->wm->screen->height,
+                             RFX_FORMAT_YUV, 0);
     }
 #endif
     else if (client_info->h264_codec_id != 0)
@@ -286,7 +286,7 @@ process_enc_jpg(struct xrdp_encoder *self, XRDP_ENC_DATA *enc)
         if (error < 0)
         {
             LLOGLN(0, ("process_enc_jpg: jpeg error %d bytes %d",
-                   error, out_data_bytes));
+                       error, out_data_bytes));
             g_free(out_data);
             return 1;
         }
@@ -338,7 +338,7 @@ process_enc_rfx(struct xrdp_encoder *self, XRDP_ENC_DATA *enc)
 
     LLOGLN(10, ("process_enc_rfx:"));
     LLOGLN(10, ("process_enc_rfx: num_crects %d num_drects %d",
-           enc->num_crects, enc->num_drects));
+                enc->num_crects, enc->num_drects));
     fifo_processed = self->fifo_processed;
     mutex = self->mutex;
     event_processed = self->xrdp_encoder_event_processed;

--- a/xrdp/xrdp_font.c
+++ b/xrdp/xrdp_font.c
@@ -80,13 +80,13 @@ xrdp_font_create(struct xrdp_wm *wm)
     struct xrdp_font_char *f;
     char file_path[256];
 
-    DEBUG(("in xrdp_font_create"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "in xrdp_font_create");
     g_snprintf(file_path, 255, "%s/%s", XRDP_SHARE_PATH, DEFAULT_FONT_NAME);
 
     if (!g_file_exist(file_path))
     {
-        log_message(LOG_LEVEL_ERROR, "xrdp_font_create: error font file [%s] does not exist",
-                    file_path);
+        LOG(LOG_LEVEL_ERROR, "xrdp_font_create: error font file [%s] does not exist",
+            file_path);
         return 0;
     }
 
@@ -94,8 +94,8 @@ xrdp_font_create(struct xrdp_wm *wm)
 
     if (file_size < 1)
     {
-        log_message(LOG_LEVEL_ERROR, "xrdp_font_create: error reading font from file [%s]",
-                    file_path);
+        LOG(LOG_LEVEL_ERROR, "xrdp_font_create: error reading font from file [%s]",
+            file_path);
         return 0;
     }
 
@@ -139,9 +139,9 @@ xrdp_font_create(struct xrdp_wm *wm)
                 if (datasize < 0 || datasize > 512)
                 {
                     /* shouldn't happen */
-                    log_message(LOG_LEVEL_ERROR, "error in xrdp_font_create, datasize wrong");
-                    log_message(LOG_LEVEL_DEBUG, "width %d height %d datasize %d index %d",
-                                f->width, f->height, datasize, index);
+                    LOG(LOG_LEVEL_ERROR, "error in xrdp_font_create, datasize wrong "
+                        "width %d, height %d, datasize %d, index %d",
+                        f->width, f->height, datasize, index);
                     break;
                 }
 
@@ -152,7 +152,7 @@ xrdp_font_create(struct xrdp_wm *wm)
                 }
                 else
                 {
-                    log_message(LOG_LEVEL_ERROR, "error in xrdp_font_create");
+                    LOG(LOG_LEVEL_ERROR, "error in xrdp_font_create");
                 }
 
                 index++;
@@ -169,7 +169,7 @@ xrdp_font_create(struct xrdp_wm *wm)
       self->font_items[0].data = g_malloc(3 * 16, 0);
       g_memcpy(self->font_items[0].data, w_char, 3 * 16);
     */
-    DEBUG(("out xrdp_font_create"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_font_create");
     return self;
 }
 

--- a/xrdp/xrdp_font.c
+++ b/xrdp/xrdp_font.c
@@ -85,8 +85,8 @@ xrdp_font_create(struct xrdp_wm *wm)
 
     if (!g_file_exist(file_path))
     {
-        log_message(LOG_LEVEL_ERROR,"xrdp_font_create: error font file [%s] does not exist",
-               file_path);
+        log_message(LOG_LEVEL_ERROR, "xrdp_font_create: error font file [%s] does not exist",
+                    file_path);
         return 0;
     }
 
@@ -94,8 +94,8 @@ xrdp_font_create(struct xrdp_wm *wm)
 
     if (file_size < 1)
     {
-        log_message(LOG_LEVEL_ERROR,"xrdp_font_create: error reading font from file [%s]",
-        file_path);
+        log_message(LOG_LEVEL_ERROR, "xrdp_font_create: error reading font from file [%s]",
+                    file_path);
         return 0;
     }
 
@@ -139,9 +139,9 @@ xrdp_font_create(struct xrdp_wm *wm)
                 if (datasize < 0 || datasize > 512)
                 {
                     /* shouldn't happen */
-                    log_message(LOG_LEVEL_ERROR,"error in xrdp_font_create, datasize wrong");
-                    log_message(LOG_LEVEL_DEBUG,"width %d height %d datasize %d index %d",
-                               f->width, f->height, datasize, index);
+                    log_message(LOG_LEVEL_ERROR, "error in xrdp_font_create, datasize wrong");
+                    log_message(LOG_LEVEL_DEBUG, "width %d height %d datasize %d index %d",
+                                f->width, f->height, datasize, index);
                     break;
                 }
 
@@ -152,7 +152,7 @@ xrdp_font_create(struct xrdp_wm *wm)
                 }
                 else
                 {
-                    log_message(LOG_LEVEL_ERROR,"error in xrdp_font_create");
+                    log_message(LOG_LEVEL_ERROR, "error in xrdp_font_create");
                 }
 
                 index++;

--- a/xrdp/xrdp_listen.c
+++ b/xrdp/xrdp_listen.c
@@ -47,7 +47,7 @@ xrdp_listen_create_pro_done(struct xrdp_listen *self)
 
     if (self->pro_done_event == 0)
     {
-        log_message(LOG_LEVEL_ERROR,"Failure creating pro_done_event");
+        log_message(LOG_LEVEL_ERROR, "Failure creating pro_done_event");
     }
 
     return 0;
@@ -387,7 +387,7 @@ xrdp_listen_parse_vsock(char *strout, int strout_max,
         else
         {
             if (((strin[strin_index] >= '0') && (strin[strin_index] <= '9')) ||
-                 (strin[strin_index] == '-'))
+                    (strin[strin_index] == '-'))
             {
                 in = 1;
                 strout[strout_index++] = strin[strin_index++];
@@ -421,7 +421,7 @@ xrdp_listen_parse_ipv4(char *strout, int strout_max,
         if (in)
         {
             if (((strin[strin_index] >= '0') && (strin[strin_index] <= '9')) ||
-                 (strin[strin_index] == '.'))
+                    (strin[strin_index] == '.'))
             {
                 strout[strout_index++] = strin[strin_index++];
                 count++;
@@ -695,8 +695,8 @@ xrdp_listen_process_startup_params(struct xrdp_listen *self)
             return 1;
         }
         if ((mode == TRANS_MODE_TCP) ||
-            (mode == TRANS_MODE_TCP4) ||
-            (mode == TRANS_MODE_TCP6))
+                (mode == TRANS_MODE_TCP4) ||
+                (mode == TRANS_MODE_TCP6))
         {
             if (startup_params->tcp_nodelay)
             {
@@ -865,13 +865,13 @@ xrdp_listen_main_loop(struct xrdp_listen *self)
     self->status = 1;
     if (xrdp_listen_get_startup_params(self) != 0)
     {
-        log_message(LOG_LEVEL_ERROR,"xrdp_listen_main_loop: xrdp_listen_get_port failed");
+        log_message(LOG_LEVEL_ERROR, "xrdp_listen_main_loop: xrdp_listen_get_port failed");
         self->status = -1;
         return 1;
     }
     if (xrdp_listen_process_startup_params(self) != 0)
     {
-        log_message(LOG_LEVEL_ERROR,"xrdp_listen_main_loop: xrdp_listen_get_port failed");
+        log_message(LOG_LEVEL_ERROR, "xrdp_listen_main_loop: xrdp_listen_get_port failed");
         self->status = -1;
         return 1;
     }

--- a/xrdp/xrdp_listen.c
+++ b/xrdp/xrdp_listen.c
@@ -912,6 +912,9 @@ xrdp_listen_main_loop(struct xrdp_listen *self)
 
         if (g_is_wait_obj_set(term_obj)) /* termination called */
         {
+            LOG(LOG_LEVEL_INFO,
+                "Received termination signal, stopping the server accept new "
+                "connections thread");
             break;
         }
 

--- a/xrdp/xrdp_listen.c
+++ b/xrdp/xrdp_listen.c
@@ -47,7 +47,7 @@ xrdp_listen_create_pro_done(struct xrdp_listen *self)
 
     if (self->pro_done_event == 0)
     {
-        log_message(LOG_LEVEL_ERROR, "Failure creating pro_done_event");
+        LOG(LOG_LEVEL_WARNING, "Failure creating pro_done_event");
     }
 
     return 0;
@@ -145,12 +145,12 @@ xrdp_process_run(void *in_val)
 {
     struct xrdp_process *process;
 
-    DEBUG(("process started"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "process started");
     process = g_process;
     g_process = 0;
     tc_sem_inc(g_process_sem);
     xrdp_process_main_loop(process);
-    DEBUG(("process done"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "process done");
     return 0;
 }
 
@@ -671,25 +671,25 @@ xrdp_listen_process_startup_params(struct xrdp_listen *self)
     {
         if (xrdp_listen_pp(self, &index, address, port, &mode) != 0)
         {
-            log_message(LOG_LEVEL_INFO, "xrdp_listen_pp done");
+            LOG(LOG_LEVEL_INFO, "xrdp_listen_pp done");
             cont = 0;
             break;
         }
-        log_message(LOG_LEVEL_INFO, "address [%s] port [%s] mode %d",
-                    address, port, mode);
+        LOG(LOG_LEVEL_INFO, "address [%s] port [%s] mode %d",
+            address, port, mode);
         ltrans = trans_create(mode, 16, 16);
         if (ltrans == NULL)
         {
-            log_message(LOG_LEVEL_ERROR, "trans_create failed");
+            LOG(LOG_LEVEL_ERROR, "trans_create failed");
             xrdp_listen_stop_all_listen(self);
             return 1;
         }
-        log_message(LOG_LEVEL_INFO, "listening to port %s on %s",
-                    port, address);
+        LOG(LOG_LEVEL_INFO, "listening to port %s on %s",
+            port, address);
         error = trans_listen_address(ltrans, port, address);
         if (error != 0)
         {
-            log_message(LOG_LEVEL_ERROR, "trans_listen_address failed");
+            LOG(LOG_LEVEL_ERROR, "trans_listen_address failed");
             trans_delete(ltrans);
             xrdp_listen_stop_all_listen(self);
             return 1;
@@ -702,60 +702,60 @@ xrdp_listen_process_startup_params(struct xrdp_listen *self)
             {
                 if (g_tcp_set_no_delay(ltrans->sck))
                 {
-                    log_message(LOG_LEVEL_ERROR, "Error setting tcp_nodelay");
+                    LOG(LOG_LEVEL_ERROR, "Error setting tcp_nodelay");
                 }
             }
             if (startup_params->tcp_keepalive)
             {
                 if (g_tcp_set_keepalive(ltrans->sck))
                 {
-                    log_message(LOG_LEVEL_ERROR, "Error setting "
-                                "tcp_keepalive");
+                    LOG(LOG_LEVEL_ERROR, "Error setting "
+                        "tcp_keepalive");
                 }
             }
             if (startup_params->tcp_send_buffer_bytes > 0)
             {
                 bytes = startup_params->tcp_send_buffer_bytes;
-                log_message(LOG_LEVEL_INFO, "setting send buffer to %d bytes",
-                            bytes);
+                LOG(LOG_LEVEL_INFO, "setting send buffer to %d bytes",
+                    bytes);
                 if (g_sck_set_send_buffer_bytes(ltrans->sck, bytes) != 0)
                 {
-                    log_message(LOG_LEVEL_ERROR, "error setting send buffer");
+                    LOG(LOG_LEVEL_WARNING, "error setting send buffer");
                 }
                 else
                 {
                     if (g_sck_get_send_buffer_bytes(ltrans->sck, &bytes) != 0)
                     {
-                        log_message(LOG_LEVEL_ERROR, "error getting send "
-                                    "buffer");
+                        LOG(LOG_LEVEL_WARNING, "error getting send "
+                            "buffer");
                     }
                     else
                     {
-                        log_message(LOG_LEVEL_INFO, "send buffer set to %d "
-                                    "bytes", bytes);
+                        LOG(LOG_LEVEL_INFO, "send buffer set to %d "
+                            "bytes", bytes);
                     }
                 }
             }
             if (startup_params->tcp_recv_buffer_bytes > 0)
             {
                 bytes = startup_params->tcp_recv_buffer_bytes;
-                log_message(LOG_LEVEL_INFO, "setting recv buffer to %d bytes",
-                            bytes);
+                LOG(LOG_LEVEL_INFO, "setting recv buffer to %d bytes",
+                    bytes);
                 if (g_sck_set_recv_buffer_bytes(ltrans->sck, bytes) != 0)
                 {
-                    log_message(LOG_LEVEL_ERROR, "error setting recv buffer");
+                    LOG(LOG_LEVEL_WARNING, "error setting recv buffer");
                 }
                 else
                 {
                     if (g_sck_get_recv_buffer_bytes(ltrans->sck, &bytes) != 0)
                     {
-                        log_message(LOG_LEVEL_ERROR, "error getting recv "
-                                    "buffer");
+                        LOG(LOG_LEVEL_WARNING, "error getting recv "
+                            "buffer");
                     }
                     else
                     {
-                        log_message(LOG_LEVEL_INFO, "recv buffer set to %d "
-                                    "bytes", bytes);
+                        LOG(LOG_LEVEL_INFO, "recv buffer set to %d "
+                            "bytes", bytes);
                     }
                 }
             }
@@ -865,13 +865,13 @@ xrdp_listen_main_loop(struct xrdp_listen *self)
     self->status = 1;
     if (xrdp_listen_get_startup_params(self) != 0)
     {
-        log_message(LOG_LEVEL_ERROR, "xrdp_listen_main_loop: xrdp_listen_get_port failed");
+        LOG(LOG_LEVEL_ERROR, "xrdp_listen_main_loop: xrdp_listen_get_port failed");
         self->status = -1;
         return 1;
     }
     if (xrdp_listen_process_startup_params(self) != 0)
     {
-        log_message(LOG_LEVEL_ERROR, "xrdp_listen_main_loop: xrdp_listen_get_port failed");
+        LOG(LOG_LEVEL_ERROR, "xrdp_listen_main_loop: xrdp_listen_get_port failed");
         self->status = -1;
         return 1;
     }

--- a/xrdp/xrdp_login_wnd.c
+++ b/xrdp/xrdp_login_wnd.c
@@ -254,18 +254,18 @@ xrdp_wm_ok_clicked(struct xrdp_bitmap *wnd)
 
 /*****************************************************************************/
 /**
-* This is an internal function in this file used to parse the domain 
-* information sent from the client. If the information starts 
-* with '_' the domain field contains the IP/DNS to connect to. 
-* If the domain field contains an additional '__' the char that 
-* follows this '__' is an index number of a preferred combo choice. 
-* Valid values for this choice is 0-9. But this function will only return 
+* This is an internal function in this file used to parse the domain
+* information sent from the client. If the information starts
+* with '_' the domain field contains the IP/DNS to connect to.
+* If the domain field contains an additional '__' the char that
+* follows this '__' is an index number of a preferred combo choice.
+* Valid values for this choice is 0-9. But this function will only return
 * index numbers between 0 and the max number of combo items -1.
-* Example: _192.168.1.2__1 result in a resultbuffer containing 
-* 192.168.1.2  and the return value will be 1. Meaning that 
-* index 1 is the preferred combo choice. 
-* 
-* Users can create shortcuts where this information is configured. These 
+* Example: _192.168.1.2__1 result in a resultbuffer containing
+* 192.168.1.2  and the return value will be 1. Meaning that
+* index 1 is the preferred combo choice.
+*
+* Users can create shortcuts where this information is configured. These
 * shortcuts simplifies login.
 * @param originalDomainInfo indata to this function
 * @param comboMax the max number of combo choices
@@ -296,7 +296,7 @@ xrdp_wm_parse_domain_information(char *originalDomainInfo, int comboMax,
          * log_message(LOG_LEVEL_DEBUG, "domain contains _");
          * We must use valid chars in the domain name.
          * Underscore is a valid name in the domain.
-         * Invalid chars are ignored in microsoft client therefore we use '_' 
+         * Invalid chars are ignored in microsoft client therefore we use '_'
          * again. this sec '__' contains the split for index.*/
         pos = g_pos(&originalDomainInfo[1], "__");
         if (pos > 0)
@@ -321,7 +321,7 @@ xrdp_wm_parse_domain_information(char *originalDomainInfo, int comboMax,
                 }
             }
             /* pos limit the String to only contain the IP */
-            g_strncpy(resultBuffer, &originalDomainInfo[1], pos); 
+            g_strncpy(resultBuffer, &originalDomainInfo[1], pos);
         }
         else
         {
@@ -446,8 +446,8 @@ xrdp_wm_show_edits(struct xrdp_wm *self, struct xrdp_bitmap *combo)
                     if (self->session->client_info->domain[0] == '_')
                     {
                         xrdp_wm_parse_domain_information(
-                                self->session->client_info->domain,
-                                combo->data_list->count, 0, resultIP);
+                            self->session->client_info->domain,
+                            combo->data_list->count, 0, resultIP);
                         g_strncpy(b->caption1, resultIP, 255);
                         b->edit_pos = g_mbstowcs(0, b->caption1, 0);
                     }
@@ -711,15 +711,15 @@ xrdp_login_wnd_create(struct xrdp_wm *self)
     /* if window title not specified, use hostname as default */
     if (globals->ls_title[0] == 0)
     {
-       g_gethostname(buf1, 256);
-       g_sprintf(buf, "Login to %s", buf1);
-       set_string(&self->login_window->caption1, buf);
+        g_gethostname(buf1, 256);
+        g_sprintf(buf, "Login to %s", buf1);
+        set_string(&self->login_window->caption1, buf);
     }
     else
     {
-       /*self->login_window->caption1 = globals->ls_title[0];*/
-       g_sprintf(buf, "%s", globals->ls_title);
-       set_string(&self->login_window->caption1, buf);
+        /*self->login_window->caption1 = globals->ls_title[0];*/
+        g_sprintf(buf, "%s", globals->ls_title);
+        set_string(&self->login_window->caption1, buf);
     }
 
     if (regular)
@@ -751,13 +751,17 @@ xrdp_login_wnd_create(struct xrdp_wm *self)
 
         /* if logo image not specified, use default */
         if (globals->ls_logo_filename[0] == 0)
+        {
             g_snprintf(globals->ls_logo_filename, 255, "%s/xrdp_logo.bmp", XRDP_SHARE_PATH);
+        }
 
         /* logo image */
         but = xrdp_bitmap_create(4, 4, self->screen->bpp, WND_TYPE_IMAGE, self);
 
         if (self->screen->bpp <= 8)
+        {
             g_snprintf(globals->ls_logo_filename, 255, "%s/ad256.bmp", XRDP_SHARE_PATH);
+        }
 
         xrdp_bitmap_load(but, globals->ls_logo_filename, self->palette);
         but->parent = self->login_window;
@@ -820,9 +824,9 @@ xrdp_login_wnd_create(struct xrdp_wm *self)
     * We only perform this the first time for each connection.
     */
     combo->item_index = xrdp_wm_parse_domain_information(
-                self->session->client_info->domain,
-                combo->data_list->count, 1,
-                resultIP /* just a dummy place holder, we ignore */ );
+                            self->session->client_info->domain,
+                            combo->data_list->count, 1,
+                            resultIP /* just a dummy place holder, we ignore */ );
     xrdp_wm_show_edits(self, combo);
 
     return 0;
@@ -851,7 +855,9 @@ load_xrdp_config(struct xrdp_config *config, const char *xrdp_ini, int bpp)
     int   i;
 
     if (!config)
+    {
         return -1;
+    }
 
     globals = &config->cfg_globals;
 
@@ -871,7 +877,7 @@ load_xrdp_config(struct xrdp_config *config, const char *xrdp_ini, int bpp)
     globals->ls_btn_ok_x_pos = 150;
     globals->ls_btn_ok_y_pos = 300;
     globals->ls_btn_ok_width = 85;
-    globals->ls_btn_ok_height =30;
+    globals->ls_btn_ok_height = 30;
     globals->ls_btn_cancel_x_pos = 245;
     globals->ls_btn_cancel_y_pos = 300;
     globals->ls_btn_cancel_width = 85;
@@ -880,7 +886,7 @@ load_xrdp_config(struct xrdp_config *config, const char *xrdp_ini, int bpp)
     /* open xrdp.ini file */
     if ((fd = g_file_open(xrdp_ini)) < 0)
     {
-        log_message(LOG_LEVEL_ERROR,"load_config: Could not read "
+        log_message(LOG_LEVEL_ERROR, "load_config: Could not read "
                     "xrdp.ini file %s", xrdp_ini);
         return -1;
 
@@ -896,7 +902,7 @@ load_xrdp_config(struct xrdp_config *config, const char *xrdp_ini, int bpp)
         list_delete(names);
         list_delete(values);
         g_file_close(fd);
-        log_message(LOG_LEVEL_ERROR,"load_config: Could not read globals "
+        log_message(LOG_LEVEL_ERROR, "load_config: Could not read globals "
                     "section from xrdp.ini file %s", xrdp_ini);
         return -1;
     }
@@ -911,117 +917,186 @@ load_xrdp_config(struct xrdp_config *config, const char *xrdp_ini, int bpp)
          */
 
         if (g_strncmp(n, "ini_version", 64) == 0)
+        {
             globals->ini_version = g_atoi(v);
+        }
 
         else if (g_strncmp(n, "bitmap_cache", 64) == 0)
+        {
             globals->use_bitmap_cache = g_text2bool(v);
+        }
 
         else if (g_strncmp(n, "bitmap_compression", 64) == 0)
+        {
             globals->use_bitmap_compression = g_text2bool(v);
+        }
 
         else if (g_strncmp(n, "port", 64) == 0)
+        {
             globals->port = g_atoi(v);
+        }
 
         else if (g_strncmp(n, "crypt_level", 64) == 0)
         {
             if (g_strcmp(v, "low") == 0)
+            {
                 globals->crypt_level = 1;
+            }
             else if (g_strcmp(v, "medium") == 0)
+            {
                 globals->crypt_level = 2;
+            }
             else
+            {
                 globals->crypt_level = 3;
+            }
         }
 
         else if (g_strncmp(n, "allow_channels", 64) == 0)
+        {
             globals->allow_channels = g_text2bool(v);
+        }
 
         else if (g_strncmp(n, "max_bpp", 64) == 0)
+        {
             globals->max_bpp = g_atoi(v);
+        }
 
         else if (g_strncmp(n, "fork", 64) == 0)
+        {
             globals->fork = g_text2bool(v);
+        }
 
         else if (g_strncmp(n, "tcp_nodelay", 64) == 0)
+        {
             globals->tcp_nodelay = g_text2bool(v);
+        }
 
         else if (g_strncmp(n, "tcp_keepalive", 64) == 0)
+        {
             globals->tcp_keepalive = g_text2bool(v);
+        }
 
         else if (g_strncmp(n, "tcp_send_buffer_bytes", 64) == 0)
+        {
             globals->tcp_send_buffer_bytes = g_atoi(v);
+        }
 
         else if (g_strncmp(n, "tcp_recv_buffer_bytes", 64) == 0)
+        {
             globals->tcp_recv_buffer_bytes = g_atoi(v);
+        }
 
         /* colors */
 
         else if (g_strncmp(n, "grey", 64) == 0)
+        {
             globals->grey = xrdp_wm_htoi(v);
+        }
 
         else if (g_strncmp(n, "black", 64) == 0)
+        {
             globals->black = xrdp_wm_htoi(v);
+        }
 
         else if (g_strncmp(n, "dark_grey", 64) == 0)
+        {
             globals->dark_grey = xrdp_wm_htoi(v);
+        }
 
         else if (g_strncmp(n, "blue", 64) == 0)
+        {
             globals->blue = xrdp_wm_htoi(v);
+        }
 
         else if (g_strncmp(n, "dark_blue", 64) == 0)
+        {
             globals->dark_blue = xrdp_wm_htoi(v);
+        }
 
         else if (g_strncmp(n, "white", 64) == 0)
+        {
             globals->white = xrdp_wm_htoi(v);
+        }
 
         else if (g_strncmp(n, "red", 64) == 0)
+        {
             globals->red = xrdp_wm_htoi(v);
+        }
 
         else if (g_strncmp(n, "green", 64) == 0)
+        {
             globals->green = xrdp_wm_htoi(v);
+        }
 
         else if (g_strncmp(n, "background", 64) == 0)
+        {
             globals->background = xrdp_wm_htoi(v);
+        }
 
         /* misc stuff */
 
         else if (g_strncmp(n, "autorun", 255) == 0)
+        {
             g_strncpy(globals->autorun, v, 255);
+        }
 
         else if (g_strncmp(n, "hidelogwindow", 64) == 0)
+        {
             globals->hidelogwindow = g_text2bool(v);
+        }
 
         else if (g_strncmp(n, "require_credentials", 64) == 0)
+        {
             globals->require_credentials = g_text2bool(v);
+        }
 
         else if (g_strncmp(n, "bulk_compression", 64) == 0)
+        {
             globals->bulk_compression = g_text2bool(v);
+        }
 
         else if (g_strncmp(n, "new_cursors", 64) == 0)
+        {
             globals->new_cursors = g_text2bool(v);
+        }
 
         else if (g_strncmp(n, "nego_sec_layer", 64) == 0)
+        {
             globals->nego_sec_layer = g_atoi(v);
+        }
 
         else if (g_strncmp(n, "allow_multimon", 64) == 0)
+        {
             globals->allow_multimon = g_text2bool(v);
+        }
 
-        else if (g_strncmp(n, "enable_token_login", 64) == 0) {
+        else if (g_strncmp(n, "enable_token_login", 64) == 0)
+        {
             log_message(LOG_LEVEL_DEBUG, "Token login detection enabled x");
             globals->enable_token_login = g_text2bool(v);
         }
 
         /* login screen values */
         else if (g_strncmp(n, "ls_top_window_bg_color", 64) == 0)
+        {
             globals->ls_top_window_bg_color = HCOLOR(bpp, xrdp_wm_htoi(v));
+        }
 
         else if (g_strncmp(n, "ls_width", 64) == 0)
+        {
             globals->ls_width = g_atoi(v);
+        }
 
         else if (g_strncmp(n, "ls_height", 64) == 0)
+        {
             globals->ls_height = g_atoi(v);
+        }
 
         else if (g_strncmp(n, "ls_bg_color", 64) == 0)
+        {
             globals->ls_bg_color = HCOLOR(bpp, xrdp_wm_htoi(v));
+        }
 
         else if (g_strncmp(n, "ls_title", 255) == 0)
         {
@@ -1040,49 +1115,79 @@ load_xrdp_config(struct xrdp_config *config, const char *xrdp_ini, int bpp)
             globals->ls_background_image[255] = 0;
         }
         else if (g_strncmp(n, "ls_logo_x_pos", 64) == 0)
+        {
             globals->ls_logo_x_pos = g_atoi(v);
+        }
 
         else if (g_strncmp(n, "ls_logo_y_pos", 64) == 0)
+        {
             globals->ls_logo_y_pos = g_atoi(v);
+        }
 
         else if (g_strncmp(n, "ls_label_x_pos", 64) == 0)
+        {
             globals->ls_label_x_pos = g_atoi(v);
+        }
 
         else if (g_strncmp(n, "ls_label_width", 64) == 0)
+        {
             globals->ls_label_width = g_atoi(v);
+        }
 
         else if (g_strncmp(n, "ls_input_x_pos", 64) == 0)
+        {
             globals->ls_input_x_pos = g_atoi(v);
+        }
 
         else if (g_strncmp(n, "ls_input_width", 64) == 0)
+        {
             globals->ls_input_width = g_atoi(v);
+        }
 
         else if (g_strncmp(n, "ls_input_y_pos", 64) == 0)
+        {
             globals->ls_input_y_pos = g_atoi(v);
+        }
 
         else if (g_strncmp(n, "ls_btn_ok_x_pos", 64) == 0)
+        {
             globals->ls_btn_ok_x_pos = g_atoi(v);
+        }
 
         else if (g_strncmp(n, "ls_btn_ok_y_pos", 64) == 0)
+        {
             globals->ls_btn_ok_y_pos = g_atoi(v);
+        }
 
         else if (g_strncmp(n, "ls_btn_ok_width", 64) == 0)
+        {
             globals->ls_btn_ok_width = g_atoi(v);
+        }
 
         else if (g_strncmp(n, "ls_btn_ok_height", 64) == 0)
+        {
             globals->ls_btn_ok_height = g_atoi(v);
+        }
 
         else if (g_strncmp(n, "ls_btn_cancel_x_pos", 64) == 0)
+        {
             globals->ls_btn_cancel_x_pos = g_atoi(v);
+        }
 
         else if (g_strncmp(n, "ls_btn_cancel_y_pos", 64) == 0)
+        {
             globals->ls_btn_cancel_y_pos = g_atoi(v);
+        }
 
         else if (g_strncmp(n, "ls_btn_cancel_width", 64) == 0)
+        {
             globals->ls_btn_cancel_width = g_atoi(v);
+        }
 
         else if (g_strncmp(n, "ls_btn_cancel_height", 64) == 0)
+        {
             globals->ls_btn_cancel_height = g_atoi(v);
+        }
     }
 
 #if 0

--- a/xrdp/xrdp_login_wnd.c
+++ b/xrdp/xrdp_login_wnd.c
@@ -1221,7 +1221,7 @@ load_xrdp_config(struct xrdp_config *config, const char *xrdp_ini, int bpp)
     LOG(LOG_LEVEL_DEBUG, "new_cursors:             %d", globals->new_cursors);
     LOG(LOG_LEVEL_DEBUG, "nego_sec_layer:          %d", globals->nego_sec_layer);
     LOG(LOG_LEVEL_DEBUG, "allow_multimon:          %d", globals->allow_multimon);
-    LOG(LOG_LEVEL_DEBUG, "enable_token_login:      %d", globals->enable_token_login)
+    LOG(LOG_LEVEL_DEBUG, "enable_token_login:      %d", globals->enable_token_login);
 
     LOG(LOG_LEVEL_DEBUG, "ls_top_window_bg_color:  %x", globals->ls_top_window_bg_color);
     LOG(LOG_LEVEL_DEBUG, "ls_width:                %d", globals->ls_width);

--- a/xrdp/xrdp_login_wnd.c
+++ b/xrdp/xrdp_login_wnd.c
@@ -246,7 +246,7 @@ xrdp_wm_ok_clicked(struct xrdp_bitmap *wnd)
     }
     else
     {
-        log_message(LOG_LEVEL_ERROR, "Combo is 0 - potential programming error");
+        LOG(LOG_LEVEL_WARNING, "Combo is NULL - potential programming error");
     }
 
     return 0;
@@ -293,7 +293,6 @@ xrdp_wm_parse_domain_information(char *originalDomainInfo, int comboMax,
     {
         /* we try to locate a number indicating what combobox index the user
          * prefer the information is loaded from domain field, from the client
-         * log_message(LOG_LEVEL_DEBUG, "domain contains _");
          * We must use valid chars in the domain name.
          * Underscore is a valid name in the domain.
          * Invalid chars are ignored in microsoft client therefore we use '_'
@@ -301,22 +300,22 @@ xrdp_wm_parse_domain_information(char *originalDomainInfo, int comboMax,
         pos = g_pos(&originalDomainInfo[1], "__");
         if (pos > 0)
         {
-            /* an index is found we try to use it
-            log_message(LOG_LEVEL_DEBUG, "domain contains index char __");*/
+            /* an index is found we try to use it */
+            LOG(LOG_LEVEL_DEBUG, "domain contains index char __");
             if (decode)
             {
                 g_memset(index, 0, 2);
                 /* we just accept values 0-9  (one figure) */
                 g_strncpy(index, &originalDomainInfo[pos + 3], 1);
                 comboxindex = g_htoi(index);
-                log_message(LOG_LEVEL_DEBUG,
-                            "index value as string: %s, as int: %d, max: %d",
-                            index, comboxindex, comboMax - 1);
+                LOG(LOG_LEVEL_DEBUG,
+                    "index value as string: %s, as int: %d, max: %d",
+                    index, comboxindex, comboMax - 1);
                 /* limit to max number of items in combo box */
                 if ((comboxindex > 0) && (comboxindex < comboMax))
                 {
-                    log_message(LOG_LEVEL_DEBUG, "domain contains a valid "
-                                "index number");
+                    LOG(LOG_LEVEL_DEBUG, "domain contains a valid "
+                        "index number");
                     ret = comboxindex; /* preferred index for combo box. */
                 }
             }
@@ -325,7 +324,7 @@ xrdp_wm_parse_domain_information(char *originalDomainInfo, int comboMax,
         }
         else
         {
-            /* log_message(LOG_LEVEL_DEBUG, "domain does not contain _"); */
+            LOG(LOG_LEVEL_DEBUG, "domain does not contain _");
             g_strncpy(resultBuffer, &originalDomainInfo[1], 255);
         }
     }
@@ -573,8 +572,8 @@ xrdp_wm_login_fill_in_combo(struct xrdp_wm *self, struct xrdp_bitmap *b)
 
     if (fd < 0)
     {
-        log_message(LOG_LEVEL_ERROR, "Could not read xrdp ini file %s",
-                    xrdp_ini);
+        LOG(LOG_LEVEL_ERROR, "Could not read xrdp ini file %s",
+            xrdp_ini);
         list_delete(sections);
         list_delete(section_names);
         list_delete(section_values);
@@ -740,7 +739,7 @@ xrdp_login_wnd_create(struct xrdp_wm *self)
                 g_snprintf(fileName, 255, "%s/%s",
                            XRDP_SHARE_PATH, globals->ls_background_image);
             }
-            log_message(LOG_LEVEL_DEBUG, "We try to load the following background file: %s", fileName);
+            LOG(LOG_LEVEL_DEBUG, "We try to load the following background file: %s", fileName);
             xrdp_bitmap_load(but, fileName, self->palette);
             but->parent = self->screen;
             but->owner = self->screen;
@@ -886,8 +885,8 @@ load_xrdp_config(struct xrdp_config *config, const char *xrdp_ini, int bpp)
     /* open xrdp.ini file */
     if ((fd = g_file_open(xrdp_ini)) < 0)
     {
-        log_message(LOG_LEVEL_ERROR, "load_config: Could not read "
-                    "xrdp.ini file %s", xrdp_ini);
+        LOG(LOG_LEVEL_ERROR, "load_config: Could not read "
+            "xrdp.ini file %s", xrdp_ini);
         return -1;
 
     }
@@ -902,8 +901,8 @@ load_xrdp_config(struct xrdp_config *config, const char *xrdp_ini, int bpp)
         list_delete(names);
         list_delete(values);
         g_file_close(fd);
-        log_message(LOG_LEVEL_ERROR, "load_config: Could not read globals "
-                    "section from xrdp.ini file %s", xrdp_ini);
+        LOG(LOG_LEVEL_ERROR, "load_config: Could not read globals "
+            "section from xrdp.ini file %s", xrdp_ini);
         return -1;
     }
 
@@ -1073,7 +1072,7 @@ load_xrdp_config(struct xrdp_config *config, const char *xrdp_ini, int bpp)
 
         else if (g_strncmp(n, "enable_token_login", 64) == 0)
         {
-            log_message(LOG_LEVEL_DEBUG, "Token login detection enabled x");
+            LOG(LOG_LEVEL_DEBUG, "Token login detection enabled x");
             globals->enable_token_login = g_text2bool(v);
         }
 
@@ -1190,63 +1189,61 @@ load_xrdp_config(struct xrdp_config *config, const char *xrdp_ini, int bpp)
         }
     }
 
-#if 0
-    g_writeln("ini_version:             %d", globals->ini_version);
-    g_writeln("use_bitmap_cache:        %d", globals->use_bitmap_cache);
-    g_writeln("use_bitmap_compression:  %d", globals->use_bitmap_compression);
-    g_writeln("port:                    %d", globals->port);
-    g_writeln("crypt_level:             %d", globals->crypt_level);
-    g_writeln("allow_channels:          %d", globals->allow_channels);
-    g_writeln("max_bpp:                 %d", globals->max_bpp);
-    g_writeln("fork:                    %d", globals->fork);
-    g_writeln("tcp_nodelay:             %d", globals->tcp_nodelay);
-    g_writeln("tcp_keepalive:           %d", globals->tcp_keepalive);
-    g_writeln("tcp_send_buffer_bytes:   %d", globals->tcp_send_buffer_bytes);
-    g_writeln("tcp_recv_buffer_bytes:   %d", globals->tcp_recv_buffer_bytes);
-    g_writeln("new_cursors:             %d", globals->new_cursors);
-    g_writeln("allow_multimon:          %d", globals->allow_multimon);
+    LOG(LOG_LEVEL_DEBUG, "ini_version:             %d", globals->ini_version);
+    LOG(LOG_LEVEL_DEBUG, "use_bitmap_cache:        %d", globals->use_bitmap_cache);
+    LOG(LOG_LEVEL_DEBUG, "use_bitmap_compression:  %d", globals->use_bitmap_compression);
+    LOG(LOG_LEVEL_DEBUG, "port:                    %d", globals->port);
+    LOG(LOG_LEVEL_DEBUG, "crypt_level:             %d", globals->crypt_level);
+    LOG(LOG_LEVEL_DEBUG, "allow_channels:          %d", globals->allow_channels);
+    LOG(LOG_LEVEL_DEBUG, "max_bpp:                 %d", globals->max_bpp);
+    LOG(LOG_LEVEL_DEBUG, "fork:                    %d", globals->fork);
+    LOG(LOG_LEVEL_DEBUG, "tcp_nodelay:             %d", globals->tcp_nodelay);
+    LOG(LOG_LEVEL_DEBUG, "tcp_keepalive:           %d", globals->tcp_keepalive);
+    LOG(LOG_LEVEL_DEBUG, "tcp_send_buffer_bytes:   %d", globals->tcp_send_buffer_bytes);
+    LOG(LOG_LEVEL_DEBUG, "tcp_recv_buffer_bytes:   %d", globals->tcp_recv_buffer_bytes);
+    LOG(LOG_LEVEL_DEBUG, "new_cursors:             %d", globals->new_cursors);
+    LOG(LOG_LEVEL_DEBUG, "allow_multimon:          %d", globals->allow_multimon);
 
-    g_writeln("grey:                    %d", globals->grey);
-    g_writeln("black:                   %d", globals->black);
-    g_writeln("dark_grey:               %d", globals->dark_grey);
-    g_writeln("blue:                    %d", globals->blue);
-    g_writeln("dark_blue:               %d", globals->dark_blue);
-    g_writeln("white:                   %d", globals->white);
-    g_writeln("red:                     %d", globals->red);
-    g_writeln("green:                   %d", globals->green);
-    g_writeln("background:              %d", globals->background);
+    LOG(LOG_LEVEL_DEBUG, "grey:                    %d", globals->grey);
+    LOG(LOG_LEVEL_DEBUG, "black:                   %d", globals->black);
+    LOG(LOG_LEVEL_DEBUG, "dark_grey:               %d", globals->dark_grey);
+    LOG(LOG_LEVEL_DEBUG, "blue:                    %d", globals->blue);
+    LOG(LOG_LEVEL_DEBUG, "dark_blue:               %d", globals->dark_blue);
+    LOG(LOG_LEVEL_DEBUG, "white:                   %d", globals->white);
+    LOG(LOG_LEVEL_DEBUG, "red:                     %d", globals->red);
+    LOG(LOG_LEVEL_DEBUG, "green:                   %d", globals->green);
+    LOG(LOG_LEVEL_DEBUG, "background:              %d", globals->background);
 
-    g_writeln("autorun:                 %s", globals->autorun);
-    g_writeln("hidelogwindow:           %d", globals->hidelogwindow);
-    g_writeln("require_credentials:     %d", globals->require_credentials);
-    g_writeln("bulk_compression:        %d", globals->bulk_compression);
-    g_writeln("new_cursors:             %d", globals->new_cursors);
-    g_writeln("nego_sec_layer:          %d", globals->nego_sec_layer);
-    g_writeln("allow_multimon:          %d", globals->allow_multimon);
-    g_writeln("enable_token_login:      %d", globals->enable_token_login)
+    LOG(LOG_LEVEL_DEBUG, "autorun:                 %s", globals->autorun);
+    LOG(LOG_LEVEL_DEBUG, "hidelogwindow:           %d", globals->hidelogwindow);
+    LOG(LOG_LEVEL_DEBUG, "require_credentials:     %d", globals->require_credentials);
+    LOG(LOG_LEVEL_DEBUG, "bulk_compression:        %d", globals->bulk_compression);
+    LOG(LOG_LEVEL_DEBUG, "new_cursors:             %d", globals->new_cursors);
+    LOG(LOG_LEVEL_DEBUG, "nego_sec_layer:          %d", globals->nego_sec_layer);
+    LOG(LOG_LEVEL_DEBUG, "allow_multimon:          %d", globals->allow_multimon);
+    LOG(LOG_LEVEL_DEBUG, "enable_token_login:      %d", globals->enable_token_login)
 
-    g_writeln("ls_top_window_bg_color:  %x", globals->ls_top_window_bg_color);
-    g_writeln("ls_width:                %d", globals->ls_width);
-    g_writeln("ls_height:               %d", globals->ls_height);
-    g_writeln("ls_bg_color:             %x", globals->ls_bg_color);
-    g_writeln("ls_title:                %s", globals->ls_title);
-    g_writeln("ls_logo_filename:        %s", globals->ls_logo_filename);
-    g_writeln("ls_logo_x_pos:           %d", globals->ls_logo_x_pos);
-    g_writeln("ls_logo_y_pos:           %d", globals->ls_logo_y_pos);
-    g_writeln("ls_label_x_pos:          %d", globals->ls_label_x_pos);
-    g_writeln("ls_label_width:          %d", globals->ls_label_width);
-    g_writeln("ls_input_x_pos:          %d", globals->ls_input_x_pos);
-    g_writeln("ls_input_width:          %d", globals->ls_input_width);
-    g_writeln("ls_input_y_pos:          %d", globals->ls_input_y_pos);
-    g_writeln("ls_btn_ok_x_pos:         %d", globals->ls_btn_ok_x_pos);
-    g_writeln("ls_btn_ok_y_pos:         %d", globals->ls_btn_ok_y_pos);
-    g_writeln("ls_btn_ok_width:         %d", globals->ls_btn_ok_width);
-    g_writeln("ls_btn_ok_height:        %d", globals->ls_btn_ok_height);
-    g_writeln("ls_btn_cancel_x_pos:     %d", globals->ls_btn_cancel_x_pos);
-    g_writeln("ls_btn_cancel_y_pos:     %d", globals->ls_btn_cancel_y_pos);
-    g_writeln("ls_btn_cancel_width:     %d", globals->ls_btn_cancel_width);
-    g_writeln("ls_btn_cancel_height:    %d", globals->ls_btn_cancel_height);
-#endif
+    LOG(LOG_LEVEL_DEBUG, "ls_top_window_bg_color:  %x", globals->ls_top_window_bg_color);
+    LOG(LOG_LEVEL_DEBUG, "ls_width:                %d", globals->ls_width);
+    LOG(LOG_LEVEL_DEBUG, "ls_height:               %d", globals->ls_height);
+    LOG(LOG_LEVEL_DEBUG, "ls_bg_color:             %x", globals->ls_bg_color);
+    LOG(LOG_LEVEL_DEBUG, "ls_title:                %s", globals->ls_title);
+    LOG(LOG_LEVEL_DEBUG, "ls_logo_filename:        %s", globals->ls_logo_filename);
+    LOG(LOG_LEVEL_DEBUG, "ls_logo_x_pos:           %d", globals->ls_logo_x_pos);
+    LOG(LOG_LEVEL_DEBUG, "ls_logo_y_pos:           %d", globals->ls_logo_y_pos);
+    LOG(LOG_LEVEL_DEBUG, "ls_label_x_pos:          %d", globals->ls_label_x_pos);
+    LOG(LOG_LEVEL_DEBUG, "ls_label_width:          %d", globals->ls_label_width);
+    LOG(LOG_LEVEL_DEBUG, "ls_input_x_pos:          %d", globals->ls_input_x_pos);
+    LOG(LOG_LEVEL_DEBUG, "ls_input_width:          %d", globals->ls_input_width);
+    LOG(LOG_LEVEL_DEBUG, "ls_input_y_pos:          %d", globals->ls_input_y_pos);
+    LOG(LOG_LEVEL_DEBUG, "ls_btn_ok_x_pos:         %d", globals->ls_btn_ok_x_pos);
+    LOG(LOG_LEVEL_DEBUG, "ls_btn_ok_y_pos:         %d", globals->ls_btn_ok_y_pos);
+    LOG(LOG_LEVEL_DEBUG, "ls_btn_ok_width:         %d", globals->ls_btn_ok_width);
+    LOG(LOG_LEVEL_DEBUG, "ls_btn_ok_height:        %d", globals->ls_btn_ok_height);
+    LOG(LOG_LEVEL_DEBUG, "ls_btn_cancel_x_pos:     %d", globals->ls_btn_cancel_x_pos);
+    LOG(LOG_LEVEL_DEBUG, "ls_btn_cancel_y_pos:     %d", globals->ls_btn_cancel_y_pos);
+    LOG(LOG_LEVEL_DEBUG, "ls_btn_cancel_width:     %d", globals->ls_btn_cancel_width);
+    LOG(LOG_LEVEL_DEBUG, "ls_btn_cancel_height:    %d", globals->ls_btn_cancel_height);
 
     list_delete(names);
     list_delete(values);

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -38,17 +38,7 @@
 #include "xrdp_encoder.h"
 #include "xrdp_sockets.h"
 
-#define LLOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do \
-    { \
-        if (_level < LLOG_LEVEL) \
-        { \
-            g_write("xrdp:xrdp_mm [%10.10u]: ", g_time3()); \
-            g_writeln _args ; \
-        } \
-    } \
-    while (0)
+
 
 /*****************************************************************************/
 struct xrdp_mm *
@@ -63,15 +53,15 @@ xrdp_mm_create(struct xrdp_wm *owner)
     self->login_values = list_create();
     self->login_values->auto_free = 1;
 
-    LLOGLN(0, ("xrdp_mm_create: bpp %d mcs_connection_type %d "
-               "jpeg_codec_id %d v3_codec_id %d rfx_codec_id %d "
-               "h264_codec_id %d",
-               self->wm->client_info->bpp,
-               self->wm->client_info->mcs_connection_type,
-               self->wm->client_info->jpeg_codec_id,
-               self->wm->client_info->v3_codec_id,
-               self->wm->client_info->rfx_codec_id,
-               self->wm->client_info->h264_codec_id));
+    LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_mm_create: bpp %d mcs_connection_type %d "
+              "jpeg_codec_id %d v3_codec_id %d rfx_codec_id %d "
+              "h264_codec_id %d",
+              self->wm->client_info->bpp,
+              self->wm->client_info->mcs_connection_type,
+              self->wm->client_info->jpeg_codec_id,
+              self->wm->client_info->v3_codec_id,
+              self->wm->client_info->rfx_codec_id,
+              self->wm->client_info->h264_codec_id);
 
     self->encoder = xrdp_encoder_create(self);
 
@@ -103,7 +93,7 @@ xrdp_mm_sync_load(long param1, long param2)
 static void
 xrdp_mm_module_cleanup(struct xrdp_mm *self)
 {
-    log_message(LOG_LEVEL_DEBUG, "xrdp_mm_module_cleanup");
+    LOG(LOG_LEVEL_DEBUG, "xrdp_mm_module_cleanup");
 
     if (self->mod != 0)
     {
@@ -410,13 +400,13 @@ xrdp_mm_setup_mod1(struct xrdp_mm *self)
 
                 if (self->mod != 0)
                 {
-                    g_writeln("loaded module '%s' ok, interface size %d, version %d", lib,
-                              self->mod->size, self->mod->version);
+                    LOG(LOG_LEVEL_INFO, "loaded module '%s' ok, interface size %d, version %d", lib,
+                        self->mod->size, self->mod->version);
                 }
             }
             else
             {
-                log_message(LOG_LEVEL_ERROR, "no mod_init or mod_exit address found");
+                LOG(LOG_LEVEL_ERROR, "no mod_init or mod_exit address found");
             }
         }
         else
@@ -482,7 +472,7 @@ xrdp_mm_setup_mod1(struct xrdp_mm *self)
     /* id self->mod is null, there must be a problem */
     if (self->mod == 0)
     {
-        DEBUG(("problem loading lib in xrdp_mm_setup_mod1"));
+        LOG(LOG_LEVEL_ERROR, "problem loading lib in xrdp_mm_setup_mod1");
         return 1;
     }
 
@@ -733,7 +723,7 @@ xrdp_mm_process_rail_create_window(struct xrdp_mm *self, struct stream *s)
     g_memset(&rwso, 0, sizeof(rwso));
     in_uint32_le(s, window_id);
 
-    g_writeln("xrdp_mm_process_rail_create_window: 0x%8.8x", window_id);
+    LOG(LOG_LEVEL_DEBUG, "xrdp_mm_process_rail_create_window: 0x%8.8x", window_id);
 
     in_uint32_le(s, rwso.owner_window_id);
     in_uint32_le(s, rwso.style);
@@ -819,7 +809,7 @@ xrdp_mm_process_rail_configure_window(struct xrdp_mm *self, struct stream *s)
     g_memset(&rwso, 0, sizeof(rwso));
     in_uint32_le(s, window_id);
 
-    g_writeln("xrdp_mm_process_rail_configure_window: 0x%8.8x", window_id);
+    LOG(LOG_LEVEL_DEBUG, "xrdp_mm_process_rail_configure_window: 0x%8.8x", window_id);
 
     in_uint32_le(s, rwso.client_offset_x);
     in_uint32_le(s, rwso.client_offset_y);
@@ -887,7 +877,7 @@ xrdp_mm_process_rail_destroy_window(struct xrdp_mm *self, struct stream *s)
     int rv;
 
     in_uint32_le(s, window_id);
-    g_writeln("xrdp_mm_process_rail_destroy_window 0x%8.8x", window_id);
+    LOG(LOG_LEVEL_DEBUG, "xrdp_mm_process_rail_destroy_window 0x%8.8x", window_id);
     rv = libxrdp_orders_init(self->wm->session);
     if (rv == 0)
     {
@@ -915,8 +905,8 @@ xrdp_mm_process_rail_show_window(struct xrdp_mm *self, struct stream *s)
     in_uint32_le(s, window_id);
     in_uint32_le(s, flags);
     in_uint32_le(s, rwso.show_state);
-    g_writeln("xrdp_mm_process_rail_show_window 0x%8.8x %x", window_id,
-              rwso.show_state);
+    LOG(LOG_LEVEL_DEBUG, "xrdp_mm_process_rail_show_window 0x%8.8x %x", window_id,
+        rwso.show_state);
     rv = libxrdp_orders_init(self->wm->session);
     if (rv == 0)
     {
@@ -941,17 +931,17 @@ xrdp_mm_process_rail_update_window_text(struct xrdp_mm *self, struct stream *s)
     int window_id;
     struct rail_window_state_order rwso;
 
-    g_writeln("xrdp_mm_process_rail_update_window_text:");
+    LOG(LOG_LEVEL_DEBUG, "xrdp_mm_process_rail_update_window_text:");
     in_uint32_le(s, window_id);
     in_uint32_le(s, flags);
-    g_writeln("  update window title info: 0x%8.8x", window_id);
+    LOG(LOG_LEVEL_DEBUG, "  update window title info: 0x%8.8x", window_id);
 
     g_memset(&rwso, 0, sizeof(rwso));
     in_uint32_le(s, size); /* title size */
     rwso.title_info = g_new(char, size + 1);
     in_uint8a(s, rwso.title_info, size);
     rwso.title_info[size] = 0;
-    g_writeln("  set window title %s size %d 0x%8.8x", rwso.title_info, size, flags);
+    LOG(LOG_LEVEL_DEBUG, "  set window title %s size %d 0x%8.8x", rwso.title_info, size, flags);
     rv = libxrdp_orders_init(self->wm->session);
     if (rv == 0)
     {
@@ -961,7 +951,7 @@ xrdp_mm_process_rail_update_window_text(struct xrdp_mm *self, struct stream *s)
     {
         rv = libxrdp_orders_send(self->wm->session);
     }
-    g_writeln("  set window title %s %d", rwso.title_info, rv);
+    LOG(LOG_LEVEL_DEBUG, "  set window title %s %d", rwso.title_info, rv);
 
     g_free(rwso.title_info);
 
@@ -1005,7 +995,7 @@ xrdp_mm_process_rail_drawing_orders(struct xrdp_mm *self, struct stream *s)
 int
 xrdp_mm_drdynvc_up(struct xrdp_mm *self)
 {
-    LLOGLN(0, ("xrdp_mm_drdynvc_up:"));
+    LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_mm_drdynvc_up:");
     return 0;
 }
 
@@ -1014,9 +1004,9 @@ int
 xrdp_mm_suppress_output(struct xrdp_mm *self, int suppress,
                         int left, int top, int right, int bottom)
 {
-    LLOGLN(0, ("xrdp_mm_suppress_output: suppress %d "
-               "left %d top %d right %d bottom %d",
-               suppress, left, top, right, bottom));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_mm_suppress_output: suppress %d "
+              "left %d top %d right %d bottom %d",
+              suppress, left, top, right, bottom);
     if (self->mod != NULL)
     {
         if (self->mod->mod_suppress_output != NULL)
@@ -1039,8 +1029,8 @@ xrdp_mm_drdynvc_open_response(intptr_t id, int chan_id, int creation_status)
     struct xrdp_process *pro;
     int chansrv_chan_id;
 
-    LLOGLN(10, ("xrdp_mm_drdynvc_open_response: chan_id %d creation_status %d",
-                chan_id, creation_status));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_mm_drdynvc_open_response: chan_id %d creation_status %d",
+              chan_id, creation_status);
     pro = (struct xrdp_process *) id;
     wm = pro->wm;
     trans = wm->mm->chan_trans;
@@ -1347,7 +1337,7 @@ xrdp_mm_chan_process_msg(struct xrdp_mm *self, struct trans *trans,
         next_msg += size;
         s_end = s->end;
         s->end = next_msg;
-        LLOGLN(10, ("xrdp_mm_chan_process_msg: got msg id %d", id));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_mm_chan_process_msg: got msg id %d", id);
         switch (id)
         {
             case 8: /* channel data */
@@ -1369,13 +1359,13 @@ xrdp_mm_chan_process_msg(struct xrdp_mm *self, struct trans *trans,
                 rv = xrdp_mm_trans_process_drdynvc_data(self, s);
                 break;
             default:
-                log_message(LOG_LEVEL_ERROR, "xrdp_mm_chan_process_msg: unknown id %d", id);
+                LOG(LOG_LEVEL_ERROR, "xrdp_mm_chan_process_msg: unknown id %d", id);
                 break;
         }
         s->end = s_end;
         if (rv != 0)
         {
-            LLOGLN(0, ("xrdp_mm_chan_process_msg: error rv %d id %d", rv, id));
+            LOG(LOG_LEVEL_ERROR, "xrdp_mm_chan_process_msg: error rv %d id %d", rv, id);
             rv = 0;
         }
 
@@ -1413,7 +1403,7 @@ xrdp_mm_chan_data_in(struct trans *trans)
     {
         in_uint8s(s, 4); /* id */
         in_uint32_le(s, size);
-        LLOGLN(10, ("xrdp_mm_chan_data_in: got header, size %d", size));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_mm_chan_data_in: got header, size %d", size);
         if (size > 8)
         {
             self->chan_trans->header_size = size;
@@ -1426,8 +1416,8 @@ xrdp_mm_chan_data_in(struct trans *trans)
     self->chan_trans->header_size = 8;
     trans->extra_flags = 0;
     init_stream(s, 0);
-    LLOGLN(10, ("xrdp_mm_chan_data_in: got whole message, reset for "
-                "next header"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_mm_chan_data_in: got whole message, reset for "
+              "next header");
     return error;
 }
 
@@ -1442,9 +1432,9 @@ xrdp_mm_connect_chansrv(struct xrdp_mm *self, const char *ip, const char *port)
 
     if (self->wm->client_info->channels_allowed == 0)
     {
-        log_message(LOG_LEVEL_DEBUG, "%s: "
-                    "skip connecting to chansrv because all channels are disabled",
-                    __func__);
+        LOG(LOG_LEVEL_DEBUG, "%s: "
+            "skip connecting to chansrv because all channels are disabled",
+            __func__);
         return 0;
     }
 
@@ -1482,27 +1472,27 @@ xrdp_mm_connect_chansrv(struct xrdp_mm *self, const char *ip, const char *port)
             break;
         }
         g_sleep(1000);
-        log_message(LOG_LEVEL_ERROR, "xrdp_mm_connect_chansrv: connect failed "
-                    "trying again...");
+        LOG(LOG_LEVEL_WARNING, "xrdp_mm_connect_chansrv: connect failed "
+            "trying again...");
     }
 
     if (!(self->chan_trans_up))
     {
-        log_message(LOG_LEVEL_ERROR, "xrdp_mm_connect_chansrv: error in "
-                    "trans_connect chan");
+        LOG(LOG_LEVEL_ERROR, "xrdp_mm_connect_chansrv: error in "
+            "trans_connect chan");
     }
 
     if (self->chan_trans_up)
     {
         if (xrdp_mm_trans_send_channel_setup(self, self->chan_trans) != 0)
         {
-            log_message(LOG_LEVEL_ERROR, "xrdp_mm_connect_chansrv: error in "
-                        "xrdp_mm_trans_send_channel_setup");
+            LOG(LOG_LEVEL_ERROR, "xrdp_mm_connect_chansrv: error in "
+                "xrdp_mm_trans_send_channel_setup");
         }
         else
         {
-            log_message(LOG_LEVEL_DEBUG, "xrdp_mm_connect_chansrv: chansrv "
-                        "connect successful");
+            LOG(LOG_LEVEL_DEBUG, "xrdp_mm_connect_chansrv: chansrv "
+                "connect successful");
         }
     }
 
@@ -1549,13 +1539,13 @@ xrdp_mm_update_allowed_channels(struct xrdp_mm *self)
             libxrdp_disable_channel(session, chan_id, disabled);
             if (disabled)
             {
-                g_writeln("xrdp_mm_update_allowed_channels: channel %s "
-                          "channel id %d is disabled", chan_name, chan_id);
+                LOG(LOG_LEVEL_INFO, "xrdp_mm_update_allowed_channels: channel %s "
+                    "channel id %d is disabled", chan_name, chan_id);
             }
             else
             {
-                g_writeln("xrdp_mm_update_allowed_channels: channel %s "
-                          "channel id %d is allowed", chan_name, chan_id);
+                LOG(LOG_LEVEL_INFO, "xrdp_mm_update_allowed_channels: channel %s "
+                    "channel id %d is allowed", chan_name, chan_id);
             }
         }
     }
@@ -1717,7 +1707,7 @@ xrdp_mm_process_channel_data(struct xrdp_mm *self, tbus param1, tbus param2,
 
             if (total_length < length)
             {
-                log_message(LOG_LEVEL_DEBUG, "WARNING in xrdp_mm_process_channel_data(): total_len < length");
+                LOG(LOG_LEVEL_WARNING, "WARNING in xrdp_mm_process_channel_data(): total_len < length");
                 total_length = length;
             }
 
@@ -1834,7 +1824,7 @@ access_control(char *username, char *password, char *srv)
             out_uint32_be(out_s, 0); /* version */
             index = (int)(out_s->end - out_s->data);
             out_uint32_be(out_s, index); /* size */
-            /* g_writeln("Number of data to send : %d",index); */
+            LOG(LOG_LEVEL_DEBUG, "Number of data to send : %d", index);
             reply = g_tcp_send(socket, out_s->data, index, 0);
             free_stream(out_s);
 
@@ -1849,7 +1839,7 @@ access_control(char *username, char *password, char *srv)
                     {
                         in_s->end =  in_s->end + reply;
                         in_uint32_be(in_s, version);
-                        /*g_writeln("Version number in reply from sesman: %d",version) ; */
+                        LOG(LOG_LEVEL_INFO, "Version number in reply from sesman: %lu", version);
                         in_uint32_be(in_s, size);
 
                         if ((size == 14) && (version == 0))
@@ -1860,8 +1850,8 @@ access_control(char *username, char *password, char *srv)
 
                             if (code != 4) /*0x04 means SCP_GW_AUTHENTICATION*/
                             {
-                                log_message(LOG_LEVEL_ERROR, "Returned cmd code from "
-                                            "sesman is corrupt");
+                                LOG(LOG_LEVEL_ERROR, "Returned cmd code from "
+                                    "sesman is corrupt");
                             }
                             else
                             {
@@ -1870,23 +1860,23 @@ access_control(char *username, char *password, char *srv)
                         }
                         else
                         {
-                            log_message(LOG_LEVEL_ERROR, "Corrupt reply size or "
-                                        "version from sesman: %ld", size);
+                            LOG(LOG_LEVEL_ERROR, "Corrupt reply size or "
+                                "version from sesman: %ld", size);
                         }
                     }
                     else
                     {
-                        log_message(LOG_LEVEL_ERROR, "No data received from sesman");
+                        LOG(LOG_LEVEL_ERROR, "No data received from sesman");
                     }
                 }
                 else
                 {
-                    log_message(LOG_LEVEL_ERROR, "Timeout when waiting for sesman");
+                    LOG(LOG_LEVEL_ERROR, "Timeout when waiting for sesman");
                 }
             }
             else
             {
-                log_message(LOG_LEVEL_ERROR, "No success sending to sesman");
+                LOG(LOG_LEVEL_ERROR, "No success sending to sesman");
             }
 
             free_stream(in_s);
@@ -1894,12 +1884,12 @@ access_control(char *username, char *password, char *srv)
         }
         else
         {
-            log_message(LOG_LEVEL_ERROR, "Failure connecting to socket sesman");
+            LOG(LOG_LEVEL_ERROR, "Failure connecting to socket sesman");
         }
     }
     else
     {
-        log_message(LOG_LEVEL_ERROR, "Failure creating socket - for access control");
+        LOG(LOG_LEVEL_ERROR, "Failure creating socket - for access control");
     }
 
     if (socket != -1)
@@ -2262,16 +2252,16 @@ xrdp_mm_connect(struct xrdp_mm *self)
         xrdp_wm_log_msg(self->wm, LOG_LEVEL_DEBUG,
                         "Please wait, we now perform access control...");
 
-        /* g_writeln("we use pam modules to check if we can approve this user"); */
+        LOG(LOG_LEVEL_DEBUG, "we use pam modules to check if we can approve this user");
         if (!g_strncmp(pam_auth_username, "same", 255))
         {
-            log_message(LOG_LEVEL_DEBUG, "pamusername copied from username - same: %s", username);
+            LOG(LOG_LEVEL_DEBUG, "pamusername copied from username - same: %s", username);
             g_strncpy(pam_auth_username, username, 255);
         }
 
         if (!g_strncmp(pam_auth_password, "same", 255))
         {
-            log_message(LOG_LEVEL_DEBUG, "pam_auth_password copied from username - same: %s", password);
+            LOG(LOG_LEVEL_DEBUG, "pam_auth_password copied from username - same: %s", password);
             g_strncpy(pam_auth_password, password, 255);
         }
 
@@ -2324,8 +2314,8 @@ xrdp_mm_connect(struct xrdp_mm *self)
                 break;
             }
             g_sleep(1000);
-            g_writeln("xrdp_mm_connect: connect failed "
-                      "trying again...");
+            LOG(LOG_LEVEL_INFO, "xrdp_mm_connect: connect failed "
+                "trying again...");
         }
 
         if (ok)
@@ -2365,7 +2355,7 @@ xrdp_mm_connect(struct xrdp_mm *self)
         }
         else
         {
-            log_message(LOG_LEVEL_ERROR, "Failure setting up module");
+            LOG(LOG_LEVEL_ERROR, "Failure setting up module");
         }
 
         if (self->wm->login_state != WMLS_CLEANUP)
@@ -2383,7 +2373,7 @@ xrdp_mm_connect(struct xrdp_mm *self)
         xrdp_mm_connect_chansrv(self, "", chansrvport);
     }
 
-    log_message(LOG_LEVEL_DEBUG, "return value from xrdp_mm_connect %d", rv);
+    LOG(LOG_LEVEL_DEBUG, "return value from xrdp_mm_connect %d", rv);
 
     return rv;
 }
@@ -2479,7 +2469,7 @@ xrdp_mm_dump_jpeg(struct xrdp_mm *self, XRDP_ENC_DATA_DONE *enc_done)
                      enc_done->pad_bytes + 2 + pheader_bytes[0],
                      enc_done->comp_bytes - (2 + pheader_bytes[0]));
         jj++;
-        g_writeln("dumping jpeg index %d", jj);
+        LOG(LOG_LEVEL_INFO, "dumping jpeg index %d", jj);
     }
     return 0;
 }
@@ -2490,7 +2480,7 @@ xrdp_mm_dump_jpeg(struct xrdp_mm *self, XRDP_ENC_DATA_DONE *enc_done)
 int
 xrdp_mm_check_chan(struct xrdp_mm *self)
 {
-    //g_writeln("xrdp_mm_check_chan:");
+    LOG(LOG_LEVEL_TRACE, "xrdp_mm_check_chan:");
     if ((self->chan_trans != 0) && self->chan_trans_up)
     {
         if (trans_check_wait_objs(self->chan_trans) != 0)
@@ -2521,8 +2511,8 @@ xrdp_mm_update_module_frame_ack(struct xrdp_mm *self)
     {
         if (encoder->frame_id_server > encoder->frame_id_server_sent)
         {
-            LLOGLN(10, ("xrdp_mm_update_module_ack: frame_id_server %d",
-                        encoder->frame_id_server));
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_mm_update_module_ack: frame_id_server %d",
+                      encoder->frame_id_server);
             encoder->frame_id_server_sent = encoder->frame_id_server;
             self->mod->mod_frame_ack(self->mod, 0, encoder->frame_id_server);
         }
@@ -2551,8 +2541,8 @@ xrdp_mm_process_enc_done(struct xrdp_mm *self)
             break;
         }
         /* do something with msg */
-        LLOGLN(10, ("xrdp_mm_process_enc_done: message back bytes %d",
-                    enc_done->comp_bytes));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_mm_process_enc_done: message back bytes %d",
+                  enc_done->comp_bytes);
         x = enc_done->x;
         y = enc_done->y;
         cx = enc_done->cx;
@@ -2574,7 +2564,7 @@ xrdp_mm_process_enc_done(struct xrdp_mm *self)
         /* free enc_done */
         if (enc_done->last)
         {
-            LLOGLN(10, ("xrdp_mm_process_enc_done: last set"));
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_mm_process_enc_done: last set");
             if (self->wm->client_info->use_frame_acks == 0)
             {
                 self->mod->mod_frame_ack(self->mod,
@@ -2672,14 +2662,14 @@ xrdp_mm_frame_ack(struct xrdp_mm *self, int frame_id)
 {
     struct xrdp_encoder *encoder;
 
-    LLOGLN(10, ("xrdp_mm_frame_ack:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_mm_frame_ack:");
     if (self->wm->client_info->use_frame_acks == 0)
     {
         return 1;
     }
     encoder = self->encoder;
-    LLOGLN(10, ("xrdp_mm_frame_ack: incoming %d, client %d, server %d",
-                frame_id, encoder->frame_id_client, encoder->frame_id_server));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_mm_frame_ack: incoming %d, client %d, server %d",
+              frame_id, encoder->frame_id_client, encoder->frame_id_server);
     if ((frame_id < 0) || (frame_id > encoder->frame_id_server))
     {
         /* if frame_id is negative or bigger then what server last sent
@@ -2895,7 +2885,7 @@ server_composite(struct xrdp_mod *mod, int srcidx, int srcformat,
     }
     else
     {
-        g_writeln("server_composite: error finding id %d or %d", srcidx, mskidx);
+        LOG(LOG_LEVEL_WARNING, "server_composite: error finding id %d or %d", srcidx, mskidx);
     }
     return 0;
 }
@@ -2917,8 +2907,7 @@ server_paint_rects(struct xrdp_mod *mod, int num_drects, short *drects,
     wm = (struct xrdp_wm *)(mod->wm);
     mm = wm->mm;
 
-    LLOGLN(10, ("server_paint_rects:"));
-    LLOGLN(10, ("server_paint_rects: %p", mm->encoder));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "server_paint_rects: %p", mm->encoder);
 
     if (mm->encoder != 0)
     {
@@ -2959,7 +2948,7 @@ server_paint_rects(struct xrdp_mod *mod, int num_drects, short *drects,
         enc_data->frame_id = frame_id;
         if (width == 0 || height == 0)
         {
-            LLOGLN(10, ("server_paint_rects: error"));
+            LOG_DEVEL(LOG_LEVEL_WARNING, "server_paint_rects: error");
         }
 
         /* insert into fifo for encoder thread to process */
@@ -2973,7 +2962,7 @@ server_paint_rects(struct xrdp_mod *mod, int num_drects, short *drects,
         return 0;
     }
 
-    //g_writeln("server_paint_rects:");
+    LOG(LOG_LEVEL_TRACE, "server_paint_rects:");
 
     p = (struct xrdp_painter *)(mod->painter);
     if (p == 0)
@@ -3000,7 +2989,7 @@ server_session_info(struct xrdp_mod *mod, const char *data, int data_bytes)
 {
     struct xrdp_wm *wm;
 
-    LLOGLN(10, ("server_session_info:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "server_session_info:");
     wm = (struct xrdp_wm *)(mod->wm);
     return libxrdp_send_session_info(wm->session, data, data_bytes);
 }
@@ -3054,7 +3043,7 @@ server_msg(struct xrdp_mod *mod, char *msg, int code)
 
     if (code == 1)
     {
-        g_writeln("%s", msg);
+        LOG(LOG_LEVEL_INFO, "%s", msg);
         return 0;
     }
 
@@ -3398,7 +3387,7 @@ server_create_os_surface(struct xrdp_mod *mod, int rdpindex,
 
     if (error != 0)
     {
-        log_message(LOG_LEVEL_ERROR, "server_create_os_surface: xrdp_cache_add_os_bitmap failed");
+        LOG(LOG_LEVEL_ERROR, "server_create_os_surface: xrdp_cache_add_os_bitmap failed");
         return 1;
     }
 
@@ -3422,7 +3411,7 @@ server_create_os_surface_bpp(struct xrdp_mod *mod, int rdpindex,
     error = xrdp_cache_add_os_bitmap(wm->cache, bitmap, rdpindex);
     if (error != 0)
     {
-        g_writeln("server_create_os_surface_bpp: xrdp_cache_add_os_bitmap failed");
+        LOG(LOG_LEVEL_ERROR, "server_create_os_surface_bpp: xrdp_cache_add_os_bitmap failed");
         return 1;
     }
     bitmap->item_index = rdpindex;
@@ -3438,18 +3427,18 @@ server_switch_os_surface(struct xrdp_mod *mod, int rdpindex)
     struct xrdp_os_bitmap_item *bi;
     struct xrdp_painter *p;
 
-    //g_writeln("server_switch_os_surface: id 0x%x", id);
+    LOG(LOG_LEVEL_DEBUG, "server_switch_os_surface: id 0x%x", rdpindex);
     wm = (struct xrdp_wm *)(mod->wm);
 
     if (rdpindex == -1)
     {
-        //g_writeln("server_switch_os_surface: setting target_surface to screen");
+        LOG(LOG_LEVEL_DEBUG, "server_switch_os_surface: setting target_surface to screen");
         wm->target_surface = wm->screen;
         p = (struct xrdp_painter *)(mod->painter);
 
         if (p != 0)
         {
-            //g_writeln("setting target");
+            LOG(LOG_LEVEL_DEBUG, "setting target");
             wm_painter_set_target(p);
         }
 
@@ -3460,19 +3449,19 @@ server_switch_os_surface(struct xrdp_mod *mod, int rdpindex)
 
     if ((bi != 0) && (bi->bitmap != 0))
     {
-        //g_writeln("server_switch_os_surface: setting target_surface to rdpid %d", id);
+        LOG(LOG_LEVEL_DEBUG, "server_switch_os_surface: setting target_surface to rdpid %d", rdpindex);
         wm->target_surface = bi->bitmap;
         p = (struct xrdp_painter *)(mod->painter);
 
         if (p != 0)
         {
-            //g_writeln("setting target");
+            LOG(LOG_LEVEL_DEBUG, "setting target");
             wm_painter_set_target(p);
         }
     }
     else
     {
-        log_message(LOG_LEVEL_ERROR, "server_switch_os_surface: error finding id %d", rdpindex);
+        LOG(LOG_LEVEL_WARNING, "server_switch_os_surface: error finding id %d", rdpindex);
     }
 
     return 0;
@@ -3485,20 +3474,20 @@ server_delete_os_surface(struct xrdp_mod *mod, int rdpindex)
     struct xrdp_wm *wm;
     struct xrdp_painter *p;
 
-    //g_writeln("server_delete_os_surface: id 0x%x", id);
+    LOG(LOG_LEVEL_DEBUG, "server_delete_os_surface: id 0x%x", rdpindex);
     wm = (struct xrdp_wm *)(mod->wm);
 
     if (wm->target_surface->type == WND_TYPE_OFFSCREEN)
     {
         if (wm->target_surface->id == rdpindex)
         {
-            g_writeln("server_delete_os_surface: setting target_surface to screen");
+            LOG(LOG_LEVEL_DEBUG, "server_delete_os_surface: setting target_surface to screen");
             wm->target_surface = wm->screen;
             p = (struct xrdp_painter *)(mod->painter);
 
             if (p != 0)
             {
-                //g_writeln("setting target");
+                LOG(LOG_LEVEL_DEBUG, "setting target");
                 wm_painter_set_target(p);
             }
         }
@@ -3535,7 +3524,7 @@ server_paint_rect_os(struct xrdp_mod *mod, int x, int y, int cx, int cy,
     }
     else
     {
-        log_message(LOG_LEVEL_ERROR, "server_paint_rect_os: error finding id %d", rdpindex);
+        LOG(LOG_LEVEL_ERROR, "server_paint_rect_os: error finding id %d", rdpindex);
     }
 
     return 0;

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -40,15 +40,15 @@
 
 #define LLOG_LEVEL 1
 #define LLOGLN(_level, _args) \
-  do \
-  { \
-    if (_level < LLOG_LEVEL) \
+    do \
     { \
-        g_write("xrdp:xrdp_mm [%10.10u]: ", g_time3()); \
-        g_writeln _args ; \
+        if (_level < LLOG_LEVEL) \
+        { \
+            g_write("xrdp:xrdp_mm [%10.10u]: ", g_time3()); \
+            g_writeln _args ; \
+        } \
     } \
-  } \
-  while (0)
+    while (0)
 
 /*****************************************************************************/
 struct xrdp_mm *
@@ -64,14 +64,14 @@ xrdp_mm_create(struct xrdp_wm *owner)
     self->login_values->auto_free = 1;
 
     LLOGLN(0, ("xrdp_mm_create: bpp %d mcs_connection_type %d "
-           "jpeg_codec_id %d v3_codec_id %d rfx_codec_id %d "
-           "h264_codec_id %d",
-           self->wm->client_info->bpp,
-           self->wm->client_info->mcs_connection_type,
-           self->wm->client_info->jpeg_codec_id,
-           self->wm->client_info->v3_codec_id,
-           self->wm->client_info->rfx_codec_id,
-           self->wm->client_info->h264_codec_id));
+               "jpeg_codec_id %d v3_codec_id %d rfx_codec_id %d "
+               "h264_codec_id %d",
+               self->wm->client_info->bpp,
+               self->wm->client_info->mcs_connection_type,
+               self->wm->client_info->jpeg_codec_id,
+               self->wm->client_info->v3_codec_id,
+               self->wm->client_info->rfx_codec_id,
+               self->wm->client_info->h264_codec_id));
 
     self->encoder = xrdp_encoder_create(self);
 
@@ -246,7 +246,7 @@ xrdp_mm_send_login(struct xrdp_mm *self)
     out_uint16_be(s, xserverbpp);
 
     /* send domain */
-    if(self->wm->client_info->domain[0]!='_')
+    if (self->wm->client_info->domain[0] != '_')
     {
         index = g_strlen(self->wm->client_info->domain);
         out_uint16_be(s, index);
@@ -416,7 +416,7 @@ xrdp_mm_setup_mod1(struct xrdp_mm *self)
             }
             else
             {
-                log_message(LOG_LEVEL_ERROR,"no mod_init or mod_exit address found");
+                log_message(LOG_LEVEL_ERROR, "no mod_init or mod_exit address found");
             }
         }
         else
@@ -720,7 +720,7 @@ xrdp_mm_trans_process_channel_data(struct xrdp_mm *self, struct stream *s)
 /* returns error
    process rail create window order */
 static int
-xrdp_mm_process_rail_create_window(struct xrdp_mm* self, struct stream* s)
+xrdp_mm_process_rail_create_window(struct xrdp_mm *self, struct stream *s)
 {
     int flags;
     int window_id;
@@ -762,7 +762,7 @@ xrdp_mm_process_rail_create_window(struct xrdp_mm* self, struct stream* s)
     if (rwso.num_window_rects > 0)
     {
         bytes = sizeof(struct rail_window_rect) * rwso.num_window_rects;
-        rwso.window_rects = (struct rail_window_rect*)g_malloc(bytes, 0);
+        rwso.window_rects = (struct rail_window_rect *)g_malloc(bytes, 0);
         for (index = 0; index < rwso.num_window_rects; index++)
         {
             in_uint16_le(s, rwso.window_rects[index].left);
@@ -777,7 +777,7 @@ xrdp_mm_process_rail_create_window(struct xrdp_mm* self, struct stream* s)
     if (rwso.num_visibility_rects > 0)
     {
         bytes = sizeof(struct rail_window_rect) * rwso.num_visibility_rects;
-        rwso.visibility_rects = (struct rail_window_rect*)g_malloc(bytes, 0);
+        rwso.visibility_rects = (struct rail_window_rect *)g_malloc(bytes, 0);
         for (index = 0; index < rwso.num_visibility_rects; index++)
         {
             in_uint16_le(s, rwso.visibility_rects[index].left);
@@ -807,7 +807,7 @@ xrdp_mm_process_rail_create_window(struct xrdp_mm* self, struct stream* s)
 /* returns error
    process rail configure window order */
 static int
-xrdp_mm_process_rail_configure_window(struct xrdp_mm* self, struct stream* s)
+xrdp_mm_process_rail_configure_window(struct xrdp_mm *self, struct stream *s)
 {
     int flags;
     int window_id;
@@ -837,7 +837,7 @@ xrdp_mm_process_rail_configure_window(struct xrdp_mm* self, struct stream* s)
     if (rwso.num_window_rects > 0)
     {
         bytes = sizeof(struct rail_window_rect) * rwso.num_window_rects;
-        rwso.window_rects = (struct rail_window_rect*)g_malloc(bytes, 0);
+        rwso.window_rects = (struct rail_window_rect *)g_malloc(bytes, 0);
         for (index = 0; index < rwso.num_window_rects; index++)
         {
             in_uint16_le(s, rwso.window_rects[index].left);
@@ -852,7 +852,7 @@ xrdp_mm_process_rail_configure_window(struct xrdp_mm* self, struct stream* s)
     if (rwso.num_visibility_rects > 0)
     {
         bytes = sizeof(struct rail_window_rect) * rwso.num_visibility_rects;
-        rwso.visibility_rects = (struct rail_window_rect*)g_malloc(bytes, 0);
+        rwso.visibility_rects = (struct rail_window_rect *)g_malloc(bytes, 0);
         for (index = 0; index < rwso.num_visibility_rects; index++)
         {
             in_uint16_le(s, rwso.visibility_rects[index].left);
@@ -881,7 +881,7 @@ xrdp_mm_process_rail_configure_window(struct xrdp_mm* self, struct stream* s)
 /* returns error
    process rail destroy window order */
 static int
-xrdp_mm_process_rail_destroy_window(struct xrdp_mm* self, struct stream* s)
+xrdp_mm_process_rail_destroy_window(struct xrdp_mm *self, struct stream *s)
 {
     int window_id;
     int rv;
@@ -904,7 +904,7 @@ xrdp_mm_process_rail_destroy_window(struct xrdp_mm* self, struct stream* s)
 /* returns error
    process rail update window (show state) order */
 static int
-xrdp_mm_process_rail_show_window(struct xrdp_mm* self, struct stream* s)
+xrdp_mm_process_rail_show_window(struct xrdp_mm *self, struct stream *s)
 {
     int window_id;
     int rv;
@@ -933,7 +933,7 @@ xrdp_mm_process_rail_show_window(struct xrdp_mm* self, struct stream* s)
 /* returns error
    process rail update window (title) order */
 static int
-xrdp_mm_process_rail_update_window_text(struct xrdp_mm* self, struct stream* s)
+xrdp_mm_process_rail_update_window_text(struct xrdp_mm *self, struct stream *s)
 {
     int size;
     int flags;
@@ -972,7 +972,7 @@ xrdp_mm_process_rail_update_window_text(struct xrdp_mm* self, struct stream* s)
 /* returns error
    process alternate secondary drawing orders for rail channel */
 static int
-xrdp_mm_process_rail_drawing_orders(struct xrdp_mm* self, struct stream *s)
+xrdp_mm_process_rail_drawing_orders(struct xrdp_mm *self, struct stream *s)
 {
     int order_type;
     int rv;
@@ -980,7 +980,7 @@ xrdp_mm_process_rail_drawing_orders(struct xrdp_mm* self, struct stream *s)
     rv = 0;
     in_uint32_le(s, order_type);
 
-    switch(order_type)
+    switch (order_type)
     {
         case 2: /* create_window */
             xrdp_mm_process_rail_create_window(self, s);
@@ -1003,7 +1003,7 @@ xrdp_mm_process_rail_drawing_orders(struct xrdp_mm* self, struct stream *s)
 
 /******************************************************************************/
 int
-xrdp_mm_drdynvc_up(struct xrdp_mm* self)
+xrdp_mm_drdynvc_up(struct xrdp_mm *self)
 {
     LLOGLN(0, ("xrdp_mm_drdynvc_up:"));
     return 0;
@@ -1011,12 +1011,12 @@ xrdp_mm_drdynvc_up(struct xrdp_mm* self)
 
 /******************************************************************************/
 int
-xrdp_mm_suppress_output(struct xrdp_mm* self, int suppress,
+xrdp_mm_suppress_output(struct xrdp_mm *self, int suppress,
                         int left, int top, int right, int bottom)
 {
     LLOGLN(0, ("xrdp_mm_suppress_output: suppress %d "
-           "left %d top %d right %d bottom %d",
-           suppress, left, top, right, bottom));
+               "left %d top %d right %d bottom %d",
+               suppress, left, top, right, bottom));
     if (self->mod != NULL)
     {
         if (self->mod->mod_suppress_output != NULL)
@@ -1035,12 +1035,12 @@ xrdp_mm_drdynvc_open_response(intptr_t id, int chan_id, int creation_status)
 {
     struct trans *trans;
     struct stream *s;
-    struct xrdp_wm* wm;
+    struct xrdp_wm *wm;
     struct xrdp_process *pro;
     int chansrv_chan_id;
 
     LLOGLN(10, ("xrdp_mm_drdynvc_open_response: chan_id %d creation_status %d",
-           chan_id, creation_status));
+                chan_id, creation_status));
     pro = (struct xrdp_process *) id;
     wm = pro->wm;
     trans = wm->mm->chan_trans;
@@ -1067,7 +1067,7 @@ xrdp_mm_drdynvc_close_response(intptr_t id, int chan_id)
 {
     struct trans *trans;
     struct stream *s;
-    struct xrdp_wm* wm;
+    struct xrdp_wm *wm;
     struct xrdp_process *pro;
     int chansrv_chan_id;
 
@@ -1097,7 +1097,7 @@ xrdp_mm_drdynvc_data_first(intptr_t id, int chan_id, char *data,
 {
     struct trans *trans;
     struct stream *s;
-    struct xrdp_wm* wm;
+    struct xrdp_wm *wm;
     struct xrdp_process *pro;
     int chansrv_chan_id;
 
@@ -1129,7 +1129,7 @@ xrdp_mm_drdynvc_data(intptr_t id, int chan_id, char *data, int bytes)
 {
     struct trans *trans;
     struct stream *s;
-    struct xrdp_wm* wm;
+    struct xrdp_wm *wm;
     struct xrdp_process *pro;
     int chansrv_chan_id;
 
@@ -1156,8 +1156,8 @@ xrdp_mm_drdynvc_data(intptr_t id, int chan_id, char *data, int bytes)
 /*****************************************************************************/
 /* open message from channel server going to client */
 static int
-xrdp_mm_trans_process_drdynvc_channel_open(struct xrdp_mm* self,
-                                           struct stream *s)
+xrdp_mm_trans_process_drdynvc_channel_open(struct xrdp_mm *self,
+        struct stream *s)
 {
     int name_bytes;
     int flags;
@@ -1227,8 +1227,8 @@ xrdp_mm_trans_process_drdynvc_channel_open(struct xrdp_mm* self,
 /*****************************************************************************/
 /* close message from channel server going to client */
 static int
-xrdp_mm_trans_process_drdynvc_channel_close(struct xrdp_mm* self,
-                                            struct stream *s)
+xrdp_mm_trans_process_drdynvc_channel_close(struct xrdp_mm *self,
+        struct stream *s)
 {
     int chansrv_chan_id;
     int chan_id;
@@ -1252,8 +1252,8 @@ xrdp_mm_trans_process_drdynvc_channel_close(struct xrdp_mm* self,
 /*****************************************************************************/
 /* data from channel server going to client */
 static int
-xrdp_mm_trans_process_drdynvc_data_first(struct xrdp_mm* self,
-                                         struct stream *s)
+xrdp_mm_trans_process_drdynvc_data_first(struct xrdp_mm *self,
+        struct stream *s)
 {
     int chansrv_chan_id;
     int chan_id;
@@ -1287,7 +1287,7 @@ xrdp_mm_trans_process_drdynvc_data_first(struct xrdp_mm* self,
 /*****************************************************************************/
 /* data from channel server going to client */
 static int
-xrdp_mm_trans_process_drdynvc_data(struct xrdp_mm* self,
+xrdp_mm_trans_process_drdynvc_data(struct xrdp_mm *self,
                                    struct stream *s)
 {
     int chansrv_chan_id;
@@ -1369,7 +1369,7 @@ xrdp_mm_chan_process_msg(struct xrdp_mm *self, struct trans *trans,
                 rv = xrdp_mm_trans_process_drdynvc_data(self, s);
                 break;
             default:
-                log_message(LOG_LEVEL_ERROR,"xrdp_mm_chan_process_msg: unknown id %d", id);
+                log_message(LOG_LEVEL_ERROR, "xrdp_mm_chan_process_msg: unknown id %d", id);
                 break;
         }
         s->end = s_end;
@@ -1427,7 +1427,7 @@ xrdp_mm_chan_data_in(struct trans *trans)
     trans->extra_flags = 0;
     init_stream(s, 0);
     LLOGLN(10, ("xrdp_mm_chan_data_in: got whole message, reset for "
-           "next header"));
+                "next header"));
     return error;
 }
 
@@ -1482,13 +1482,13 @@ xrdp_mm_connect_chansrv(struct xrdp_mm *self, const char *ip, const char *port)
             break;
         }
         g_sleep(1000);
-        log_message(LOG_LEVEL_ERROR,"xrdp_mm_connect_chansrv: connect failed "
-                  "trying again...");
+        log_message(LOG_LEVEL_ERROR, "xrdp_mm_connect_chansrv: connect failed "
+                    "trying again...");
     }
 
     if (!(self->chan_trans_up))
     {
-        log_message(LOG_LEVEL_ERROR,"xrdp_mm_connect_chansrv: error in "
+        log_message(LOG_LEVEL_ERROR, "xrdp_mm_connect_chansrv: error in "
                     "trans_connect chan");
     }
 
@@ -1496,12 +1496,12 @@ xrdp_mm_connect_chansrv(struct xrdp_mm *self, const char *ip, const char *port)
     {
         if (xrdp_mm_trans_send_channel_setup(self, self->chan_trans) != 0)
         {
-            log_message(LOG_LEVEL_ERROR,"xrdp_mm_connect_chansrv: error in "
-                      "xrdp_mm_trans_send_channel_setup");
+            log_message(LOG_LEVEL_ERROR, "xrdp_mm_connect_chansrv: error in "
+                        "xrdp_mm_trans_send_channel_setup");
         }
         else
         {
-            log_message(LOG_LEVEL_DEBUG,"xrdp_mm_connect_chansrv: chansrv "
+            log_message(LOG_LEVEL_DEBUG, "xrdp_mm_connect_chansrv: chansrv "
                         "connect successful");
         }
     }
@@ -1574,7 +1574,7 @@ xrdp_mm_process_login_response(struct xrdp_mm *self, struct stream *s)
     char ip[256];
     char port[256];
     tui8 guid[16];
-    tui8* pguid;
+    tui8 *pguid;
 
     rv = 0;
     in_uint16_be(s, ok);
@@ -1717,7 +1717,7 @@ xrdp_mm_process_channel_data(struct xrdp_mm *self, tbus param1, tbus param2,
 
             if (total_length < length)
             {
-                log_message(LOG_LEVEL_DEBUG,"WARNING in xrdp_mm_process_channel_data(): total_len < length");
+                log_message(LOG_LEVEL_DEBUG, "WARNING in xrdp_mm_process_channel_data(): total_len < length");
                 total_length = length;
             }
 
@@ -1773,7 +1773,7 @@ xrdp_mm_sesman_data_in(struct trans *trans)
 
         switch (code)
         {
-                /* even when the request is denied the reply will hold 3 as the command. */
+            /* even when the request is denied the reply will hold 3 as the command. */
             case 3:
                 error = xrdp_mm_process_login_response(self, s);
                 break;
@@ -1796,7 +1796,7 @@ static int
 access_control(char *username, char *password, char *srv)
 {
     int reply;
-    int rec = 32+1; /* 32 is reserved for PAM failures this means connect failure */
+    int rec = 32 + 1; /* 32 is reserved for PAM failures this means connect failure */
     struct stream *in_s;
     struct stream *out_s;
     unsigned long version;
@@ -1903,7 +1903,9 @@ access_control(char *username, char *password, char *srv)
     }
 
     if (socket != -1)
+    {
         g_tcp_close(socket);
+    }
 
     return rec;
 }
@@ -2363,7 +2365,7 @@ xrdp_mm_connect(struct xrdp_mm *self)
         }
         else
         {
-            log_message(LOG_LEVEL_ERROR,"Failure setting up module");
+            log_message(LOG_LEVEL_ERROR, "Failure setting up module");
         }
 
         if (self->wm->login_state != WMLS_CLEANUP)
@@ -2381,7 +2383,7 @@ xrdp_mm_connect(struct xrdp_mm *self)
         xrdp_mm_connect_chansrv(self, "", chansrvport);
     }
 
-    log_message(LOG_LEVEL_DEBUG,"return value from xrdp_mm_connect %d", rv);
+    log_message(LOG_LEVEL_DEBUG, "return value from xrdp_mm_connect %d", rv);
 
     return rv;
 }
@@ -2472,7 +2474,7 @@ xrdp_mm_dump_jpeg(struct xrdp_mm *self, XRDP_ENC_DATA_DONE *enc_done)
     }
     if (ii != 0)
     {
-        g_file_write(ii, (char*)&header, sizeof(header));
+        g_file_write(ii, (char *)&header, sizeof(header));
         g_file_write(ii, enc_done->comp_pad_data +
                      enc_done->pad_bytes + 2 + pheader_bytes[0],
                      enc_done->comp_bytes - (2 + pheader_bytes[0]));
@@ -2520,7 +2522,7 @@ xrdp_mm_update_module_frame_ack(struct xrdp_mm *self)
         if (encoder->frame_id_server > encoder->frame_id_server_sent)
         {
             LLOGLN(10, ("xrdp_mm_update_module_ack: frame_id_server %d",
-                   encoder->frame_id_server));
+                        encoder->frame_id_server));
             encoder->frame_id_server_sent = encoder->frame_id_server;
             self->mod->mod_frame_ack(self->mod, 0, encoder->frame_id_server);
         }
@@ -2550,7 +2552,7 @@ xrdp_mm_process_enc_done(struct xrdp_mm *self)
         }
         /* do something with msg */
         LLOGLN(10, ("xrdp_mm_process_enc_done: message back bytes %d",
-               enc_done->comp_bytes));
+                    enc_done->comp_bytes));
         x = enc_done->x;
         y = enc_done->y;
         cx = enc_done->cx;
@@ -2677,7 +2679,7 @@ xrdp_mm_frame_ack(struct xrdp_mm *self, int frame_id)
     }
     encoder = self->encoder;
     LLOGLN(10, ("xrdp_mm_frame_ack: incoming %d, client %d, server %d",
-           frame_id, encoder->frame_id_client, encoder->frame_id_server));
+                frame_id, encoder->frame_id_client, encoder->frame_id_server));
     if ((frame_id < 0) || (frame_id > encoder->frame_id_server))
     {
         /* if frame_id is negative or bigger then what server last sent
@@ -2827,20 +2829,20 @@ server_paint_rect(struct xrdp_mod *mod, int x, int y, int cx, int cy,
 
 /*****************************************************************************/
 int
-server_paint_rect_bpp(struct xrdp_mod* mod, int x, int y, int cx, int cy,
-                      char* data, int width, int height, int srcx, int srcy,
+server_paint_rect_bpp(struct xrdp_mod *mod, int x, int y, int cx, int cy,
+                      char *data, int width, int height, int srcx, int srcy,
                       int bpp)
 {
-    struct xrdp_wm* wm;
-    struct xrdp_bitmap* b;
-    struct xrdp_painter* p;
+    struct xrdp_wm *wm;
+    struct xrdp_bitmap *b;
+    struct xrdp_painter *p;
 
-    p = (struct xrdp_painter*)(mod->painter);
+    p = (struct xrdp_painter *)(mod->painter);
     if (p == 0)
     {
         return 0;
     }
-    wm = (struct xrdp_wm*)(mod->wm);
+    wm = (struct xrdp_wm *)(mod->wm);
     b = xrdp_bitmap_create_with_data(width, height, bpp, data, wm);
     xrdp_painter_copy(p, b, wm->target_surface, x, y, cx, cy, srcx, srcy);
     xrdp_bitmap_delete(b);
@@ -2849,25 +2851,25 @@ server_paint_rect_bpp(struct xrdp_mod* mod, int x, int y, int cx, int cy,
 
 /*****************************************************************************/
 int
-server_composite(struct xrdp_mod* mod, int srcidx, int srcformat,
-                 int srcwidth, int srcrepeat, int* srctransform,
+server_composite(struct xrdp_mod *mod, int srcidx, int srcformat,
+                 int srcwidth, int srcrepeat, int *srctransform,
                  int mskflags, int mskidx, int mskformat, int mskwidth,
                  int mskrepeat, int op, int srcx, int srcy,
                  int mskx, int msky, int dstx, int dsty,
                  int width, int height, int dstformat)
 {
-    struct xrdp_wm* wm;
-    struct xrdp_bitmap* b;
-    struct xrdp_bitmap* msk;
-    struct xrdp_painter* p;
-    struct xrdp_os_bitmap_item* bi;
+    struct xrdp_wm *wm;
+    struct xrdp_bitmap *b;
+    struct xrdp_bitmap *msk;
+    struct xrdp_painter *p;
+    struct xrdp_os_bitmap_item *bi;
 
-    p = (struct xrdp_painter*)(mod->painter);
+    p = (struct xrdp_painter *)(mod->painter);
     if (p == 0)
     {
         return 0;
     }
-    wm = (struct xrdp_wm*)(mod->wm);
+    wm = (struct xrdp_wm *)(mod->wm);
     b = 0;
     msk = 0;
     bi = xrdp_cache_get_os_bitmap(wm->cache, srcidx);
@@ -2900,19 +2902,19 @@ server_composite(struct xrdp_mod* mod, int srcidx, int srcformat,
 
 /*****************************************************************************/
 int
-server_paint_rects(struct xrdp_mod* mod, int num_drects, short *drects,
+server_paint_rects(struct xrdp_mod *mod, int num_drects, short *drects,
                    int num_crects, short *crects, char *data, int width,
                    int height, int flags, int frame_id)
 {
-    struct xrdp_wm* wm;
-    struct xrdp_mm* mm;
-    struct xrdp_painter* p;
+    struct xrdp_wm *wm;
+    struct xrdp_mm *mm;
+    struct xrdp_painter *p;
     struct xrdp_bitmap *b;
     short *s;
     int index;
     XRDP_ENC_DATA *enc_data;
 
-    wm = (struct xrdp_wm*)(mod->wm);
+    wm = (struct xrdp_wm *)(mod->wm);
     mm = wm->mm;
 
     LLOGLN(10, ("server_paint_rects:"));
@@ -2973,7 +2975,7 @@ server_paint_rects(struct xrdp_mod* mod, int num_drects, short *drects,
 
     //g_writeln("server_paint_rects:");
 
-    p = (struct xrdp_painter*)(mod->painter);
+    p = (struct xrdp_painter *)(mod->painter);
     if (p == 0)
     {
         return 0;
@@ -3052,7 +3054,7 @@ server_msg(struct xrdp_mod *mod, char *msg, int code)
 
     if (code == 1)
     {
-        g_writeln("%s",msg);
+        g_writeln("%s", msg);
         return 0;
     }
 
@@ -3296,9 +3298,9 @@ server_reset(struct xrdp_mod *mod, int width, int height, int bpp)
 
     /* if same (and only one monitor on client) don't need to do anything */
     if (wm->client_info->width == width &&
-        wm->client_info->height == height &&
-        wm->client_info->bpp == bpp &&
-        (wm->client_info->monitorCount == 0 || wm->client_info->multimon == 0))
+            wm->client_info->height == height &&
+            wm->client_info->bpp == bpp &&
+            (wm->client_info->monitorCount == 0 || wm->client_info->multimon == 0))
     {
         return 0;
     }
@@ -3396,7 +3398,7 @@ server_create_os_surface(struct xrdp_mod *mod, int rdpindex,
 
     if (error != 0)
     {
-        log_message(LOG_LEVEL_ERROR,"server_create_os_surface: xrdp_cache_add_os_bitmap failed");
+        log_message(LOG_LEVEL_ERROR, "server_create_os_surface: xrdp_cache_add_os_bitmap failed");
         return 1;
     }
 
@@ -3407,14 +3409,14 @@ server_create_os_surface(struct xrdp_mod *mod, int rdpindex,
 
 /*****************************************************************************/
 int
-server_create_os_surface_bpp(struct xrdp_mod* mod, int rdpindex,
+server_create_os_surface_bpp(struct xrdp_mod *mod, int rdpindex,
                              int width, int height, int bpp)
 {
-    struct xrdp_wm* wm;
-    struct xrdp_bitmap* bitmap;
+    struct xrdp_wm *wm;
+    struct xrdp_bitmap *bitmap;
     int error;
 
-    wm = (struct xrdp_wm*)(mod->wm);
+    wm = (struct xrdp_wm *)(mod->wm);
     bitmap = xrdp_bitmap_create(width, height, bpp,
                                 WND_TYPE_OFFSCREEN, wm);
     error = xrdp_cache_add_os_bitmap(wm->cache, bitmap, rdpindex);
@@ -3470,7 +3472,7 @@ server_switch_os_surface(struct xrdp_mod *mod, int rdpindex)
     }
     else
     {
-        log_message(LOG_LEVEL_ERROR,"server_switch_os_surface: error finding id %d", rdpindex);
+        log_message(LOG_LEVEL_ERROR, "server_switch_os_surface: error finding id %d", rdpindex);
     }
 
     return 0;
@@ -3533,7 +3535,7 @@ server_paint_rect_os(struct xrdp_mod *mod, int x, int y, int cx, int cy,
     }
     else
     {
-        log_message(LOG_LEVEL_ERROR,"server_paint_rect_os: error finding id %d", rdpindex);
+        log_message(LOG_LEVEL_ERROR, "server_paint_rect_os: error finding id %d", rdpindex);
     }
 
     return 0;
@@ -3650,9 +3652,9 @@ server_monitored_desktop(struct xrdp_mod *mod,
 
 /*****************************************************************************/
 int
-server_add_char_alpha(struct xrdp_mod* mod, int font, int character,
+server_add_char_alpha(struct xrdp_mod *mod, int font, int character,
                       int offset, int baseline,
-                      int width, int height, char* data)
+                      int width, int height, char *data)
 {
     struct xrdp_font_char fi;
 
@@ -3663,6 +3665,6 @@ server_add_char_alpha(struct xrdp_mod* mod, int font, int character,
     fi.incby = 0;
     fi.data = data;
     fi.bpp = 8;
-    return libxrdp_orders_send_font(((struct xrdp_wm*)mod->wm)->session,
+    return libxrdp_orders_send_font(((struct xrdp_wm *)mod->wm)->session,
                                     &fi, font, character);
 }

--- a/xrdp/xrdp_painter.c
+++ b/xrdp/xrdp_painter.c
@@ -29,17 +29,7 @@
 #include <painter.h> /* libpainter */
 #endif
 
-#define LLOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do \
-    { \
-        if (_level < LLOG_LEVEL) \
-        { \
-            g_write("xrdp:xrdp_painter [%10.10u]: ", g_time3()); \
-            g_writeln _args ; \
-        } \
-    } \
-    while (0)
+
 
 #if defined(XRDP_PAINTER)
 
@@ -72,8 +62,8 @@ xrdp_painter_add_dirty_rect(struct xrdp_painter *self, int x, int y,
     rect.right = x + cx;
     rect.bottom = y + cy;
     xrdp_region_add_rect(self->dirty_region, &rect);
-    LLOGLN(10, ("xrdp_painter_add_dirty_rect: x %d y %d cx %d cy %d",
-                x, y, cx, cy));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_painter_add_dirty_rect: x %d y %d cx %d cy %d",
+              x, y, cx, cy);
     return 0;
 }
 
@@ -93,7 +83,7 @@ xrdp_painter_send_dirty(struct xrdp_painter *self)
     char *dst;
     struct xrdp_rect rect;
 
-    LLOGLN(10, ("xrdp_painter_send_dirty:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_painter_send_dirty:");
 
     bpp = self->wm->screen->bpp;
     Bpp = (bpp + 7) / 8;
@@ -123,8 +113,8 @@ xrdp_painter_send_dirty(struct xrdp_painter *self)
             src += self->wm->screen->line_size;
             dst += cx * Bpp;
         }
-        LLOGLN(10, ("xrdp_painter_send_dirty: x %d y %d cx %d cy %d",
-                    rect.left, rect.top, cx, cy));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_painter_send_dirty: x %d y %d cx %d cy %d",
+                  rect.left, rect.top, cx, cy);
         libxrdp_send_bitmap(self->session, cx, cy, bpp,
                             ldata, rect.left, rect.top, cx, cy);
         g_free(ldata);
@@ -147,7 +137,7 @@ xrdp_painter_create(struct xrdp_wm *wm, struct xrdp_session *session)
 {
     struct xrdp_painter *self;
 
-    LLOGLN(10, ("xrdp_painter_create:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_painter_create:");
     self = (struct xrdp_painter *)g_malloc(sizeof(struct xrdp_painter), 1);
     self->wm = wm;
     self->session = session;
@@ -161,11 +151,11 @@ xrdp_painter_create(struct xrdp_wm *wm, struct xrdp_session *session)
         if (painter_create(&(self->painter)) != PT_ERROR_NONE)
         {
             self->painter = 0;
-            LLOGLN(0, ("xrdp_painter_create: painter_create failed"));
+            LOG_DEVEL(LOG_LEVEL_WARNING, "xrdp_painter_create: painter_create failed");
         }
         else
         {
-            LLOGLN(10, ("xrdp_painter_create: painter_create success"));
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_painter_create: painter_create success");
         }
         self->dirty_region = xrdp_region_create(wm);
 #endif
@@ -178,7 +168,7 @@ xrdp_painter_create(struct xrdp_wm *wm, struct xrdp_session *session)
 void
 xrdp_painter_delete(struct xrdp_painter *self)
 {
-    LLOGLN(10, ("xrdp_painter_delete:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_painter_delete:");
     if (self == 0)
     {
         return;
@@ -200,7 +190,7 @@ wm_painter_set_target(struct xrdp_painter *self)
     int index;
     struct list *del_list;
 
-    LLOGLN(10, ("wm_painter_set_target:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "wm_painter_set_target:");
 
     if (self->painter != 0)
     {
@@ -240,7 +230,7 @@ wm_painter_set_target(struct xrdp_painter *self)
     }
     else
     {
-        g_writeln("xrdp_painter_begin_update: bad target_surface");
+        LOG(LOG_LEVEL_WARNING, "xrdp_painter_begin_update: bad target_surface");
     }
 
     return 0;
@@ -250,7 +240,7 @@ wm_painter_set_target(struct xrdp_painter *self)
 int
 xrdp_painter_begin_update(struct xrdp_painter *self)
 {
-    LLOGLN(10, ("xrdp_painter_begin_update:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_painter_begin_update:");
     if (self == 0)
     {
         return 0;
@@ -272,7 +262,7 @@ xrdp_painter_begin_update(struct xrdp_painter *self)
 int
 xrdp_painter_end_update(struct xrdp_painter *self)
 {
-    LLOGLN(10, ("xrdp_painter_end_update:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_painter_end_update:");
     if (self == 0)
     {
         return 0;
@@ -445,7 +435,7 @@ xrdp_painter_text_width(struct xrdp_painter *self, const char *text)
     struct xrdp_font_char *font_item;
     twchar *wstr;
 
-    LLOGLN(10, ("xrdp_painter_text_width:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_painter_text_width:");
     xrdp_painter_font_needed(self);
 
     if (self->font == 0)
@@ -483,7 +473,7 @@ xrdp_painter_text_height(struct xrdp_painter *self, const char *text)
     struct xrdp_font_char *font_item;
     twchar *wstr;
 
-    LLOGLN(10, ("xrdp_painter_text_height:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_painter_text_height:");
     xrdp_painter_font_needed(self);
 
     if (self->font == 0)
@@ -519,7 +509,7 @@ xrdp_painter_setup_brush(struct xrdp_painter *self,
 {
     int cache_id;
 
-    LLOGLN(10, ("xrdp_painter_setup_brush:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_painter_setup_brush:");
 
     if (self->painter != 0)
     {
@@ -591,7 +581,7 @@ xrdp_painter_fill_rect(struct xrdp_painter *self,
     int dy;
     int rop;
 
-    LLOGLN(10, ("xrdp_painter_fill_rect:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_painter_fill_rect:");
 
     if (self == 0)
     {
@@ -608,10 +598,10 @@ xrdp_painter_fill_rect(struct xrdp_painter *self,
         struct xrdp_bitmap *ldst;
         struct painter_bitmap pat;
 
-        LLOGLN(10, ("xrdp_painter_fill_rect: dst->type %d", dst->type));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_painter_fill_rect: dst->type %d", dst->type);
         if (dst->type != WND_TYPE_OFFSCREEN)
         {
-            LLOGLN(10, ("xrdp_painter_fill_rect: using painter"));
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_painter_fill_rect: using painter");
 
             ldst = self->wm->screen;
 
@@ -622,9 +612,9 @@ xrdp_painter_fill_rect(struct xrdp_painter *self,
             dst_pb.height = ldst->height;
             dst_pb.data = ldst->data;
 
-            LLOGLN(10, ("xrdp_painter_fill_rect: ldst->width %d ldst->height %d "
-                        "dst->data %p self->fg_color %d",
-                        ldst->width, ldst->height, ldst->data, self->fg_color));
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_painter_fill_rect: ldst->width %d ldst->height %d "
+                      "dst->data %p self->fg_color %d",
+                      ldst->width, ldst->height, ldst->data, self->fg_color);
 
             xrdp_bitmap_get_screen_clip(dst, self, &clip_rect, &dx, &dy);
             region = xrdp_region_create(self->wm);
@@ -833,7 +823,7 @@ xrdp_painter_draw_text(struct xrdp_painter *self,
     struct xrdp_font_char *font_item;
     twchar *wstr;
 
-    LLOGLN(10, ("xrdp_painter_draw_text:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_painter_draw_text:");
 
     if (self == 0)
     {
@@ -1026,7 +1016,7 @@ xrdp_painter_draw_text2(struct xrdp_painter *self,
     int dx;
     int dy;
 
-    LLOGLN(0, ("xrdp_painter_draw_text2:"));
+    LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_painter_draw_text2:");
 
     if (self == 0)
     {
@@ -1128,7 +1118,7 @@ xrdp_painter_copy(struct xrdp_painter *self,
     int index;
     struct list *del_list;
 
-    LLOGLN(10, ("xrdp_painter_copy:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_painter_copy:");
 
     if (self == 0 || src == 0 || dst == 0)
     {
@@ -1142,12 +1132,12 @@ xrdp_painter_copy(struct xrdp_painter *self,
         struct painter_bitmap dst_pb;
         struct xrdp_bitmap *ldst;
 
-        LLOGLN(10, ("xrdp_painter_copy: src->type %d dst->type %d", src->type, dst->type));
-        LLOGLN(10, ("xrdp_painter_copy: self->rop 0x%2.2x", self->rop));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_painter_copy: src->type %d dst->type %d", src->type, dst->type);
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_painter_copy: self->rop 0x%2.2x", self->rop);
 
         if (dst->type != WND_TYPE_OFFSCREEN)
         {
-            LLOGLN(10, ("xrdp_painter_copy: using painter"));
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_painter_copy: using painter");
             ldst = self->wm->screen;
 
             g_memset(&dst_pb, 0, sizeof(dst_pb));
@@ -1181,8 +1171,8 @@ xrdp_painter_copy(struct xrdp_painter *self,
                                      draw_rect.left, draw_rect.top,
                                      draw_rect.right - draw_rect.left,
                                      draw_rect.bottom - draw_rect.top);
-                    LLOGLN(10, ("  x %d y %d cx %d cy %d srcx %d srcy %d",
-                                x, y, cx, cy, srcx, srcy));
+                    LOG_DEVEL(LOG_LEVEL_DEBUG, "  x %d y %d cx %d cy %d srcx %d srcy %d",
+                              x, y, cx, cy, srcx, srcy);
                     painter_copy(self->painter, &dst_pb, x, y, cx, cy,
                                  &src_pb, srcx, srcy);
                     xrdp_painter_add_dirty_rect(self, x, y, cx, cy,
@@ -1241,20 +1231,20 @@ xrdp_painter_copy(struct xrdp_painter *self,
     }
     else if (src->type == WND_TYPE_OFFSCREEN)
     {
-        //g_writeln("xrdp_painter_copy: todo");
+        LOG(LOG_LEVEL_DEBUG, "xrdp_painter_copy: todo");
 
         xrdp_bitmap_get_screen_clip(dst, self, &clip_rect, &dx, &dy);
         region = xrdp_region_create(self->wm);
 
         if (dst->type != WND_TYPE_OFFSCREEN)
         {
-            //g_writeln("off screen to screen");
+            LOG(LOG_LEVEL_DEBUG, "off screen to screen");
             xrdp_wm_get_vis_region(self->wm, dst, x, y, cx, cy,
                                    region, self->clip_children);
         }
         else
         {
-            //g_writeln("off screen to off screen");
+            LOG(LOG_LEVEL_DEBUG, "off screen to off screen");
             xrdp_region_add_rect(region, &clip_rect);
         }
 
@@ -1267,7 +1257,7 @@ xrdp_painter_copy(struct xrdp_painter *self,
 
         if (src->tab_stop == 0)
         {
-            g_writeln("xrdp_painter_copy: warning src not created");
+            LOG(LOG_LEVEL_WARNING, "xrdp_painter_copy: warning src not created");
             del_list = self->wm->cache->xrdp_os_del_list;
             index = list_index_of(del_list, cache_idx);
             list_remove_item(del_list, index);
@@ -1400,7 +1390,7 @@ xrdp_painter_composite(struct xrdp_painter *self,
     int cache_srcidx;
     int cache_mskidx;
 
-    LLOGLN(0, ("xrdp_painter_composite:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_painter_composite:");
 
     if (self == 0 || src == 0 || dst == 0)
     {
@@ -1474,7 +1464,7 @@ xrdp_painter_line(struct xrdp_painter *self,
     int dy;
     int rop;
 
-    LLOGLN(10, ("xrdp_painter_line:"));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_painter_line:");
     if (self == 0)
     {
         return 0;
@@ -1489,12 +1479,12 @@ xrdp_painter_line(struct xrdp_painter *self,
         struct painter_bitmap dst_pb;
         struct xrdp_bitmap *ldst;
 
-        LLOGLN(10, ("xrdp_painter_line: dst->type %d", dst->type));
-        LLOGLN(10, ("xrdp_painter_line: self->rop 0x%2.2x", self->rop));
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_painter_line: dst->type %d", dst->type);
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_painter_line: self->rop 0x%2.2x", self->rop);
 
         if (dst->type != WND_TYPE_OFFSCREEN)
         {
-            LLOGLN(10, ("xrdp_painter_line: using painter"));
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_painter_line: using painter");
             ldst = self->wm->screen;
 
             g_memset(&dst_pb, 0, sizeof(dst_pb));

--- a/xrdp/xrdp_painter.c
+++ b/xrdp/xrdp_painter.c
@@ -31,15 +31,15 @@
 
 #define LLOG_LEVEL 1
 #define LLOGLN(_level, _args) \
-  do \
-  { \
-    if (_level < LLOG_LEVEL) \
+    do \
     { \
-        g_write("xrdp:xrdp_painter [%10.10u]: ", g_time3()); \
-        g_writeln _args ; \
+        if (_level < LLOG_LEVEL) \
+        { \
+            g_write("xrdp:xrdp_painter [%10.10u]: ", g_time3()); \
+            g_writeln _args ; \
+        } \
     } \
-  } \
-  while (0)
+    while (0)
 
 #if defined(XRDP_PAINTER)
 
@@ -73,7 +73,7 @@ xrdp_painter_add_dirty_rect(struct xrdp_painter *self, int x, int y,
     rect.bottom = y + cy;
     xrdp_region_add_rect(self->dirty_region, &rect);
     LLOGLN(10, ("xrdp_painter_add_dirty_rect: x %d y %d cx %d cy %d",
-           x, y, cx, cy));
+                x, y, cx, cy));
     return 0;
 }
 
@@ -124,7 +124,7 @@ xrdp_painter_send_dirty(struct xrdp_painter *self)
             dst += cx * Bpp;
         }
         LLOGLN(10, ("xrdp_painter_send_dirty: x %d y %d cx %d cy %d",
-               rect.left, rect.top, cx, cy));
+                    rect.left, rect.top, cx, cy));
         libxrdp_send_bitmap(self->session, cx, cy, bpp,
                             ldata, rect.left, rect.top, cx, cy);
         g_free(ldata);
@@ -623,8 +623,8 @@ xrdp_painter_fill_rect(struct xrdp_painter *self,
             dst_pb.data = ldst->data;
 
             LLOGLN(10, ("xrdp_painter_fill_rect: ldst->width %d ldst->height %d "
-                       "dst->data %p self->fg_color %d",
-                       ldst->width, ldst->height, ldst->data, self->fg_color));
+                        "dst->data %p self->fg_color %d",
+                        ldst->width, ldst->height, ldst->data, self->fg_color));
 
             xrdp_bitmap_get_screen_clip(dst, self, &clip_rect, &dx, &dy);
             region = xrdp_region_create(self->wm);
@@ -1182,7 +1182,7 @@ xrdp_painter_copy(struct xrdp_painter *self,
                                      draw_rect.right - draw_rect.left,
                                      draw_rect.bottom - draw_rect.top);
                     LLOGLN(10, ("  x %d y %d cx %d cy %d srcx %d srcy %d",
-                           x, y, cx, cy, srcx, srcy));
+                                x, y, cx, cy, srcx, srcy));
                     painter_copy(self->painter, &dst_pb, x, y, cx, cy,
                                  &src_pb, srcx, srcy);
                     xrdp_painter_add_dirty_rect(self, x, y, cx, cy,
@@ -1376,15 +1376,15 @@ xrdp_painter_copy(struct xrdp_painter *self,
 
 /*****************************************************************************/
 int
-xrdp_painter_composite(struct xrdp_painter* self,
-                       struct xrdp_bitmap* src,
+xrdp_painter_composite(struct xrdp_painter *self,
+                       struct xrdp_bitmap *src,
                        int srcformat,
                        int srcwidth,
                        int srcrepeat,
-                       struct xrdp_bitmap* dst,
-                       int* srctransform,
+                       struct xrdp_bitmap *dst,
+                       int *srctransform,
                        int mskflags,
-                       struct xrdp_bitmap* msk,
+                       struct xrdp_bitmap *msk,
                        int mskformat, int mskwidth, int mskrepeat, int op,
                        int srcx, int srcy, int mskx, int msky,
                        int dstx, int dsty, int width, int height, int dstformat)
@@ -1393,7 +1393,7 @@ xrdp_painter_composite(struct xrdp_painter* self,
     struct xrdp_rect draw_rect;
     struct xrdp_rect rect1;
     struct xrdp_rect rect2;
-    struct xrdp_region* region;
+    struct xrdp_region *region;
     int k;
     int dx;
     int dy;

--- a/xrdp/xrdp_process.c
+++ b/xrdp/xrdp_process.c
@@ -273,6 +273,9 @@ xrdp_process_main_loop(struct xrdp_process *self)
 
             if (g_is_wait_obj_set(term_obj)) /* term */
             {
+                LOG(LOG_LEVEL_DEBUG,
+                    "Received termination signal, stopping the client message "
+                    "processor thread");
                 break;
             }
 

--- a/xrdp/xrdp_process.c
+++ b/xrdp/xrdp_process.c
@@ -77,7 +77,7 @@ xrdp_process_loop(struct xrdp_process *self, struct stream *s)
 
         if ((self->wm == 0) && (self->session->up_and_running) && (rv == 0))
         {
-            DEBUG(("calling xrdp_wm_init and creating wm"));
+            LOG_DEVEL(LOG_LEVEL_TRACE, "calling xrdp_wm_init and creating wm");
             self->wm = xrdp_wm_create(self, self->session->client_info);
             /* at this point the wm(window manager) is created and
                wm::login_state is WMLS_RESET and wm::login_state_event is set
@@ -127,7 +127,7 @@ xrdp_process_data_in(struct trans *self)
     struct stream *s;
     int len;
 
-    DEBUG(("xrdp_process_data_in"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_process_data_in");
     pro = (struct xrdp_process *)(self->callback_data);
 
     s = pro->server_trans->in_s;
@@ -137,8 +137,8 @@ xrdp_process_data_in(struct trans *self)
             /* early in connection sequence, we're in this mode */
             if (xrdp_process_loop(pro, 0) != 0)
             {
-                g_writeln("xrdp_process_data_in: "
-                          "xrdp_process_loop failed");
+                LOG(LOG_LEVEL_ERROR, "xrdp_process_data_in: "
+                    "xrdp_process_loop failed");
                 return 1;
             }
             if (pro->session->up_and_running)
@@ -184,8 +184,8 @@ xrdp_process_data_in(struct trans *self)
             len = libxrdp_get_pdu_bytes(s->p);
             if (len == -1)
             {
-                g_writeln("xrdp_process_data_in: "
-                          "xrdp_process_get_packet_bytes failed");
+                LOG(LOG_LEVEL_ERROR, "xrdp_process_data_in: "
+                    "xrdp_process_get_packet_bytes failed");
                 return 1;
             }
             pro->server_trans->header_size = len;
@@ -204,8 +204,8 @@ xrdp_process_data_in(struct trans *self)
             s->p = s->data;
             if (xrdp_process_loop(pro, s) != 0)
             {
-                g_writeln("xrdp_process_data_in: "
-                          "xrdp_process_loop failed");
+                LOG(LOG_LEVEL_ERROR, "xrdp_process_data_in: "
+                    "xrdp_process_loop failed");
                 return 1;
             }
             init_stream(s, 0);
@@ -228,7 +228,7 @@ xrdp_process_main_loop(struct xrdp_process *self)
     tbus wobjs[32];
     tbus term_obj;
 
-    DEBUG(("xrdp_process_main_loop"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_process_main_loop");
     self->status = 1;
     self->server_trans->extra_flags = 0;
     self->server_trans->header_size = 0;
@@ -296,7 +296,7 @@ xrdp_process_main_loop(struct xrdp_process *self)
     }
     else
     {
-        g_writeln("xrdp_process_main_loop: libxrdp_process_incoming failed");
+        LOG(LOG_LEVEL_ERROR, "xrdp_process_main_loop: libxrdp_process_incoming failed");
         /* this will try to send a disconnect,
            maybe should check that connection got far enough */
         libxrdp_disconnect(self->session);

--- a/xrdp/xrdp_process.c
+++ b/xrdp/xrdp_process.c
@@ -177,7 +177,7 @@ xrdp_process_data_in(struct trans *self)
                 /* not enough data read yet */
                 break;
             }
-            /* FALLTHROUGH */
+        /* FALLTHROUGH */
 
         case 2:
             /* we have enough now to get the PDU bytes */
@@ -197,7 +197,7 @@ xrdp_process_data_in(struct trans *self)
                 /* not enough data read yet */
                 break;
             }
-            /* FALLTHROUGH */
+        /* FALLTHROUGH */
 
         case 3:
             /* the whole PDU is read in now process */

--- a/xrdp/xrdp_region.c
+++ b/xrdp/xrdp_region.c
@@ -39,7 +39,7 @@ xrdp_region_create(struct xrdp_wm *wm)
     self = (struct xrdp_region *)g_malloc(sizeof(struct xrdp_region), 1);
     self->wm = wm;
     self->reg = (struct pixman_region16 *)
-            g_malloc(sizeof(struct pixman_region16), 1);
+                g_malloc(sizeof(struct pixman_region16), 1);
     pixman_region_init(self->reg);
     return self;
 }
@@ -98,7 +98,7 @@ xrdp_region_subtract_rect(struct xrdp_region *self, struct xrdp_rect *rect)
 /*****************************************************************************/
 /* returns error */
 int
-xrdp_region_intersect_rect(struct xrdp_region* self, struct xrdp_rect* rect)
+xrdp_region_intersect_rect(struct xrdp_region *self, struct xrdp_rect *rect)
 {
     struct pixman_region16 lreg;
 

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -36,195 +36,195 @@ struct source_info;
 /* lib */
 struct xrdp_mod
 {
-  int size; /* size of this struct */
-  int version; /* internal version */
-  /* client functions */
-  int (*mod_start)(struct xrdp_mod* v, int w, int h, int bpp);
-  int (*mod_connect)(struct xrdp_mod* v);
-  int (*mod_event)(struct xrdp_mod* v, int msg, long param1, long param2,
-                   long param3, long param4);
-  int (*mod_signal)(struct xrdp_mod* v);
-  int (*mod_end)(struct xrdp_mod* v);
-  int (*mod_set_param)(struct xrdp_mod *v, const char *name, const char *value);
-  int (*mod_session_change)(struct xrdp_mod* v, int, int);
-  int (*mod_get_wait_objs)(struct xrdp_mod* v, tbus* read_objs, int* rcount,
-                           tbus* write_objs, int* wcount, int* timeout);
-  int (*mod_check_wait_objs)(struct xrdp_mod* v);
-  int (*mod_frame_ack)(struct xrdp_mod* v, int flags, int frame_id);
-  int (*mod_suppress_output)(struct xrdp_mod* v, int suppress,
-                             int left, int top, int right, int bottom);
-  tintptr mod_dumby[100 - 11]; /* align, 100 minus the number of mod
+    int size; /* size of this struct */
+    int version; /* internal version */
+    /* client functions */
+    int (*mod_start)(struct xrdp_mod *v, int w, int h, int bpp);
+    int (*mod_connect)(struct xrdp_mod *v);
+    int (*mod_event)(struct xrdp_mod *v, int msg, long param1, long param2,
+                     long param3, long param4);
+    int (*mod_signal)(struct xrdp_mod *v);
+    int (*mod_end)(struct xrdp_mod *v);
+    int (*mod_set_param)(struct xrdp_mod *v, const char *name, const char *value);
+    int (*mod_session_change)(struct xrdp_mod *v, int, int);
+    int (*mod_get_wait_objs)(struct xrdp_mod *v, tbus *read_objs, int *rcount,
+                             tbus *write_objs, int *wcount, int *timeout);
+    int (*mod_check_wait_objs)(struct xrdp_mod *v);
+    int (*mod_frame_ack)(struct xrdp_mod *v, int flags, int frame_id);
+    int (*mod_suppress_output)(struct xrdp_mod *v, int suppress,
+                               int left, int top, int right, int bottom);
+    tintptr mod_dumby[100 - 11]; /* align, 100 minus the number of mod
                                   functions above */
-  /* server functions */
-  int (*server_begin_update)(struct xrdp_mod* v);
-  int (*server_end_update)(struct xrdp_mod* v);
-  int (*server_fill_rect)(struct xrdp_mod* v, int x, int y, int cx, int cy);
-  int (*server_screen_blt)(struct xrdp_mod* v, int x, int y, int cx, int cy,
-                           int srcx, int srcy);
-  int (*server_paint_rect)(struct xrdp_mod* v, int x, int y, int cx, int cy,
-                           char* data, int width, int height,
-                           int srcx, int srcy);
-  int (*server_set_pointer)(struct xrdp_mod* v, int x, int y,
-                            char* data, char* mask);
-  int (*server_palette)(struct xrdp_mod* v, int* palette);
-  int (*server_msg)(struct xrdp_mod* v, char* msg, int code);
-  int (*server_is_term)(struct xrdp_mod* v);
-  int (*server_set_clip)(struct xrdp_mod* v, int x, int y, int cx, int cy);
-  int (*server_reset_clip)(struct xrdp_mod* v);
-  int (*server_set_fgcolor)(struct xrdp_mod* v, int fgcolor);
-  int (*server_set_bgcolor)(struct xrdp_mod* v, int bgcolor);
-  int (*server_set_opcode)(struct xrdp_mod* v, int opcode);
-  int (*server_set_mixmode)(struct xrdp_mod* v, int mixmode);
-  int (*server_set_brush)(struct xrdp_mod* v, int x_origin, int y_origin,
-                          int style, char* pattern);
-  int (*server_set_pen)(struct xrdp_mod* v, int style,
-                        int width);
-  int (*server_draw_line)(struct xrdp_mod* v, int x1, int y1, int x2, int y2);
-  int (*server_add_char)(struct xrdp_mod* v, int font, int character,
-                         int offset, int baseline,
-                         int width, int height, char* data);
-  int (*server_draw_text)(struct xrdp_mod* v, int font,
-                          int flags, int mixmode, int clip_left, int clip_top,
-                          int clip_right, int clip_bottom,
-                          int box_left, int box_top,
-                          int box_right, int box_bottom,
-                          int x, int y, char* data, int data_len);
-  int (*server_reset)(struct xrdp_mod* v, int width, int height, int bpp);
-  int (*server_query_channel)(struct xrdp_mod* v, int index,
-                              char* channel_name,
-                              int* channel_flags);
-  int (*server_get_channel_id)(struct xrdp_mod* v, const char *name);
-  int (*server_send_to_channel)(struct xrdp_mod* v, int channel_id,
-                                char* data, int data_len,
-                                int total_data_len, int flags);
-  int (*server_bell_trigger)(struct xrdp_mod* v);
-  /* off screen bitmaps */
-  int (*server_create_os_surface)(struct xrdp_mod* v, int rdpindex,
-                                  int width, int height);
-  int (*server_switch_os_surface)(struct xrdp_mod* v, int rdpindex);
-  int (*server_delete_os_surface)(struct xrdp_mod* v, int rdpindex);
-  int (*server_paint_rect_os)(struct xrdp_mod* mod, int x, int y,
-                              int cx, int cy,
-                              int rdpindex, int srcx, int srcy);
-  int (*server_set_hints)(struct xrdp_mod* mod, int hints, int mask);
-  /* rail */
-  int (*server_window_new_update)(struct xrdp_mod* mod, int window_id,
-                                  struct rail_window_state_order* window_state,
-                                  int flags);
-  int (*server_window_delete)(struct xrdp_mod* mod, int window_id);
-  int (*server_window_icon)(struct xrdp_mod* mod,
-                            int window_id, int cache_entry, int cache_id,
-                            struct rail_icon_info* icon_info,
-                            int flags);
-  int (*server_window_cached_icon)(struct xrdp_mod* mod,
-                                   int window_id, int cache_entry,
-                                   int cache_id, int flags);
-  int (*server_notify_new_update)(struct xrdp_mod* mod,
-                                  int window_id, int notify_id,
-                                  struct rail_notify_state_order* notify_state,
-                                  int flags);
-  int (*server_notify_delete)(struct xrdp_mod* mod, int window_id,
-                              int notify_id);
-  int (*server_monitored_desktop)(struct xrdp_mod* mod,
-                                  struct rail_monitored_desktop_order* mdo,
-                                  int flags);
-  int (*server_set_pointer_ex)(struct xrdp_mod* v, int x, int y, char* data,
-                               char* mask, int bpp);
-  int (*server_add_char_alpha)(struct xrdp_mod* mod, int font, int character,
-                               int offset, int baseline,
-                               int width, int height, char* data);
+    /* server functions */
+    int (*server_begin_update)(struct xrdp_mod *v);
+    int (*server_end_update)(struct xrdp_mod *v);
+    int (*server_fill_rect)(struct xrdp_mod *v, int x, int y, int cx, int cy);
+    int (*server_screen_blt)(struct xrdp_mod *v, int x, int y, int cx, int cy,
+                             int srcx, int srcy);
+    int (*server_paint_rect)(struct xrdp_mod *v, int x, int y, int cx, int cy,
+                             char *data, int width, int height,
+                             int srcx, int srcy);
+    int (*server_set_pointer)(struct xrdp_mod *v, int x, int y,
+                              char *data, char *mask);
+    int (*server_palette)(struct xrdp_mod *v, int *palette);
+    int (*server_msg)(struct xrdp_mod *v, char *msg, int code);
+    int (*server_is_term)(struct xrdp_mod *v);
+    int (*server_set_clip)(struct xrdp_mod *v, int x, int y, int cx, int cy);
+    int (*server_reset_clip)(struct xrdp_mod *v);
+    int (*server_set_fgcolor)(struct xrdp_mod *v, int fgcolor);
+    int (*server_set_bgcolor)(struct xrdp_mod *v, int bgcolor);
+    int (*server_set_opcode)(struct xrdp_mod *v, int opcode);
+    int (*server_set_mixmode)(struct xrdp_mod *v, int mixmode);
+    int (*server_set_brush)(struct xrdp_mod *v, int x_origin, int y_origin,
+                            int style, char *pattern);
+    int (*server_set_pen)(struct xrdp_mod *v, int style,
+                          int width);
+    int (*server_draw_line)(struct xrdp_mod *v, int x1, int y1, int x2, int y2);
+    int (*server_add_char)(struct xrdp_mod *v, int font, int character,
+                           int offset, int baseline,
+                           int width, int height, char *data);
+    int (*server_draw_text)(struct xrdp_mod *v, int font,
+                            int flags, int mixmode, int clip_left, int clip_top,
+                            int clip_right, int clip_bottom,
+                            int box_left, int box_top,
+                            int box_right, int box_bottom,
+                            int x, int y, char *data, int data_len);
+    int (*server_reset)(struct xrdp_mod *v, int width, int height, int bpp);
+    int (*server_query_channel)(struct xrdp_mod *v, int index,
+                                char *channel_name,
+                                int *channel_flags);
+    int (*server_get_channel_id)(struct xrdp_mod *v, const char *name);
+    int (*server_send_to_channel)(struct xrdp_mod *v, int channel_id,
+                                  char *data, int data_len,
+                                  int total_data_len, int flags);
+    int (*server_bell_trigger)(struct xrdp_mod *v);
+    /* off screen bitmaps */
+    int (*server_create_os_surface)(struct xrdp_mod *v, int rdpindex,
+                                    int width, int height);
+    int (*server_switch_os_surface)(struct xrdp_mod *v, int rdpindex);
+    int (*server_delete_os_surface)(struct xrdp_mod *v, int rdpindex);
+    int (*server_paint_rect_os)(struct xrdp_mod *mod, int x, int y,
+                                int cx, int cy,
+                                int rdpindex, int srcx, int srcy);
+    int (*server_set_hints)(struct xrdp_mod *mod, int hints, int mask);
+    /* rail */
+    int (*server_window_new_update)(struct xrdp_mod *mod, int window_id,
+                                    struct rail_window_state_order *window_state,
+                                    int flags);
+    int (*server_window_delete)(struct xrdp_mod *mod, int window_id);
+    int (*server_window_icon)(struct xrdp_mod *mod,
+                              int window_id, int cache_entry, int cache_id,
+                              struct rail_icon_info *icon_info,
+                              int flags);
+    int (*server_window_cached_icon)(struct xrdp_mod *mod,
+                                     int window_id, int cache_entry,
+                                     int cache_id, int flags);
+    int (*server_notify_new_update)(struct xrdp_mod *mod,
+                                    int window_id, int notify_id,
+                                    struct rail_notify_state_order *notify_state,
+                                    int flags);
+    int (*server_notify_delete)(struct xrdp_mod *mod, int window_id,
+                                int notify_id);
+    int (*server_monitored_desktop)(struct xrdp_mod *mod,
+                                    struct rail_monitored_desktop_order *mdo,
+                                    int flags);
+    int (*server_set_pointer_ex)(struct xrdp_mod *v, int x, int y, char *data,
+                                 char *mask, int bpp);
+    int (*server_add_char_alpha)(struct xrdp_mod *mod, int font, int character,
+                                 int offset, int baseline,
+                                 int width, int height, char *data);
 
-  int (*server_create_os_surface_bpp)(struct xrdp_mod* v, int rdpindex,
-                                      int width, int height, int bpp);
-  int (*server_paint_rect_bpp)(struct xrdp_mod* v, int x, int y, int cx, int cy,
-                               char* data, int width, int height,
-                               int srcx, int srcy, int bpp);
-  int (*server_composite)(struct xrdp_mod* v, int srcidx, int srcformat,
-                          int srcwidth, int srcrepeat, int* srctransform,
-                          int mskflags, int mskidx, int mskformat,
-                          int mskwidth, int mskrepeat, int op,
-                          int srcx, int srcy, int mskx, int msky,
-                          int dstx, int dsty, int width, int height,
-                          int dstformat);
-  int (*server_paint_rects)(struct xrdp_mod* v,
-                            int num_drects, short *drects,
-                            int num_crects, short *crects,
-                            char *data, int width, int height,
-                            int flags, int frame_id);
-  int (*server_session_info)(struct xrdp_mod* v, const char *data,
-                             int data_bytes);
-  tintptr server_dumby[100 - 44]; /* align, 100 minus the number of server
+    int (*server_create_os_surface_bpp)(struct xrdp_mod *v, int rdpindex,
+                                        int width, int height, int bpp);
+    int (*server_paint_rect_bpp)(struct xrdp_mod *v, int x, int y, int cx, int cy,
+                                 char *data, int width, int height,
+                                 int srcx, int srcy, int bpp);
+    int (*server_composite)(struct xrdp_mod *v, int srcidx, int srcformat,
+                            int srcwidth, int srcrepeat, int *srctransform,
+                            int mskflags, int mskidx, int mskformat,
+                            int mskwidth, int mskrepeat, int op,
+                            int srcx, int srcy, int mskx, int msky,
+                            int dstx, int dsty, int width, int height,
+                            int dstformat);
+    int (*server_paint_rects)(struct xrdp_mod *v,
+                              int num_drects, short *drects,
+                              int num_crects, short *crects,
+                              char *data, int width, int height,
+                              int flags, int frame_id);
+    int (*server_session_info)(struct xrdp_mod *v, const char *data,
+                               int data_bytes);
+    tintptr server_dumby[100 - 44]; /* align, 100 minus the number of server
                                      functions above */
-  /* common */
-  tintptr handle; /* pointer to self as int */
-  tintptr wm; /* struct xrdp_wm* */
-  tintptr painter;
-  struct source_info *si;
+    /* common */
+    tintptr handle; /* pointer to self as int */
+    tintptr wm; /* struct xrdp_wm* */
+    tintptr painter;
+    struct source_info *si;
 };
 
 /* header for bmp file */
 struct xrdp_bmp_header
 {
-  int size;
-  int image_width;
-  int image_height;
-  short planes;
-  short bit_count;
-  int compression;
-  int image_size;
-  int x_pels_per_meter;
-  int y_pels_per_meter;
-  int clr_used;
-  int clr_important;
+    int size;
+    int image_width;
+    int image_height;
+    short planes;
+    short bit_count;
+    int compression;
+    int image_size;
+    int x_pels_per_meter;
+    int y_pels_per_meter;
+    int clr_used;
+    int clr_important;
 };
 
 struct xrdp_palette_item
 {
-  int stamp;
-  int palette[256];
+    int stamp;
+    int palette[256];
 };
 
 struct xrdp_bitmap_item
 {
-  int stamp;
-  int lru_index;
-  struct xrdp_bitmap* bitmap;
+    int stamp;
+    int lru_index;
+    struct xrdp_bitmap *bitmap;
 };
 
 struct xrdp_lru_item
 {
-  int next;
-  int prev;
+    int next;
+    int prev;
 };
 
 struct xrdp_os_bitmap_item
 {
-  int id;
-  struct xrdp_bitmap* bitmap;
+    int id;
+    struct xrdp_bitmap *bitmap;
 };
 
 struct xrdp_char_item
 {
-  int stamp;
-  struct xrdp_font_char font_item;
+    int stamp;
+    struct xrdp_font_char font_item;
 };
 
 struct xrdp_pointer_item
 {
-  int stamp;
-  int x; /* hotspot */
-  int y;
-  char data[32 * 32 * 4];
-  char mask[32 * 32 / 8];
-  int bpp;
+    int stamp;
+    int x; /* hotspot */
+    int y;
+    char data[32 * 32 * 4];
+    char mask[32 * 32 / 8];
+    int bpp;
 };
 
 struct xrdp_brush_item
 {
-  int stamp;
-  /* expand this to a structure to handle more complicated brushes
-     for now it's 8x8 1bpp brushes only */
-  char pattern[8];
+    int stamp;
+    /* expand this to a structure to handle more complicated brushes
+       for now it's 8x8 1bpp brushes only */
+    char pattern[8];
 };
 
 /* moved to xrdp_constants.h
@@ -233,46 +233,46 @@ struct xrdp_brush_item
 /* difference caches */
 struct xrdp_cache
 {
-  struct xrdp_wm* wm; /* owner */
-  struct xrdp_session* session;
-  /* palette */
-  int palette_stamp;
-  struct xrdp_palette_item palette_items[6];
-  /* bitmap */
-  int bitmap_stamp;
-  struct xrdp_bitmap_item bitmap_items[XRDP_MAX_BITMAP_CACHE_ID]
-                                      [XRDP_MAX_BITMAP_CACHE_IDX];
+    struct xrdp_wm *wm; /* owner */
+    struct xrdp_session *session;
+    /* palette */
+    int palette_stamp;
+    struct xrdp_palette_item palette_items[6];
+    /* bitmap */
+    int bitmap_stamp;
+    struct xrdp_bitmap_item bitmap_items[XRDP_MAX_BITMAP_CACHE_ID]
+        [XRDP_MAX_BITMAP_CACHE_IDX];
 
-  /* lru optimize */
-  struct xrdp_lru_item bitmap_lrus[XRDP_MAX_BITMAP_CACHE_ID]
-                                  [XRDP_MAX_BITMAP_CACHE_IDX];
-  int lru_head[XRDP_MAX_BITMAP_CACHE_ID];
-  int lru_tail[XRDP_MAX_BITMAP_CACHE_ID];
-  int lru_reset[XRDP_MAX_BITMAP_CACHE_ID];
+    /* lru optimize */
+    struct xrdp_lru_item bitmap_lrus[XRDP_MAX_BITMAP_CACHE_ID]
+        [XRDP_MAX_BITMAP_CACHE_IDX];
+    int lru_head[XRDP_MAX_BITMAP_CACHE_ID];
+    int lru_tail[XRDP_MAX_BITMAP_CACHE_ID];
+    int lru_reset[XRDP_MAX_BITMAP_CACHE_ID];
 
-  /* crc optimize */
-  struct list16 crc16[XRDP_MAX_BITMAP_CACHE_ID][64 * 1024];
+    /* crc optimize */
+    struct list16 crc16[XRDP_MAX_BITMAP_CACHE_ID][64 * 1024];
 
-  int use_bitmap_comp;
-  int cache1_entries;
-  int cache1_size;
-  int cache2_entries;
-  int cache2_size;
-  int cache3_entries;
-  int cache3_size;
-  int bitmap_cache_persist_enable;
-  int bitmap_cache_version;
-  /* font */
-  int char_stamp;
-  struct xrdp_char_item char_items[12][256];
-  /* pointer */
-  int pointer_stamp;
-  struct xrdp_pointer_item pointer_items[32];
-  int pointer_cache_entries;
-  int brush_stamp;
-  struct xrdp_brush_item brush_items[64];
-  struct xrdp_os_bitmap_item os_bitmap_items[2000];
-  struct list* xrdp_os_del_list;
+    int use_bitmap_comp;
+    int cache1_entries;
+    int cache1_size;
+    int cache2_entries;
+    int cache2_size;
+    int cache3_entries;
+    int cache3_size;
+    int bitmap_cache_persist_enable;
+    int bitmap_cache_version;
+    /* font */
+    int char_stamp;
+    struct xrdp_char_item char_items[12][256];
+    /* pointer */
+    int pointer_stamp;
+    struct xrdp_pointer_item pointer_items[32];
+    int pointer_cache_entries;
+    int brush_stamp;
+    struct xrdp_brush_item brush_items[64];
+    struct xrdp_os_bitmap_item os_bitmap_items[2000];
+    struct list *xrdp_os_del_list;
 };
 
 /* defined later */
@@ -280,46 +280,46 @@ struct xrdp_enc_data;
 
 struct xrdp_mm
 {
-  struct xrdp_wm* wm; /* owner */
-  int connected_state; /* true if connected to sesman else false */
-  struct trans* sesman_trans; /* connection to sesman */
-  int sesman_trans_up; /* true once connected to sesman */
-  int delete_sesman_trans; /* boolean set when done with sesman connection */
-  struct list* login_names;
-  struct list* login_values;
-  /* mod vars */
-  long mod_handle; /* returned from g_load_library */
-  struct xrdp_mod* (*mod_init)(void);
-  int (*mod_exit)(struct xrdp_mod*);
-  struct xrdp_mod* mod; /* module interface */
-  int display; /* 10 for :10.0, 11 for :11.0, etc */
-  int code; /* 0=Xvnc session, 10=X11rdp session, 20=xorg driver mode */
-  int sesman_controlled; /* true if this is a sesman session */
-  struct trans* chan_trans; /* connection to chansrv */
-  int chan_trans_up; /* true once connected to chansrv */
-  int delete_chan_trans; /* boolean set when done with channel connection */
-  int usechansrv; /* true if chansrvport is set in xrdp.ini or using sesman */
-  struct xrdp_encoder *encoder;
-  int cs2xr_cid_map[256];
-  int xr2cr_cid_map[256];
+    struct xrdp_wm *wm; /* owner */
+    int connected_state; /* true if connected to sesman else false */
+    struct trans *sesman_trans; /* connection to sesman */
+    int sesman_trans_up; /* true once connected to sesman */
+    int delete_sesman_trans; /* boolean set when done with sesman connection */
+    struct list *login_names;
+    struct list *login_values;
+    /* mod vars */
+    long mod_handle; /* returned from g_load_library */
+    struct xrdp_mod *(*mod_init)(void);
+    int (*mod_exit)(struct xrdp_mod *);
+    struct xrdp_mod *mod; /* module interface */
+    int display; /* 10 for :10.0, 11 for :11.0, etc */
+    int code; /* 0=Xvnc session, 10=X11rdp session, 20=xorg driver mode */
+    int sesman_controlled; /* true if this is a sesman session */
+    struct trans *chan_trans; /* connection to chansrv */
+    int chan_trans_up; /* true once connected to chansrv */
+    int delete_chan_trans; /* boolean set when done with channel connection */
+    int usechansrv; /* true if chansrvport is set in xrdp.ini or using sesman */
+    struct xrdp_encoder *encoder;
+    int cs2xr_cid_map[256];
+    int xr2cr_cid_map[256];
 };
 
 struct xrdp_key_info
 {
-  int sym;
-  int chr;
+    int sym;
+    int chr;
 };
 
 struct xrdp_keymap
 {
-  struct xrdp_key_info keys_noshift[256];
-  struct xrdp_key_info keys_shift[256];
-  struct xrdp_key_info keys_altgr[256];
-  struct xrdp_key_info keys_shiftaltgr[256];
-  struct xrdp_key_info keys_capslock[256];
-  struct xrdp_key_info keys_capslockaltgr[256];
-  struct xrdp_key_info keys_shiftcapslock[256];
-  struct xrdp_key_info keys_shiftcapslockaltgr[256];
+    struct xrdp_key_info keys_noshift[256];
+    struct xrdp_key_info keys_shift[256];
+    struct xrdp_key_info keys_altgr[256];
+    struct xrdp_key_info keys_shiftaltgr[256];
+    struct xrdp_key_info keys_capslock[256];
+    struct xrdp_key_info keys_capslockaltgr[256];
+    struct xrdp_key_info keys_shiftcapslock[256];
+    struct xrdp_key_info keys_shiftcapslockaltgr[256];
 };
 
 /* the window manager */
@@ -361,175 +361,175 @@ enum wm_login_state
 
 struct xrdp_wm
 {
-  struct xrdp_process* pro_layer; /* owner */
-  struct xrdp_bitmap* screen;
-  struct xrdp_session* session;
-  struct xrdp_painter* painter;
-  struct xrdp_cache* cache;
-  int palette[256];
-  struct xrdp_bitmap* login_window;
-  /* generic colors */
-  int black;
-  int grey;
-  int dark_grey;
-  int blue;
-  int dark_blue;
-  int white;
-  int red;
-  int green;
-  int background;
-  /* dragging info */
-  int dragging;
-  int draggingx;
-  int draggingy;
-  int draggingcx;
-  int draggingcy;
-  int draggingdx;
-  int draggingdy;
-  int draggingorgx;
-  int draggingorgy;
-  int draggingxorstate;
-  struct xrdp_bitmap* dragging_window;
-  /* the down(clicked) button */
-  struct xrdp_bitmap* button_down;
-  /* popup for combo box */
-  struct xrdp_bitmap* popup_wnd;
-  /* focused window */
-  struct xrdp_bitmap* focused_window;
-  /* pointer */
-  int current_pointer;
-  int mouse_x;
-  int mouse_y;
-  /* keyboard info */
-  int keys[256]; /* key states 0 up 1 down*/
-  int caps_lock;
-  int scroll_lock;
-  int num_lock;
-  /* client info */
-  struct xrdp_client_info* client_info;
-  /* session log */
-  struct list* log;
-  struct xrdp_bitmap* log_wnd;
-  enum wm_login_state login_state;
-  tbus login_state_event;
-  struct xrdp_mm* mm;
-  struct xrdp_font* default_font;
-  struct xrdp_keymap keymap;
-  int hide_log_window;
-  struct xrdp_bitmap* target_surface; /* either screen or os surface */
-  int current_surface_index;
-  int hints;
-  char pamerrortxt[256];
+    struct xrdp_process *pro_layer; /* owner */
+    struct xrdp_bitmap *screen;
+    struct xrdp_session *session;
+    struct xrdp_painter *painter;
+    struct xrdp_cache *cache;
+    int palette[256];
+    struct xrdp_bitmap *login_window;
+    /* generic colors */
+    int black;
+    int grey;
+    int dark_grey;
+    int blue;
+    int dark_blue;
+    int white;
+    int red;
+    int green;
+    int background;
+    /* dragging info */
+    int dragging;
+    int draggingx;
+    int draggingy;
+    int draggingcx;
+    int draggingcy;
+    int draggingdx;
+    int draggingdy;
+    int draggingorgx;
+    int draggingorgy;
+    int draggingxorstate;
+    struct xrdp_bitmap *dragging_window;
+    /* the down(clicked) button */
+    struct xrdp_bitmap *button_down;
+    /* popup for combo box */
+    struct xrdp_bitmap *popup_wnd;
+    /* focused window */
+    struct xrdp_bitmap *focused_window;
+    /* pointer */
+    int current_pointer;
+    int mouse_x;
+    int mouse_y;
+    /* keyboard info */
+    int keys[256]; /* key states 0 up 1 down*/
+    int caps_lock;
+    int scroll_lock;
+    int num_lock;
+    /* client info */
+    struct xrdp_client_info *client_info;
+    /* session log */
+    struct list *log;
+    struct xrdp_bitmap *log_wnd;
+    enum wm_login_state login_state;
+    tbus login_state_event;
+    struct xrdp_mm *mm;
+    struct xrdp_font *default_font;
+    struct xrdp_keymap keymap;
+    int hide_log_window;
+    struct xrdp_bitmap *target_surface; /* either screen or os surface */
+    int current_surface_index;
+    int hints;
+    char pamerrortxt[256];
 
-  /* configuration derived from xrdp.ini */
-  struct xrdp_config *xrdp_config;
+    /* configuration derived from xrdp.ini */
+    struct xrdp_config *xrdp_config;
 };
 
 /* rdp process */
 struct xrdp_process
 {
-  int status;
-  struct trans* server_trans; /* in tcp server mode */
-  tbus self_term_event;
-  struct xrdp_listen* lis_layer; /* owner */
-  struct xrdp_session* session;
-  /* create these when up and running */
-  struct xrdp_wm* wm;
-  //int app_sck;
-  tbus done_event;
-  int session_id;
+    int status;
+    struct trans *server_trans; /* in tcp server mode */
+    tbus self_term_event;
+    struct xrdp_listen *lis_layer; /* owner */
+    struct xrdp_session *session;
+    /* create these when up and running */
+    struct xrdp_wm *wm;
+    //int app_sck;
+    tbus done_event;
+    int session_id;
 };
 
 /* rdp listener */
 struct xrdp_listen
 {
-  int status;
-  struct list *trans_list; /* list of struct trans* */
-  struct list *process_list;
-  struct list *fork_list;
-  tbus pro_done_event;
-  struct xrdp_startup_params* startup_params;
+    int status;
+    struct list *trans_list; /* list of struct trans* */
+    struct list *process_list;
+    struct list *fork_list;
+    tbus pro_done_event;
+    struct xrdp_startup_params *startup_params;
 };
 
 /* region */
 struct xrdp_region
 {
-  struct xrdp_wm* wm; /* owner */
-  struct pixman_region16 *reg;
+    struct xrdp_wm *wm; /* owner */
+    struct pixman_region16 *reg;
 };
 
 /* painter */
 struct xrdp_painter
 {
-  int rop;
-  struct xrdp_rect* use_clip; /* nil if not using clip */
-  struct xrdp_rect clip;
-  int clip_children;
-  int bg_color;
-  int fg_color;
-  int mix_mode;
-  struct xrdp_brush brush;
-  struct xrdp_pen pen;
-  struct xrdp_session* session;
-  struct xrdp_wm* wm; /* owner */
-  struct xrdp_font* font;
-  void *painter;
-  struct xrdp_region *dirty_region;
-  int begin_end_level;
+    int rop;
+    struct xrdp_rect *use_clip; /* nil if not using clip */
+    struct xrdp_rect clip;
+    int clip_children;
+    int bg_color;
+    int fg_color;
+    int mix_mode;
+    struct xrdp_brush brush;
+    struct xrdp_pen pen;
+    struct xrdp_session *session;
+    struct xrdp_wm *wm; /* owner */
+    struct xrdp_font *font;
+    void *painter;
+    struct xrdp_region *dirty_region;
+    int begin_end_level;
 };
 
 /* window or bitmap */
 struct xrdp_bitmap
 {
-  /* 0 = bitmap 1 = window 2 = screen 3 = button 4 = image 5 = edit
-     6 = label 7 = combo 8 = special */
-  int type;
-  int width;
-  int height;
-  struct xrdp_wm* wm;
-  /* msg 1 = click 2 = mouse move 3 = paint 100 = modal result */
-  /* see messages in constants.h */
-  int (*notify)(struct xrdp_bitmap* wnd, struct xrdp_bitmap* sender,
-                int msg, long param1, long param2);
-  /* for bitmap */
-  int bpp;
-  int line_size; /* in bytes */
-  int do_not_free_data;
-  char* data;
-  /* for all but bitmap */
-  int left;
-  int top;
-  int pointer;
-  int bg_color;
-  int tab_stop;
-  int id;
-  char* caption1;
-  /* for window or screen */
-  struct xrdp_bitmap* modal_dialog;
-  struct xrdp_bitmap* focused_control;
-  struct xrdp_bitmap* owner; /* window that created us */
-  struct xrdp_bitmap* parent; /* window contained in */
-  /* for modal dialog */
-  struct xrdp_bitmap* default_button; /* button when enter is pressed */
-  struct xrdp_bitmap* esc_button; /* button when esc is pressed */
-  /* list of child windows */
-  struct list* child_list;
-  /* for edit */
-  int edit_pos;
-  twchar password_char;
-  /* for button or combo */
-  int state; /* for button 0 = normal 1 = down */
-  /* for combo */
-  struct list* string_list;
-  struct list* data_list;
-  /* for combo or popup */
-  int item_index;
-  /* for popup */
-  struct xrdp_bitmap* popped_from;
-  int item_height;
-  /* crc */
-  int crc32;
-  int crc16;
+    /* 0 = bitmap 1 = window 2 = screen 3 = button 4 = image 5 = edit
+       6 = label 7 = combo 8 = special */
+    int type;
+    int width;
+    int height;
+    struct xrdp_wm *wm;
+    /* msg 1 = click 2 = mouse move 3 = paint 100 = modal result */
+    /* see messages in constants.h */
+    int (*notify)(struct xrdp_bitmap *wnd, struct xrdp_bitmap *sender,
+                  int msg, long param1, long param2);
+    /* for bitmap */
+    int bpp;
+    int line_size; /* in bytes */
+    int do_not_free_data;
+    char *data;
+    /* for all but bitmap */
+    int left;
+    int top;
+    int pointer;
+    int bg_color;
+    int tab_stop;
+    int id;
+    char *caption1;
+    /* for window or screen */
+    struct xrdp_bitmap *modal_dialog;
+    struct xrdp_bitmap *focused_control;
+    struct xrdp_bitmap *owner; /* window that created us */
+    struct xrdp_bitmap *parent; /* window contained in */
+    /* for modal dialog */
+    struct xrdp_bitmap *default_button; /* button when enter is pressed */
+    struct xrdp_bitmap *esc_button; /* button when esc is pressed */
+    /* list of child windows */
+    struct list *child_list;
+    /* for edit */
+    int edit_pos;
+    twchar password_char;
+    /* for button or combo */
+    int state; /* for button 0 = normal 1 = down */
+    /* for combo */
+    struct list *string_list;
+    struct list *data_list;
+    /* for combo or popup */
+    int item_index;
+    /* for popup */
+    struct xrdp_bitmap *popped_from;
+    int item_height;
+    /* crc */
+    int crc32;
+    int crc16;
 };
 
 #define NUM_FONTS 0x4e00
@@ -551,36 +551,36 @@ struct xrdp_bitmap
 /* font */
 struct xrdp_font
 {
-  struct xrdp_wm* wm;
-  struct xrdp_font_char font_items[NUM_FONTS];
-  char name[32];
-  int size;
-  int style;
+    struct xrdp_wm *wm;
+    struct xrdp_font_char font_items[NUM_FONTS];
+    char name[32];
+    int size;
+    int style;
 };
 
 /* module */
 struct xrdp_mod_data
 {
-  struct list* names;
-  struct list* values;
+    struct list *names;
+    struct list *values;
 };
 
 struct xrdp_startup_params
 {
-  /* xrdp_ini is not malloc'd and has at least the same lifetime as main() */
-  const char *xrdp_ini;
-  char port[1024];
-  int kill;
-  int no_daemon;
-  int help;
-  int version;
-  int fork;
-  int dump_config;
-  int tcp_send_buffer_bytes;
-  int tcp_recv_buffer_bytes;
-  int tcp_nodelay;
-  int tcp_keepalive;
-  int use_vsock;
+    /* xrdp_ini is not malloc'd and has at least the same lifetime as main() */
+    const char *xrdp_ini;
+    char port[1024];
+    int kill;
+    int no_daemon;
+    int help;
+    int version;
+    int fork;
+    int dump_config;
+    int tcp_send_buffer_bytes;
+    int tcp_recv_buffer_bytes;
+    int tcp_nodelay;
+    int tcp_keepalive;
+    int use_vsock;
 };
 
 /*

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -29,17 +29,7 @@
 #include "log.h"
 #include "string_calls.h"
 
-#define LLOG_LEVEL 1
-#define LLOGLN(_level, _args) \
-    do \
-    { \
-        if (_level < LLOG_LEVEL) \
-        { \
-            g_write("xrdp:xrdp_wm [%10.10u]: ", g_time3()); \
-            g_writeln _args ; \
-        } \
-    } \
-    while (0)
+
 
 /*****************************************************************************/
 struct xrdp_wm *
@@ -65,7 +55,7 @@ xrdp_wm_create(struct xrdp_process *owner,
     pid = g_getpid();
     g_snprintf(event_name, 255, "xrdp_%8.8x_wm_login_state_event_%8.8x",
                pid, owner->session_id);
-    log_message(LOG_LEVEL_DEBUG, "%s", event_name);
+    LOG(LOG_LEVEL_DEBUG, "%s", event_name);
     self->login_state_event = g_create_wait_obj(event_name);
     self->painter = xrdp_painter_create(self, self->session);
     self->cache = xrdp_cache_create(self, self->session, self->client_info);
@@ -249,8 +239,8 @@ xrdp_wm_load_pointer(struct xrdp_wm *self, char *file_name, char *data,
 
     if (!g_file_exist(file_name))
     {
-        log_message(LOG_LEVEL_ERROR, "xrdp_wm_load_pointer: error pointer file [%s] does not exist",
-                    file_name);
+        LOG(LOG_LEVEL_ERROR, "xrdp_wm_load_pointer: error pointer file [%s] does not exist",
+            file_name);
         return 1;
     }
 
@@ -260,8 +250,8 @@ xrdp_wm_load_pointer(struct xrdp_wm *self, char *file_name, char *data,
 
     if (fd < 0)
     {
-        log_message(LOG_LEVEL_ERROR, "xrdp_wm_load_pointer: error loading pointer from file [%s]",
-                    file_name);
+        LOG(LOG_LEVEL_ERROR, "xrdp_wm_load_pointer: error loading pointer from file [%s]",
+            file_name);
         xstream_free(fs);
         return 1;
     }
@@ -508,7 +498,7 @@ xrdp_wm_load_static_colors_plus(struct xrdp_wm *self, char *autorun_name)
     }
     else
     {
-        log_message(LOG_LEVEL_ERROR, "xrdp_wm_load_static_colors: Could not read xrdp.ini file %s", self->session->xrdp_ini);
+        LOG(LOG_LEVEL_WARNING, "xrdp_wm_load_static_colors: Could not read xrdp.ini file %s", self->session->xrdp_ini);
     }
 
     if (self->screen->bpp == 8)
@@ -542,13 +532,13 @@ xrdp_wm_load_static_pointers(struct xrdp_wm *self)
     struct xrdp_pointer_item pointer_item;
     char file_path[256];
 
-    DEBUG(("sending cursor"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "sending cursor");
     g_snprintf(file_path, 255, "%s/cursor1.cur", XRDP_SHARE_PATH);
     g_memset(&pointer_item, 0, sizeof(pointer_item));
     xrdp_wm_load_pointer(self, file_path, pointer_item.data,
                          pointer_item.mask, &pointer_item.x, &pointer_item.y);
     xrdp_cache_add_pointer_static(self->cache, &pointer_item, 1);
-    DEBUG(("sending cursor"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "sending cursor");
     g_snprintf(file_path, 255, "%s/cursor0.cur", XRDP_SHARE_PATH);
     g_memset(&pointer_item, 0, sizeof(pointer_item));
     xrdp_wm_load_pointer(self, file_path, pointer_item.data,
@@ -572,7 +562,7 @@ xrdp_wm_init(struct xrdp_wm *self)
     char section_name[256];
     char autorun_name[256];
 
-    g_writeln("in xrdp_wm_init: ");
+    LOG(LOG_LEVEL_DEBUG, "in xrdp_wm_init: ");
 
     load_xrdp_config(self->xrdp_config, self->session->xrdp_ini,
                      self->screen->bpp);
@@ -683,14 +673,14 @@ xrdp_wm_init(struct xrdp_wm *self)
              * in xrdp.ini, fallback to default_section_name */
             if (file_read_section(fd, section_name, names, values) != 0)
             {
-                log_message(LOG_LEVEL_INFO,
-                            "Module \"%s\" specified by %s from %s port %s "
-                            "is not configured. Using \"%s\" instead.",
-                            section_name,
-                            self->session->client_info->username,
-                            self->session->client_info->client_addr,
-                            self->session->client_info->client_port,
-                            default_section_name);
+                LOG(LOG_LEVEL_INFO,
+                    "Module \"%s\" specified by %s from %s port %s "
+                    "is not configured. Using \"%s\" instead.",
+                    section_name,
+                    self->session->client_info->username,
+                    self->session->client_info->client_addr,
+                    self->session->client_info->client_port,
+                    default_section_name);
                 list_clear(names);
                 list_clear(values);
 
@@ -763,8 +753,8 @@ xrdp_wm_init(struct xrdp_wm *self)
             else
             {
                 /* Hopefully, we never reach here. */
-                log_message(LOG_LEVEL_DEBUG,
-                            "Control should never reach %s:%d", __FILE__, __LINE__);
+                LOG(LOG_LEVEL_WARNING,
+                    "Control should never reach %s:%d", __FILE__, __LINE__);
             }
 
             list_delete(names);
@@ -773,14 +763,14 @@ xrdp_wm_init(struct xrdp_wm *self)
         }
         else
         {
-            log_message(LOG_LEVEL_ERROR,
-                        "xrdp_wm_init: Could not read xrdp.ini file %s",
-                        self->session->xrdp_ini);
+            LOG(LOG_LEVEL_WARNING,
+                "xrdp_wm_init: Could not read xrdp.ini file %s",
+                self->session->xrdp_ini);
         }
     }
     else
     {
-        g_writeln("   xrdp_wm_init: no autologin / auto run detected, draw login window");
+        LOG(LOG_LEVEL_DEBUG, "   xrdp_wm_init: no autologin / auto run detected, draw login window");
         xrdp_login_wnd_create(self);
         /* clear screen */
         xrdp_bitmap_invalidate(self->screen, 0);
@@ -788,7 +778,7 @@ xrdp_wm_init(struct xrdp_wm *self)
         xrdp_wm_set_login_state(self, WMLS_USER_PROMPT);
     }
 
-    g_writeln("out xrdp_wm_init: ");
+    LOG(LOG_LEVEL_DEBUG, "out xrdp_wm_init: ");
     return 0;
 }
 
@@ -1724,7 +1714,7 @@ static int
 xrdp_wm_process_input_mouse(struct xrdp_wm *self, int device_flags,
                             int x, int y)
 {
-    DEBUG(("mouse event flags %4.4x x %d y %d", device_flags, x, y));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "mouse event flags %4.4x x %d y %d", device_flags, x, y);
 
     if (device_flags & PTRFLAGS_MOVE)
     {
@@ -1919,7 +1909,7 @@ callback(intptr_t id, int msg, intptr_t param1, intptr_t param2,
             rv = xrdp_mm_check_chan(wm->mm);
             break;
         case 0x5557:
-            //g_writeln("callback: frame ack %d", param1);
+            LOG(LOG_LEVEL_DEBUG, "callback: frame ack %p", (void *) param1);
             xrdp_mm_frame_ack(wm->mm, param1);
             break;
         case 0x5558:
@@ -1945,6 +1935,7 @@ xrdp_wm_login_state_changed(struct xrdp_wm *self)
         return 0;
     }
 
+    LOG(LOG_LEVEL_DEBUG, "xrdp_wm_login_mode_changed: login_mode is %d", self->login_state);
     if (self->login_state == WMLS_RESET)
     {
         /* this is the initial state of the login window */
@@ -2054,7 +2045,7 @@ add_string_to_logwindow(const char *msg, struct list *log)
     do
     {
         new_part_message = g_strndup(current_pointer, LOG_WINDOW_CHAR_PER_LINE);
-        g_writeln("%s", new_part_message);
+        LOG(LOG_LEVEL_INFO, "%s", new_part_message);
         list_add_item(log, (tintptr) new_part_message);
         len_done += g_strlen(new_part_message);
         current_pointer += g_strlen(new_part_message);
@@ -2163,7 +2154,7 @@ xrdp_wm_log_msg(struct xrdp_wm *self, enum logLevels loglevel,
     vsnprintf(msg, sizeof(msg), fmt, ap);
     va_end(ap);
 
-    log_message(loglevel, "xrdp_wm_log_msg: %s", msg);
+    LOG(loglevel, "xrdp_wm_log_msg: %s", msg);
     add_string_to_logwindow(msg, self->log);
     return 0;
 }
@@ -2247,7 +2238,7 @@ wm_login_state_to_str(enum wm_login_state login_state)
 
 /*****************************************************************************/
 int
-xrdp_wm_set_login_state(struct xrdp_wm* self, enum wm_login_state login_state)
+xrdp_wm_set_login_state(struct xrdp_wm *self, enum wm_login_state login_state)
 {
     LOG(LOG_LEVEL_DEBUG, "Login state change request %s -> %s",
         wm_login_state_to_str(self->login_state),

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -31,15 +31,15 @@
 
 #define LLOG_LEVEL 1
 #define LLOGLN(_level, _args) \
-  do \
-  { \
-    if (_level < LLOG_LEVEL) \
+    do \
     { \
-        g_write("xrdp:xrdp_wm [%10.10u]: ", g_time3()); \
-        g_writeln _args ; \
+        if (_level < LLOG_LEVEL) \
+        { \
+            g_write("xrdp:xrdp_wm [%10.10u]: ", g_time3()); \
+            g_writeln _args ; \
+        } \
     } \
-  } \
-  while (0)
+    while (0)
 
 /*****************************************************************************/
 struct xrdp_wm *
@@ -105,7 +105,9 @@ xrdp_wm_delete(struct xrdp_wm *self)
     g_delete_wait_obj(self->login_state_event);
 
     if (self->xrdp_config)
+    {
         g_free(self->xrdp_config);
+    }
 
     /* free self */
     g_free(self);
@@ -247,8 +249,8 @@ xrdp_wm_load_pointer(struct xrdp_wm *self, char *file_name, char *data,
 
     if (!g_file_exist(file_name))
     {
-        log_message(LOG_LEVEL_ERROR,"xrdp_wm_load_pointer: error pointer file [%s] does not exist",
-                  file_name);
+        log_message(LOG_LEVEL_ERROR, "xrdp_wm_load_pointer: error pointer file [%s] does not exist",
+                    file_name);
         return 1;
     }
 
@@ -258,8 +260,8 @@ xrdp_wm_load_pointer(struct xrdp_wm *self, char *file_name, char *data,
 
     if (fd < 0)
     {
-        log_message(LOG_LEVEL_ERROR,"xrdp_wm_load_pointer: error loading pointer from file [%s]",
-                  file_name);
+        log_message(LOG_LEVEL_ERROR, "xrdp_wm_load_pointer: error loading pointer from file [%s]",
+                    file_name);
         xstream_free(fs);
         return 1;
     }
@@ -435,7 +437,7 @@ xrdp_wm_load_static_colors_plus(struct xrdp_wm *self, char *autorun_name)
                     if (g_strcasecmp(val, "black") == 0)
                     {
                         val = (char *)list_get_item(values, index);
-                        self->black = HCOLOR(self->screen->bpp,xrdp_wm_htoi(val));
+                        self->black = HCOLOR(self->screen->bpp, xrdp_wm_htoi(val));
                     }
                     else if (g_strcasecmp(val, "grey") == 0)
                     {
@@ -506,7 +508,7 @@ xrdp_wm_load_static_colors_plus(struct xrdp_wm *self, char *autorun_name)
     }
     else
     {
-        log_message(LOG_LEVEL_ERROR,"xrdp_wm_load_static_colors: Could not read xrdp.ini file %s", self->session->xrdp_ini);
+        log_message(LOG_LEVEL_ERROR, "xrdp_wm_load_static_colors: Could not read xrdp.ini file %s", self->session->xrdp_ini);
     }
 
     if (self->screen->bpp == 8)
@@ -643,9 +645,9 @@ xrdp_wm_init(struct xrdp_wm *self)
             {
                 q = (char *)list_get_item(names, index);
                 if ((g_strncasecmp("globals", q, 8) != 0) &&
-                    (g_strncasecmp("Logging", q, 8) != 0) &&
-                    (g_strncasecmp("LoggingPerLogger", q, 17) != 0) &&
-                    (g_strncasecmp("channels", q, 9) != 0))
+                        (g_strncasecmp("Logging", q, 8) != 0) &&
+                        (g_strncasecmp("LoggingPerLogger", q, 17) != 0) &&
+                        (g_strncasecmp("channels", q, 9) != 0))
                 {
                     g_strncpy(default_section_name, q, 255);
                     break;
@@ -1517,7 +1519,8 @@ xrdp_wm_key(struct xrdp_wm *self, int device_flags, int scan_code)
 
     // workaround odd shift behavior
     // see https://github.com/neutrinolabs/xrdp/issues/397
-    if (scan_code == 42 && device_flags == (KBD_FLAG_UP | KBD_FLAG_EXT)) {
+    if (scan_code == 42 && device_flags == (KBD_FLAG_UP | KBD_FLAG_EXT))
+    {
         return 0;
     }
 
@@ -1800,7 +1803,7 @@ xrdp_wm_process_input_mouse(struct xrdp_wm *self, int device_flags,
 
 /*****************************************************************************/
 static int
-xrdp_wm_process_input_mousex(struct xrdp_wm* self, int device_flags,
+xrdp_wm_process_input_mousex(struct xrdp_wm *self, int device_flags,
                              int x, int y)
 {
     if (device_flags & PTRXFLAGS_DOWN)
@@ -2055,7 +2058,8 @@ add_string_to_logwindow(const char *msg, struct list *log)
         list_add_item(log, (tintptr) new_part_message);
         len_done += g_strlen(new_part_message);
         current_pointer += g_strlen(new_part_message);
-    } while ((len_done < g_strlen(msg)) && (len_done < DEFAULT_STRING_LEN));
+    }
+    while ((len_done < g_strlen(msg)) && (len_done < DEFAULT_STRING_LEN));
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
Follow-on pull request to #1633 which migrates all logging in the xrdp directory to use the LOG() and LOG_DEVEL() macros.

Changes:
* Migrate logging to the LOG() and LOG_DEVEL() macros (using text transform script)
* error logs use the LOG macro 
* add XRDP_BOOT_LOG_LEVEL environment variable to enable run time debugging of xrdp before the logging sub-system is initialized.
* update code formatting with astyle for all files in xrdp/*
