### PR TITLE
neutrinordp: Log the IP address, port, and user name of the NeutrioRDP Proxy connection.

### DIFF
--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -182,18 +182,30 @@ lxrdp_connect(struct mod *mod)
         }
 
 #endif
-        LOG(LOG_LEVEL_ERROR, "freerdp_connect Failed to "
-            "destination :%s:%d",
+        LOG(LOG_LEVEL_ERROR, "NeutrinoRDP proxy connection: status [Failed]," 
+            " RDP client [%s:%s], RDP server [%s:%d], RDP server username [%s],"
+            " xrdp pamusername [%s], xrdp process id [%d]",
+            mod->client_info.client_addr,
+            mod->client_info.client_port,
             mod->inst->settings->hostname,
-            mod->inst->settings->port);
+            mod->inst->settings->port,
+            mod->inst->settings->username,
+            mod->pamusername,
+            g_getpid());
         return 1;
     }
     else
     {
-        LOG(LOG_LEVEL_INFO, "freerdp_connect returned Success to "
-            "destination :%s:%d",
+        LOG(LOG_LEVEL_INFO, "NeutrinoRDP proxy connection: status [Success],"
+            " RDP client [%s:%s], RDP server [%s:%d], RDP server username [%s],"
+            " xrdp pamusername [%s], xrdp process id [%d]",
+            mod->client_info.client_addr,
+            mod->client_info.client_port,
             mod->inst->settings->hostname,
-            mod->inst->settings->port);
+            mod->inst->settings->port,
+            mod->inst->settings->username,
+            mod->pamusername,
+            g_getpid());
     }
 
     return 0;
@@ -433,6 +445,16 @@ lxrdp_end(struct mod *mod)
     }
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "lxrdp_end:");
+    LOG(LOG_LEVEL_INFO, "NeutrinoRDP proxy connection: status [Disconnect],"
+        " RDP client [%s:%s], RDP server [%s:%d], RDP server username [%s],"
+        " xrdp pamusername [%s], xrdp process id [%d]",
+        mod->client_info.client_addr,
+        mod->client_info.client_port,
+        mod->inst->settings->hostname,
+        mod->inst->settings->port,
+        mod->inst->settings->username,
+        mod->pamusername,
+        g_getpid());
     return 0;
 }
 
@@ -504,9 +526,12 @@ lxrdp_set_param(struct mod *mod, const char *name, const char *value)
     {
         settings->desktop_resize = g_text2bool(value);
     }
-    else if (g_strcmp(name, "pamusername") == 0 ||
-             g_strcmp(name, "pampassword") == 0 ||
-             g_strcmp(name, "pammsessionmng") == 0)
+    else if (g_strcmp(name, "pamusername") == 0)
+    {
+        g_strncpy(mod->pamusername, value, 255);
+    }
+    else if (g_strcmp(name, "pampassword") == 0 ||
+             g_strcmp(name, "pamsessionmng") == 0)
     {
         /* Valid (but unused) parameters not logged */
     }

--- a/neutrinordp/xrdp-neutrinordp.h
+++ b/neutrinordp/xrdp-neutrinordp.h
@@ -216,5 +216,5 @@ struct mod
     struct bitmap_item bitmap_cache[4][4096];
     struct brush_item brush_cache[64];
     struct pointer_item pointer_cache[32];
-
+    char pamusername[255];
 };

--- a/xrdp/xrdp.ini.in
+++ b/xrdp/xrdp.ini.in
@@ -111,6 +111,12 @@ grey=dedede
 ls_top_window_bg_color=009cb5
 
 ; width and height of login screen
+;
+; The default height allows for about 5 fields to be comfortably displayed
+; above the buttons at the bottom. To display more fields, make <ls_height>
+; larger, and also increase <ls_btn_ok_y_pos> and <ls_btn_cancel_y_pos>
+; below
+;
 ls_width=350
 ls_height=430
 
@@ -216,6 +222,9 @@ port=-1
 ; display number of the session
 #chansrvport=DISPLAY(0)
 
+; Generic VNC Proxy
+; Tailor this to specific hosts and VNC instances by specifying an ip
+; and port and setting a suitable name.
 [vnc-any]
 name=vnc-any
 lib=libvnc.@lib_extension@
@@ -228,13 +237,23 @@ password=ask
 #pamsessionmng=127.0.0.1
 #delay_ms=2000
 
+; Generic RDP proxy using NeutrinoRDP
+; Tailor this to specific hosts by specifying an ip and port and setting
+; a suitable name.
 [neutrinordp-any]
 name=neutrinordp-any
+; To use this section, you should build xrdp with configure option
+; --enable-neutrinordp.
 lib=libxrdpneutrinordp.@lib_extension@
 ip=ask
 port=ask3389
 username=ask
 password=ask
+; Uncomment the following lines to enable PAM authentication for proxy
+; connections.
+#pamusername=ask
+#pampassword=ask
+#pamsessionmng=127.0.0.1
 ; Currently NeutrinoRDP doesn't support dynamic resizing. Uncomment
 ; this line if you're using a client which does.
 #enable_dynamic_resizing=false


### PR DESCRIPTION
#1873
I made sure to log the IP address, port, and user name of the NeutrioRDP Proxy connection.

The following will be recorded in xrdp.log.
`
[20210503-17:07:11] [INFO ] NeutrinoRDP: connection [Success], destination [192.168.102.101:3389], username [user], source [192.168.0.212:62118], pamusername [xrdp], pid [7443]
`

I don't know the C language very well.
I made the patch as an example.
If you have better code, please let me know.

I would like to log the disconnect as well.
Where should I add the code in xrdp-neutrinordp.c?
Please advise.

Best regards