### PR TITLE
Rename USE_NOPAM as USE_PAM

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -263,9 +263,9 @@ then
   AC_DEFINE([XRDP_ENABLE_IPV6],1,[Enable IPv6])
 fi
 
-if test "x$enable_pam" != "xyes"
+if test "x$enable_pam" = "xyes"
 then
-  AC_DEFINE([USE_NOPAM],1,[Disable PAM])
+  AC_DEFINE([USE_PAM],1,[Enable PAM])
 fi
 
 AS_IF( [test "x$enable_neutrinordp" = "xyes"] , [PKG_CHECK_MODULES(FREERDP, freerdp >= 1.0.0)] )

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -25,7 +25,7 @@
 #include "log.h"
 #include "string_calls.h"
 
-#ifndef USE_NOPAM
+#ifdef USE_PAM
 #if defined(HAVE__PAM_TYPES_H)
 #define LINUXPAM 1
 #include <security/_pam_types.h>
@@ -33,7 +33,7 @@
 #define OPENPAM 1
 #include <security/pam_constants.h>
 #endif
-#endif /* USE_NOPAM */
+#endif /* USE_PAM */
 
 #include "xrdp_encoder.h"
 #include "xrdp_sockets.h"
@@ -1789,7 +1789,7 @@ xrdp_mm_sesman_data_in(struct trans *trans)
     return error;
 }
 
-#ifndef USE_NOPAM
+#ifdef USE_PAM
 /*********************************************************************/
 /* return 0 on success */
 static int
@@ -1932,7 +1932,7 @@ cleanup_states(struct xrdp_mm *self)
     }
 }
 
-#ifndef USE_NOPAM
+#ifdef USE_PAM
 static const char *
 getPAMError(const int pamError, char *text, int text_bytes)
 {
@@ -2183,7 +2183,7 @@ xrdp_mm_connect(struct xrdp_mm *self)
     char ip[256];
     char port[8];
     char chansrvport[256];
-#ifndef USE_NOPAM
+#ifdef USE_PAM
     int use_pam_auth = 0;
     char pam_auth_sessionIP[256];
     char pam_auth_password[256];
@@ -2221,7 +2221,7 @@ xrdp_mm_connect(struct xrdp_mm *self)
             }
         }
 
-#ifndef USE_NOPAM
+#ifdef USE_PAM
         else if (g_strcasecmp(name, "pamusername") == 0)
         {
             use_pam_auth = 1;
@@ -2251,7 +2251,7 @@ xrdp_mm_connect(struct xrdp_mm *self)
         }
     }
 
-#ifndef USE_NOPAM
+#ifdef USE_PAM
     if (use_pam_auth)
     {
         int reply;


### PR DESCRIPTION
This is addressing a minor annoyance of mine.

I had a conversation with @metalefty a while ago about avoiding double negatives where possible (i.e. replace `if (!no_daemon)` with `if (daemon)`) to improve readability for developers whose first language isn't English.

This PR replaces `#ifdef USE_NOPAM` with `#ifdef USE_PAM` in the xrdp daemon code. I have to say that even as a native English speaker I find this one needs a couple of tries to parse in my head.