### PR TITLE
Unify logging in xup/*

### DIFF
--- a/xup/xup.c
+++ b/xup/xup.c
@@ -27,12 +27,6 @@
 #include "trans.h"
 #include "string_calls.h"
 
-#define LOG_LEVEL 1
-#define LLOG(_level, _args) \
-    do { if (_level < LOG_LEVEL) { g_write _args ; } } while (0)
-#define LLOGLN(_level, _args) \
-    do { if (_level < LOG_LEVEL) { g_writeln _args ; } } while (0)
-
 static int
 lib_mod_process_message(struct mod *mod, struct stream *s);
 
@@ -48,11 +42,11 @@ lib_send_copy(struct mod *mod, struct stream *s)
 int
 lib_mod_start(struct mod *mod, int w, int h, int bpp)
 {
-    LIB_DEBUG(mod, "in lib_mod_start");
+    LOG_DEVEL(LOG_LEVEL_TRACE, "in lib_mod_start");
     mod->width = w;
     mod->height = h;
     mod->bpp = bpp;
-    LIB_DEBUG(mod, "out lib_mod_start");
+    LOG_DEVEL(LOG_LEVEL_TRACE, "out lib_mod_start");
     return 0;
 }
 
@@ -68,17 +62,17 @@ lib_mod_log_peer(struct mod *mod)
     my_pid = g_getpid();
     if (g_sck_get_peer_cred(mod->trans->sck, &pid, &uid, &gid) == 0)
     {
-        log_message(LOG_LEVEL_INFO, "lib_mod_log_peer: xrdp_pid=%d connected "
-                    "to X11rdp_pid=%d X11rdp_uid=%d X11rdp_gid=%d "
-                    "client_ip=%s client_port=%s",
-                    my_pid, pid, uid, gid,
-                    mod->client_info.client_addr,
-                    mod->client_info.client_port);
+        LOG(LOG_LEVEL_INFO, "lib_mod_log_peer: xrdp_pid=%d connected "
+            "to X11rdp_pid=%d X11rdp_uid=%d X11rdp_gid=%d "
+            "client_ip=%s client_port=%s",
+            my_pid, pid, uid, gid,
+            mod->client_info.client_addr,
+            mod->client_info.client_port);
     }
     else
     {
-        log_message(LOG_LEVEL_ERROR, "lib_mod_log_peer: g_sck_get_peer_cred "
-                    "failed");
+        LOG(LOG_LEVEL_ERROR, "lib_mod_log_peer: g_sck_get_peer_cred "
+            "failed");
     }
     return 0;
 }
@@ -91,7 +85,7 @@ lib_data_in(struct trans *trans)
     struct stream *s;
     int len;
 
-    LLOGLN(10, ("lib_data_in:"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "lib_data_in:");
     if (trans == 0)
     {
         return 1;
@@ -113,7 +107,7 @@ lib_data_in(struct trans *trans)
             in_uint32_le(s, len);
             if (len < 0 || len > 128 * 1024)
             {
-                g_writeln("lib_data_in: bad size");
+                LOG(LOG_LEVEL_ERROR, "lib_data_in: bad size");
                 return 1;
             }
             if (len > 0)
@@ -122,12 +116,12 @@ lib_data_in(struct trans *trans)
                 trans->extra_flags = 2;
                 break;
             }
-            /* fall through */
+        /* fall through */
         case 2:
             s->p = s->data;
             if (lib_mod_process_message(self, s) != 0)
             {
-                g_writeln("lib_data_in: lib_mod_process_message failed");
+                LOG(LOG_LEVEL_ERROR, "lib_data_in: lib_mod_process_message failed");
                 return 1;
             }
             init_stream(s, 0);
@@ -151,8 +145,6 @@ lib_mod_connect(struct mod *mod)
     struct stream *s;
     char con_port[256];
 
-    LIB_DEBUG(mod, "in lib_mod_connect");
-
     mod->server_msg(mod, "started connecting", 0);
 
     /* only support 8, 15, 16, 24, and 32 bpp connections from rdp client */
@@ -160,14 +152,12 @@ lib_mod_connect(struct mod *mod)
     {
         mod->server_msg(mod,
                         "error - only supporting 8, 15, 16, 24, and 32 bpp rdp connections", 0);
-        LIB_DEBUG(mod, "out lib_mod_connect error");
         return 1;
     }
 
     if (g_strcmp(mod->ip, "") == 0)
     {
         mod->server_msg(mod, "error - no ip set", 0);
-        LIB_DEBUG(mod, "out lib_mod_connect error");
         return 1;
     }
 
