### PR TITLE
Fix #1616 allowing clipboard to work both ways

### DIFF
--- a/vnc/vnc.c
+++ b/vnc/vnc.c
@@ -189,7 +189,7 @@ lib_process_channel_data(struct vnc *v, int chanid, int flags, int size,
                 v->server_send_to_channel(v, v->clip_chanid, out_s->data,
                                           length, length, 3);
                 free_stream(out_s);
-#if 0
+
                 // Send the CLIPRDR_DATA_REQUEST message to the cliprdr channel.
                 //
                 make_stream(out_s);
@@ -204,7 +204,6 @@ lib_process_channel_data(struct vnc *v, int chanid, int flags, int size,
                 v->server_send_to_channel(v, v->clip_chanid, out_s->data,
                                           length, length, 3);
                 free_stream(out_s);
-#endif
                 break;
 
             case 3: /* CLIPRDR_FORMAT_ACK */


### PR DESCRIPTION
Currently the clipboard copy and paste is working to copy from a the server running xrdp and vncserver and paste to a client running Windows Remote Desktop, but it does not work to copy data from the Windows client and paste to the server running xdrp / vncserver. The code that requests the data from the client clipboard after an announcement / notification that new data is available appears to have been disabled.