### PR TITLE
Unify logging in mc/*

### DIFF
--- a/common/defines.h
+++ b/common/defines.h
@@ -24,10 +24,8 @@
 /* check for debug */
 #ifdef XRDP_DEBUG
 #define DEBUG(args) g_writeln args;
-#define LIB_DEBUG(_mod, _text) _mod->server_msg(_mod, _text, 1);
 #else
 #define DEBUG(args)
-#define LIB_DEBUG(_mod, _text)
 #endif
 /* other macros */
 #undef MIN

--- a/mc/mc.c
+++ b/mc/mc.c
@@ -23,17 +23,18 @@
 #endif
 
 #include "mc.h"
+#include "log.h"
 
 /*****************************************************************************/
 /* return error */
 int
 lib_mod_start(struct mod *mod, int w, int h, int bpp)
 {
-    LIB_DEBUG(mod, "in lib_mod_start");
+    LOG_DEVEL(LOG_LEVEL_TRACE, "in lib_mod_start");
     mod->width = w;
     mod->height = h;
     mod->bpp = bpp;
-    LIB_DEBUG(mod, "out lib_mod_start");
+    LOG_DEVEL(LOG_LEVEL_TRACE, "out lib_mod_start");
     return 0;
 }
 
@@ -42,8 +43,8 @@ lib_mod_start(struct mod *mod, int w, int h, int bpp)
 int
 lib_mod_connect(struct mod *mod)
 {
-    LIB_DEBUG(mod, "in lib_mod_connect");
-    LIB_DEBUG(mod, "out lib_mod_connect");
+    LOG_DEVEL(LOG_LEVEL_TRACE, "in lib_mod_connect");
+    LOG_DEVEL(LOG_LEVEL_TRACE, "out lib_mod_connect");
     return 0;
 }
 
@@ -53,8 +54,8 @@ int
 lib_mod_event(struct mod *mod, int msg, long param1, long param2,
               long param3, long param4)
 {
-    LIB_DEBUG(mod, "in lib_mod_event");
-    LIB_DEBUG(mod, "out lib_mod_event");
+    LOG_DEVEL(LOG_LEVEL_TRACE, "in lib_mod_event");
+    LOG_DEVEL(LOG_LEVEL_TRACE, "out lib_mod_event");
     return 0;
 }
 
