### PR TITLE
Fix regressions in auth modules

### DIFF
--- a/sesman/Makefile.am
+++ b/sesman/Makefile.am
@@ -15,10 +15,6 @@ if XRDP_DEBUG
 AM_CPPFLAGS += -DXRDP_DEBUG
 endif
 
-if SESMAN_NOPAM
-AUTH_C = verify_user.c
-AUTH_LIB = -lcrypt
-else
 if SESMAN_BSD
 AUTH_C = verify_user_bsd.c
 AUTH_LIB =
@@ -30,6 +26,10 @@ else
 if SESMAN_KERBEROS
 AUTH_C = verify_user_kerberos.c
 AUTH_LIB = -lkrb5
+else
+if SESMAN_NOPAM
+AUTH_C = verify_user.c
+AUTH_LIB = -lcrypt
 else
 AUTH_C = verify_user_pam.c
 AUTH_LIB = -lpam

--- a/sesman/verify_user.c
+++ b/sesman/verify_user.c
@@ -29,6 +29,7 @@
 #endif
 
 #include "sesman.h"
+#include "string_calls.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/sesman/verify_user_kerberos.c
+++ b/sesman/verify_user_kerberos.c
@@ -30,6 +30,7 @@
 
 #include "arch.h"
 #include "os_calls.h"
+#include "string_calls.h"
 
 #include <krb5.h>
 

--- a/sesman/verify_user_pam_userpass.c
+++ b/sesman/verify_user_pam_userpass.c
@@ -30,6 +30,7 @@
 
 #include "arch.h"
 #include "os_calls.h"
+#include "string_calls.h"
 
 #include <security/pam_userpass.h>
 


### PR DESCRIPTION
This PR is prompted by #1768 

Investigation showed that:-
- some of the auth modules use functions now moved to the new string_calls.h module (see 0a1a8f40e52934718df666e64696e79802802d7e) and the CI doesn't check these.
- The `verify_user_pam_userpass.c` module accessed with `--enable-pamuserpass` could no longer be called. This is a regression introduced with c69a26e9b434a3b68edfb3a3a91086a6e0703cc1 (#1751) which made in compulsory in this instance to also specify `--disable-pam`.

Both of these issues are fixed with this PR.