### PR TITLE
Resolution switching without reconnecting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,15 @@
 ## Overview
 
 **xrdp** provides a graphical login to remote machines using Microsoft
-Remote Desktop Protocol (RDP). xrdp accepts connections from a variety of
-RDP clients: FreeRDP, rdesktop, KRDC, NeutrinoRDP and Microsoft Remote Desktop
-Client (for Windows, Mac OS, iOS and Android).
+Remote Desktop Protocol (RDP). xrdp accepts connections from a variety of RDP clients:
+  - FreeRDP
+  - rdesktop
+  - KRDC
+  - NeutrinoRDP
+  - Windows MSTSC (Microsoft Terminal Services Client)
+  - Microsoft Remote Desktop (which is distinct from MSTSC)
+
+Many of these work on some or all of Windows, Mac OS, iOS, and/or Android.
 
 RDP transport is encrypted using TLS by default.
 
@@ -24,7 +30,7 @@ RDP transport is encrypted using TLS by default.
  * Connect to a Linux desktop using RDP from anywhere (requires
    [xorgxrdp](https://github.com/neutrinolabs/xorgxrdp) Xorg module)
  * Reconnect to an existing session
- * Session resizing
+ * Session resizing on connect and while an existing session is active.
  * RDP/VNC proxy (connect to another RDP/VNC server via xrdp)
 
 ### Access to Remote Resources

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -14,6 +14,7 @@ include_HEADERS = \
   ms-rdpegdi.h \
   ms-rdpele.h \
   ms-rdperp.h \
+  ms-rdpedisp.h \
   ms-smb2.h \
   xrdp_client_info.h \
   xrdp_constants.h \

--- a/common/ms-rdpbcgr.h
+++ b/common/ms-rdpbcgr.h
@@ -78,7 +78,12 @@
 /* This isn't explicitly named in MS-RDPBCGR */
 #define CHANNEL_NAME_LEN                7
 
-/* Oprions field */
+/* 2.2.1.3.6 Client Monitor Data - */
+/* monitorCount (4 bytes): A 32-bit, unsigned integer. The number of display */
+/* monitor definitions in the monitorDefArray field (the maximum allowed is 16). */
+#define CLIENT_MONITOR_DATA_MAXIMUM_MONITORS 16
+
+/* Options field */
 /* NOTE: XR_ prefixed to avoid conflict with FreeRDP */
 #define XR_CHANNEL_OPTION_INITIALIZED   0x80000000
 #define XR_CHANNEL_OPTION_ENCRYPT_RDP   0x40000000

--- a/common/ms-rdpedisp.h
+++ b/common/ms-rdpedisp.h
@@ -1,0 +1,29 @@
+/**
+ * xrdp: A Remote Desktop Protocol server.
+ *
+ * MS-RDPEDISP : Definitions from [MS-RDPEDISP]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * References to MS-RDPEDISP are currently correct for v20201030 of that
+ * document
+ */
+
+#if !defined(MS_RDPEDISP_H)
+#define MS_RDPEDISP_H
+
+/* Display Control Messages: Display Virtual Channel Extension (2.2.2) */
+#define DISPLAYCONTROL_PDU_TYPE_MONITOR_LAYOUT 0x00000002
+#define DISPLAYCONTROL_PDU_TYPE_CAPS           0x00000005
+
+#endif /* MS_RDPEDISP_H */

--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -19,6 +19,7 @@
  */
 
 #include "xrdp_constants.h"
+#include "ms-rdpbcgr.h"
 
 #if !defined(XRDP_CLIENT_INFO_H)
 #define XRDP_CLIENT_INFO_H
@@ -120,8 +121,8 @@ struct xrdp_client_info
     int security_layer; /* 0 = rdp, 1 = tls , 2 = hybrid */
     int multimon; /* 0 = deny , 1 = allow */
     int monitorCount; /* number of monitors detected (max = 16) */
-    struct monitor_info minfo[16]; /* client monitor data */
-    struct monitor_info minfo_wm[16]; /* client monitor data, non-negative values */
+    struct monitor_info minfo[CLIENT_MONITOR_DATA_MAXIMUM_MONITORS]; /* client monitor data */
+    struct monitor_info minfo_wm[CLIENT_MONITOR_DATA_MAXIMUM_MONITORS]; /* client monitor data, non-negative values */
 
     int keyboard_type;
     int keyboard_subtype;

--- a/libxrdp/xrdp_channel.c
+++ b/libxrdp/xrdp_channel.c
@@ -776,7 +776,12 @@ xrdp_channel_drdynvc_start(struct xrdp_channel *self)
     struct mcs_channel_item *ci;
     struct mcs_channel_item *dci;
 
-
+    LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_channel_drdynvc_start: drdynvc_channel_id %d", self->drdynvc_channel_id);
+    if (self->drdynvc_channel_id != -1)
+    {
+        LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_channel_drdynvc_start: already started");
+        return 0;
+    }
     dci = NULL;
     count = self->mcs_layer->channel_list->count;
     for (index = 0; index < count; index++)

--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -492,6 +492,10 @@ lxrdp_set_param(struct mod *mod, const char *name, const char *value)
     {
         settings->nla_security = g_text2bool(value);
     }
+    else if (g_strcmp(name, "enable_dynamic_resizing") == 0)
+    {
+        settings->desktop_resize = g_text2bool(value);
+    }
     else
     {
         LOG(LOG_LEVEL_WARNING, "lxrdp_set_param: unknown name [%s] value [%s]", name, value);
@@ -596,6 +600,27 @@ lxrdp_suppress_output(struct mod *mod, int suppress,
 #if defined(NEUTRINORDP_HAS_SUPPRESS_OUTPUT)
     mod->inst->SendSuppressOutput(mod->inst, !suppress, left, top, right, bottom);
 #endif
+    return 0;
+}
+
+/******************************************************************************/
+static int
+lxrdp_server_version_message(struct mod *mod)
+{
+    return 0;
+}
+
+/******************************************************************************/
+static int
+lxrdp_server_monitor_resize(struct mod *mod, int width, int height)
+{
+    return 0;
+}
+
+/******************************************************************************/
+static int
+lxrdp_server_monitor_full_invalidate(struct mod *mod, int width, int height)
+{
     return 0;
 }
 
@@ -2074,6 +2099,9 @@ mod_init(void)
     mod->mod_check_wait_objs = lxrdp_check_wait_objs;
     mod->mod_frame_ack = lxrdp_frame_ack;
     mod->mod_suppress_output = lxrdp_suppress_output;
+    mod->mod_server_version_message = lxrdp_server_version_message;
+    mod->mod_server_monitor_resize = lxrdp_server_monitor_resize;
+    mod->mod_server_monitor_full_invalidate = lxrdp_server_monitor_full_invalidate;
 
     mod->inst = freerdp_new();
     mod->inst->PreConnect = lfreerdp_pre_connect;

--- a/neutrinordp/xrdp-neutrinordp.h
+++ b/neutrinordp/xrdp-neutrinordp.h
@@ -82,8 +82,13 @@ struct mod
     int (*mod_frame_ack)(struct mod *mod, int flags, int frame_id);
     int (*mod_suppress_output)(struct mod *mod, int suppress,
                                int left, int top, int right, int bottom);
-    tintptr mod_dumby[100 - 11]; /* align, 100 minus the number of mod
-                                    functions above */
+    int (*mod_server_monitor_resize)(struct mod *mod,
+                               int width, int height);
+    int (*mod_server_monitor_full_invalidate)(struct mod *mod,
+                               int width, int height);
+    int (*mod_server_version_message)(struct mod *mod);
+    tintptr mod_dumby[100 - 14]; /* align, 100 minus the number of mod
+                                 functions above */
     /* server functions */
     int (*server_begin_update)(struct mod *v);
     int (*server_end_update)(struct mod *v);

--- a/vnc/vnc.h
+++ b/vnc/vnc.h
@@ -77,7 +77,12 @@ struct vnc
     int (*mod_frame_ack)(struct vnc *v, int flags, int frame_id);
     int (*mod_suppress_output)(struct vnc *v, int suppress,
                                int left, int top, int right, int bottom);
-    tintptr mod_dumby[100 - 11]; /* align, 100 minus the number of mod
+    int (*mod_server_monitor_resize)(struct vnc *v,
+                               int width, int height);
+    int (*mod_server_monitor_full_invalidate)(struct vnc *v,
+                               int width, int height);
+    int (*mod_server_version_message)(struct vnc *v);
+    tintptr mod_dumby[100 - 14]; /* align, 100 minus the number of mod
                                   functions above */
     /* server functions */
     int (*server_begin_update)(struct vnc *v);
@@ -152,5 +157,5 @@ struct vnc
     unsigned int enabled_encodings_mask;
     /* Resizeable support */
     struct vnc_screen_layout client_layout;
-    enum vnc_resize_status initial_resize_status;
+    enum vnc_resize_status resize_status;
 };

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -367,6 +367,21 @@ xrdp_bitmap_compress(char *in_data, int width, int height,
                      int e);
 
 /* xrdp_mm.c */
+
+struct dynamic_monitor_layout
+{
+    int flags;
+    int left;
+    int top;
+    int width;
+    int height;
+    int physical_width;
+    int physical_height;
+    int orientation;
+    int desktop_scale_factor;
+    int device_scale_factor;
+};
+
 int
 xrdp_mm_drdynvc_up(struct xrdp_mm *self);
 int

--- a/xrdp/xrdp.ini.in
+++ b/xrdp/xrdp.ini.in
@@ -235,6 +235,9 @@ ip=ask
 port=ask3389
 username=ask
 password=ask
+; Currently NeutrinoRDP doesn't support dynamic resizing. Uncomment
+; this line if you're using a client which does.
+#enable_dynamic_resizing=false
 
 ; You can override the common channel settings for each session type
 #channel.rdpdr=true

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -53,7 +53,12 @@ struct xrdp_mod
     int (*mod_frame_ack)(struct xrdp_mod *v, int flags, int frame_id);
     int (*mod_suppress_output)(struct xrdp_mod *v, int suppress,
                                int left, int top, int right, int bottom);
-    tintptr mod_dumby[100 - 11]; /* align, 100 minus the number of mod
+    int (*mod_server_monitor_resize)(struct xrdp_mod* v,
+                               int width, int height);
+    int (*mod_server_monitor_full_invalidate)(struct xrdp_mod* v,
+                               int width, int height);
+    int (*mod_server_version_message)(struct xrdp_mod* v);
+    tintptr mod_dumby[100 - 14]; /* align, 100 minus the number of mod
                                   functions above */
     /* server functions */
     int (*server_begin_update)(struct xrdp_mod *v);
@@ -302,6 +307,7 @@ struct xrdp_mm
     struct xrdp_encoder *encoder;
     int cs2xr_cid_map[256];
     int xr2cr_cid_map[256];
+    int dynamic_monitor_chanid;
 };
 
 struct xrdp_key_info

--- a/xup/xup.h
+++ b/xup/xup.h
@@ -51,7 +51,12 @@ struct mod
     int (*mod_frame_ack)(struct mod *v, int flags, int frame_id);
     int (*mod_suppress_output)(struct mod *v, int suppress,
                                int left, int top, int right, int bottom);
-    tintptr mod_dumby[100 - 11]; /* align, 100 minus the number of mod
+    int (*mod_server_monitor_resize)(struct mod* v,
+                               int width, int height);
+    int (*mod_server_monitor_full_invalidate)(struct mod* v,
+                               int width, int height);
+    int (*mod_server_version_message)(struct mod* v);
+    tintptr mod_dumby[100 - 14]; /* align, 100 minus the number of mod
                                  functions above */
     /* server functions */
     int (*server_begin_update)(struct mod *v);


### PR DESCRIPTION
Implements https://github.com/neutrinolabs/xrdp/issues/448

- Based on https://github.com/jsorg71/xrdp/tree/dynamic_monitor
- Tested with xorgxrdp
- Tested with vnc
- Only works with single monitor.

Depends on https://github.com/neutrinolabs/xorgxrdp/pull/183


To test either use Microsoft Remote Desktop (From the Windows or Mac OS app store) and configure to resize the screen or FreeRDP with the `/dynamic-resolution` flag set.