### PR TITLE
Remove openssl:i386 from 32-bit builds

### DIFF
--- a/scripts/install_xrdp_build_dependencies_with_apt.sh
+++ b/scripts/install_xrdp_build_dependencies_with_apt.sh
@@ -77,7 +77,6 @@ in
             libxfixes-dev:i386 \
             libxrandr-dev:i386 \
             libxrender-dev:i386 \
-            openssl:i386 \
             libfuse-dev:i386"
         
         dpkg --add-architecture i386


### PR DESCRIPTION
We recently had an issue with 32-bit CI builds, spotted by @aquesnel in #1826.

The linked issue https://github.com/actions/virtual-environments/issues/2917 which was undoubtedly a problem has been resolved, and yet our own builds were still breaking with this particular error from `apt install`:-

```
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 openjdk-8-jre-headless : Depends: ca-certificates-java but it is not going to be installed
E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.
```

A bit more triage shows the problem was related to the request to install `openssl:i386` in `scripts/install_xrdp_build_dependencies_with_apt.sh`.

However, we shouldn't be installing this package anyway! `openssl:amd64` is already installed and we are already installing the 32-bit library package `libssl-dev:i386`.

I've tried removing the `openssl:i386` package and it seems to fix the build. Also, openssl is being used as part of the build. Actions log is [here](https://github.com/matt335672/xrdp/actions/runs/667937203). From the log file for `max features with gcc for 32-bit arch (legacy OS) `:-

```
checking for OPENSSL... yes
```