@@ -63,8 +64,8 @@ lib_mod_event(struct mod *mod, int msg, long param1, long param2,
 int
 lib_mod_signal(struct mod *mod)
 {
-    LIB_DEBUG(mod, "in lib_mod_signal");
-    LIB_DEBUG(mod, "out lib_mod_signal");
+    LOG_DEVEL(LOG_LEVEL_TRACE, "in lib_mod_signal");
+    LOG_DEVEL(LOG_LEVEL_TRACE, "out lib_mod_signal");
     return 0;
 }
 

--- a/mc/mc.h
+++ b/mc/mc.h
@@ -30,73 +30,73 @@ struct source_info;
 
 struct mod
 {
-  int size; /* size of this struct */
-  int version; /* internal version */
-  /* client functions */
-  int (*mod_start)(struct mod* v, int w, int h, int bpp);
-  int (*mod_connect)(struct mod* v);
-  int (*mod_event)(struct mod* v, int msg, long param1, long param2,
-                   long param3, long param4);
-  int (*mod_signal)(struct mod* v);
-  int (*mod_end)(struct mod* v);
-  int (*mod_set_param)(struct mod *v, const char *name, const char *value);
-  int (*mod_session_change)(struct mod* v, int, int);
-  int (*mod_get_wait_objs)(struct mod* v, tbus* read_objs, int* rcount,
-                           tbus* write_objs, int* wcount, int* timeout);
-  int (*mod_check_wait_objs)(struct mod* v);
-  tintptr mod_dumby[100 - 9]; /* align, 100 minus the number of mod
+    int size; /* size of this struct */
+    int version; /* internal version */
+    /* client functions */
+    int (*mod_start)(struct mod *v, int w, int h, int bpp);
+    int (*mod_connect)(struct mod *v);
+    int (*mod_event)(struct mod *v, int msg, long param1, long param2,
+                     long param3, long param4);
+    int (*mod_signal)(struct mod *v);
+    int (*mod_end)(struct mod *v);
+    int (*mod_set_param)(struct mod *v, const char *name, const char *value);
+    int (*mod_session_change)(struct mod *v, int, int);
+    int (*mod_get_wait_objs)(struct mod *v, tbus *read_objs, int *rcount,
+                             tbus *write_objs, int *wcount, int *timeout);
+    int (*mod_check_wait_objs)(struct mod *v);
+    tintptr mod_dumby[100 - 9]; /* align, 100 minus the number of mod
                                  functions above */
-  /* server functions */
-  int (*server_begin_update)(struct mod* v);
-  int (*server_end_update)(struct mod* v);
-  int (*server_fill_rect)(struct mod* v, int x, int y, int cx, int cy);
-  int (*server_screen_blt)(struct mod* v, int x, int y, int cx, int cy,
-                           int srcx, int srcy);
-  int (*server_paint_rect)(struct mod* v, int x, int y, int cx, int cy,
-                           char* data, int width, int height, int srcx, int srcy);
-  int (*server_set_cursor)(struct mod* v, int x, int y, char* data, char* mask);
-  int (*server_palette)(struct mod* v, int* palette);
-  int (*server_msg)(struct mod* v, const char* msg, int code);
-  int (*server_is_term)(struct mod* v);
-  int (*server_set_clip)(struct mod* v, int x, int y, int cx, int cy);
-  int (*server_reset_clip)(struct mod* v);
-  int (*server_set_fgcolor)(struct mod* v, int fgcolor);
-  int (*server_set_bgcolor)(struct mod* v, int bgcolor);
-  int (*server_set_opcode)(struct mod* v, int opcode);
-  int (*server_set_mixmode)(struct mod* v, int mixmode);
-  int (*server_set_brush)(struct mod* v, int x_origin, int y_origin,
-                          int style, char* pattern);
-  int (*server_set_pen)(struct mod* v, int style,
-                        int width);
-  int (*server_draw_line)(struct mod* v, int x1, int y1, int x2, int y2);
-  int (*server_add_char)(struct mod* v, int font, int character,
-                         int offset, int baseline,
-                         int width, int height, char* data);
-  int (*server_draw_text)(struct mod* v, int font,
-                          int flags, int mixmode, int clip_left, int clip_top,
-                          int clip_right, int clip_bottom,
-                          int box_left, int box_top,
-                          int box_right, int box_bottom,
-                          int x, int y, char* data, int data_len);
-  int (*server_reset)(struct mod* v, int width, int height, int bpp);
-  int (*server_query_channel)(struct mod* v, int index,
-                              char* channel_name,
-                              int* channel_flags);
-  int (*server_get_channel_id)(struct mod* v, const char *name);
-  int (*server_send_to_channel)(struct mod* v, int channel_id,
-                                char* data, int data_len,
-                                int total_data_len, int flags);
-  int (*server_bell_trigger)(struct mod* v);
-  tintptr server_dumby[100 - 25]; /* align, 100 minus the number of server
+    /* server functions */
+    int (*server_begin_update)(struct mod *v);
+    int (*server_end_update)(struct mod *v);
+    int (*server_fill_rect)(struct mod *v, int x, int y, int cx, int cy);
+    int (*server_screen_blt)(struct mod *v, int x, int y, int cx, int cy,
+                             int srcx, int srcy);
+    int (*server_paint_rect)(struct mod *v, int x, int y, int cx, int cy,
+                             char *data, int width, int height, int srcx, int srcy);
+    int (*server_set_cursor)(struct mod *v, int x, int y, char *data, char *mask);
+    int (*server_palette)(struct mod *v, int *palette);
+    int (*server_msg)(struct mod *v, const char *msg, int code);
+    int (*server_is_term)(struct mod *v);
+    int (*server_set_clip)(struct mod *v, int x, int y, int cx, int cy);
+    int (*server_reset_clip)(struct mod *v);
+    int (*server_set_fgcolor)(struct mod *v, int fgcolor);
+    int (*server_set_bgcolor)(struct mod *v, int bgcolor);
+    int (*server_set_opcode)(struct mod *v, int opcode);
+    int (*server_set_mixmode)(struct mod *v, int mixmode);
+    int (*server_set_brush)(struct mod *v, int x_origin, int y_origin,
+                            int style, char *pattern);
+    int (*server_set_pen)(struct mod *v, int style,
+                          int width);
+    int (*server_draw_line)(struct mod *v, int x1, int y1, int x2, int y2);
+    int (*server_add_char)(struct mod *v, int font, int character,
+                           int offset, int baseline,
+                           int width, int height, char *data);
+    int (*server_draw_text)(struct mod *v, int font,
+                            int flags, int mixmode, int clip_left, int clip_top,
+                            int clip_right, int clip_bottom,
+                            int box_left, int box_top,
+                            int box_right, int box_bottom,
+                            int x, int y, char *data, int data_len);
+    int (*server_reset)(struct mod *v, int width, int height, int bpp);
+    int (*server_query_channel)(struct mod *v, int index,
+                                char *channel_name,
+                                int *channel_flags);
+    int (*server_get_channel_id)(struct mod *v, const char *name);
+    int (*server_send_to_channel)(struct mod *v, int channel_id,
+                                  char *data, int data_len,
+                                  int total_data_len, int flags);
+    int (*server_bell_trigger)(struct mod *v);
+    tintptr server_dumby[100 - 25]; /* align, 100 minus the number of server
                                      functions above */
-  /* common */
-  tintptr handle; /* pointer to self as long */
-  tintptr wm;
-  tintptr painter;
-  struct source_info *si;
-  /* mod data */
-  int sck;
-  int width;
-  int height;
-  int bpp;
+    /* common */
+    tintptr handle; /* pointer to self as long */
+    tintptr wm;
+    tintptr painter;
+    struct source_info *si;
+    /* mod data */
+    int sck;
+    int width;
+    int height;
+    int bpp;
 };


### PR DESCRIPTION
Follow-on pull request to #1633 which migrates all logging in the mc directory to use the LOG() and LOG_DEVEL() macros.

Changes:

* Migrate logging to the LOG() and LOG_DEVEL() macros (using text transform script)
* update code formatting with astyle for all files in mc/*
* removed `LIB_DEBUG` since it is no longer used