@@ -186,6 +176,7 @@ lib_mod_connect(struct mod *mod)
 
     if (use_uds)
     {
+        LOG(LOG_LEVEL_INFO, "lib_mod_connect: connecting via UNIX socket");
         mod->trans = trans_create(TRANS_MODE_UNIX, 8 * 8192, 8192);
         if (mod->trans == 0)
         {
@@ -195,6 +186,7 @@ lib_mod_connect(struct mod *mod)
     }
     else
     {
+        LOG(LOG_LEVEL_INFO, "lib_mod_connect: connecting via TCP socket");
         mod->trans = trans_create(TRANS_MODE_TCP, 8 * 8192, 8192);
         if (mod->trans == 0)
         {
@@ -214,9 +206,9 @@ lib_mod_connect(struct mod *mod)
         error = -1;
         if (trans_connect(mod->trans, mod->ip, con_port, 3000) == 0)
         {
-            LLOGLN(0, ("lib_mod_connect: connected to Xserver "
-                   "(Xorg or X11rdp) sck %lld",
-                   (long long) (mod->trans->sck)));
+            LOG_DEVEL(LOG_LEVEL_INFO, "lib_mod_connect: connected to Xserver "
+                      "(Xorg or X11rdp) sck %lld",
+                      (long long) (mod->trans->sck));
             error = 0;
         }
 
@@ -314,7 +306,6 @@ lib_mod_connect(struct mod *mod)
         trans_delete(mod->trans);
         mod->trans = 0;
         mod->server_msg(mod, "some problem", 0);
-        LIB_DEBUG(mod, "out lib_mod_connect error");
         return 1;
     }
     else
@@ -327,7 +318,7 @@ lib_mod_connect(struct mod *mod)
         mod->trans->extra_flags = 1;
     }
 
-    LIB_DEBUG(mod, "out lib_mod_connect");
+    LOG_DEVEL(LOG_LEVEL_TRACE, "out lib_mod_connect");
     return 0;
 }
 
