### PR TITLE
Support EC cryptographic keys for TLS

### DIFF
--- a/common/ssl_calls.c
+++ b/common/ssl_calls.c
@@ -64,8 +64,8 @@ static inline void
 RSA_get0_key(const RSA *key, const BIGNUM **n, const BIGNUM **e,
              const BIGNUM **d)
 {
-     *n = key->n;
-     *d = key->d;
+    *n = key->n;
+    *d = key->d;
 }
 
 static inline int
@@ -75,7 +75,7 @@ DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g)
      * parameters MUST be non-NULL.  q may remain NULL.
      */
     if ((dh->p == NULL && p == NULL)
-        || (dh->g == NULL && g == NULL))
+            || (dh->g == NULL && g == NULL))
     {
         return 0;
     }
@@ -230,7 +230,7 @@ ssl_md5_complete(void *md5_info, char *data)
 
 /*****************************************************************************/
 void *
-ssl_des3_encrypt_info_create(const char *key, const char* ivec)
+ssl_des3_encrypt_info_create(const char *key, const char *ivec)
 {
     EVP_CIPHER_CTX *des3_ctx;
     const tui8 *lkey;
@@ -246,7 +246,7 @@ ssl_des3_encrypt_info_create(const char *key, const char* ivec)
 
 /*****************************************************************************/
 void *
-ssl_des3_decrypt_info_create(const char *key, const char* ivec)
+ssl_des3_decrypt_info_create(const char *key, const char *ivec)
 {
     EVP_CIPHER_CTX *des3_ctx;
     const tui8 *lkey;
@@ -348,7 +348,7 @@ ssl_hmac_transform(void *hmac, const char *data, int len)
     const tui8 *ldata;
 
     hmac_ctx = (HMAC_CTX *) hmac;
-    ldata = (const tui8*) data;
+    ldata = (const tui8 *) data;
     HMAC_Update(hmac_ctx, ldata, len);
 }
 
@@ -357,7 +357,7 @@ void
 ssl_hmac_complete(void *hmac, char *data, int len)
 {
     HMAC_CTX *hmac_ctx;
-    tui8* ldata;
+    tui8 *ldata;
     tui32 llen;
 
     hmac_ctx = (HMAC_CTX *) hmac;
@@ -464,7 +464,7 @@ ssl_gen_key_xrdp1(int key_size_in_bits, const char *exp, int exp_len,
     int diff;
 
     if ((exp_len != 4) || ((mod_len != 64) && (mod_len != 256)) ||
-                          ((pri_len != 64) && (pri_len != 256)))
+            ((pri_len != 64) && (pri_len != 256)))
     {
         return 1;
     }
@@ -532,7 +532,8 @@ see also
 */
 static DH *ssl_get_dh2236()
 {
-    static unsigned char dh2236_p[] = {
+    static unsigned char dh2236_p[] =
+    {
         0x0E, 0xF8, 0x69, 0x0B, 0x35, 0x2F, 0x62, 0x59, 0xF7, 0xAF, 0x4E, 0x19,
         0xB5, 0x9B, 0xD2, 0xEB, 0x33, 0x78, 0x1D, 0x43, 0x1D, 0xB6, 0xE4, 0xA3,
         0x63, 0x47, 0x6A, 0xD4, 0xA8, 0x28, 0x11, 0x8C, 0x3F, 0xC8, 0xF1, 0x32,
@@ -558,7 +559,8 @@ static DH *ssl_get_dh2236()
         0x70, 0xAC, 0x58, 0x3A, 0x3C, 0x18, 0x15, 0x54, 0x84, 0xA8, 0xAA, 0x41,
         0x26, 0x7B, 0xE0, 0xA3,
     };
-    static unsigned char dh2236_g[] = {
+    static unsigned char dh2236_g[] =
+    {
         0x02,
     };
 
@@ -613,14 +615,13 @@ ssl_tls_create(struct trans *trans, const char *key, const char *cert)
 }
 
 /*****************************************************************************/
-int
-ssl_tls_print_error(const char *func, SSL *connection, int value)
+static int
+ssl_tls_log_error(const char *func, SSL *connection, int value)
 {
     switch (SSL_get_error(connection, value))
     {
         case SSL_ERROR_ZERO_RETURN:
-            g_writeln("ssl_tls_print_error: %s: Server closed TLS connection",
-                      func);
+            LOG(LOG_LEVEL_ERROR, "%s: Server closed TLS connection", func);
             return 1;
 
         case SSL_ERROR_WANT_READ:
@@ -628,16 +629,15 @@ ssl_tls_print_error(const char *func, SSL *connection, int value)
             return 0;
 
         case SSL_ERROR_SYSCALL:
-            g_writeln("ssl_tls_print_error: %s: I/O error", func);
+            LOG(LOG_LEVEL_ERROR, "%s: I/O error", func);
             return 1;
 
         case SSL_ERROR_SSL:
-            g_writeln("ssl_tls_print_error: %s: Failure in SSL library (protocol error?)",
-                      func);
+            LOG(LOG_LEVEL_ERROR, "%s: Failure in SSL library (protocol error?)", func);
             return 1;
 
         default:
-            g_writeln("ssl_tls_print_error: %s: Unknown error", func);
+            LOG(LOG_LEVEL_ERROR, "%s: Unknown SSL error", func);
             return 1;
     }
 }
@@ -694,7 +694,7 @@ ssl_tls_accept(struct ssl_tls *self, long ssl_protocols,
     self->ctx = SSL_CTX_new(SSLv23_server_method());
     if (self->ctx == NULL)
     {
-        log_message(LOG_LEVEL_ERROR, "ssl_tls_accept: SSL_CTX_new failed");
+        LOG(LOG_LEVEL_ERROR, "Unable to negotiate a TLS connection with the client");
         return 1;
     }
 
@@ -708,20 +708,19 @@ ssl_tls_accept(struct ssl_tls *self, long ssl_protocols,
     DH *dh = ssl_get_dh2236();
     if (dh == NULL)
     {
-        log_message(LOG_LEVEL_ERROR, "ssl_tls_accept: ssl_get_dh2236 failed");
+        LOG(LOG_LEVEL_ERROR, "Unable to generate DHE parameters for TLS");
         return 1;
     }
 
     if (SSL_CTX_set_tmp_dh(self->ctx, dh) != 1)
     {
-        log_message(LOG_LEVEL_ERROR,
-                    "ssl_tls_accept: SSL_CTX_set_tmp_dh failed");
+        LOG(LOG_LEVEL_ERROR, "Unable to setup DHE parameters for TLS");
         return 1;
     }
     DH_free(dh); // ok to free, copied into ctx by SSL_CTX_set_tmp_dh()
 
 #if defined(SSL_CTX_set_ecdh_auto)
-    if(!SSL_CTX_set_ecdh_auto(self->ctx, 1))
+    if (!SSL_CTX_set_ecdh_auto(self->ctx, 1))
     {
         LOG(LOG_LEVEL_WARNING, "TLS ecdh auto failed to be enabled");
     }
@@ -729,27 +728,26 @@ ssl_tls_accept(struct ssl_tls *self, long ssl_protocols,
 
     if (g_strlen(tls_ciphers) > 1)
     {
-        log_message(LOG_LEVEL_TRACE, "ssl_tls_accept: tls_ciphers=%s",
-            tls_ciphers);
+        LOG(LOG_LEVEL_TRACE, "tls_ciphers=%s", tls_ciphers);
         if (SSL_CTX_set_cipher_list(self->ctx, tls_ciphers) == 0)
         {
-            g_writeln("ssl_tls_accept: invalid cipher options");
+            LOG(LOG_LEVEL_ERROR, "Invalid TLS cipher options %s", tls_ciphers);
             return 1;
         }
     }
 
     SSL_CTX_set_read_ahead(self->ctx, 0);
 
-    if (SSL_CTX_use_RSAPrivateKey_file(self->ctx, self->key, SSL_FILETYPE_PEM)
+    if (SSL_CTX_use_PrivateKey_file(self->ctx, self->key, SSL_FILETYPE_PEM)
             <= 0)
     {
-        g_writeln("ssl_tls_accept: SSL_CTX_use_RSAPrivateKey_file failed");
+        LOG(LOG_LEVEL_ERROR, "Error loading TLS private key from %s", self->key);
         return 1;
     }
 
     if (SSL_CTX_use_certificate_chain_file(self->ctx, self->cert) <= 0)
     {
-        g_writeln("ssl_tls_accept: SSL_CTX_use_certificate_chain_file failed");
+        LOG(LOG_LEVEL_ERROR, "Error loading TLS certificate chain from %s", self->cert);
         return 1;
     }
 
@@ -757,22 +755,24 @@ ssl_tls_accept(struct ssl_tls *self, long ssl_protocols,
 
     if (self->ssl == NULL)
     {
-        g_writeln("ssl_tls_accept: SSL_new failed");
+        LOG(LOG_LEVEL_ERROR, "Unable to create an SSL structure");
         return 1;
     }
 
     if (SSL_set_fd(self->ssl, self->trans->sck) < 1)
     {
-        g_writeln("ssl_tls_accept: SSL_set_fd failed");
+        LOG(LOG_LEVEL_ERROR, "Unable to set up an SSL structure on fd %d",
+            (int)self->trans->sck);
         return 1;
     }
 
-    while(1) {
+    while (1)
+    {
         connection_status = SSL_accept(self->ssl);
 
         if (connection_status <= 0)
         {
-            if (ssl_tls_print_error("SSL_accept", self->ssl, connection_status))
+            if (ssl_tls_log_error("SSL_accept", self->ssl, connection_status))
             {
                 return 1;
             }
@@ -797,7 +797,7 @@ ssl_tls_accept(struct ssl_tls *self, long ssl_protocols,
         }
     }
 
-    g_writeln("ssl_tls_accept: TLS connection accepted");
+    LOG(LOG_LEVEL_TRACE, "TLS connection accepted");
 
     return 0;
 }
@@ -823,7 +823,7 @@ ssl_tls_disconnect(struct ssl_tls *self)
         status = SSL_shutdown(self->ssl);
         if (status <= 0)
         {
-            if (ssl_tls_print_error("SSL_shutdown", self->ssl, status))
+            if (ssl_tls_log_error("SSL_shutdown", self->ssl, status))
             {
                 return 1;
             }
@@ -844,10 +844,14 @@ ssl_tls_delete(struct ssl_tls *self)
     if (self != NULL)
     {
         if (self->ssl)
+        {
             SSL_free(self->ssl);
+        }
 
         if (self->ctx)
+        {
             SSL_CTX_free(self->ctx);
+        }
 
         g_delete_wait_obj(self->rwo);
 
@@ -862,7 +866,8 @@ ssl_tls_read(struct ssl_tls *tls, char *data, int length)
     int status;
     int break_flag;
 
-    while(1) {
+    while (1)
+    {
         status = SSL_read(tls->ssl, data, length);
 
         switch (SSL_get_error(tls->ssl, status))
@@ -888,7 +893,7 @@ ssl_tls_read(struct ssl_tls *tls, char *data, int length)
                 return 0;
 
             default:
-                ssl_tls_print_error("SSL_read", tls->ssl, status);
+                ssl_tls_log_error("SSL_read", tls->ssl, status);
                 status = -1;
                 break_flag = 1;
                 break;
@@ -915,7 +920,8 @@ ssl_tls_write(struct ssl_tls *tls, const char *data, int length)
     int status;
     int break_flag;
 
-    while(1) {
+    while (1)
+    {
         status = SSL_write(tls->ssl, data, length);
 
         switch (SSL_get_error(tls->ssl, status))
@@ -941,7 +947,7 @@ ssl_tls_write(struct ssl_tls *tls, const char *data, int length)
                 return 0;
 
             default:
-                ssl_tls_print_error("SSL_write", tls->ssl, status);
+                ssl_tls_log_error("SSL_write", tls->ssl, status);
                 status = -1;
                 break_flag = 1;
                 break;
@@ -1016,68 +1022,68 @@ ssl_get_protocols_from_string(const char *str, long *ssl_protocols)
     if (g_pos(str, ",TLSv1.3,") >= 0)
     {
 #if defined(SSL_OP_NO_TLSv1_3)
-        log_message(LOG_LEVEL_DEBUG, "TLSv1.3 enabled");
+        LOG(LOG_LEVEL_DEBUG, "TLSv1.3 enabled");
         protocols &= ~SSL_OP_NO_TLSv1_3;
 #else
-        log_message(LOG_LEVEL_WARNING,
-                    "TLSv1.3 enabled by config, "
-                    "but not supported by system OpenSSL");
+        LOG(LOG_LEVEL_WARNING,
+            "TLSv1.3 enabled by config, "
+            "but not supported by system OpenSSL");
         rv |= (1 << 6);
 #endif
     }
     if (g_pos(str, ",TLSv1.2,") >= 0)
     {
 #if defined(SSL_OP_NO_TLSv1_2)
-        log_message(LOG_LEVEL_DEBUG, "TLSv1.2 enabled");
+        LOG(LOG_LEVEL_DEBUG, "TLSv1.2 enabled");
         protocols &= ~SSL_OP_NO_TLSv1_2;
 #else
-        log_message(LOG_LEVEL_WARNING,
-                    "TLSv1.2 enabled by config, "
-                    "but not supported by system OpenSSL");
+        LOG(LOG_LEVEL_WARNING,
+            "TLSv1.2 enabled by config, "
+            "but not supported by system OpenSSL");
         rv |= (1 << 1);
 #endif
     }
     if (g_pos(str, ",TLSv1.1,") >= 0)
     {
 #if defined(SSL_OP_NO_TLSv1_1)
-        log_message(LOG_LEVEL_DEBUG, "TLSv1.1 enabled");
+        LOG(LOG_LEVEL_DEBUG, "TLSv1.1 enabled");
         protocols &= ~SSL_OP_NO_TLSv1_1;
 #else
-        log_message(LOG_LEVEL_WARNING,
-                    "TLSv1.1 enabled by config, "
-                    "but not supported by system OpenSSL");
+        LOG(LOG_LEVEL_WARNING,
+            "TLSv1.1 enabled by config, "
+            "but not supported by system OpenSSL");
         rv |= (1 << 2);
 #endif
     }
     if (g_pos(str, ",TLSv1,") >= 0)
     {
 #if defined(SSL_OP_NO_TLSv1)
-        log_message(LOG_LEVEL_DEBUG, "TLSv1 enabled");
+        LOG(LOG_LEVEL_DEBUG, "TLSv1 enabled");
         protocols &= ~SSL_OP_NO_TLSv1;
 #else
-        log_message(LOG_LEVEL_WARNING,
-                    "TLSv1 enabled by config, "
-                    "but not supported by system OpenSSL");
+        LOG(LOG_LEVEL_WARNING,
+            "TLSv1 enabled by config, "
+            "but not supported by system OpenSSL");
         rv |= (1 << 3);
 #endif
     }
     if (g_pos(str, ",SSLv3,") >= 0)
     {
 #if defined(SSL_OP_NO_SSLv3)
-        log_message(LOG_LEVEL_DEBUG, "SSLv3 enabled");
+        LOG(LOG_LEVEL_DEBUG, "SSLv3 enabled");
         protocols &= ~SSL_OP_NO_SSLv3;
 #else
-        log_message(LOG_LEVEL_WARNING,
-                    "SSLv3 enabled by config, "
-                    "but not supported by system OpenSSL");
+        LOG(LOG_LEVEL_WARNING,
+            "SSLv3 enabled by config, "
+            "but not supported by system OpenSSL");
         rv |= (1 << 4);
 #endif
     }
     if (protocols == bad_protocols)
     {
-        log_message(LOG_LEVEL_WARNING, "No SSL/TLS protocols enabled. "
-                    "At least one protocol should be enabled to accept "
-                    "TLS connections.");
+        LOG(LOG_LEVEL_WARNING, "No SSL/TLS protocols enabled. "
+            "At least one protocol should be enabled to accept "
+            "TLS connections.");
         rv |= (1 << 5);
     }
     *ssl_protocols = protocols;

--- a/common/ssl_calls.h
+++ b/common/ssl_calls.h
@@ -26,38 +26,38 @@ int
 ssl_init(void);
 int
 ssl_finish(void);
-void*
+void *
 ssl_rc4_info_create(void);
 void
-ssl_rc4_info_delete(void* rc4_info);
+ssl_rc4_info_delete(void *rc4_info);
 void
-ssl_rc4_set_key(void* rc4_info, char* key, int len);
+ssl_rc4_set_key(void *rc4_info, char *key, int len);
 void
-ssl_rc4_crypt(void* rc4_info, char* data, int len);
-void*
+ssl_rc4_crypt(void *rc4_info, char *data, int len);
+void *
 ssl_sha1_info_create(void);
 void
-ssl_sha1_info_delete(void* sha1_info);
+ssl_sha1_info_delete(void *sha1_info);
 void
-ssl_sha1_clear(void* sha1_info);
+ssl_sha1_clear(void *sha1_info);
 void
-ssl_sha1_transform(void* sha1_info, const char *data, int len);
+ssl_sha1_transform(void *sha1_info, const char *data, int len);
 void
-ssl_sha1_complete(void* sha1_info, char* data);
-void*
+ssl_sha1_complete(void *sha1_info, char *data);
+void *
 ssl_md5_info_create(void);
 void
-ssl_md5_info_delete(void* md5_info);
+ssl_md5_info_delete(void *md5_info);
 void
-ssl_md5_clear(void* md5_info);
+ssl_md5_clear(void *md5_info);
 void
-ssl_md5_transform(void* md5_info, char* data, int len);
+ssl_md5_transform(void *md5_info, char *data, int len);
 void
-ssl_md5_complete(void* md5_info, char* data);
+ssl_md5_complete(void *md5_info, char *data);
 void *
-ssl_des3_encrypt_info_create(const char *key, const char* ivec);
+ssl_des3_encrypt_info_create(const char *key, const char *ivec);
 void *
-ssl_des3_decrypt_info_create(const char *key, const char* ivec);
+ssl_des3_decrypt_info_create(const char *key, const char *ivec);
 void
 ssl_des3_info_delete(void *des3);
 int
@@ -78,8 +78,8 @@ int
 ssl_mod_exp(char *out, int out_len, const char *in, int in_len,
             const char *mod, int mod_len, const char *exp, int exp_len);
 int
-ssl_gen_key_xrdp1(int key_size_in_bits, const char* exp, int exp_len,
-                  char* mod, int mod_len, char* pri, int pri_len);
+ssl_gen_key_xrdp1(int key_size_in_bits, const char *exp, int exp_len,
+                  char *mod, int mod_len, char *pri, int pri_len);
 
 /* ssl_tls */
 struct ssl_tls


### PR DESCRIPTION
Fixes #1776 

At present the certificate chain presented for TLS needs to be RSA. However, current mstsc.exe and Remmina clients can accept ECC certificates if they are presented with them.

xrdp can be made usable with non-RSA certificates and private keys by changing the call to `SSL_CTX_use_RSAPrivateKey_file()` (which only loads RSA keys) to `SSL_CTX_use_PrivateKey_file()` (which loads any private key type). This call has been present in OpenSSL since at least version 0.9.6.

During the course of investigating #1776, it was found that the error logging in `ssl_calls.c` is simply not working. Much of it goes to stdout which is disabled.

There are three commits in this PR:-
1. Move all logging to user the new macros
2. Run the ssl_calls files through `astyle`
3. Replace the call to load the private key.

Regression testing shows:-
- the new code can read either an RSA key or an secp384r1 key (other types have not been tried).
- Without the change to `SSL_CTX_use_PrivateKey_file` in 849a8e7, the following error is logged when trying to load a non-RSA key:-
   ```
   Error loading TLS RSA private key from /etc/xrdp/ec-key.pem
   ```