### PR TITLE
Relax dependency checking on check and miscellaneous fixes for pkg-config usage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,8 @@
 ACLOCAL_AMFLAGS = -I m4
 AM_DISTCHECK_CONFIGURE_FLAGS = \
   --without-systemdsystemunitdir \
-  --enable-strict-locations
+  --enable-strict-locations \
+  --enable-tests
 
 EXTRA_DIST = \
   COPYING \

--- a/Makefile.am
+++ b/Makefile.am
@@ -67,5 +67,9 @@ SUBDIRS = \
   tests \
   tools
 
+if PERFORM_UNIT_TESTS
+SUBDIRS += tests
+endif
+
 distclean-local:
 	-rm -f xrdp_configure_options.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -68,9 +68,5 @@ SUBDIRS = \
   tests \
   tools
 
-if PERFORM_UNIT_TESTS
-SUBDIRS += tests
-endif
-
 distclean-local:
 	-rm -f xrdp_configure_options.h

--- a/configure.ac
+++ b/configure.ac
@@ -358,8 +358,7 @@ AC_CHECK_HEADER([X11/extensions/Xrandr.h], [],
 CFLAGS="$save_CFLAGS"
 
 # checking for libcheck (used for unit testing)
-PKG_CHECK_MODULES([CHECK], [check >= 0.10.0])
-AC_CHECK_HEADER([check.h], [],
+PKG_CHECK_MODULES([CHECK], [check >= 0.10.0], [],
   [AC_MSG_ERROR([please install check])])
 
 AC_SUBST([moduledir], '${libdir}/xrdp')

--- a/configure.ac
+++ b/configure.ac
@@ -377,9 +377,6 @@ if test "x$perform_unit_tests" == "xyes"; then
 else
     AC_MSG_NOTICE([libcheck not found, unit tests will be skipped])
 fi
-
-AM_CONDITIONAL(PERFORM_UNIT_TESTS,
-               [test "x$perform_unit_tests" = "xyes"])
 # -- end perform unit tests
 
 AC_SUBST([moduledir], '${libdir}/xrdp')

--- a/configure.ac
+++ b/configure.ac
@@ -357,9 +357,20 @@ AC_CHECK_HEADER([X11/extensions/Xrandr.h], [],
 
 CFLAGS="$save_CFLAGS"
 
-# checking for libcheck (used for unit testing)
-PKG_CHECK_MODULES([CHECK], [check >= 0.10.0], [],
-  [AC_MSG_ERROR([please install check])])
+# perform unit tests if libcheck found
+PKG_CHECK_MODULES([CHECK], [check >= 0.10.0],
+    [perform_unit_tests=yes],
+    [perform_unit_tests=no])
+
+if test "x$perform_unit_tests" == "xyes"; then
+    AC_MSG_NOTICE([libcheck found, unit tests will be performed])
+else
+    AC_MSG_NOTICE([libcheck not found, unit tests will be skipped])
+fi
+
+AM_CONDITIONAL(PERFORM_UNIT_TESTS,
+               [test "x$perform_unit_tests" = "xyes"])
+# -- end perform unit tests
 
 AC_SUBST([moduledir], '${libdir}/xrdp')
 
@@ -442,6 +453,8 @@ echo "  exec_prefix             $exec_prefix"
 echo "  libdir                  $libdir"
 echo "  bindir                  $bindir"
 echo "  sysconfdir              $sysconfdir"
+echo ""
+echo "  perform unit tests      $perform_unit_tests"
 echo ""
 echo "  CFLAGS = $CFLAGS"
 echo "  LDFLAGS = $LDFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -65,6 +65,10 @@ if test "x$with_systemdsystemunitdir" != xno; then
 fi
 AM_CONDITIONAL(HAVE_SYSTEMD, [test -n "$with_systemdsystemunitdir" -a "x$with_systemdsystemunitdir" != xno ])
 
+AC_ARG_ENABLE(tests,
+              AC_HELP_STRING([--enable-tests],
+              [Ensure dependencies for the tests are installed]),
+              [ensure_tests_deps=yes], [])
 AC_ARG_ENABLE(pam, AS_HELP_STRING([--enable-pam],
               [Build PAM support (default: yes)]),
               [], [enable_pam=yes])
@@ -358,9 +362,15 @@ AC_CHECK_HEADER([X11/extensions/Xrandr.h], [],
 CFLAGS="$save_CFLAGS"
 
 # perform unit tests if libcheck found
-PKG_CHECK_MODULES([CHECK], [check >= 0.10.0],
-    [perform_unit_tests=yes],
-    [perform_unit_tests=no])
+if test "x$ensure_tests_deps" == "xyes"; then
+    PKG_CHECK_MODULES([CHECK], [check >= 0.10.0],
+        [perform_unit_tests=yes],
+        [AC_MSG_ERROR([please install check, the unit test framework])])
+else
+    PKG_CHECK_MODULES([CHECK], [check >= 0.10.0],
+        [perform_unit_tests=yes],
+        [perform_unit_tests=no])
+fi
 
 if test "x$perform_unit_tests" == "xyes"; then
     AC_MSG_NOTICE([libcheck found, unit tests will be performed])
@@ -454,7 +464,7 @@ echo "  libdir                  $libdir"
 echo "  bindir                  $bindir"
 echo "  sysconfdir              $sysconfdir"
 echo ""
-echo "  perform unit tests      $perform_unit_tests"
+echo "  unit tests performable  $perform_unit_tests"
 echo ""
 echo "  CFLAGS = $CFLAGS"
 echo "  LDFLAGS = $LDFLAGS"

--- a/tests/common/Makefile.am
+++ b/tests/common/Makefile.am
@@ -18,6 +18,9 @@ test_common_SOURCES = \
     test_common_main.c \
     test_string_calls.c
 
+test_common_CFLAGS = \
+    @CHECK_CFLAGS@
+
 test_common_LDADD = \
     $(top_builddir)/common/libcommon.la \
     @CHECK_LIBS@

--- a/tests/memtest/Makefile.am
+++ b/tests/memtest/Makefile.am
@@ -6,9 +6,6 @@ if XRDP_DEBUG
 AM_CPPFLAGS += -DXRDP_DEBUG
 endif
 
-noinst_PROGRAMS = \
-  memtest
-
 check_PROGRAMS = \
   memtest
 


### PR DESCRIPTION
Fix for pkg-config usage:
* rely on pkg-config when finding check 
* add missing CFLAGS when using check obtained via pkg-config

Adjust unit tests:
* relax dependency checking on check (check is not necessary if unit tests are not run)
* `make distcheck` should only succeed if check is installed