### PR TITLE
Minor manpage fixes

### DIFF
--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -15,10 +15,12 @@ EXTRA_DIST = $(man_MANS:=.in)
 SUBST_VARS = sed \
    -e 's|@PACKAGE_VERSION[@]|$(PACKAGE_VERSION)|g' \
    -e 's|@bindir[@]|$(bindir)|g' \
+   -e 's|@sbindir[@]|$(sbindir)|g' \
    -e 's|@localstatedir[@]|$(localstatedir)|g' \
    -e 's|@sysconfdir[@]|$(sysconfdir)|g' \
    -e 's|@socketdir[@]|$(socketdir)|g' \
-   -e 's|@xrdpconfdir[@]|$(sysconfdir)/xrdp|g'
+   -e 's|@xrdpconfdir[@]|$(sysconfdir)/xrdp|g' \
+   -e 's|@xrdphomeurl[@]|http://www.xrdp.org/|g'
 
 subst_verbose = $(subst_verbose_@AM_V@)
 subst_verbose_ = $(subst_verbose_@AM_DEFAULT_V@)

--- a/docs/man/sesman.ini.5.in
+++ b/docs/man/sesman.ini.5.in
@@ -304,4 +304,6 @@ environment variables in the user's session.
 .BR xrdp (8),
 .BR xrdp.ini (5)
 
-For more info on \fBxrdp\fR see http://www.xrdp.org/
+For more info on \fBxrdp\fR see
+.UR @xrdphomeurl@
+.UE

--- a/docs/man/xrdp-chansrv.8.in
+++ b/docs/man/xrdp-chansrv.8.in
@@ -57,4 +57,6 @@ description of \fBCHANSRV_LOG_PATH\fP above for the file's location.
 .BR xrdp\-sesman (8),
 .BR sesman.ini (5).
 
-for more info on \fBxrdp\fR see http://www.xrdp.org/
+For more info on \fBxrdp\fR see
+.UR @xrdphomeurl@
+.UE

--- a/docs/man/xrdp-genkeymap.8.in
+++ b/docs/man/xrdp-genkeymap.8.in
@@ -61,7 +61,13 @@ Simone Fedele <ilsimo@users.sourceforge.net>
 .SH "SEE ALSO"
 .BR xrdp (8),
 .BR setxkbmap (1),
-.BR unicode (7),
-.URL "https://github.com/FreeRDP/FreeRDP/wiki/Keyboard" "Description of Keyboard Input mapping" .
-
-for more info on \fBxrdp\fR see http://www.xrdp.org/
+.BR unicode (7)
+.PP
+Description of Keyboard Input mapping on the
+.UR https://github.com/FreeRDP/FreeRDP/wiki/Keyboard
+FreeRDP wiki
+.UE
+.PP
+For more info on \fBxrdp\fR see
+.UR @xrdphomeurl@
+.UE

--- a/docs/man/xrdp-sesadmin.8.in
+++ b/docs/man/xrdp-sesadmin.8.in
@@ -55,3 +55,8 @@ xrdp\-sesadmin.log
 
 .SH SEE ALSO
 .BR xrdp (8).
+
+More info on \fBxrdp\fR can be found on the
+.UR @xrdphomeurl@
+xrdp homepage
+.UE

--- a/docs/man/xrdp-sesman.8.in
+++ b/docs/man/xrdp-sesman.8.in
@@ -49,7 +49,7 @@ the system (notably \fBxrdp(8)\fR and \fBxrdp\-chansrv(8)\fR) will want
 to read it.
 .RE
 .SH "FILES"
-@bindir@/xrdp\-sesman
+@sbindir@/xrdp\-sesman
 .br
 @bindir@/xrdp\-sesrun
 .br
@@ -70,4 +70,6 @@ Simone Fedele <ilsimo@users.sourceforge.net>
 .BR xrdp (8),
 .BR xrdp.ini (5)
 
-for more info on \fBxrdp\fR see http://www.xrdp.org/
+for more info on \fBxrdp\fR see
+.UR @xrdphomeurl@
+.UE

--- a/docs/man/xrdp-sesrun.8.in
+++ b/docs/man/xrdp-sesrun.8.in
@@ -77,7 +77,7 @@ properly. Note you would need to install the \fBxterm\fR utility
 first. The \fBgnome\-terminal\fR utility probably won't work here.
 
 .SH "FILES"
-@bindir@/xrdp\-sesman
+@sbindir@/xrdp\-sesman
 .br
 @bindir@/xrdp\-sesrun
 .br
@@ -94,4 +94,6 @@ Simone Fedele <ilsimo@users.sourceforge.net>
 .BR xrdp (8),
 .BR xrdp.ini (5)
 
-for more info on \fBxrdp\fR see http://www.xrdp.org/
+For more info on \fBxrdp\fR see
+.UR @xrdphomeurl@
+.UE

--- a/docs/man/xrdp.8.in
+++ b/docs/man/xrdp.8.in
@@ -55,7 +55,7 @@ to be used primarily for testing or for unusual configurations.
 
 
 .SH "FILES"
-@bindir@/xrdp
+@sbindir@/xrdp
 .br
 @sysconfdir@/xrdp/xrdp.ini
 .br
@@ -74,4 +74,6 @@ Simone Fedele <ilsimo@users.sourceforge.net>
 .BR sesman.ini (5),
 .BR sesrun (8)
 
-for more info on \fBxrdp\fR see http://www.xrdp.org/
+for more info on \fBxrdp\fR see
+.UR @xrdphomeurl@
+.UE

--- a/docs/man/xrdp.ini.5.in
+++ b/docs/man/xrdp.ini.5.in
@@ -373,4 +373,6 @@ password={base64}cGFzc3dvcmQhCg==
 .BR sesrun (8),
 .BR sesman.ini (5)
 
-for more info on \fBxrdp\fR see http://www.xrdp.org/
+For more info on \fBxrdp\fR see
+.UR @xrdphomeurl@
+.UE


### PR DESCRIPTION
Minor manpage fixes and improvements

- `xrdp`, `xrdp-sesman` and `xrdp-chansrv` are in `$(sbindir)` rather than `$(bindir)`. This change makes that clear in the pages.
- The groff macros `.UR` and `.RE` are used for web urls so that HTML manpages (when we generate them) will work properly.
- The repeated string 'http://www.xrdp.org/' for the xrdp homepage has been replaced with a macro.

Any other suggestions welcome.