### PR TITLE
Bump cppcheck version to 2.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,8 +126,8 @@ jobs:
     env:
       CC: gcc
       # This is required to use a version of cppcheck other than that
-      # suplied with the operating system
-      CPPCHECK_VER: 2.1
+      # supplied with the operating system
+      CPPCHECK_VER: 2.3
       CPPCHECK_REPO: https://github.com/danmar/cppcheck.git
     steps:
       - uses: actions/checkout@v2
@@ -142,4 +142,3 @@ jobs:
       - run: ./bootstrap
       - run: scripts/install_cppcheck.sh $CPPCHECK_REPO $CPPCHECK_VER
       - run: scripts/run_cppcheck.sh -v $CPPCHECK_VER
-      

--- a/common/pixman-region.c
+++ b/common/pixman-region.c
@@ -1799,7 +1799,10 @@ validate (region_type_t * badreg)
     *badreg = ri[0].reg;
 
     if (ri != stack_regions)
+    {
+        /* cppcheck-suppress autovarInvalidDeallocation */
         free (ri);
+    }
 
     GOOD (badreg);
     return ret;
@@ -1809,7 +1812,10 @@ bail:
         FREE_DATA (&ri[i].reg);
 
     if (ri != stack_regions)
+    {
+        /* cppcheck-suppress autovarInvalidDeallocation */
         free (ri);
+    }
 
     return pixman_break (badreg);
 }

--- a/scripts/install_cppcheck.sh
+++ b/scripts/install_cppcheck.sh
@@ -129,6 +129,12 @@ fi
             make_args="FILESDIR=$FILESDIR PREFIX=$FILESDIR CFGDIR=$FILESDIR"
             ;;
         *)  make_args="FILESDIR=$FILESDIR PREFIX=$FILESDIR USE_Z3=yes"
+            # Check that the Z3 development files appear to be installed
+            # before trying to create z3_version.h. Otherwise we may
+            # mislead the user as to what needs to be done.
+            if [ ! -f /usr/include/z3.h ]; then
+                echo "** libz3-dev (or equivalent) does not appear to be installed" >&2
+            fi
             if [ ! -f /usr/include/z3_version.h ]; then
                 create_z3_version_h
             fi

--- a/sesman/chansrv/chansrv_xfs.c
+++ b/sesman/chansrv/chansrv_xfs.c
@@ -273,7 +273,11 @@ xfs_create_xfs_fs(mode_t umask, uid_t uid, gid_t gid)
         xfs->free_list   = NULL;
         xfs->generation = 1;
 
+        /* xfs->inode_table check should be superfluous here, but it
+         * prevents cppcheck 2.2/2.3 generating a false positive nullPointer
+         * report */
         if (!grow_xfs(xfs, INODE_TABLE_ALLOCATION_INITIAL) ||
+                xfs->inode_table == NULL ||
                 (xino1 = g_new0(XFS_INODE_ALL, 1)) == NULL ||
                 (xino2 = g_new0(XFS_INODE_ALL, 1)) == NULL)
         {


### PR DESCRIPTION
Cppcheck bumped to 2.3.

This version of cppcheck generated additional warnings:-
<details>
<summary>sesman/chansrv/chansrv_xfs.c</summary>
<pre>
sesman/chansrv/chansrv_xfs.c:293:16: error: Null pointer dereference: xfs-&gt;inode_table [nullPointer]
            xfs-&gt;inode_table[0] = NULL;
               ^
sesman/chansrv/chansrv_xfs.c:272:26: note: xfs-&gt;inode_table is assigned value 0
        xfs-&gt;inode_table = NULL;
                         ^
sesman/chansrv/chansrv_xfs.c:293:16: note: Null pointer dereference
            xfs-&gt;inode_table[0] = NULL;
               ^
sesman/chansrv/chansrv_xfs.c:294:16: error: Null pointer dereference: xfs-&gt;inode_table [nullPointer]
            xfs-&gt;inode_table[FUSE_ROOT_ID] = xino1;
               ^
sesman/chansrv/chansrv_xfs.c:272:26: note: xfs-&gt;inode_table is assigned value 0
        xfs-&gt;inode_table = NULL;
                         ^
sesman/chansrv/chansrv_xfs.c:294:16: note: Null pointer dereference
            xfs-&gt;inode_table[FUSE_ROOT_ID] = xino1;
               ^
sesman/chansrv/chansrv_xfs.c:295:16: error: Null pointer dereference: xfs-&gt;inode_table [nullPointer]
            xfs-&gt;inode_table[DELETE_PENDING_ID] = xino2;
               ^
sesman/chansrv/chansrv_xfs.c:272:26: note: xfs-&gt;inode_table is assigned value 0
        xfs-&gt;inode_table = NULL;
                         ^
sesman/chansrv/chansrv_xfs.c:295:16: note: Null pointer dereference
            xfs-&gt;inode_table[DELETE_PENDING_ID] = xino2;
               ^
</pre>
</details>
<details>
<summary>common/pixman_region.c</summary>
<pre>
common/pixman-region.c:1802:15: error: Deallocation of an auto-variable (stack_regions) results in undefined behaviour. [autovarInvalidDeallocation]
        free (ri);
              ^
common/pixman-region.c:1638:10: note: Assignment 'ri=stack_regions', assigned value is stack_regions
    ri = stack_regions;
         ^
common/pixman-region.c:1802:15: note: Deallocating memory that was not dynamically allocated
        free (ri);
              ^
</pre>
</details>

Warnings addressed as follows
## sesman/chansrv/chansrv_xfs.c
This is believed to be a false positive, as `grow_xfs()` cannot return with `xfs->inode_table == NULL`. A report was raised on this for cppcheck 2.2 with the cppcheck team in the [discussion forum](https://sourceforge.net/p/cppcheck/discussion/general/thread/aae37d7def/) but no response was ever received.

The simplest resolution was to add an extra guard check for `xfs->inode_table` being NULL. This is extremely cheap to do as this code is only called once.

## common/pixman-region.c
This one is unsurprising in many ways, as the `ri` variable is used to point to both stack memory and heap memory. A guard check on the `free()` call prevents stack memory being free'd.
Code was compared with upstream at https://cgit.freedesktop.org/pixman/tree/pixman/pixman-region.c but no significant differences were found in this area. The warnings on the affected lines are simply disabled, as the code clearly works and there is nothing to be gained from deviating significantly from upstream.

## Other notes
An extra check was also added to `scripts/install_cppcheck.sh` to provide better error reporting if the z3 development files are not installed.