### PR TITLE
Add versioning to xrdp_client_info

### DIFF
--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -25,143 +25,155 @@
 
 struct monitor_info
 {
-  int left;
-  int top;
-  int right;
-  int bottom;
-  int is_primary;
+    int left;
+    int top;
+    int right;
+    int bottom;
+    int is_primary;
 };
 
+/**
+ * Information about the xrdp client
+ *
+ * @note This structure is shared with xorgxrdp. If you change anything
+ *       above the 'private to xrdp below this line' comment, you MUST
+ *       bump the CLIENT_INFO_CURRENT_VERSION number so that the mismatch
+ *       can be detected.
+ */
 struct xrdp_client_info
 {
-  int size; /* bytes for this structure */
-  int bpp;
-  int width;
-  int height;
-  /* bitmap cache info */
-  int cache1_entries;
-  int cache1_size;
-  int cache2_entries;
-  int cache2_size;
-  int cache3_entries;
-  int cache3_size;
-  int bitmap_cache_persist_enable; /* 0 or 2 */
-  int bitmap_cache_version; /* ored 1 = original version, 2 = v2, 4 = v3 */
-  /* pointer info */
-  int pointer_cache_entries;
-  /* other */
-  int use_bitmap_comp;
-  int use_bitmap_cache;
-  int op1; /* use smaller bitmap header, non cache */
-  int op2; /* use smaller bitmap header in bitmap cache */
-  int desktop_cache;
-  int use_compact_packets; /* rdp5 smaller packets */
-  char hostname[32];
-  int build;
-  int keylayout;
-  char username[INFO_CLIENT_MAX_CB_LEN];
-  char password[INFO_CLIENT_MAX_CB_LEN];
-  char domain[INFO_CLIENT_MAX_CB_LEN];
-  char program[INFO_CLIENT_MAX_CB_LEN];
-  char directory[INFO_CLIENT_MAX_CB_LEN];
-  int rdp_compression;
-  int rdp_autologin;
-  int crypt_level; /* 1, 2, 3 = low, medium, high */
-  int channels_allowed; /* 0 = no channels 1 = channels */
-  int sound_code; /* 1 = leave sound at server */
-  int is_mce;
-  int rdp5_performanceflags;
-  int brush_cache_code; /* 0 = no cache 1 = 8x8 standard cache
+    int size; /* bytes for this structure */
+    int version; /* Should be CLIENT_INFO_CURRENT_VERSION */
+    int bpp;
+    int width;
+    int height;
+    /* bitmap cache info */
+    int cache1_entries;
+    int cache1_size;
+    int cache2_entries;
+    int cache2_size;
+    int cache3_entries;
+    int cache3_size;
+    int bitmap_cache_persist_enable; /* 0 or 2 */
+    int bitmap_cache_version; /* ored 1 = original version, 2 = v2, 4 = v3 */
+    /* pointer info */
+    int pointer_cache_entries;
+    /* other */
+    int use_bitmap_comp;
+    int use_bitmap_cache;
+    int op1; /* use smaller bitmap header, non cache */
+    int op2; /* use smaller bitmap header in bitmap cache */
+    int desktop_cache;
+    int use_compact_packets; /* rdp5 smaller packets */
+    char hostname[32];
+    int build;
+    int keylayout;
+    char username[INFO_CLIENT_MAX_CB_LEN];
+    char password[INFO_CLIENT_MAX_CB_LEN];
+    char domain[INFO_CLIENT_MAX_CB_LEN];
+    char program[INFO_CLIENT_MAX_CB_LEN];
+    char directory[INFO_CLIENT_MAX_CB_LEN];
+    int rdp_compression;
+    int rdp_autologin;
+    int crypt_level; /* 1, 2, 3 = low, medium, high */
+    int channels_allowed; /* 0 = no channels 1 = channels */
+    int sound_code; /* 1 = leave sound at server */
+    int is_mce;
+    int rdp5_performanceflags;
+    int brush_cache_code; /* 0 = no cache 1 = 8x8 standard cache
                            2 = arbitrary dimensions */
-  char client_ip[256];
-  int max_bpp;
-  int jpeg; /* non standard bitmap cache v2 cap */
-  int offscreen_support_level;
-  int offscreen_cache_size;
-  int offscreen_cache_entries;
-  int rfx;
+    char client_ip[256];
+    int max_bpp;
+    int jpeg; /* non standard bitmap cache v2 cap */
+    int offscreen_support_level;
+    int offscreen_cache_size;
+    int offscreen_cache_entries;
+    int rfx;
 
-  /* CAPSETTYPE_RAIL */
-  int rail_support_level;
-  /* CAPSETTYPE_WINDOW */
-  int wnd_support_level;
-  int wnd_num_icon_caches;
-  int wnd_num_icon_cache_entries;
-  /* codecs */
-  int rfx_codec_id;
-  int rfx_prop_len;
-  char rfx_prop[64];
-  int ns_codec_id;
-  int ns_prop_len;
-  char ns_prop[64];
-  int jpeg_codec_id;
-  int jpeg_prop_len;
-  char jpeg_prop[64];
-  int v3_codec_id;
-  int rfx_min_pixel;
-  char orders[32];
-  int order_flags_ex;
-  int use_bulk_comp;
-  int pointer_flags; /* 0 color, 1 new, 2 no new */
-  int use_fast_path;
-  int require_credentials; /* when true, credentials *must* be passed on cmd line */
-  char client_addr[256];
-  char client_port[256];
+    /* CAPSETTYPE_RAIL */
+    int rail_support_level;
+    /* CAPSETTYPE_WINDOW */
+    int wnd_support_level;
+    int wnd_num_icon_caches;
+    int wnd_num_icon_cache_entries;
+    /* codecs */
+    int rfx_codec_id;
+    int rfx_prop_len;
+    char rfx_prop[64];
+    int ns_codec_id;
+    int ns_prop_len;
+    char ns_prop[64];
+    int jpeg_codec_id;
+    int jpeg_prop_len;
+    char jpeg_prop[64];
+    int v3_codec_id;
+    int rfx_min_pixel;
+    char orders[32];
+    int order_flags_ex;
+    int use_bulk_comp;
+    int pointer_flags; /* 0 color, 1 new, 2 no new */
+    int use_fast_path;
+    int require_credentials; /* when true, credentials *must* be passed on cmd line */
+    char client_addr[256];
+    char client_port[256];
 
-  int security_layer; /* 0 = rdp, 1 = tls , 2 = hybrid */
-  int multimon; /* 0 = deny , 1 = allow */
-  int monitorCount; /* number of monitors detected (max = 16) */
-  struct monitor_info minfo[16]; /* client monitor data */
-  struct monitor_info minfo_wm[16]; /* client monitor data, non-negative values */
+    int security_layer; /* 0 = rdp, 1 = tls , 2 = hybrid */
+    int multimon; /* 0 = deny , 1 = allow */
+    int monitorCount; /* number of monitors detected (max = 16) */
+    struct monitor_info minfo[16]; /* client monitor data */
+    struct monitor_info minfo_wm[16]; /* client monitor data, non-negative values */
 
-  int keyboard_type;
-  int keyboard_subtype;
+    int keyboard_type;
+    int keyboard_subtype;
 
-  int png_codec_id;
-  int png_prop_len;
-  char png_prop[64];
-  int vendor_flags[4];
-  int mcs_connection_type;
-  int mcs_early_capability_flags;
+    int png_codec_id;
+    int png_prop_len;
+    char png_prop[64];
+    int vendor_flags[4];
+    int mcs_connection_type;
+    int mcs_early_capability_flags;
 
-  int max_fastpath_frag_bytes;
-  int capture_code;
-  int capture_format;
+    int max_fastpath_frag_bytes;
+    int capture_code;
+    int capture_format;
 
-  char certificate[1024];
-  char key_file[1024];
+    char certificate[1024];
+    char key_file[1024];
 
-  /* X11 keyboard layout - inferred from keyboard type/subtype */
-  char model[16];
-  char layout[16];
-  char variant[16];
-  char options[256];
+    /* X11 keyboard layout - inferred from keyboard type/subtype */
+    char model[16];
+    char layout[16];
+    char variant[16];
+    char options[256];
 
-  /* !!!!!!!!!!!!!!!!!!!!!!!!!! */
-  /* NO CHANGES ABOVE THIS LINE */
-  /* !!!!!!!!!!!!!!!!!!!!!!!!!! */
+    /* ==================================================================== */
+    /* Private to xrdp below this line */
+    /* ==================================================================== */
 
-  /* codec */
-  int h264_codec_id;
-  int h264_prop_len;
-  char h264_prop[64];
+    /* codec */
+    int h264_codec_id;
+    int h264_prop_len;
+    char h264_prop[64];
 
-  int use_frame_acks;
-  int max_unacknowledged_frame_count;
+    int use_frame_acks;
+    int max_unacknowledged_frame_count;
 
-  long ssl_protocols;
-  char *tls_ciphers;
+    long ssl_protocols;
+    char *tls_ciphers;
 
-  int client_os_major;
-  int client_os_minor;
+    int client_os_major;
+    int client_os_minor;
 
-  int no_orders_supported;
-  int use_cache_glyph_v2;
-  int rail_enable;
-  int suppress_output;
+    int no_orders_supported;
+    int use_cache_glyph_v2;
+    int rail_enable;
+    int suppress_output;
 
-  int enable_token_login;
-  char domain_user_separator[16];
+    int enable_token_login;
+    char domain_user_separator[16];
 };
+
+/* yyyymmdd of last incompatible change to xrdp_client_info */
+#define CLIENT_INFO_CURRENT_VERSION 20210225
 
 #endif

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -370,6 +370,7 @@ xrdp_rdp_create(struct xrdp_session *session, struct trans *trans)
     rfx_context_set_cpu_opt(self->rfx_enc, xrdp_rdp_detect_cpu());
 #endif
     self->client_info.size = sizeof(self->client_info);
+    self->client_info.version = CLIENT_INFO_CURRENT_VERSION;
     LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_rdp_create");
     return self;
 }


### PR DESCRIPTION
As discussed in gitter, add a version guard to xrdp_client_info.

There's probably more that can be done here in terms of restructuring this. I notice a lot of the stuff above the line 'Private to xrdp below this line' is not actually used by xorgxrdp. Alternatively, maybe we should split this into two structures so the compiler can pick up differences. Thoughts?

BTW : the include's been run through astyle. All I've actually done is add the 'version' field and the macro and change the comment 'NO CHANGES ABOVE THIS LINE' to the (hopefully) more informative 'Private to xrdp below this line'