### PR TITLE
Bump FreeBSD version to 12.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@ FreeBSD_task:
       SSL: libressl
   matrix:
     freebsd_instance:
-      image_family: freebsd-12-1
+      image_family: freebsd-12-2
   prepare_script:
     - pkg install -y $SSL git autoconf automake libtool pkgconf opus jpeg-turbo fdk-aac pixman libX11 libXfixes libXrandr nasm
     - git submodule update --init --recursive


### PR DESCRIPTION
FreeBSD 12.1 CI builds are currently failing with the following error:-

```
./bootstrap
/usr/local/bin/autoconf
/usr/local/bin/automake
/usr/local/bin/libtool
/usr/local/bin/pkg-config
autoreconf-2.69: Entering directory `.'
autoreconf-2.69: configure.ac: not using Gettext
autoreconf-2.69: running: aclocal --force -I m4
autom4te-2.69: need GNU m4 1.4 or later: /usr/local/bin/gm4
aclocal: error: /usr/local/bin/autom4te-2.69 failed with exit status: 1
autoreconf-2.69: aclocal failed with exit status: 1
```

Installing a FreeBSD 12.1 VM replicates the problem. On further investigation:-

```
$ /usr/local/bin/gm4 --version
m4 (GNU M4) 1.4.18
ld-elf.so.1: /usr/local/bin/gm4: Undefined symbol "fputs_unlocked@FBSD_1.6"
```

The reason is that the FreeBSD packages are provided by major version, and the FreeBSD packages now seem to be built against 12.2. On FreeBSD 12.1:-

```
$ readelf -a /lib/libc.so.7 | grep fputs_unlocked
$ 
```

On FreeBSD 12.2:-

```
$ readelf -a /lib/libc.so.7 | grep fputs_unlocked
   571: 000000000019dd20   139 FUNC    GLOBAL DEFAULT   12 fputs_unlocked@@FBSD_1.6 (8)
$ 
```

Fix is possible to bump the FreeBSD version in .cirrus.yml. This PR attempts to test that.