### PR TITLE
Bumped cppcheck to v2.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
       CC: gcc
       # This is required to use a version of cppcheck other than that
       # supplied with the operating system
-      CPPCHECK_VER: 2.3
+      CPPCHECK_VER: 2.4
       CPPCHECK_REPO: https://github.com/danmar/cppcheck.git
     steps:
       # This is currently the only way to get a version into


### PR DESCRIPTION
cppcheck 2.4 was released on 2021-03-21.

A quick check showed no code changes are needed on our part to get a clean scan from cppcheck 2.3. Any reason not to upgrade anyone can think of?