### PR TITLE
Readability fix for WM states

### DIFF
--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -150,7 +150,7 @@ xrdp_wm_get_wait_objs(struct xrdp_wm* self, tbus* robjs, int* rc,
 int
 xrdp_wm_check_wait_objs(struct xrdp_wm* self);
 int
-xrdp_wm_set_login_mode(struct xrdp_wm* self, int login_mode);
+xrdp_wm_set_login_state(struct xrdp_wm* self, enum wm_login_state login_state);
 
 /* xrdp_process.c */
 struct xrdp_process*

--- a/xrdp/xrdp_login_wnd.c
+++ b/xrdp/xrdp_login_wnd.c
@@ -241,7 +241,7 @@ xrdp_wm_ok_clicked(struct xrdp_bitmap *wnd)
             /* will copy these cause dialog gets freed */
             list_append_list_strdup(mod_data->names, wm->mm->login_names, 0);
             list_append_list_strdup(mod_data->values, wm->mm->login_values, 0);
-            xrdp_wm_set_login_mode(wm, 2);
+            xrdp_wm_set_login_state(wm, WMLS_START_CONNECT);
         }
     }
     else

--- a/xrdp/xrdp_process.c
+++ b/xrdp/xrdp_process.c
@@ -79,9 +79,10 @@ xrdp_process_loop(struct xrdp_process *self, struct stream *s)
         {
             DEBUG(("calling xrdp_wm_init and creating wm"));
             self->wm = xrdp_wm_create(self, self->session->client_info);
-            /* at this point the wm(window manager) is create and wm::login_mode is
-               zero and login_mode_event is set so xrdp_wm_init should be called by
-               xrdp_wm_check_wait_objs */
+            /* at this point the wm(window manager) is created and
+               wm::login_state is WMLS_RESET and wm::login_state_event is set
+               so xrdp_wm_init should be called by xrdp_wm_check_wait_objs
+               */
         }
     }
 

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -323,6 +323,42 @@ struct xrdp_keymap
 };
 
 /* the window manager */
+
+/***
+ * Window manager login mode states
+ *
+ * Use with xrdp_wm_set_login_state()
+ */
+enum wm_login_state
+{
+    /**
+     * Place the window manager in this state to reset it
+     */
+    WMLS_RESET = 0,
+    /**
+     * In this state, the window manager is waiting for the user to fill
+     * in the login box
+     */
+    WMLS_USER_PROMPT,
+    /**
+     * Place the window manager in this state to request xrdp connects to
+     * the X server, sesman, chansrv etc
+     */
+    WMLS_START_CONNECT,
+    /**
+     * In this state, the window manager is making required connections
+     */
+    WMLS_CONNECT_IN_PROGRESS,
+    /**
+     * Place the window manager in this state to request it finishes.
+     */
+    WMLS_CLEANUP,
+    /**
+     * In this state, the window manager is inactive
+     */
+    WMLS_INACTIVE
+};
+
 struct xrdp_wm
 {
   struct xrdp_process* pro_layer; /* owner */
@@ -374,8 +410,8 @@ struct xrdp_wm
   /* session log */
   struct list* log;
   struct xrdp_bitmap* log_wnd;
-  int login_mode;
-  tbus login_mode_event;
+  enum wm_login_state login_state;
+  tbus login_state_event;
   struct xrdp_mm* mm;
   struct xrdp_font* default_font;
   struct xrdp_keymap keymap;


### PR DESCRIPTION
Readability change for xrdp_wm.

Currently, a `login_mode` member variable is used to keep track of the state of the login box and connection state. It takes the values 0, 1, 2, 3, 10 and 11.

The PR replaces `login_mode` with `login_state` and changes the values assigned to it as follows:-

Was | Now
---|---
0| WMLS_RESET
1| WMLS_USER_PROMPT
2| WMLS_START_CONNECT
3| WMLS_CONNECT_IN_PROGRESS
10| WMLS_CLEANUP
11| WMLS_INACTIVE

These enumeration constants are documented in xrdp_types.h