@@ -342,7 +333,7 @@ lib_mod_event(struct mod *mod, int msg, tbus param1, tbus param2,
     int key;
     int rv;
 
-    LIB_DEBUG(mod, "in lib_mod_event");
+    LOG_DEVEL(LOG_LEVEL_TRACE, "in lib_mod_event");
     make_stream(s);
 
     if ((msg >= 15) && (msg <= 16)) /* key events */
@@ -355,7 +346,7 @@ lib_mod_event(struct mod *mod, int msg, tbus param1, tbus param2,
             {
                 if (mod->shift_state)
                 {
-                    g_writeln("special");
+                    LOG_DEVEL(LOG_LEVEL_TRACE, "special");
                     /* fix for mstsc sending left control down with altgr */
                     /* control down / up
                     msg param1 param2 param3 param4
@@ -398,7 +389,7 @@ lib_mod_event(struct mod *mod, int msg, tbus param1, tbus param2,
     out_uint32_le(s, len);
     rv = lib_send_copy(mod, s);
     free_stream(s);
-    LIB_DEBUG(mod, "out lib_mod_event");
+    LOG_DEVEL(LOG_LEVEL_TRACE, "out lib_mod_event");
     return rv;
 }
 
@@ -783,7 +774,7 @@ process_server_window_delete(struct mod *mod, struct stream *s)
 /******************************************************************************/
 /* return error */
 static int
-process_server_window_show(struct mod* mod, struct stream* s)
+process_server_window_show(struct mod *mod, struct stream *s)
 {
     int window_id;
     int rv;
@@ -1098,7 +1089,7 @@ process_server_paint_rect_shmem(struct mod *amod, struct stream *s)
     {
         amod->screen_shmem_id = shmem_id;
         amod->screen_shmem_pixels = (char *) g_shmat(amod->screen_shmem_id);
-        if (amod->screen_shmem_pixels == (void*)-1)
+        if (amod->screen_shmem_pixels == (void *) -1)
         {
             /* failed */
             amod->screen_shmem_id = 0;
@@ -1115,7 +1106,7 @@ process_server_paint_rect_shmem(struct mod *amod, struct stream *s)
         amod->screen_shmem_id = shmem_id;
         g_shmdt(amod->screen_shmem_pixels);
         amod->screen_shmem_pixels = (char *) g_shmat(amod->screen_shmem_id);
-        if (amod->screen_shmem_pixels == (void*)-1)
+        if (amod->screen_shmem_pixels == (void *) -1)
         {
             /* failed */
             amod->screen_shmem_id = 0;
@@ -1249,7 +1240,7 @@ process_server_paint_rect_shmem_ex(struct mod *amod, struct stream *s)
         {
             amod->screen_shmem_id = shmem_id;
             amod->screen_shmem_pixels = (char *) g_shmat(amod->screen_shmem_id);
-            if (amod->screen_shmem_pixels == (void*)-1)
+            if (amod->screen_shmem_pixels == (void *) -1)
             {
                 /* failed */
                 amod->screen_shmem_id = 0;
@@ -1266,7 +1257,7 @@ process_server_paint_rect_shmem_ex(struct mod *amod, struct stream *s)
             amod->screen_shmem_id = shmem_id;
             g_shmdt(amod->screen_shmem_pixels);
             amod->screen_shmem_pixels = (char *) g_shmat(amod->screen_shmem_id);
-            if (amod->screen_shmem_pixels == (void*)-1)
+            if (amod->screen_shmem_pixels == (void *) -1)
             {
                 /* failed */
                 amod->screen_shmem_id = 0;
@@ -1292,7 +1283,7 @@ process_server_paint_rect_shmem_ex(struct mod *amod, struct stream *s)
         rv = 1;
     }
 
-    //g_writeln("frame_id %d", frame_id);
+    //LOG_DEVEL(LOG_LEVEL_TRACE, "frame_id %d", frame_id);
     //send_paint_rect_ex_ack(amod, flags, frame_id);
 
     g_free(lcrects);
@@ -1308,7 +1299,7 @@ lib_mod_process_orders(struct mod *mod, int type, struct stream *s)
 {
     int rv;
 
-    LLOGLN(10, ("lib_mod_process_orders: type %d", type));
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "lib_mod_process_orders: type %d", type);
     rv = 0;
     switch (type)
     {
@@ -1403,7 +1394,7 @@ lib_mod_process_orders(struct mod *mod, int type, struct stream *s)
             rv = process_server_paint_rect_shmem_ex(mod, s);
             break;
         default:
-            g_writeln("lib_mod_process_orders: unknown order type %d", type);
+            LOG_DEVEL(LOG_LEVEL_WARNING, "lib_mod_process_orders: unknown order type %d", type);
             rv = 0;
             break;
     }
@@ -1418,7 +1409,7 @@ lib_send_client_info(struct mod *mod)
     struct stream *s;
     int len;
 
-    g_writeln("lib_send_client_info:");
+    LOG_DEVEL(LOG_LEVEL_TRACE, "lib_send_client_info:");
     make_stream(s);
     init_stream(s, 8192);
     s_push_layer(s, iso_hdr, 4);
@@ -1446,14 +1437,14 @@ lib_mod_process_message(struct mod *mod, struct stream *s)
     int type;
     char *phold;
 
-    LLOGLN(10, ("lib_mod_process_message:"));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "lib_mod_process_message:");
     rv = 0;
     if (rv == 0)
     {
         in_uint16_le(s, type);
         in_uint16_le(s, num_orders);
         in_uint32_le(s, len);
-        LLOGLN(10, ("lib_mod_process_message: type %d", type));
+        LOG_DEVEL(LOG_LEVEL_TRACE, "lib_mod_process_message: type %d", type);
 
         if (type == 1) /* original order list */
         {
@@ -1470,7 +1461,7 @@ lib_mod_process_message(struct mod *mod, struct stream *s)
         }
         else if (type == 2) /* caps */
         {
-            g_writeln("lib_mod_process_message: type 2 len %d", len);
+            LOG_DEVEL(LOG_LEVEL_TRACE, "lib_mod_process_message: type 2 len %d", len);
             for (index = 0; index < num_orders; index++)
             {
                 phold = s->p;
@@ -1480,7 +1471,7 @@ lib_mod_process_message(struct mod *mod, struct stream *s)
                 switch (type)
                 {
                     default:
-                        g_writeln("lib_mod_process_message: unknown cap type %d len %d",
+                        LOG_DEVEL(LOG_LEVEL_TRACE, "lib_mod_process_message: unknown cap type %d len %d",
                                   type, len);
                         break;
                 }
@@ -1509,7 +1500,7 @@ lib_mod_process_message(struct mod *mod, struct stream *s)
         }
         else
         {
-            g_writeln("unknown type %d", type);
+            LOG_DEVEL(LOG_LEVEL_TRACE, "unknown type %d", type);
         }
     }
 
@@ -1521,7 +1512,7 @@ lib_mod_process_message(struct mod *mod, struct stream *s)
 int
 lib_mod_signal(struct mod *mod)
 {
-    g_writeln("lib_mod_signal: not used");
+    // no-op
     return 0;
 }
 
@@ -1545,11 +1536,11 @@ lib_mod_set_param(struct mod *mod, const char *name, const char *value)
 {
     if (g_strcasecmp(name, "username") == 0)
     {
-        g_strncpy(mod->username, value, INFO_CLIENT_MAX_CB_LEN-1);
+        g_strncpy(mod->username, value, INFO_CLIENT_MAX_CB_LEN - 1);
     }
     else if (g_strcasecmp(name, "password") == 0)
     {
-        g_strncpy(mod->password, value, INFO_CLIENT_MAX_CB_LEN-1);
+        g_strncpy(mod->password, value, INFO_CLIENT_MAX_CB_LEN - 1);
     }
     else if (g_strcasecmp(name, "ip") == 0)
     {
@@ -1608,7 +1599,7 @@ lib_mod_check_wait_objs(struct mod *mod)
 int
 lib_mod_frame_ack(struct mod *amod, int flags, int frame_id)
 {
-    LLOGLN(10, ("lib_mod_frame_ack: flags 0x%8.8x frame_id %d", flags, frame_id));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "lib_mod_frame_ack: flags 0x%8.8x frame_id %d", flags, frame_id);
     send_paint_rect_ex_ack(amod, flags, frame_id);
     return 0;
 }
@@ -1619,8 +1610,8 @@ int
 lib_mod_suppress_output(struct mod *amod, int suppress,
                         int left, int top, int right, int bottom)
 {
-    LLOGLN(10, ("lib_mod_suppress_output: suppress 0x%8.8x left %d top %d "
-           "right %d bottom %d", suppress, left, top, right, bottom));
+    LOG_DEVEL(LOG_LEVEL_TRACE, "lib_mod_suppress_output: suppress 0x%8.8x left %d top %d "
+              "right %d bottom %d", suppress, left, top, right, bottom);
     send_suppress_output(amod, suppress, left, top, right, bottom);
     return 0;
 }

--- a/xup/xup.h
+++ b/xup/xup.h
@@ -23,6 +23,7 @@
 #include "parse.h"
 #include "os_calls.h"
 #include "defines.h"
+#include "log.h"
 #include "xrdp_client_info.h"
 #include "xrdp_constants.h"
 #include "xrdp_rail.h"
@@ -33,138 +34,138 @@ struct source_info;
 
 struct mod
 {
-  int size; /* size of this struct */
-  int version; /* internal version */
-  /* client functions */
-  int (*mod_start)(struct mod* v, int w, int h, int bpp);
-  int (*mod_connect)(struct mod* v);
-  int (*mod_event)(struct mod* v, int msg, tbus param1, tbus param2,
-                   tbus param3, tbus param4);
-  int (*mod_signal)(struct mod* v);
-  int (*mod_end)(struct mod* v);
-  int (*mod_set_param)(struct mod *v, const char *name, const char *value);
-  int (*mod_session_change)(struct mod* v, int, int);
-  int (*mod_get_wait_objs)(struct mod* v, tbus* read_objs, int* rcount,
-                           tbus* write_objs, int* wcount, int* timeout);
-  int (*mod_check_wait_objs)(struct mod* v);
-  int (*mod_frame_ack)(struct mod* v, int flags, int frame_id);
-  int (*mod_suppress_output)(struct mod* v, int suppress,
-                             int left, int top, int right, int bottom);
-  tintptr mod_dumby[100 - 11]; /* align, 100 minus the number of mod
+    int size; /* size of this struct */
+    int version; /* internal version */
+    /* client functions */
+    int (*mod_start)(struct mod *v, int w, int h, int bpp);
+    int (*mod_connect)(struct mod *v);
+    int (*mod_event)(struct mod *v, int msg, tbus param1, tbus param2,
+                     tbus param3, tbus param4);
+    int (*mod_signal)(struct mod *v);
+    int (*mod_end)(struct mod *v);
+    int (*mod_set_param)(struct mod *v, const char *name, const char *value);
+    int (*mod_session_change)(struct mod *v, int, int);
+    int (*mod_get_wait_objs)(struct mod *v, tbus *read_objs, int *rcount,
+                             tbus *write_objs, int *wcount, int *timeout);
+    int (*mod_check_wait_objs)(struct mod *v);
+    int (*mod_frame_ack)(struct mod *v, int flags, int frame_id);
+    int (*mod_suppress_output)(struct mod *v, int suppress,
+                               int left, int top, int right, int bottom);
+    tintptr mod_dumby[100 - 11]; /* align, 100 minus the number of mod
                                  functions above */
-  /* server functions */
-  int (*server_begin_update)(struct mod* v);
-  int (*server_end_update)(struct mod* v);
-  int (*server_fill_rect)(struct mod* v, int x, int y, int cx, int cy);
-  int (*server_screen_blt)(struct mod* v, int x, int y, int cx, int cy,
-                           int srcx, int srcy);
-  int (*server_paint_rect)(struct mod* v, int x, int y, int cx, int cy,
-                           char* data, int width, int height,
-                           int srcx, int srcy);
-  int (*server_set_cursor)(struct mod* v, int x, int y, char* data, char* mask);
-  int (*server_palette)(struct mod* v, int* palette);
-  int (*server_msg)(struct mod* v, const char *msg, int code);
-  int (*server_is_term)(struct mod* v);
-  int (*server_set_clip)(struct mod* v, int x, int y, int cx, int cy);
-  int (*server_reset_clip)(struct mod* v);
-  int (*server_set_fgcolor)(struct mod* v, int fgcolor);
-  int (*server_set_bgcolor)(struct mod* v, int bgcolor);
-  int (*server_set_opcode)(struct mod* v, int opcode);
-  int (*server_set_mixmode)(struct mod* v, int mixmode);
-  int (*server_set_brush)(struct mod* v, int x_origin, int y_origin,
-                          int style, char* pattern);
-  int (*server_set_pen)(struct mod* v, int style,
-                        int width);
-  int (*server_draw_line)(struct mod* v, int x1, int y1, int x2, int y2);
-  int (*server_add_char)(struct mod* v, int font, int character,
-                         int offset, int baseline,
-                         int width, int height, char* data);
-  int (*server_draw_text)(struct mod* v, int font,
-                          int flags, int mixmode, int clip_left, int clip_top,
-                          int clip_right, int clip_bottom,
-                          int box_left, int box_top,
-                          int box_right, int box_bottom,
-                          int x, int y, char* data, int data_len);
-  int (*server_reset)(struct mod* v, int width, int height, int bpp);
-  int (*server_query_channel)(struct mod* v, int index,
-                              char* channel_name,
-                              int* channel_flags);
-  int (*server_get_channel_id)(struct mod* v, const char *name);
-  int (*server_send_to_channel)(struct mod* v, int channel_id,
-                                char* data, int data_len,
-                                int total_data_len, int flags);
-  int (*server_bell_trigger)(struct mod* v);
-  /* off screen bitmaps */
-  int (*server_create_os_surface)(struct mod* v, int rdpindex,
-                                  int width, int height);
-  int (*server_switch_os_surface)(struct mod* v, int rdpindex);
-  int (*server_delete_os_surface)(struct mod* v, int rdpindex);
-  int (*server_paint_rect_os)(struct mod* v, int x, int y,
-                              int cx, int cy,
-                              int rdpindex, int srcx, int srcy);
-  int (*server_set_hints)(struct mod* v, int hints, int mask);
-  /* rail */
-  int (*server_window_new_update)(struct mod* v, int window_id,
-                                  struct rail_window_state_order* window_state,
-                                  int flags);
-  int (*server_window_delete)(struct mod* v, int window_id);
-  int (*server_window_icon)(struct mod* v,
-                            int window_id, int cache_entry, int cache_id,
-                            struct rail_icon_info* icon_info,
-                            int flags);
-  int (*server_window_cached_icon)(struct mod* v,
-                                   int window_id, int cache_entry,
-                                   int cache_id, int flags);
-  int (*server_notify_new_update)(struct mod* v,
-                                  int window_id, int notify_id,
-                                  struct rail_notify_state_order* notify_state,
-                                  int flags);
-  int (*server_notify_delete)(struct mod* v, int window_id,
-                              int notify_id);
-  int (*server_monitored_desktop)(struct mod* v,
-                                  struct rail_monitored_desktop_order* mdo,
-                                  int flags);
-  int (*server_set_cursor_ex)(struct mod* v, int x, int y, char* data,
-                              char* mask, int bpp);
-  int (*server_add_char_alpha)(struct mod* v, int font, int character,
-                               int offset, int baseline,
-                               int width, int height, char* data);
-  int (*server_create_os_surface_bpp)(struct mod* v, int rdpindex,
-                                      int width, int height, int bpp);
-  int (*server_paint_rect_bpp)(struct mod* v, int x, int y, int cx, int cy,
-                               char* data, int width, int height,
-                               int srcx, int srcy, int bpp);
-  int (*server_composite)(struct mod* v, int srcidx, int srcformat, int srcwidth,
-                          int srcrepeat, int* srctransform, int mskflags, int mskidx,
-                          int mskformat, int mskwidth, int mskrepeat, int op,
-                          int srcx, int srcy, int mskx, int msky,
-                          int dstx, int dsty, int width, int height, int dstformat);
-  int (*server_paint_rects)(struct mod* v,
-                            int num_drects, short *drects,
-                            int num_crects, short *crects,
-                            char *data, int width, int height,
-                            int flags, int frame_id);
+    /* server functions */
+    int (*server_begin_update)(struct mod *v);
+    int (*server_end_update)(struct mod *v);
+    int (*server_fill_rect)(struct mod *v, int x, int y, int cx, int cy);
+    int (*server_screen_blt)(struct mod *v, int x, int y, int cx, int cy,
+                             int srcx, int srcy);
+    int (*server_paint_rect)(struct mod *v, int x, int y, int cx, int cy,
+                             char *data, int width, int height,
+                             int srcx, int srcy);
+    int (*server_set_cursor)(struct mod *v, int x, int y, char *data, char *mask);
+    int (*server_palette)(struct mod *v, int *palette);
+    int (*server_msg)(struct mod *v, const char *msg, int code);
+    int (*server_is_term)(struct mod *v);
+    int (*server_set_clip)(struct mod *v, int x, int y, int cx, int cy);
+    int (*server_reset_clip)(struct mod *v);
+    int (*server_set_fgcolor)(struct mod *v, int fgcolor);
+    int (*server_set_bgcolor)(struct mod *v, int bgcolor);
+    int (*server_set_opcode)(struct mod *v, int opcode);
+    int (*server_set_mixmode)(struct mod *v, int mixmode);
+    int (*server_set_brush)(struct mod *v, int x_origin, int y_origin,
+                            int style, char *pattern);
+    int (*server_set_pen)(struct mod *v, int style,
+                          int width);
+    int (*server_draw_line)(struct mod *v, int x1, int y1, int x2, int y2);
+    int (*server_add_char)(struct mod *v, int font, int character,
+                           int offset, int baseline,
+                           int width, int height, char *data);
+    int (*server_draw_text)(struct mod *v, int font,
+                            int flags, int mixmode, int clip_left, int clip_top,
+                            int clip_right, int clip_bottom,
+                            int box_left, int box_top,
+                            int box_right, int box_bottom,
+                            int x, int y, char *data, int data_len);
+    int (*server_reset)(struct mod *v, int width, int height, int bpp);
+    int (*server_query_channel)(struct mod *v, int index,
+                                char *channel_name,
+                                int *channel_flags);
+    int (*server_get_channel_id)(struct mod *v, const char *name);
+    int (*server_send_to_channel)(struct mod *v, int channel_id,
+                                  char *data, int data_len,
+                                  int total_data_len, int flags);
+    int (*server_bell_trigger)(struct mod *v);
+    /* off screen bitmaps */
+    int (*server_create_os_surface)(struct mod *v, int rdpindex,
+                                    int width, int height);
+    int (*server_switch_os_surface)(struct mod *v, int rdpindex);
+    int (*server_delete_os_surface)(struct mod *v, int rdpindex);
+    int (*server_paint_rect_os)(struct mod *v, int x, int y,
+                                int cx, int cy,
+                                int rdpindex, int srcx, int srcy);
+    int (*server_set_hints)(struct mod *v, int hints, int mask);
+    /* rail */
+    int (*server_window_new_update)(struct mod *v, int window_id,
+                                    struct rail_window_state_order *window_state,
+                                    int flags);
+    int (*server_window_delete)(struct mod *v, int window_id);
+    int (*server_window_icon)(struct mod *v,
+                              int window_id, int cache_entry, int cache_id,
+                              struct rail_icon_info *icon_info,
+                              int flags);
+    int (*server_window_cached_icon)(struct mod *v,
+                                     int window_id, int cache_entry,
+                                     int cache_id, int flags);
+    int (*server_notify_new_update)(struct mod *v,
+                                    int window_id, int notify_id,
+                                    struct rail_notify_state_order *notify_state,
+                                    int flags);
+    int (*server_notify_delete)(struct mod *v, int window_id,
+                                int notify_id);
+    int (*server_monitored_desktop)(struct mod *v,
+                                    struct rail_monitored_desktop_order *mdo,
+                                    int flags);
+    int (*server_set_cursor_ex)(struct mod *v, int x, int y, char *data,
+                                char *mask, int bpp);
+    int (*server_add_char_alpha)(struct mod *v, int font, int character,
+                                 int offset, int baseline,
+                                 int width, int height, char *data);
+    int (*server_create_os_surface_bpp)(struct mod *v, int rdpindex,
+                                        int width, int height, int bpp);
+    int (*server_paint_rect_bpp)(struct mod *v, int x, int y, int cx, int cy,
+                                 char *data, int width, int height,
+                                 int srcx, int srcy, int bpp);
+    int (*server_composite)(struct mod *v, int srcidx, int srcformat, int srcwidth,
+                            int srcrepeat, int *srctransform, int mskflags, int mskidx,
+                            int mskformat, int mskwidth, int mskrepeat, int op,
+                            int srcx, int srcy, int mskx, int msky,
+                            int dstx, int dsty, int width, int height, int dstformat);
+    int (*server_paint_rects)(struct mod *v,
+                              int num_drects, short *drects,
+                              int num_crects, short *crects,
+                              char *data, int width, int height,
+                              int flags, int frame_id);
 
-  tintptr server_dumby[100 - 43]; /* align, 100 minus the number of server
+    tintptr server_dumby[100 - 43]; /* align, 100 minus the number of server
                                      functions above */
-  /* common */
-  tintptr handle; /* pointer to self as long */
-  tintptr wm;
-  tintptr painter;
-  struct source_info *si;
-  /* mod data */
-  int width;
-  int height;
-  int bpp;
-  int sck_closed;
-  char username[INFO_CLIENT_MAX_CB_LEN];
-  char password[INFO_CLIENT_MAX_CB_LEN];
-  char ip[256];
-  char port[256];
-  int shift_state;
-  struct xrdp_client_info client_info;
-  int screen_shmem_id;
-  int screen_shmem_id_mapped; /* boolean */
-  char *screen_shmem_pixels;
-  struct trans *trans;
+    /* common */
+    tintptr handle; /* pointer to self as long */
+    tintptr wm;
+    tintptr painter;
+    struct source_info *si;
+    /* mod data */
+    int width;
+    int height;
+    int bpp;
+    int sck_closed;
+    char username[INFO_CLIENT_MAX_CB_LEN];
+    char password[INFO_CLIENT_MAX_CB_LEN];
+    char ip[256];
+    char port[256];
+    int shift_state;
+    struct xrdp_client_info client_info;
+    int screen_shmem_id;
+    int screen_shmem_id_mapped; /* boolean */
+    char *screen_shmem_pixels;
+    struct trans *trans;
 };


### PR DESCRIPTION
Follow-on pull request to #1633 which migrates all logging in the xup directory to use the LOG() and LOG_DEVEL() macros.

Changes:

* Migrate logging to the LOG() and LOG_DEVEL() macros (using text transform script)
* error logs use the LOG macro
* update code formatting with astyle for all files in xup/*