### PR TITLE
Fixing TS_PLAY_SOUND_PDU_DATA to set the correct frequency and duration

### DIFF
--- a/libxrdp/libxrdp.c
+++ b/libxrdp/libxrdp.c
@@ -376,9 +376,11 @@ libxrdp_send_bell(struct xrdp_session *session)
         return 1;
     }
 
-    out_uint32_le(s, 440); /* frequency */
     out_uint32_le(s, 100); /* duration (ms) */
+    out_uint32_le(s, 440); /* frequency */
     s_mark_end(s);
+    LOG_DEVEL(LOG_LEVEL_TRACE, "Sending [MS-RDPBCGR] TS_PLAY_SOUND_PDU_DATA "
+              "duration 100 ms, frequency 440 Hz");
 
     if (xrdp_rdp_send_data((struct xrdp_rdp *)session->rdp, s, RDP_DATA_PDU_PLAY_SOUND) != 0)
     {


### PR DESCRIPTION
The `libxrdp_send_bell` function does not follow the MS-RDPBCGR spec for the [TS_PLAY_SOUND_PDU_DATA](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/4c1683b2-3a92-4319-8f7e-2318b3546c02) message.

This pull request reconciles the original author's intent based on their comments with the spec.

This pull request has been tested using the VNC backend since the Xorg backend does not seem to support sending bell messages.