### PR TITLE
neutrinordp: avoid pampassword leakage

### DIFF
--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -443,7 +443,14 @@ lxrdp_set_param(struct mod *mod, const char *name, const char *value)
 {
     rdpSettings *settings;
 
-    LOG_DEVEL(LOG_LEVEL_DEBUG, "lxrdp_set_param: name [%s] value [%s]", name, value);
+    if (g_strcmp(name, "password") == 0 || g_strcmp(name, "pampassword") == 0)
+    {
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "lxrdp_set_param: name [%s] value [******]", name);
+    }
+    else
+    {
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "lxrdp_set_param: name [%s] value [%s]", name, value);
+    }
     settings = mod->inst->settings;
 
     if (g_strcmp(name, "hostname") == 0)
@@ -495,6 +502,10 @@ lxrdp_set_param(struct mod *mod, const char *name, const char *value)
     else if (g_strcmp(name, "enable_dynamic_resizing") == 0)
     {
         settings->desktop_resize = g_text2bool(value);
+    }
+    else if (g_strcmp(name, "pampassword") == 0)
+    {
+        LOG(LOG_LEVEL_WARNING, "lxrdp_set_param: unknown name [%s] value [******]", name);
     }
     else
     {

--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -451,6 +451,7 @@ lxrdp_set_param(struct mod *mod, const char *name, const char *value)
     {
         LOG_DEVEL(LOG_LEVEL_DEBUG, "lxrdp_set_param: name [%s] value [%s]", name, value);
     }
+
     settings = mod->inst->settings;
 
     if (g_strcmp(name, "hostname") == 0)
@@ -503,9 +504,11 @@ lxrdp_set_param(struct mod *mod, const char *name, const char *value)
     {
         settings->desktop_resize = g_text2bool(value);
     }
-    else if (g_strcmp(name, "pampassword") == 0)
+    else if (g_strcmp(name, "pamusername") == 0 ||
+             g_strcmp(name, "pampassword") == 0 ||
+             g_strcmp(name, "pammsessionmng") == 0)
     {
-        LOG(LOG_LEVEL_WARNING, "lxrdp_set_param: unknown name [%s] value [******]", name);
+        /* Valid (but unused) parameters not logged */
     }
     else
     {


### PR DESCRIPTION
The leakage does not occur in the most usual use case of xrdp.
It occurs in NeutrinoRDP proxy mode with PAM authentication enabled.

Reported by @TOMATO-ONE

---

Note: It shouldn't be a problem in the most use case of xrdp and it is not a vulnerability such as remote code execution. So I've raised the fix as a usual public PR.