### PR TITLE
Added libxrdp_get_channel_count()

### DIFF
--- a/libxrdp/libxrdp.c
+++ b/libxrdp/libxrdp.c
@@ -1235,12 +1235,33 @@ libxrdp_orders_send_bitmap3(struct xrdp_session *session,
 }
 
 /*****************************************************************************/
+int EXPORT_CC
+libxrdp_get_channel_count(const struct xrdp_session *session)
+{
+    int count = 0;
+    const struct xrdp_rdp *rdp = (const struct xrdp_rdp *)session->rdp;
+    const struct xrdp_mcs *mcs = rdp->sec_layer->mcs_layer;
+
+    if (mcs->channel_list == NULL)
+    {
+        LOG(LOG_LEVEL_WARNING,
+            "libxrdp_get_channel_count - No channel initialized");
+    }
+    else
+    {
+        count = mcs->channel_list->count;
+    }
+
+    return count;
+}
+
+/*****************************************************************************/
 /* returns error */
 /* this function gets the channel name and its flags, index is zero
    based.  either channel_name or channel_flags can be passed in nil if
    they are not needed */
 int EXPORT_CC
-libxrdp_query_channel(struct xrdp_session *session, int index,
+libxrdp_query_channel(struct xrdp_session *session, int channel_id,
                       char *channel_name, int *channel_flags)
 {
     int count = 0;
@@ -1259,16 +1280,16 @@ libxrdp_query_channel(struct xrdp_session *session, int index,
 
     count = mcs->channel_list->count;
 
-    if (index < 0 || index >= count)
+    if (channel_id < 0 || channel_id >= count)
     {
         LOG(LOG_LEVEL_ERROR, "libxrdp_query_channel: Channel index out of range. "
             "max channel index %d, received channel index %d",
-            count, index);
+            count, channel_id);
         return 1;
     }
 
     channel_item = (struct mcs_channel_item *)
-                   list_get_item(mcs->channel_list, index);
+                   list_get_item(mcs->channel_list, channel_id);
 
     if (channel_item == NULL)
     {
@@ -1280,7 +1301,8 @@ libxrdp_query_channel(struct xrdp_session *session, int index,
     if (channel_name != 0)
     {
         g_strncpy(channel_name, channel_item->name, 8);
-        LOG(LOG_LEVEL_DEBUG, "libxrdp_query_channel - Channel %d name %s", index, channel_name);
+        LOG(LOG_LEVEL_DEBUG, "libxrdp_query_channel - Channel %d name %s",
+            channel_id, channel_name);
     }
 
     if (channel_flags != 0)

--- a/libxrdp/libxrdpinc.h
+++ b/libxrdp/libxrdpinc.h
@@ -203,9 +203,28 @@ int
 libxrdp_orders_send_bitmap3(struct xrdp_session *session,
                             int width, int height, int bpp, char *data,
                             int cache_id, int cache_idx, int hints);
+/**
+ * Returns the number of channels in the session
+ *
+ * This value is one more than the last valid channel ID
+ *
+ * @param session RDP session
+ * @return Number of available channels
+ */
 int
-libxrdp_query_channel(struct xrdp_session *session, int index,
+libxrdp_get_channel_count(const struct xrdp_session *session);
+int
+libxrdp_query_channel(struct xrdp_session *session, int channel_id,
                       char *channel_name, int *channel_flags);
+/**
+ * Gets the channel ID for the named channel
+ *
+ * Channel IDs are in the range 0..(channel_count-1)
+ *
+ * @param session RDP session
+ * @param name name of channel
+ * @return channel ID, or -1 if the channel cannot be found
+ */
 int
 libxrdp_get_channel_id(struct xrdp_session *session, const char *name);
 int


### PR DESCRIPTION
Fixes #1775 

The particular error focussed on here this :-

```
[yyyymmdd-hh:mm:ss] [ERROR] libxrdp_query_channel - Channel out of range 4
```

Previous to this PR, the only way that xrdp code had to iterate over the channels was to call `libxrdp_query_channel()` with channel ID values increasing from zero until the call failed. This method would always result in the above message being generated when the maximum channel ID was exceeded. Although the message is harmless it is misleading in the sense that no error has actually occured.

The PR adds the call `libxrdp_get_channel_count()` so that code which needs to iterate over the channels can use a `for` loop to do this. This occurs in two places:-

1. `xrdp_mm_trans_send_channel_setup()` iterates over the channels when sending them to chansrv
2. `xrdp_wm_init()` iterates over the channels when processing the `[Channels]` section in xrdp.ini

In both cases, the resulting code now reads more easily.

Two other cleanups have been incorporated:-
1. The channel ID parameter to `libxrdp_query_channel()` has been renamed from `index` to `channel_id` for consistency with other channel calls.
2. A couple of `g_writeln()` calls in `xrdp_wm.c` have been replaced with a single call to the `LOG()` macro.

This PR conflicts a little with #1742 - that PR also addresses these particular errors:-

```
[yyyymmdd-hh:mm:ss] [ERROR] libxrdp_query_channel - Channel 0 name rdpdr
```