### PR TITLE
Allow DISPLAY=:0 for chansrv

### DIFF
--- a/common/string_calls.c
+++ b/common/string_calls.c
@@ -24,6 +24,8 @@
 #include <string.h>
 #include <strings.h>
 #include <stdlib.h>
+#include <ctype.h>
+
 
 #include "log.h"
 #include "os_calls.h"
@@ -138,6 +140,36 @@ g_text2bool(const char *s)
         return 1;
     }
     return 0;
+}
+
+/*****************************************************************************/
+int
+g_get_display_num_from_display(const char *display_text)
+{
+    int rv = -1;
+    const char *p;
+
+    /* Skip over the hostname part of the DISPLAY */
+    if (display_text != NULL && (p = strchr(display_text, ':')) != NULL)
+    {
+        ++p; /* Skip the ':' */
+
+        /* Cater for the (still supported) double-colon. See
+         * https://www.x.org/releases/X11R7.7/doc/libX11/libX11/libX11.html */
+        if (*p == ':')
+        {
+            ++p;
+        }
+
+        /* Check it starts with a digit, to avoid oddities like DISPLAY=":zz.0"
+         * being parsed successfully */
+        if (isdigit(*p))
+        {
+            rv = g_atoi(p);
+        }
+    }
+
+    return rv;
 }
 
 /*****************************************************************************/
@@ -774,4 +806,3 @@ g_strtrim(char *str, int trim_flags)
     free(text1);
     return 0;
 }
-

--- a/common/string_calls.h
+++ b/common/string_calls.h
@@ -103,6 +103,16 @@ g_text2bool(const char *s);
 char *
 g_bytes_to_hexdump(const char *src, int len);
 
+/**
+ * Extracts the display number from an X11 display string
+ *
+ * @param Display string (i.e. g_getenv("DISPLAY"))
+ *
+ * @result <0 if the string could not be parsed, or >=0 for a display number
+ */
+int
+g_get_display_num_from_display(const char *display_text);
+
 int      g_strlen(const char *text);
 const char *g_strchr(const char *text, int c);
 char    *g_strcpy(char *dest, const char *src);

--- a/docs/man/xrdp.ini.5.in
+++ b/docs/man/xrdp.ini.5.in
@@ -232,7 +232,7 @@ This option can have one of the following values:
 
 \fBINFO\fR or \fB3\fR \- Logs errors, warnings and informational messages
 
-\fBDEBUG\fR or \fB4\fR \- Log everything. If \fBsesman\fR is compiled in debug mode, this options will output many more low\-level message, useful for developers
+\fBDEBUG\fR or \fB4\fR \- Log everything. If \fBxrdp-sesman\fR is compiled in debug mode, this options will output many more low\-level message, useful for developers
 
 .TP
 \fBEnableSyslog\fR=\fI[true|false]\fR
@@ -338,6 +338,16 @@ values supported for a particular release of \fBxrdp\fR(8) are documented in
 Specifies the session type. The default, \fI0\fR, is Xvnc, \fI10\fR is
 X11rdp, and \fI20\fR is Xorg with xorgxrdp modules.
 
+.TP
+\fBchansrvport\fR=\fBDISPLAY(\fR\fIn\fR\fB)\fR|\fI/path/to/domain-socket\fR
+Asks xrdp to connect to a manually started \fBxrdp-chansrv\fR instance.
+This can be useful if you wish to use to use xrdp to connect to a VNC session
+which has been started other than by \fBxrdp-sesman\fR, as you can then make
+use of \fBxrdp\-chansrv\fR facilities in the VNC session.
+
+The first form of this setting is recommended, replacing \fIn\fR with the
+X11 display number of the session.
+
 .SH "EXAMPLES"
 This is an example \fBxrdp.ini\fR:
 
@@ -369,8 +379,9 @@ password={base64}cGFzc3dvcmQhCg==
 
 .SH "SEE ALSO"
 .BR xrdp (8),
-.BR sesman (8),
-.BR sesrun (8),
+.BR xrdp\-chansrv (8),
+.BR xrdp\-sesman (8),
+.BR xrdp\-sesrun (8),
 .BR sesman.ini (5)
 
 For more info on \fBxrdp\fR see

