### PR TITLE
do not install test & development tool

### DIFF
--- a/tests/memtest/Makefile.am
+++ b/tests/memtest/Makefile.am
@@ -6,7 +6,7 @@ if XRDP_DEBUG
 AM_CPPFLAGS += -DXRDP_DEBUG
 endif
 
-sbin_PROGRAMS = \
+noinst_PROGRAMS = \
   memtest
 
 memtest_SOURCES = \

--- a/tools/devel/tcp_proxy/Makefile.am
+++ b/tools/devel/tcp_proxy/Makefile.am
@@ -6,7 +6,7 @@ if XRDP_DEBUG
 AM_CPPFLAGS += -DXRDP_DEBUG
 endif
 
-sbin_PROGRAMS = \
+noinst_PROGRAMS = \
   tcp_proxy
 
 tcp_proxy_SOURCES = \


### PR DESCRIPTION
These tools shouldn't be delivered to end-users, included in distro
packages. Also the execuable names "memtest" and "tcp_proxy" are too
general to install into sbin dir.