--- a/sesman/chansrv/chansrv.c
+++ b/sesman/chansrv/chansrv.c
@@ -17,8 +17,6 @@
  * limitations under the License.
  */
 
-#include <ctype.h>
-
 #if defined(HAVE_CONFIG_H)
 #include <config_ac.h>
 #endif
@@ -1560,34 +1558,6 @@ x_server_fatal_handler(void)
 }
 
 /*****************************************************************************/
-static int
-get_display_num_from_display(const char *display_text)
-{
-    int rv = -1;
-    const char *p;
-
-    /* Skip over the hostname part of the DISPLAY */
-    if ((p = g_strchr(display_text, ':')) != NULL)
-    {
-        ++p; /* Skip the ':' */
-
-        /* Cater for the (still supported) double-colon. See
-         * https://www.x.org/releases/X11R7.7/doc/libX11/libX11/libX11.html */
-        if (*p == ':')
-        {
-            ++p;
-        }
-
-        if (isdigit(*p))
-        {
-            rv = g_atoi(p);
-        }
-    }
-
-    return rv;
-}
-
-/*****************************************************************************/
 int
 main_cleanup(void)
 {
@@ -1721,7 +1691,7 @@ main(int argc, char **argv)
         main_cleanup();
         return 1;
     }
-    g_display_num = get_display_num_from_display(display_text);
+    g_display_num = g_get_display_num_from_display(display_text);
     if (g_display_num < 0)
     {
         g_writeln("Unable to get display from DISPLAY='%s'", display_text);

--- a/sesman/chansrv/pcsc/xrdp_pcsc.c
+++ b/sesman/chansrv/pcsc/xrdp_pcsc.c
@@ -11,6 +11,8 @@
 #include <sys/un.h>
 #include <sys/stat.h>
 
+#include "string_calls.h"
+
 #define PCSC_API
 
 typedef unsigned char BYTE;
@@ -155,70 +157,6 @@ lhexdump(void *p, int len)
 
 /*****************************************************************************/
 static int
-get_display_num_from_display(const char *display_text)
-{
-    int rv;
-    int index;
-    int mode;
-    int host_index;
-    int disp_index;
-    int scre_index;
-    char host[256];
-    char disp[256];
-    char scre[256];
-
-    memset(host, 0, 256);
-    memset(disp, 0, 256);
-    memset(scre, 0, 256);
-
-    index = 0;
-    host_index = 0;
-    disp_index = 0;
-    scre_index = 0;
-    mode = 0;
-
-    while (display_text[index] != 0)
-    {
-        if (display_text[index] == ':')
-        {
-            mode = 1;
-        }
-        else if (display_text[index] == '.')
-        {
-            mode = 2;
-        }
-        else if (mode == 0)
-        {
-            host[host_index] = display_text[index];
-            host_index++;
-        }
-        else if (mode == 1)
-        {
-            if (display_text[index] < '0' || display_text[index] > '9')
-            {
-                return -1;
-            }
-            disp[disp_index] = display_text[index];
-            disp_index++;
-        }
-        else if (mode == 2)
-        {
-            scre[scre_index] = display_text[index];
-            scre_index++;
-        }
-        index++;
-    }
-    host[host_index] = 0;
-    disp[disp_index] = 0;
-    scre[scre_index] = 0;
-    LLOGLN(10, ("get_display_num_from_display: host [%s] disp [%s] scre [%s]",
-                host, disp, scre));
-    rv = (disp_index== 0) ? -1 : atoi(disp);
-    return rv;
-}
-
-/*****************************************************************************/
-static int
 connect_to_chansrv(void)
 {
     int bytes;
@@ -256,7 +194,7 @@ connect_to_chansrv(void)
         LLOGLN(0, ("connect_to_chansrv: error, home not set"));
         return 1;
     }
-    dis = get_display_num_from_display(xrdp_display);
+    dis = g_get_display_num_from_display(xrdp_display);
     if (dis < 0)
     {
         LLOGLN(0, ("connect_to_chansrv: error, don't understand DISPLAY='%s'",

--- a/sesman/chansrv/pcsc/xrdp_pcsc.c
+++ b/sesman/chansrv/pcsc/xrdp_pcsc.c
@@ -194,6 +194,10 @@ get_display_num_from_display(const char *display_text)
         }
         else if (mode == 1)
         {
+            if (display_text[index] < '0' || display_text[index] > '9')
+            {
+                return -1;
+            }
             disp[disp_index] = display_text[index];
             disp_index++;
         }
@@ -209,7 +213,7 @@ get_display_num_from_display(const char *display_text)
     scre[scre_index] = 0;
     LLOGLN(10, ("get_display_num_from_display: host [%s] disp [%s] scre [%s]",
                 host, disp, scre));
-    rv = atoi(disp);
+    rv = (disp_index== 0) ? -1 : atoi(disp);
     return rv;
 }
 
@@ -253,10 +257,10 @@ connect_to_chansrv(void)
         return 1;
     }
     dis = get_display_num_from_display(xrdp_display);
-    if (dis < 10)
+    if (dis < 0)
     {
-        /* DISPLAY must be > 9 */
-        LLOGLN(0, ("connect_to_chansrv: error, display not > 9 %d", dis));
+        LLOGLN(0, ("connect_to_chansrv: error, don't understand DISPLAY='%s'",
+               xrdp_display));
         return 1;
     }
     g_sck = socket(PF_LOCAL, SOCK_STREAM, 0);

--- a/sesman/tools/Makefile.am
+++ b/sesman/tools/Makefile.am
@@ -38,6 +38,9 @@ xrdp_sesadmin_SOURCES = \
 xrdp_dis_SOURCES = \
   dis.c
 
+xrdp_dis_LDADD = \
+  $(top_builddir)/common/libcommon.la
+
 xrdp_xcon_SOURCES = \
   xcon.c
 

--- a/sesman/tools/dis.c
+++ b/sesman/tools/dis.c
@@ -29,6 +29,7 @@
 #include <errno.h>
 
 #include "xrdp_sockets.h"
+#include "string_calls.h"
 
 int main(int argc, char **argv)
 {
@@ -36,7 +37,6 @@ int main(int argc, char **argv)
     int dis;
     struct sockaddr_un sa;
     size_t len;
-    char *p;
     char *display;
 
     if (argc != 1)
@@ -54,7 +54,12 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    dis = strtol(display + 1, &p, 10);
+    dis = g_get_display_num_from_display(display);
+    if (dis < 0)
+    {
+        printf("Can't parse DISPLAY='%s'\n", display);
+        return 1;
+    }
     memset(&sa, 0, sizeof(sa));
     sa.sun_family = AF_UNIX;
     sprintf(sa.sun_path, XRDP_DISCONNECT_STR, dis);

--- a/xrdp/xrdp.ini.in
+++ b/xrdp/xrdp.ini.in
@@ -182,9 +182,6 @@ tcutils=true
 ; for debugging xrdp, in section xrdp1, change port=-1 to this:
 #port=/tmp/.xrdp/xrdp_display_10
 
-; for debugging xrdp, add following line to section xrdp1
-#chansrvport=/tmp/.xrdp/xrdp_chansrv_socket_7210
-
 
 ;
 ; Session types
@@ -214,7 +211,10 @@ port=-1
 ; Disable requested encodings to support buggy VNC servers
 ; (1 = ExtendedDesktopSize)
 #disabled_encodings_mask=0
-
+; Use this to connect to a chansrv instance created outside of sesman
+; (e.g. as part of an x11vnc console session). Replace '0' with the
+; display number of the session
+#chansrvport=DISPLAY(0)
 
 [vnc-any]
 name=vnc-any

--- a/xrdpapi/xrdpapi.c
+++ b/xrdpapi/xrdpapi.c
@@ -35,6 +35,7 @@
 
 #include "log.h"
 #include "xrdp_sockets.h"
+#include "string_calls.h"
 #include "xrdpapi.h"
 
 struct wts_obj
@@ -44,8 +45,6 @@ struct wts_obj
 };
 
 /* helper functions used by WTSxxx API - do not invoke directly */
-static int
-get_display_num_from_display(char *display_text);
 static int
 can_send(int sck, int millis);
 static int
@@ -93,7 +92,6 @@ WTSVirtualChannelOpenEx(unsigned int SessionId, const char *pVirtualName,
                         unsigned int flags)
 {
     struct wts_obj *wts;
-    char *display_text;
     int bytes;
     unsigned long long1;
     struct sockaddr_un s;
@@ -113,13 +111,7 @@ WTSVirtualChannelOpenEx(unsigned int SessionId, const char *pVirtualName,
         return 0;
     }
     wts->fd = -1;
-    display_text = getenv("DISPLAY");
-
-    if (display_text != 0)
-    {
-        wts->display_num = get_display_num_from_display(display_text);
-    }
-
+    wts->display_num = g_get_display_num_from_display(getenv("DISPLAY"));
     if (wts->display_num < 0)
     {
         LOG(LOG_LEVEL_ERROR, "WTSVirtualChannelOpenEx: fatal error; invalid DISPLAY");
@@ -525,43 +517,4 @@ can_recv(int sck, int millis)
     }
 
     return 0;
-}
-
-/*****************************************************************************/
-static int
-get_display_num_from_display(char *display_text)
-{
-    int index;
-    int mode;
-    int disp_index;
-    char disp[256];
-
-    index = 0;
-    disp_index = 0;
-    mode = 0;
-
-    while (display_text[index] != 0)
-    {
-        if (display_text[index] == ':')
-        {
-            mode = 1;
-        }
-        else if (display_text[index] == '.')
-        {
-            mode = 2;
-        }
-        else if (mode == 1)
-        {
-            if (display_text[index] < '0' || display_text[index] > '9')
-            {
-                return -1;
-            }
-            disp[disp_index] = display_text[index];
-            disp_index++;
-        }
-        index++;
-    }
-
-    disp[disp_index] = 0;
-    return (disp_index== 0) ? -1 : atoi(disp);
 }

--- a/xrdpapi/xrdpapi.c
+++ b/xrdpapi/xrdpapi.c
@@ -120,9 +120,9 @@ WTSVirtualChannelOpenEx(unsigned int SessionId, const char *pVirtualName,
         wts->display_num = get_display_num_from_display(display_text);
     }
 
-    if (wts->display_num <= 0)
+    if (wts->display_num < 0)
     {
-        LOG(LOG_LEVEL_ERROR, "WTSVirtualChannelOpenEx: fatal error; display is <= 0");
+        LOG(LOG_LEVEL_ERROR, "WTSVirtualChannelOpenEx: fatal error; invalid DISPLAY");
         free(wts);
         return NULL;
     }
@@ -552,6 +552,10 @@ get_display_num_from_display(char *display_text)
         }
         else if (mode == 1)
         {
+            if (display_text[index] < '0' || display_text[index] > '9')
+            {
+                return -1;
+            }
             disp[disp_index] = display_text[index];
             disp_index++;
         }
@@ -559,5 +563,5 @@ get_display_num_from_display(char *display_text)
     }
 
     disp[disp_index] = 0;
-    return atoi(disp);
+    return (disp_index== 0) ? -1 : atoi(disp);
 }


### PR DESCRIPTION
While triaging #1846, I noticed that chansrv won't run if the DISPLAY is :0

This prevents the following use case being possible:-
- User starts console session
- User runs Vino/x11vnc/whatever to expose console session on port 5900 (VNC).
- User runs xrdp-chansrv in console session
- User uses `chansrvport=/path/to/xrdp_chansrv_socket_0`  in `xrdp.ini` to connect to chansrv while connecting to the existing VNC session on port 5900.

This doesn't sound like a bad use-case to me. Am I missing something?

This PR allows chansrv to connect to DISPLAY 0, and also cleans up the function `get_display_num_from_display()`.

Also, shall I add code to `xrdp_mm.c` to default the path to the socks dir, so the user can just specify `xrdp_chansrv_socket_0` rather than needing the socks dir path which is set at compile time?

Thanks.