### PR TITLE
Add checking the code formatting with astyle during CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,3 +146,32 @@ jobs:
       - run: ./bootstrap
       - run: scripts/install_cppcheck.sh $CPPCHECK_REPO $CPPCHECK_VER
       - run: scripts/run_cppcheck.sh -v $CPPCHECK_VER
+
+  code_formatting_check:
+    name: code formatting check
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc
+      # This is required to use a version of astyle other than that
+      # supplied with the operating system
+      ASTYLE_VER: 3.1
+      ASTYLE_REPO: https://svn.code.sf.net/p/astyle/code/tags
+    steps:
+      # This is currently the only way to get a version into
+      # the cache tag name - see https://github.com/actions/cache/issues/543
+      - run: |
+          echo "OS_VERSION=`lsb_release -sr`" >> $GITHUB_ENV
+      - uses: actions/checkout@v2
+      - name: Cache astyle
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-astyle
+        with:
+          path: ~/astyle.local
+          key: ${{ runner.os }}-${{ env.OS_VERSION }}-build-${{ env.cache-name }}-${{ env.ASTYLE_VER }}
+      - run: sudo scripts/install_astyle_dependencies_with_apt.sh
+      - run: scripts/install_astyle.sh $ASTYLE_REPO $ASTYLE_VER
+      - name: Format code with astyle
+        run: scripts/run_astyle.sh
+      - name: Check code formatting
+        run: git diff --exit-code

--- a/astyle_config.as
+++ b/astyle_config.as
@@ -45,6 +45,14 @@
 # For each directory in the command line, process all subdirectories recursively.
 --recursive
 
+# Exclude git submodule directories and generated files.
+--exclude=libpainter
+--exclude=librfxcodec
+--exclude=xrdp_configure_options.h
+
+# ignore errors from generated files that do not exist
+--ignore-exclude-errors
+
 # Preserve the original file's date and time modified.
 --preserve-date
 
@@ -53,4 +61,3 @@
 --formatted
 
 --lineend=linux
-

--- a/common/log.c
+++ b/common/log.c
@@ -767,9 +767,9 @@ log_end(void)
 /* log a hex dump */
 enum logReturns
 log_hexdump(const enum logLevels log_level,
-              const char *message,
-              const char *src,
-              int len)
+            const char *message,
+            const char *src,
+            int len)
 {
     return log_hexdump_with_location("", "", 0, log_level, message, src, len);
 }
@@ -820,12 +820,12 @@ log_hexdump_with_location(const char *function_name,
         if (g_strlen(file_name) > 0)
         {
             rv = log_message_with_location(function_name, file_name, line_number,
-                                           log_level, "%s %s%s", 
+                                           log_level, "%s %s%s",
                                            message, HEX_DUMP_HEADER, dump_buffer);
         }
         else
         {
-            rv = log_message(log_level, "%s %s%s", 
+            rv = log_message(log_level, "%s %s%s",
                              message, HEX_DUMP_HEADER, dump_buffer);
         }
         g_free(dump_buffer);

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -27,7 +27,7 @@ struct exit_status
 {
     /* set to -1 when the process exited via a signal */
     uint8_t exit_code;
-    
+
     /* set to 0 when the process exited normally */
     uint8_t signal_no;
 };

--- a/common/string_calls.c
+++ b/common/string_calls.c
@@ -537,7 +537,7 @@ g_bytes_to_hexdump(const char *src, int len)
                         + HEX_DUMP_NEWLINE_SIZE);
 
     dump_number_lines = (len / HEX_DUMP_SOURCE_BYTES_PER_LINE) + 1; /* +1 to round up */
-    dump_length = (dump_number_lines *dump_line_length    /* hex dump lines */
+    dump_length = (dump_number_lines * dump_line_length   /* hex dump lines */
                    + 1);    /* terminating NULL */
     dump_buffer = (char *)g_malloc(dump_length, 1);
     if (dump_buffer == NULL)
@@ -818,7 +818,7 @@ g_strnjoin(char *dest, int dest_len, const char *joiner, const char *src[], int 
     int dest_remaining;
     char *dest_pos = dest;
     char *dest_end;
-    
+
     if (dest == NULL || dest_len < 1)
     {
         return dest;

--- a/genkeymap/evdev-map.c
+++ b/genkeymap/evdev-map.c
@@ -22,7 +22,8 @@
  * xfree86(base)->evdev keycode mapping
  */
 
-int xfree86_to_evdev[137-8+1] = {
+int xfree86_to_evdev[137 - 8 + 1] =
+{
     /* MDSW */ 203,
     /* ESC */ 9,
     /* AE01 */ 10,

--- a/genkeymap/genkeymap.c
+++ b/genkeymap/genkeymap.c
@@ -44,7 +44,7 @@
 #include <X11/XKBlib.h>
 #include <locale.h>
 
-extern int xfree86_to_evdev[137-8+1];
+extern int xfree86_to_evdev[137 - 8 + 1];
 
 int main(int argc, char **argv)
 {
@@ -52,7 +52,8 @@ int main(int argc, char **argv)
     char text[256];
     char *displayname = NULL;
     char *outfname;
-    const char *sections[8] = {
+    const char *sections[8] =
+    {
         "noshift", "shift", "altgr", "shiftaltgr",
         "capslock", "capslockaltgr", "shiftcapslock", "shiftcapslockaltgr"
     };
@@ -139,9 +140,13 @@ int main(int argc, char **argv)
         for (i = 8; i < 137; i++) /* Keycodes */
         {
             if (is_evdev)
-                e.keycode = xfree86_to_evdev[i-8];
+            {
+                e.keycode = xfree86_to_evdev[i - 8];
+            }
             else
+            {
                 e.keycode = i;
+            }
             nbytes = XLookupString(&e, text, 255, &ks, NULL);
             text[nbytes] = 0;
             char_count = mbstowcs(wtext, text, 255);

--- a/neutrinordp/xrdp-neutrinordp.h
+++ b/neutrinordp/xrdp-neutrinordp.h
@@ -83,9 +83,9 @@ struct mod
     int (*mod_suppress_output)(struct mod *mod, int suppress,
                                int left, int top, int right, int bottom);
     int (*mod_server_monitor_resize)(struct mod *mod,
-                               int width, int height);
+                                     int width, int height);
     int (*mod_server_monitor_full_invalidate)(struct mod *mod,
-                               int width, int height);
+            int width, int height);
     int (*mod_server_version_message)(struct mod *mod);
     tintptr mod_dumby[100 - 14]; /* align, 100 minus the number of mod
                                  functions above */

--- a/scripts/install_astyle.sh
+++ b/scripts/install_astyle.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+
+# Script to install a version of astyle in ~/astyle.local/
+#
+# Used by CI builds
+#
+# Currently only supports git repos as sources
+#
+# Usage: /path/to/install_astyle.sh <astyle-git-repo> <version-tag>
+
+INSTALL_ROOT=~/astyle.local
+
+# ----------------------------------------------------------------------------
+# U S A G E
+# ----------------------------------------------------------------------------
+usage()
+{
+    echo "** Usage: $0 <svn-tags-url> <tag-name>"
+    echo "   e.g. $0 https://svn.code.sf.net/p/astyle/code/tags 3.1"
+} >&2
+
+# ----------------------------------------------------------------------------
+# C A L L _ M A K E
+#
+# Calls make with the specified parameters, but only displays the error
+# log if it fails
+# ----------------------------------------------------------------------------
+call_make()
+{
+    # Disable set -e, if active
+    set_entry_opts=`set +o`
+    set +e
+
+    status=1
+    log=`mktemp /tmp/astyle-log.XXXXXXXXXX`
+    if [ -n "$log" ]; then
+        make "$@" >$log 2>&1
+        status=$?
+        if [ $status -ne 0 ]; then
+            cat $log >&2
+        fi
+        rm $log
+    fi
+
+    # Re-enable `set -e` if active before
+    $set_entry_opts
+
+    return $status
+}
+
+
+# ----------------------------------------------------------------------------
+# M A I N
+# ----------------------------------------------------------------------------
+if [ $# -ne 2 ]; then
+    usage
+    exit 1
+fi
+
+REPO_URL="$1"
+ASTYLE_VER="$2"
+
+# Already installed?
+exe=$INSTALL_ROOT/$ASTYLE_VER/usr/bin/astyle
+if [ -x "$exe" ]; then
+    echo "astyle version $ASTYLE_VER is already installed at $exe" >&2
+    exit 0
+fi
+
+workdir=`mktemp -d /tmp/astyle.XXXXXXXXXX`
+if [ -z "$workdir" ]; then
+    echo "** Unable to create temporary working directory" 2>&1
+    exit 1
+fi
+
+# Use a sub-process for the next bit to restrict the scope of 'set -e'
+(
+    set -e ; # Exit sub-process on first error
+
+    # Put everything in this directory
+    FILESDIR=$INSTALL_ROOT/$ASTYLE_VER
+
+    svn checkout ${REPO_URL}/${ASTYLE_VER}/AStyle $workdir
+
+    cd $workdir
+
+    make_args="DESTDIR=$FILESDIR"
+    
+    echo "Creating Makefiles..."
+    cmake .
+    
+    echo "Making astyle..."
+    call_make $make_args
+
+    echo "Installing astyle..."
+    mkdir -p $FILESDIR
+    call_make install $make_args
+    # make install DESTDIR=~/astyle.local/3.1
+)
+status=$?
+
+if [ $status -eq 0 ]; then
+    rm -rf $workdir
+else
+    "** Script failed. Work dir is $workdir" >&2
+fi
+
+exit $status

--- a/scripts/install_astyle_dependencies_with_apt.sh
+++ b/scripts/install_astyle_dependencies_with_apt.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eufx
+
+PACKAGES="subversion cmake"
+        
+apt-get -yq --no-install-suggests --no-install-recommends install $PACKAGES

--- a/scripts/run_astyle.sh
+++ b/scripts/run_astyle.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+
+# Script to run astyle on the code
+#
+# Usage: /path/to/run_astyle.sh
+#
+# Note: the script must be run from the root directory of the xrdp repository
+
+INSTALL_ROOT=~/astyle.local
+ASTYLE_FROM_XRDP=$INSTALL_ROOT/3.1/usr/bin/astyle
+MIN_ASTYLE_VER="3.1"
+
+# ----------------------------------------------------------------------------
+# U S A G E
+# ----------------------------------------------------------------------------
+usage()
+{
+    echo "** Usage: $0"
+    echo "   e.g. $0"
+} >&2
+
+# ----------------------------------------------------------------------------
+# M A I N
+# ----------------------------------------------------------------------------
+if [ $# -ne 0 ]; then
+    usage
+    exit 1
+fi
+
+# check if the built-in astyle meets the minimum requrements
+ASTYLE_FROM_OS_VER_OUTPUT=`astyle --version | grep "Artistic Style Version" | cut -d' ' -f4`
+
+ASTYLE=""
+ERROR_MESSAGE=""
+if [ ! -z "$ASTYLE_FROM_OS_VER_OUTPUT" ]; then
+    # astyle is installed, so check if it's version meets the minimum requirements
+    LOWEST_VERSION=`echo -e "$MIN_ASTYLE_VER\n$ASTYLE_FROM_OS_VER_OUTPUT" | sort -V | head -n1`
+    if [ "$MIN_ASTYLE_VER" = "$LOWEST_VERSION" ]; then
+        ASTYLE=astyle
+    else
+        ERROR_MESSAGE="The version of astyle installed does not meet the minimum version requirement: >= $MIN_ASTYLE_VER "
+    fi
+else
+    ERROR_MESSAGE="astyle is not installed on the system path"
+fi
+
+if [ -z "$ASTYLE" ]; then
+    # astyle from the os is invlid, fallback to the xrdp version if it is installed
+    if [ -x "$ASTYLE_FROM_XRDP" ]; then
+        ASTYLE="$ASTYLE_FROM_XRDP"
+        ERROR_MESSAGE=""
+    else
+        ERROR_MESSAGE="${ERROR_MESSAGE}\nastyle $MIN_ASTYLE_VER is not installed at the expected path: $ASTYLE_FROM_XRDP"
+    fi
+fi
+
+if [ ! -z "$ERROR_MESSAGE" ]; then
+    echo "$ERROR_MESSAGE"
+    exit 1
+fi
+
+if [ ! -f "astyle_config.as" ]; then
+    echo "$0 must be run from the root xrdp repository directory which "
+    echo "contains the 'astyle_config.as' file."
+    exit 2
+fi
+
+ASTYLE_FLAGS="--options=astyle_config.as ./\*.c ./\*.h"
+
+# Display the astyle version and command for debugging
+"$ASTYLE" --version && {
+    echo Command: $ASTYLE $ASTYLE_FLAGS
+    "$ASTYLE" $ASTYLE_FLAGS
+}

--- a/sesman/chansrv/chansrv.h
+++ b/sesman/chansrv/chansrv.h
@@ -35,9 +35,9 @@ int
 g_is_term(void);
 
 int send_channel_data(int chan_id, const char *data, int size);
-int send_rail_drawing_orders(char* data, int size);
+int send_rail_drawing_orders(char *data, int size);
 int main_cleanup(void);
-int add_timeout(int msoffset, void (*callback)(void* data), void* data);
+int add_timeout(int msoffset, void (*callback)(void *data), void *data);
 
 #ifndef GSET_UINT8
 #define GSET_UINT8(_ptr, _offset, _data) \

--- a/sesman/chansrv/chansrv_fuse.c
+++ b/sesman/chansrv/chansrv_fuse.c
@@ -805,7 +805,7 @@ xfuse_add_clip_dir_item(const char *filename, int flags, int size, int lindex)
                                            (0666 | S_IFREG));
         if (xinode == NULL)
         {
-            LOG(LOG_LEVEL_INFO, 
+            LOG(LOG_LEVEL_INFO,
                 "failed to create file %s in xrdp filesystem", filename);
         }
         else

--- a/sesman/chansrv/chansrv_fuse.h
+++ b/sesman/chansrv/chansrv_fuse.h
@@ -76,9 +76,9 @@ struct state_close;
 
 /* functions that are invoked from devredir */
 void xfuse_devredir_cb_enum_dir_add_entry(
-                                 struct state_dirscan *fip,
-                                 const char *name,
-                                 const struct file_attr *fattr);
+    struct state_dirscan *fip,
+    const char *name,
+    const struct file_attr *fattr);
 void xfuse_devredir_cb_enum_dir_done(struct state_dirscan *fip,
                                      enum NTSTATUS IoStatus);
 
@@ -101,10 +101,10 @@ void xfuse_devredir_cb_read_file(struct state_read *fip,
                                  enum NTSTATUS IoStatus,
                                  const char *buf, size_t length);
 void xfuse_devredir_cb_write_file(
-                                 struct state_write *fip,
-                                 enum NTSTATUS IoStatus,
-                                 off_t offset,
-                                 size_t length);
+    struct state_write *fip,
+    enum NTSTATUS IoStatus,
+    off_t offset,
+    size_t length);
 
 void xfuse_devredir_cb_rmdir_or_file(struct state_remove *fip,
                                      enum NTSTATUS IoStatus);

--- a/sesman/chansrv/chansrv_xfs.h
+++ b/sesman/chansrv/chansrv_xfs.h
@@ -278,7 +278,7 @@ xfs_get_file_open_count(struct xfs_fs *xfs, fuse_ino_t inum);
  */
 void
 xfs_delete_redirected_entries_with_device_id(struct xfs_fs *xfs,
-                                             tui32 device_id);
+        tui32 device_id);
 
 /*
  * Check an entry move will be successful

--- a/sesman/chansrv/clipboard_common.h
+++ b/sesman/chansrv/clipboard_common.h
@@ -128,7 +128,7 @@ struct clip_file_desc /* CLIPRDR_FILEDESCRIPTOR */
 };
 
 int clipboard_out_unicode(struct stream *s, const char *text,
-                                 int num_chars);
+                          int num_chars);
 int clipboard_in_unicode(struct stream *s, char *text, int *num_chars);
 
 #endif

--- a/sesman/chansrv/devredir.h
+++ b/sesman/chansrv/devredir.h
@@ -27,10 +27,10 @@
 int devredir_init(void);
 int devredir_deinit(void);
 
-int devredir_data_in(struct stream* s, int chan_id, int chan_flags,
+int devredir_data_in(struct stream *s, int chan_id, int chan_flags,
                      int length, int total_length);
 
-int devredir_get_wait_objs(tbus* objs, int* count, int* timeout);
+int devredir_get_wait_objs(tbus *objs, int *count, int *timeout);
 int devredir_check_wait_objs(void);
 
 /* misc stuff */
@@ -57,23 +57,23 @@ struct state_close;
 /* called from FUSE module */
 
 int devredir_get_dir_listing(struct state_dirscan *fusep, tui32 device_id,
-                              const char *path);
+                             const char *path);
 
 int devredir_lookup_entry(struct state_lookup *fusep, tui32 device_id,
-                           const char *path);
+                          const char *path);
 
 int devredir_setattr_for_entry(
-                           struct state_setattr *fusep, tui32 device_id,
-                           const char *filename,
-                           const struct file_attr *fattr,
-                           tui32 to_set);
+    struct state_setattr *fusep, tui32 device_id,
+    const char *filename,
+    const struct file_attr *fattr,
+    tui32 to_set);
 
 int devredir_file_create(
-                        struct state_create *fusep, tui32 device_id,
-                        const char *path, int mode);
+    struct state_create *fusep, tui32 device_id,
+    const char *path, int mode);
 
 int devredir_file_open(struct state_open *fusep, tui32 device_id,
-                        const char *path, int flags);
+                       const char *path, int flags);
 
 int devredir_file_close(struct state_close *fusep, tui32 device_id,
                         tui32 file_id);
@@ -87,9 +87,9 @@ devredir_file_write(struct state_write *fusep, tui32 DeviceId, tui32 FileId,
                     const char *buf, int Length, tui64 Offset);
 
 int devredir_file_rename(
-                        struct state_rename *fusep, tui32 device_id,
-                        const char *old_name,
-                        const char *new_name);
+    struct state_rename *fusep, tui32 device_id,
+    const char *old_name,
+    const char *new_name);
 
 int
 devredir_rmdir_or_file(struct state_remove *fusep, tui32 device_id,

--- a/sesman/chansrv/fifo.h
+++ b/sesman/chansrv/fifo.h
@@ -16,20 +16,20 @@
  * limitations under the License.
  */
 
- /* FIFO implementation to store a pointer to a user struct */
+/* FIFO implementation to store a pointer to a user struct */
 
 typedef struct fifo
 {
-    long* user_data;
+    long *user_data;
     int   rd_ptr;
     int   wr_ptr;
     int   entries;
 } FIFO;
 
-int   fifo_init(FIFO* fp, int num_entries);
-int   fifo_deinit(FIFO* fp);
-int   fifo_is_empty(FIFO* fp);
-int   fifo_insert(FIFO* fp, void* data);
-void* fifo_remove(FIFO* fp);
-void* fifo_peek(FIFO* fp);
+int   fifo_init(FIFO *fp, int num_entries);
+int   fifo_deinit(FIFO *fp);
+int   fifo_is_empty(FIFO *fp);
+int   fifo_insert(FIFO *fp, void *data);
+void *fifo_remove(FIFO *fp);
+void *fifo_peek(FIFO *fp);
 

--- a/sesman/chansrv/irp.h
+++ b/sesman/chansrv/irp.h
@@ -105,18 +105,18 @@ struct irp
     void      *user_data;
 };
 
-IRP * devredir_irp_new(void);
+IRP *devredir_irp_new(void);
 /* As above, but allocates sufficent space for the specified
  * pathname, and copies it in to the pathname field */
-IRP * devredir_irp_with_pathname_new(const char *pathname);
+IRP *devredir_irp_with_pathname_new(const char *pathname);
 /* As above, but specifies a pathname length with pathname
  * initially set to "". Use if you need to modify the pathname
  * significantly */
-IRP * devredir_irp_with_pathnamelen_new(unsigned int pathnamelen);
+IRP *devredir_irp_with_pathnamelen_new(unsigned int pathnamelen);
 int   devredir_irp_delete(IRP *irp);
-IRP * devredir_irp_find(tui32 completion_id);
-IRP * devredir_irp_find_by_fileid(tui32 FileId);
-IRP * devredir_irp_get_last(void);
+IRP *devredir_irp_find(tui32 completion_id);
+IRP *devredir_irp_find_by_fileid(tui32 FileId);
+IRP *devredir_irp_get_last(void);
 void  devredir_irp_dump(void);
 
 #endif /* end ifndef __IRP_H */

--- a/sesman/chansrv/pcsc/xrdp_pcsc.c
+++ b/sesman/chansrv/pcsc/xrdp_pcsc.c
@@ -198,7 +198,7 @@ connect_to_chansrv(void)
     if (dis < 0)
     {
         LLOGLN(0, ("connect_to_chansrv: error, don't understand DISPLAY='%s'",
-               xrdp_display));
+                   xrdp_display));
         return 1;
     }
     g_sck = socket(PF_LOCAL, SOCK_STREAM, 0);

--- a/sesman/chansrv/rail.h
+++ b/sesman/chansrv/rail.h
@@ -28,10 +28,10 @@ rail_init(void);
 int
 rail_deinit(void);
 int
-rail_data_in(struct stream* s, int chan_id, int chan_flags,
+rail_data_in(struct stream *s, int chan_id, int chan_flags,
              int length, int total_length);
 int
-rail_xevent(void* xevent);
+rail_xevent(void *xevent);
 int rail_request_title(int window_id);
 
 #endif

--- a/sesman/chansrv/smartcard.h
+++ b/sesman/chansrv/smartcard.h
@@ -112,61 +112,61 @@ int  scard_init(void);
 int  scard_deinit(void);
 int  scard_send_establish_context(void *user_data, int scope);
 int  scard_send_release_context(void *user_data,
-                                       char *context, int context_bytes);
+                                char *context, int context_bytes);
 int  scard_send_is_valid_context(void *user_data,
-                                        char *context, int context_bytes);
+                                 char *context, int context_bytes);
 int  scard_send_list_readers(void *user_data,
-                                    char *context, int context_bytes,
-                                    char *groups, int cchReaders, int wide);
+                             char *context, int context_bytes,
+                             char *groups, int cchReaders, int wide);
 
 int  scard_send_get_status_change(void *user_data,
-                                         char *context, int context_bytes,
-                                         int wide, tui32 timeout,
-                                         tui32 num_readers, READER_STATE* rsa);
+                                  char *context, int context_bytes,
+                                  int wide, tui32 timeout,
+                                  tui32 num_readers, READER_STATE *rsa);
 
 int  scard_send_connect(void *user_data,
-                               char *context, int context_bytes, int wide,
-                               READER_STATE* rs);
+                        char *context, int context_bytes, int wide,
+                        READER_STATE *rs);
 
 int  scard_send_reconnect(void *user_data,
-                                 char *context, int context_bytes,
-                                 char *card, int card_bytes,
-                                 READER_STATE* rs);
+                          char *context, int context_bytes,
+                          char *card, int card_bytes,
+                          READER_STATE *rs);
 
 int  scard_send_begin_transaction(void *user_data,
-                                         char *context, int context_bytes,
-                                         char *card, int card_bytes);
-int  scard_send_end_transaction(void *user_data,
-                                       char *context, int context_bytes,
-                                       char *card, int card_bytes,
-                                       tui32 dwDisposition);
-int  scard_send_status(void *user_data, int wide,
-                              char *context, int context_bytes,
-                              char *card, int card_bytes,
-                              int cchReaderLen, int cbAtrLen);
-int  scard_send_disconnect(void *user_data,
                                   char *context, int context_bytes,
-                                  char *card, int card_bytes,
-                                  int dwDisposition);
-
-int  scard_send_transmit(void *user_data,
+                                  char *card, int card_bytes);
+int  scard_send_end_transaction(void *user_data,
                                 char *context, int context_bytes,
                                 char *card, int card_bytes,
-                                char *send_data, int send_bytes, int recv_bytes,
-                                struct xrdp_scard_io_request *send_ior,
-                                struct xrdp_scard_io_request *recv_ior);
+                                tui32 dwDisposition);
+int  scard_send_status(void *user_data, int wide,
+                       char *context, int context_bytes,
+                       char *card, int card_bytes,
+                       int cchReaderLen, int cbAtrLen);
+int  scard_send_disconnect(void *user_data,
+                           char *context, int context_bytes,
+                           char *card, int card_bytes,
+                           int dwDisposition);
+
+int  scard_send_transmit(void *user_data,
+                         char *context, int context_bytes,
+                         char *card, int card_bytes,
+                         char *send_data, int send_bytes, int recv_bytes,
+                         struct xrdp_scard_io_request *send_ior,
+                         struct xrdp_scard_io_request *recv_ior);
 
 int  scard_send_control(void *user_data,
-                               char *context, int context_bytes,
-                               char *card, int card_bytes,
-                               char *send_data, int send_bytes,
-                               int recv_bytes, int control_code);
+                        char *context, int context_bytes,
+                        char *card, int card_bytes,
+                        char *send_data, int send_bytes,
+                        int recv_bytes, int control_code);
 
 int  scard_send_cancel(void *user_data,
-                              char *context, int context_bytes);
+                       char *context, int context_bytes);
 
 int  scard_send_get_attrib(void *user_data, char *card, int card_bytes,
-                                  READER_STATE* rs);
+                           READER_STATE *rs);
 
 /*
  * Notes:

--- a/sesman/chansrv/smartcard_pcsc.h
+++ b/sesman/chansrv/smartcard_pcsc.h
@@ -29,61 +29,61 @@ int scard_pcsc_check_wait_objs(void);
 int scard_pcsc_init(void);
 int scard_pcsc_deinit(void);
 int scard_function_establish_context_return(void *user_data,
-                                                   struct stream *in_s,
-                                                   int len, int status);
+        struct stream *in_s,
+        int len, int status);
 int scard_function_release_context_return(void *user_data,
-                                                 struct stream *in_s,
-                                                 int len, int status);
+        struct stream *in_s,
+        int len, int status);
 int scard_function_list_readers_return(void *user_data,
-                                              struct stream *in_s,
-                                              int len, int status);
+                                       struct stream *in_s,
+                                       int len, int status);
 
 int scard_function_transmit_return(void *user_data,
-                                          struct stream *in_s,
-                                          int len, int status);
+                                   struct stream *in_s,
+                                   int len, int status);
 
 int scard_function_control_return(void *user_data,
-                                         struct stream *in_s,
-                                         int len, int status);
+                                  struct stream *in_s,
+                                  int len, int status);
 
 int scard_function_get_status_change_return(void *user_data,
-                                                   struct stream *in_s,
-                                                   int len, int status);
+        struct stream *in_s,
+        int len, int status);
 
 int scard_function_connect_return(void *user_data,
-                                         struct stream *in_s,
-                                         int len, int status);
+                                  struct stream *in_s,
+                                  int len, int status);
 
 int scard_function_status_return(void *user_data,
-                                        struct stream *in_s,
-                                        int len, int status);
+                                 struct stream *in_s,
+                                 int len, int status);
 
 int scard_function_begin_transaction_return(void *user_data,
-                                                   struct stream *in_s,
-                                                   int len, int status);
+        struct stream *in_s,
+        int len, int status);
 
 int scard_function_end_transaction_return(void *user_data,
-                                                 struct stream *in_s,
-                                                 int len, int status);
+        struct stream *in_s,
+        int len, int status);
 
 int scard_function_is_context_valid_return(void *user_data,
-                                                  struct stream *in_s,
-                                                  int len, int status);
+        struct stream *in_s,
+        int len, int status);
 
 int scard_function_reconnect_return(void *user_data,
-                                           struct stream *in_s,
-                                           int len, int status);
+                                    struct stream *in_s,
+                                    int len, int status);
 
 int scard_function_disconnect_return(void *user_data,
-                                            struct stream *in_s,
-                                            int len, int status);
+                                     struct stream *in_s,
+                                     int len, int status);
 
 int scard_function_cancel_return(void *user_data,
-                                        struct stream *in_s,
-                                        int len, int status);
+                                 struct stream *in_s,
+                                 int len, int status);
 
 int scard_function_get_attrib_return(void *user_data,
-                                            struct stream *in_s,
-                                            int len, int status);
+                                     struct stream *in_s,
+                                     int len, int status);
 
 #endif /* end #ifndef _SMARTCARD_PCSC_H */

--- a/sesman/chansrv/sound.h
+++ b/sesman/chansrv/sound.h
@@ -52,10 +52,10 @@
 
 int sound_init(void);
 int sound_deinit(void);
-int sound_get_wait_objs(tbus* objs, int* count, int* timeout);
+int sound_get_wait_objs(tbus *objs, int *count, int *timeout);
 int sound_check_wait_objs(void);
 
-int sound_data_in(struct stream* s, int chan_id, int chan_flags,
-                         int length, int total_length);
+int sound_data_in(struct stream *s, int chan_id, int chan_flags,
+                  int length, int total_length);
 
 #endif

--- a/sesman/chansrv/xcommon.h
+++ b/sesman/chansrv/xcommon.h
@@ -33,7 +33,7 @@ xcommon_get_local_time(void);
 int
 xcommon_init(void);
 int
-xcommon_get_wait_objs(tbus* objs, int* count, int* timeout);
+xcommon_get_wait_objs(tbus *objs, int *count, int *timeout);
 int
 xcommon_check_wait_objs(void);
 void

--- a/sesman/config.h
+++ b/sesman/config.h
@@ -77,13 +77,15 @@
 #define SESMAN_CFG_SESS_POLICY_UBDI_S "UBDI"
 #define SESMAN_CFG_SESS_POLICY_UBDC_S "UBDC"
 
-enum SESMAN_CFG_SESS_POLICY_BITS {
+enum SESMAN_CFG_SESS_POLICY_BITS
+{
     SESMAN_CFG_SESS_POLICY_D = 0x01,
     SESMAN_CFG_SESS_POLICY_I = 0x02,
     SESMAN_CFG_SESS_POLICY_C = 0x04
 };
 
-enum SESMAN_CFG_SESS_POLICY {
+enum SESMAN_CFG_SESS_POLICY
+{
     SESMAN_CFG_SESS_POLICY_DFLT = 0,
     SESMAN_CFG_SESS_POLICY_UBD = SESMAN_CFG_SESS_POLICY_D,
     SESMAN_CFG_SESS_POLICY_UBI = SESMAN_CFG_SESS_POLICY_I,
@@ -100,38 +102,38 @@ enum SESMAN_CFG_SESS_POLICY {
  */
 struct config_security
 {
-  /**
-   * @var allow_root
-   * @brief allow root login on TS
-   */
-  int allow_root;
-  /**
-   * @var login_retry
-   * @brief maximum login attempts
-   */
-  int login_retry;
-  /**
-   * @var ts_users
-   * @brief Terminal Server Users group
-   */
-  int ts_users_enable;
-  int ts_users;
-  /**
-   * @var ts_admins
-   * @brief Terminal Server Administrators group
-   */
-  int ts_admins_enable;
-  int ts_admins;
-  /**
-   * @var ts_always_group_check
-   * @brief if the Groups are not found deny access
-   */
-  int ts_always_group_check;
-  /**
-   * @var restrict_outbound_clipboard
-   * @brief if the clipboard should be enforced restricted. If true only allow client -> server, not vice versa.
-   */
-  int restrict_outbound_clipboard;
+    /**
+     * @var allow_root
+     * @brief allow root login on TS
+     */
+    int allow_root;
+    /**
+     * @var login_retry
+     * @brief maximum login attempts
+     */
+    int login_retry;
+    /**
+     * @var ts_users
+     * @brief Terminal Server Users group
+     */
+    int ts_users_enable;
+    int ts_users;
+    /**
+     * @var ts_admins
+     * @brief Terminal Server Administrators group
+     */
+    int ts_admins_enable;
+    int ts_admins;
+    /**
+     * @var ts_always_group_check
+     * @brief if the Groups are not found deny access
+     */
+    int ts_always_group_check;
+    /**
+     * @var restrict_outbound_clipboard
+     * @brief if the clipboard should be enforced restricted. If true only allow client -> server, not vice versa.
+     */
+    int restrict_outbound_clipboard;
 };
 
 /**
@@ -142,36 +144,36 @@ struct config_security
  */
 struct config_sessions
 {
-  /**
-   * @var x11_display_offset
-   * @brief X11 TCP port offset. default value: 10
-   */
-  int x11_display_offset;
-  /**
-   * @var max_sessions
-   * @brief maximum number of allowed sessions. 0 for unlimited
-   */
-  int max_sessions;
-  /**
-   * @var max_idle_time
-   * @brief maximum idle time for each session
-   */
-  int max_idle_time;
-  /**
-   * @var max_disc_time
-   * @brief maximum disconnected time for each session
-   */
-  int max_disc_time;
-  /**
-   * @var kill_disconnected
-   * @brief enables automatic killing of disconnected session
-   */
-  int kill_disconnected;
-  /**
-   * @var policy
-   * @brief session allocation policy
-   */
-  enum SESMAN_CFG_SESS_POLICY policy;
+    /**
+     * @var x11_display_offset
+     * @brief X11 TCP port offset. default value: 10
+     */
+    int x11_display_offset;
+    /**
+     * @var max_sessions
+     * @brief maximum number of allowed sessions. 0 for unlimited
+     */
+    int max_sessions;
+    /**
+     * @var max_idle_time
+     * @brief maximum idle time for each session
+     */
+    int max_idle_time;
+    /**
+     * @var max_disc_time
+     * @brief maximum disconnected time for each session
+     */
+    int max_disc_time;
+    /**
+     * @var kill_disconnected
+     * @brief enables automatic killing of disconnected session
+     */
+    int kill_disconnected;
+    /**
+     * @var policy
+     * @brief session allocation policy
+     */
+    enum SESMAN_CFG_SESS_POLICY policy;
 };
 
 /**
@@ -186,88 +188,88 @@ struct config_sessions
  */
 struct config_sesman
 {
-  /**
-   * @var sesman_ini
-   * @brief File that these parameters are read from
-   */
-  char *sesman_ini;
+    /**
+     * @var sesman_ini
+     * @brief File that these parameters are read from
+     */
+    char *sesman_ini;
 
-  /**
-   * @var listen_address
-   * @brief Listening address
-   */
-  char listen_address[32];
-  /**
-   * @var listen_port
-   * @brief Listening port
-   */
-  char listen_port[16];
-  /**
-   * @var enable_user_wm
-   * @brief Flag that enables user specific wm
-   */
-  int enable_user_wm;
-  /**
-   * @var default_wm
-   * @brief Default window manager
-   */
-  char *default_wm;
-  /**
-   * @var user_wm
-   * @brief Default window manager
-   */
-  char user_wm[32];
-  /**
-   * @var reconnect_sh
-   * @brief Script executed when reconnected
-   */
-  char *reconnect_sh;
-  /**
-   * @var auth_file_path
-   * @brief Auth file path
-   */
-  char* auth_file_path;
-  /**
-   * @var vnc_params
-   * @brief Xvnc additional parameter list
-   */
-  struct list* vnc_params;
-  /**
-   * @var rdp_params
-   * @brief X11rdp additional parameter list
-   */
-  struct list* rdp_params;
-  /**
-   * @var xorg_params
-   * @brief Xorg additional parameter list
-   */
-  struct list* xorg_params;
-  /**
-   * @var log
-   * @brief Log configuration struct
-   */
-  //struct log_config log;
-  /**
-   * @var sec
-   * @brief Security configuration options struct
-   */
-  struct config_security sec;
-  /**
-   * @var sess
-   * @brief Session configuration options struct
-   */
-  struct config_sessions sess;
+    /**
+     * @var listen_address
+     * @brief Listening address
+     */
+    char listen_address[32];
+    /**
+     * @var listen_port
+     * @brief Listening port
+     */
+    char listen_port[16];
+    /**
+     * @var enable_user_wm
+     * @brief Flag that enables user specific wm
+     */
+    int enable_user_wm;
+    /**
+     * @var default_wm
+     * @brief Default window manager
+     */
+    char *default_wm;
+    /**
+     * @var user_wm
+     * @brief Default window manager
+     */
+    char user_wm[32];
+    /**
+     * @var reconnect_sh
+     * @brief Script executed when reconnected
+     */
+    char *reconnect_sh;
+    /**
+     * @var auth_file_path
+     * @brief Auth file path
+     */
+    char *auth_file_path;
+    /**
+     * @var vnc_params
+     * @brief Xvnc additional parameter list
+     */
+    struct list *vnc_params;
+    /**
+     * @var rdp_params
+     * @brief X11rdp additional parameter list
+     */
+    struct list *rdp_params;
+    /**
+     * @var xorg_params
+     * @brief Xorg additional parameter list
+     */
+    struct list *xorg_params;
+    /**
+     * @var log
+     * @brief Log configuration struct
+     */
+    //struct log_config log;
+    /**
+     * @var sec
+     * @brief Security configuration options struct
+     */
+    struct config_security sec;
+    /**
+     * @var sess
+     * @brief Session configuration options struct
+     */
+    struct config_sessions sess;
 
-  /**
-   * @var env_names
-   * @brief environment variable name list
-   */
-  struct list* env_names;
-   /**
-   * @var env_values
-   * @brief environment variable value list
-   */
-  struct list* env_values;
+    /**
+     * @var env_names
+     * @brief environment variable name list
+     */
+    struct list *env_names;
+    /**
+    * @var env_values
+    * @brief environment variable value list
+    */
+    struct list *env_values;
 };
 
 /**
@@ -279,7 +281,7 @@ struct config_sesman
  * @post pass return value to config_free() to prevent memory leaks
  *
  */
-struct config_sesman*
+struct config_sesman *
 config_read(const char *sesman_ini);
 
 /**

--- a/sesman/libscp/libscp_connection.h
+++ b/sesman/libscp/libscp_connection.h
@@ -37,7 +37,7 @@
  * @return a struct SCP_CONNECTION* object on success, NULL otherwise
  *
  */
-struct SCP_CONNECTION*
+struct SCP_CONNECTION *
 scp_connection_create(int sck);
 
 /**
@@ -47,6 +47,6 @@ scp_connection_create(int sck);
  *
  */
 void
-scp_connection_destroy(struct SCP_CONNECTION* c);
+scp_connection_destroy(struct SCP_CONNECTION *c);
 
 #endif

--- a/sesman/libscp/libscp_session.h
+++ b/sesman/libscp/libscp_session.h
@@ -37,59 +37,59 @@
  * @return a struct SCP_SESSION* object on success, NULL otherwise
  *
  */
-struct SCP_SESSION*
+struct SCP_SESSION *
 scp_session_create(void);
 
 int
-scp_session_set_type(struct SCP_SESSION* s, tui8 type);
+scp_session_set_type(struct SCP_SESSION *s, tui8 type);
 
 int
-scp_session_set_version(struct SCP_SESSION* s, tui32 version);
+scp_session_set_version(struct SCP_SESSION *s, tui32 version);
 
 int
-scp_session_set_height(struct SCP_SESSION* s, tui16 h);
+scp_session_set_height(struct SCP_SESSION *s, tui16 h);
 
 int
-scp_session_set_width(struct SCP_SESSION* s, tui16 w);
+scp_session_set_width(struct SCP_SESSION *s, tui16 w);
 
 int
-scp_session_set_bpp(struct SCP_SESSION* s, tui8 bpp);
+scp_session_set_bpp(struct SCP_SESSION *s, tui8 bpp);
 
 int
-scp_session_set_rsr(struct SCP_SESSION* s, tui8 rsr);
+scp_session_set_rsr(struct SCP_SESSION *s, tui8 rsr);
 
 int
-scp_session_set_locale(struct SCP_SESSION* s, const char *str);
+scp_session_set_locale(struct SCP_SESSION *s, const char *str);
 
 int
-scp_session_set_username(struct SCP_SESSION* s, const char *str);
+scp_session_set_username(struct SCP_SESSION *s, const char *str);
 
 int
-scp_session_set_password(struct SCP_SESSION* s, const char *str);
+scp_session_set_password(struct SCP_SESSION *s, const char *str);
 
 int
-scp_session_set_domain(struct SCP_SESSION* s, const char *str);
+scp_session_set_domain(struct SCP_SESSION *s, const char *str);
 
 int
-scp_session_set_program(struct SCP_SESSION* s, const char *str);
+scp_session_set_program(struct SCP_SESSION *s, const char *str);
 
 int
-scp_session_set_directory(struct SCP_SESSION* s, const char *str);
+scp_session_set_directory(struct SCP_SESSION *s, const char *str);
 
 int
-scp_session_set_client_ip(struct SCP_SESSION* s, const char *str);
+scp_session_set_client_ip(struct SCP_SESSION *s, const char *str);
 
 int
-scp_session_set_hostname(struct SCP_SESSION* s, const char *str);
+scp_session_set_hostname(struct SCP_SESSION *s, const char *str);
 
 int
-scp_session_set_addr(struct SCP_SESSION* s, int type, const void* addr);
+scp_session_set_addr(struct SCP_SESSION *s, int type, const void *addr);
 
 int
-scp_session_set_display(struct SCP_SESSION* s, SCP_DISPLAY display);
+scp_session_set_display(struct SCP_SESSION *s, SCP_DISPLAY display);
 
 int
-scp_session_set_errstr(struct SCP_SESSION* s, const char *str);
+scp_session_set_errstr(struct SCP_SESSION *s, const char *str);
 
 int
 scp_session_set_guid(struct SCP_SESSION *s, const tui8 *guid);
@@ -101,6 +101,6 @@ scp_session_set_guid(struct SCP_SESSION *s, const tui8 *guid);
  *
  */
 void
-scp_session_destroy(struct SCP_SESSION* s);
+scp_session_destroy(struct SCP_SESSION *s);
 
 #endif

--- a/sesman/libscp/libscp_tcp.h
+++ b/sesman/libscp/libscp_tcp.h
@@ -39,7 +39,7 @@
  *
  */
 int
-scp_tcp_force_recv(int sck, char* data, int len);
+scp_tcp_force_recv(int sck, char *data, int len);
 
 /**
  *
@@ -51,7 +51,7 @@ scp_tcp_force_recv(int sck, char* data, int len);
  *
  */
 int
-scp_tcp_force_send(int sck, char* data, int len);
+scp_tcp_force_send(int sck, char *data, int len);
 
 /**
  *
@@ -63,6 +63,6 @@ scp_tcp_force_send(int sck, char* data, int len);
  *
  */
 int
-scp_tcp_bind(int sck, char* addr, char* port);
+scp_tcp_bind(int sck, char *addr, char *port);
 
 #endif

--- a/sesman/libscp/libscp_types.h
+++ b/sesman/libscp/libscp_types.h
@@ -65,90 +65,90 @@
 
 struct SCP_CONNECTION
 {
-  int in_sck;
-  struct stream* in_s;
-  struct stream* out_s;
+    int in_sck;
+    struct stream *in_s;
+    struct stream *out_s;
 };
 
 struct SCP_SESSION
 {
-  tui8  type;
-  tui32 version;
-  tui16 height;
-  tui16 width;
-  tui8  bpp;
-  tui8  rsr;
-  char  locale[18];
-  char* username;
-  char* password;
-  char* hostname;
-  tui8  addr_type;
-  tui32 ipv4addr;
-  tui8  ipv6addr[16];
-  SCP_DISPLAY display;
-  char* errstr;
-  struct SCP_MNG_DATA* mng;
-  char* domain;
-  char* program;
-  char* directory;
-  char* client_ip;
-  tui8 guid[16];
+    tui8  type;
+    tui32 version;
+    tui16 height;
+    tui16 width;
+    tui8  bpp;
+    tui8  rsr;
+    char  locale[18];
+    char *username;
+    char *password;
+    char *hostname;
+    tui8  addr_type;
+    tui32 ipv4addr;
+    tui8  ipv6addr[16];
+    SCP_DISPLAY display;
+    char *errstr;
+    struct SCP_MNG_DATA *mng;
+    char *domain;
+    char *program;
+    char *directory;
+    char *client_ip;
+    tui8 guid[16];
 };
 
 struct SCP_DISCONNECTED_SESSION
 {
-  tui32 SID;
-  tui8  type;
-  tui8  status;
-  tui16 height;
-  tui16 width;
-  tui8  bpp;
-  tui8  idle_days;
-  tui8  idle_hours;
-  tui8  idle_minutes;
-  tui16 conn_year;
-  tui8  conn_month;
-  tui8  conn_day;
-  tui8  conn_hour;
-  tui8  conn_minute;
-  tui8  addr_type;
-  tui32 ipv4addr;
-  tui8  ipv6addr[16];
+    tui32 SID;
+    tui8  type;
+    tui8  status;
+    tui16 height;
+    tui16 width;
+    tui8  bpp;
+    tui8  idle_days;
+    tui8  idle_hours;
+    tui8  idle_minutes;
+    tui16 conn_year;
+    tui8  conn_month;
+    tui8  conn_day;
+    tui8  conn_hour;
+    tui8  conn_minute;
+    tui8  addr_type;
+    tui32 ipv4addr;
+    tui8  ipv6addr[16];
 };
 
 enum SCP_CLIENT_STATES_E
 {
-  SCP_CLIENT_STATE_OK,
-  SCP_CLIENT_STATE_NETWORK_ERR,
-  SCP_CLIENT_STATE_VERSION_ERR,
-  SCP_CLIENT_STATE_SEQUENCE_ERR,
-  SCP_CLIENT_STATE_SIZE_ERR,
-  SCP_CLIENT_STATE_INTERNAL_ERR,
-  SCP_CLIENT_STATE_SESSION_LIST,
-  SCP_CLIENT_STATE_LIST_OK,
-  SCP_CLIENT_STATE_RESEND_CREDENTIALS,
-  SCP_CLIENT_STATE_CONNECTION_DENIED,
-  SCP_CLIENT_STATE_PWD_CHANGE_REQ,
-  SCP_CLIENT_STATE_RECONNECT_SINGLE,
-  SCP_CLIENT_STATE_SELECTION_CANCEL,
-  SCP_CLIENT_STATE_END
+    SCP_CLIENT_STATE_OK,
+    SCP_CLIENT_STATE_NETWORK_ERR,
+    SCP_CLIENT_STATE_VERSION_ERR,
+    SCP_CLIENT_STATE_SEQUENCE_ERR,
+    SCP_CLIENT_STATE_SIZE_ERR,
+    SCP_CLIENT_STATE_INTERNAL_ERR,
+    SCP_CLIENT_STATE_SESSION_LIST,
+    SCP_CLIENT_STATE_LIST_OK,
+    SCP_CLIENT_STATE_RESEND_CREDENTIALS,
+    SCP_CLIENT_STATE_CONNECTION_DENIED,
+    SCP_CLIENT_STATE_PWD_CHANGE_REQ,
+    SCP_CLIENT_STATE_RECONNECT_SINGLE,
+    SCP_CLIENT_STATE_SELECTION_CANCEL,
+    SCP_CLIENT_STATE_END
 };
 
 enum SCP_SERVER_STATES_E
 {
-  SCP_SERVER_STATE_OK,
-  SCP_SERVER_STATE_VERSION_ERR,
-  SCP_SERVER_STATE_NETWORK_ERR,
-  SCP_SERVER_STATE_SEQUENCE_ERR,
-  SCP_SERVER_STATE_INTERNAL_ERR,
-  SCP_SERVER_STATE_SESSION_TYPE_ERR,
-  SCP_SERVER_STATE_SIZE_ERR,
-  SCP_SERVER_STATE_SELECTION_CANCEL,
-  /*SCP_SERVER_STATE_FORCE_NEW,*/
-  SCP_SERVER_STATE_START_MANAGE,
-  SCP_SERVER_STATE_MNG_LISTREQ,
-  SCP_SERVER_STATE_MNG_ACTION,
-  SCP_SERVER_STATE_END
+    SCP_SERVER_STATE_OK,
+    SCP_SERVER_STATE_VERSION_ERR,
+    SCP_SERVER_STATE_NETWORK_ERR,
+    SCP_SERVER_STATE_SEQUENCE_ERR,
+    SCP_SERVER_STATE_INTERNAL_ERR,
+    SCP_SERVER_STATE_SESSION_TYPE_ERR,
+    SCP_SERVER_STATE_SIZE_ERR,
+    SCP_SERVER_STATE_SELECTION_CANCEL,
+    /*SCP_SERVER_STATE_FORCE_NEW,*/
+    SCP_SERVER_STATE_START_MANAGE,
+    SCP_SERVER_STATE_MNG_LISTREQ,
+    SCP_SERVER_STATE_MNG_ACTION,
+    SCP_SERVER_STATE_END
 };
 
 #endif

--- a/sesman/libscp/libscp_types_mng.h
+++ b/sesman/libscp/libscp_types_mng.h
@@ -34,14 +34,14 @@
 
 enum SCP_MNG_COMMAND
 {
-  SCP_MNG_CMD_KILL,
-  SCP_MNG_CMD_DISCONNECT
+    SCP_MNG_CMD_KILL,
+    SCP_MNG_CMD_DISCONNECT
 };
 
 struct SCP_MNG_DATA
 {
-  enum SCP_MNG_COMMAND cmd;
-  SCP_SID sid;
+    enum SCP_MNG_COMMAND cmd;
+    SCP_SID sid;
 };
 
 #endif

--- a/sesman/libscp/libscp_v0.h
+++ b/sesman/libscp/libscp_v0.h
@@ -39,7 +39,7 @@
  *
  */
 enum SCP_CLIENT_STATES_E
-scp_v0c_connect(struct SCP_CONNECTION* c, struct SCP_SESSION* s);
+scp_v0c_connect(struct SCP_CONNECTION *c, struct SCP_SESSION *s);
 
 /* server API */
 /**
@@ -52,7 +52,7 @@ scp_v0c_connect(struct SCP_CONNECTION* c, struct SCP_SESSION* s);
  *
  */
 enum SCP_SERVER_STATES_E
-scp_v0s_accept(struct SCP_CONNECTION* c, struct SCP_SESSION** s, int skipVchk);
+scp_v0s_accept(struct SCP_CONNECTION *c, struct SCP_SESSION **s, int skipVchk);
 
 /**
  *
@@ -61,7 +61,7 @@ scp_v0s_accept(struct SCP_CONNECTION* c, struct SCP_SESSION** s, int skipVchk);
  *
  */
 enum SCP_SERVER_STATES_E
-scp_v0s_allow_connection(struct SCP_CONNECTION* c, SCP_DISPLAY d, const tui8 *guid);
+scp_v0s_allow_connection(struct SCP_CONNECTION *c, SCP_DISPLAY d, const tui8 *guid);
 
 /**
  *
@@ -70,7 +70,7 @@ scp_v0s_allow_connection(struct SCP_CONNECTION* c, SCP_DISPLAY d, const tui8 *gu
  *
  */
 enum SCP_SERVER_STATES_E
-scp_v0s_deny_connection(struct SCP_CONNECTION* c);
+scp_v0s_deny_connection(struct SCP_CONNECTION *c);
 
 /**
  * @brief send reply to an authentication request
@@ -79,6 +79,6 @@ scp_v0s_deny_connection(struct SCP_CONNECTION* c);
  * @return
  */
 enum SCP_SERVER_STATES_E
-scp_v0s_replyauthentication(struct SCP_CONNECTION* c, unsigned short int value);
+scp_v0s_replyauthentication(struct SCP_CONNECTION *c, unsigned short int value);
 
 #endif

--- a/sesman/libscp/libscp_v1c.h
+++ b/sesman/libscp/libscp_v1c.h
@@ -32,32 +32,32 @@
 /* client API */
 /* 001 */
 enum SCP_CLIENT_STATES_E
-scp_v1c_connect(struct SCP_CONNECTION* c, struct SCP_SESSION* s);
+scp_v1c_connect(struct SCP_CONNECTION *c, struct SCP_SESSION *s);
 
 /* 004 */
 enum SCP_CLIENT_STATES_E
-scp_v1c_resend_credentials(struct SCP_CONNECTION* c, struct SCP_SESSION* s);
+scp_v1c_resend_credentials(struct SCP_CONNECTION *c, struct SCP_SESSION *s);
 
 /* 021 */
 enum SCP_CLIENT_STATES_E
-scp_v1c_pwd_change(struct SCP_CONNECTION* c, char* newpass);
+scp_v1c_pwd_change(struct SCP_CONNECTION *c, char *newpass);
 
 /* 022 */
 enum SCP_CLIENT_STATES_E
-scp_v1c_pwd_change_cancel(struct SCP_CONNECTION* c);
+scp_v1c_pwd_change_cancel(struct SCP_CONNECTION *c);
 
 /* 041 */
 enum SCP_CLIENT_STATES_E
-scp_v1c_get_session_list(struct SCP_CONNECTION* c, int* scount,
-                         struct SCP_DISCONNECTED_SESSION** s);
+scp_v1c_get_session_list(struct SCP_CONNECTION *c, int *scount,
+                         struct SCP_DISCONNECTED_SESSION **s);
 
 /* 043 */
 enum SCP_CLIENT_STATES_E
-scp_v1c_select_session(struct SCP_CONNECTION* c, struct SCP_SESSION* s,
+scp_v1c_select_session(struct SCP_CONNECTION *c, struct SCP_SESSION *s,
                        SCP_SID sid);
 
 /* 044 */
 enum SCP_CLIENT_STATES_E
-scp_v1c_select_session_cancel(struct SCP_CONNECTION* c);
+scp_v1c_select_session_cancel(struct SCP_CONNECTION *c);
 
 #endif

--- a/sesman/libscp/libscp_v1c_mng.h
+++ b/sesman/libscp/libscp_v1c_mng.h
@@ -32,7 +32,7 @@
 /* client API */
 /* 001 */
 enum SCP_CLIENT_STATES_E
-scp_v1c_mng_connect(struct SCP_CONNECTION* c, struct SCP_SESSION* s);
+scp_v1c_mng_connect(struct SCP_CONNECTION *c, struct SCP_SESSION *s);
 
 /* 004 * /
 enum SCP_CLIENT_STATES_E
@@ -49,7 +49,7 @@ scp_v1c_pwd_change_cancel(struct SCP_CONNECTION* c);
 
 /* 041 */
 enum SCP_CLIENT_STATES_E
-scp_v1c_mng_get_session_list(struct SCP_CONNECTION* c, int* scount,
-                         struct SCP_DISCONNECTED_SESSION** s);
+scp_v1c_mng_get_session_list(struct SCP_CONNECTION *c, int *scount,
+                             struct SCP_DISCONNECTED_SESSION **s);
 
 #endif

--- a/sesman/libscp/libscp_v1s.h
+++ b/sesman/libscp/libscp_v1s.h
@@ -42,7 +42,7 @@
  * that should be free()d
  */
 enum SCP_SERVER_STATES_E
-scp_v1s_accept(struct SCP_CONNECTION* c, struct SCP_SESSION** s, int skipVchk);
+scp_v1s_accept(struct SCP_CONNECTION *c, struct SCP_SESSION **s, int skipVchk);
 
 /**
  *
@@ -53,35 +53,35 @@ scp_v1s_accept(struct SCP_CONNECTION* c, struct SCP_SESSION** s, int skipVchk);
  */
 /* 002 */
 enum SCP_SERVER_STATES_E
-scp_v1s_deny_connection(struct SCP_CONNECTION* c, const char *reason);
+scp_v1s_deny_connection(struct SCP_CONNECTION *c, const char *reason);
 
 enum SCP_SERVER_STATES_E
-scp_v1s_request_password(struct SCP_CONNECTION* c, struct SCP_SESSION* s,
+scp_v1s_request_password(struct SCP_CONNECTION *c, struct SCP_SESSION *s,
                          const char *reason);
 
 /* 020 */
 enum SCP_SERVER_STATES_E
-scp_v1s_request_pwd_change(struct SCP_CONNECTION* c, char* reason, char* npw);
+scp_v1s_request_pwd_change(struct SCP_CONNECTION *c, char *reason, char *npw);
 
 /* 023 */
 enum SCP_SERVER_STATES_E
-scp_v1s_pwd_change_error(struct SCP_CONNECTION* c, char* error, int retry, char* npw);
+scp_v1s_pwd_change_error(struct SCP_CONNECTION *c, char *error, int retry, char *npw);
 
 /* 030 */
 enum SCP_SERVER_STATES_E
-scp_v1s_connect_new_session(struct SCP_CONNECTION* c, SCP_DISPLAY d);
+scp_v1s_connect_new_session(struct SCP_CONNECTION *c, SCP_DISPLAY d);
 
 /* 032 */
 enum SCP_SERVER_STATES_E
-scp_v1s_connection_error(struct SCP_CONNECTION* c, const char *error);
+scp_v1s_connection_error(struct SCP_CONNECTION *c, const char *error);
 
 /* 040 */
 enum SCP_SERVER_STATES_E
-scp_v1s_list_sessions(struct SCP_CONNECTION* c, int sescnt,
-                      struct SCP_DISCONNECTED_SESSION* ds, SCP_SID* sid);
+scp_v1s_list_sessions(struct SCP_CONNECTION *c, int sescnt,
+                      struct SCP_DISCONNECTED_SESSION *ds, SCP_SID *sid);
 
 /* 046 was: 031 struct SCP_DISCONNECTED_SESSION* ds, */
 enum SCP_SERVER_STATES_E
-scp_v1s_reconnect_session(struct SCP_CONNECTION* c, SCP_DISPLAY d);
+scp_v1s_reconnect_session(struct SCP_CONNECTION *c, SCP_DISPLAY d);
 
 #endif

--- a/sesman/libscp/libscp_v1s_mng.h
+++ b/sesman/libscp/libscp_v1s_mng.h
@@ -40,7 +40,7 @@
  * that should be free()d
  */
 enum SCP_SERVER_STATES_E
-scp_v1s_mng_accept(struct SCP_CONNECTION* c, struct SCP_SESSION** s);
+scp_v1s_mng_accept(struct SCP_CONNECTION *c, struct SCP_SESSION **s);
 
 /**
  *
@@ -50,7 +50,7 @@ scp_v1s_mng_accept(struct SCP_CONNECTION* c, struct SCP_SESSION** s);
  */
 /* 002 */
 enum SCP_SERVER_STATES_E
-scp_v1s_mng_allow_connection(struct SCP_CONNECTION* c, struct SCP_SESSION* s);
+scp_v1s_mng_allow_connection(struct SCP_CONNECTION *c, struct SCP_SESSION *s);
 
 /**
  *
@@ -61,7 +61,7 @@ scp_v1s_mng_allow_connection(struct SCP_CONNECTION* c, struct SCP_SESSION* s);
  */
 /* 003 */
 enum SCP_SERVER_STATES_E
-scp_v1s_mng_deny_connection(struct SCP_CONNECTION* c, const char *reason);
+scp_v1s_mng_deny_connection(struct SCP_CONNECTION *c, const char *reason);
 
 /**
  *
@@ -71,8 +71,8 @@ scp_v1s_mng_deny_connection(struct SCP_CONNECTION* c, const char *reason);
  */
 /* 006 */
 enum SCP_SERVER_STATES_E
-scp_v1s_mng_list_sessions(struct SCP_CONNECTION* c, struct SCP_SESSION* s,
-                          int sescnt, struct SCP_DISCONNECTED_SESSION* ds);
+scp_v1s_mng_list_sessions(struct SCP_CONNECTION *c, struct SCP_SESSION *s,
+                          int sescnt, struct SCP_DISCONNECTED_SESSION *ds);
 //                           SCP_SID* sid);
 
 #endif

--- a/sesman/libscp/libscp_vX.h
+++ b/sesman/libscp/libscp_vX.h
@@ -42,6 +42,6 @@
  *          It this memory needs to be g_free()d
  *
  */
-enum SCP_SERVER_STATES_E scp_vXs_accept(struct SCP_CONNECTION* c, struct SCP_SESSION** s);
+enum SCP_SERVER_STATES_E scp_vXs_accept(struct SCP_CONNECTION *c, struct SCP_SESSION **s);
 
 #endif

--- a/sesman/scp.h
+++ b/sesman/scp.h
@@ -39,7 +39,7 @@
  * @param socket the connection socket
  *
  */
-void*
-scp_process_start(void* sck);
+void *
+scp_process_start(void *sck);
 
 #endif

--- a/sesman/scp_v0.h
+++ b/sesman/scp_v0.h
@@ -38,6 +38,6 @@
  *
  */
 void
-scp_v0_process(struct SCP_CONNECTION* c, struct SCP_SESSION* s);
+scp_v0_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s);
 
 #endif

--- a/sesman/scp_v1.h
+++ b/sesman/scp_v1.h
@@ -36,6 +36,6 @@
  *
  */
 void
-scp_v1_process(struct SCP_CONNECTION* c, struct SCP_SESSION* s);
+scp_v1_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s);
 
 #endif

--- a/sesman/scp_v1_mng.h
+++ b/sesman/scp_v1_mng.h
@@ -36,6 +36,6 @@
  *
  */
 void
-scp_v1_mng_process(struct SCP_CONNECTION* c, struct SCP_SESSION* s);
+scp_v1_mng_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s);
 
 #endif

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -351,7 +351,7 @@ wait_for_xserver(int display)
     i = 0;
 
     LOG(LOG_LEVEL_DEBUG, "Waiting for X server to start on display %d", display);
-    
+
     while (!x_server_running(display))
     {
         i++;
@@ -390,7 +390,7 @@ session_start_chansrv(char *username, int display)
         /* building parameters */
         g_snprintf(exe_path, sizeof(exe_path), "%s/xrdp-chansrv",
                    XRDP_SBIN_PATH);
-        
+
         list_add_item(chansrv_params, (intptr_t) g_strdup(exe_path));
         list_add_item(chansrv_params, 0); /* mandatory */
 
@@ -400,7 +400,7 @@ session_start_chansrv(char *username, int display)
 
         /* executing chansrv */
         g_execvp(exe_path, (char **) (chansrv_params->items));
-        
+
         /* should not get here */
         list_delete(chansrv_params);
         g_exit(1);
@@ -491,7 +491,7 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
     }
     else if (pid == 0)
     {
-        LOG(LOG_LEVEL_INFO, 
+        LOG(LOG_LEVEL_INFO,
             "[session start] (display %d): calling auth_start_session from pid %d",
             display, g_getpid());
         auth_start_session(data, display);
@@ -525,7 +525,7 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
             if (g_setsid() < 0)
             {
                 LOG(LOG_LEVEL_WARNING,
-                    "[session start] (display %d): setsid failed - pid %d", 
+                    "[session start] (display %d): setsid failed - pid %d",
                     display, g_getpid());
             }
 
@@ -579,7 +579,7 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
                     {
                         LOG(LOG_LEVEL_INFO,
                             "Starting user requested window manager on "
-                            "display %d with embeded arguments using a shell: %s", 
+                            "display %d with embeded arguments using a shell: %s",
                             display, s->program);
                         const char *params[] = {"sh", "-c", s->program, NULL};
                         g_execvp("/bin/sh", (char **)params);
@@ -597,7 +597,7 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
                     LOG(LOG_LEVEL_DEBUG, "The user session on display %d did "
                         "not request a specific window manager", display);
                 }
-                
+
                 /* try to execute user window manager if enabled */
                 if (g_cfg->enable_user_wm)
                 {
@@ -611,15 +611,15 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
                     }
                     else
                     {
-                        LOG(LOG_LEVEL_DEBUG, 
+                        LOG(LOG_LEVEL_DEBUG,
                             "The user home directory window manager configuration "
-                            "is enabled but window manager program does not exist: %s", 
+                            "is enabled but window manager program does not exist: %s",
                             text);
                     }
                 }
-                
+
                 LOG(LOG_LEVEL_INFO,
-                    "Starting the default window manager on display %d: %s", 
+                    "Starting the default window manager on display %d: %s",
                     display, g_cfg->default_wm);
                 g_execlp3(g_cfg->default_wm, g_cfg->default_wm, 0);
 
@@ -696,7 +696,7 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
                     LOG(LOG_LEVEL_ERROR,
                         "Error setting the xauth cookie for display %d in file %s",
                         display, authfile);
-                    
+
                     LOG(LOG_LEVEL_ERROR, "A fatal error has occured attempting to start "
                         "the X server on display %d, aborting connection",
                         display);
@@ -819,17 +819,17 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
                 }
 
                 /* fire up X server */
-                LOG(LOG_LEVEL_INFO, "Starting X server on display %d: %s", 
+                LOG(LOG_LEVEL_INFO, "Starting X server on display %d: %s",
                     display, dumpItemsToString(xserver_params, execvpparams, 2048));
                 g_execvp(xserver, pp1);
-                
+
                 /* should not get here */
                 LOG(LOG_LEVEL_ERROR,
                     "Error starting X server on display %d", display);
                 LOG(LOG_LEVEL_ERROR, "A fatal error has occured attempting "
                     "to start the X server on display %d, aborting connection",
                     display);
-                
+
                 list_delete(xserver_params);
                 g_exit(1);
             }
@@ -843,7 +843,7 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
                 wait_for_xserver(display);
                 chansrv_pid = session_start_chansrv(s->username, display);
 
-                LOG(LOG_LEVEL_INFO, 
+                LOG(LOG_LEVEL_INFO,
                     "Session started successfully for user %s on display %d",
                     s->username, display);
 
@@ -851,7 +851,7 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
                  * window manager. This is approximately how long the window
                  * manager was running for */
                 LOG(LOG_LEVEL_INFO, "Session in progress on display %d, waiting "
-                    "until the window manager (pid %d) exits to end the session", 
+                    "until the window manager (pid %d) exits to end the session",
                     display, window_manager_pid);
                 wm_wait_time = g_time1();
                 wm_exit_status = g_waitpid_status(window_manager_pid);
@@ -878,14 +878,14 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
                         "was running for %d seconds.",
                         window_manager_pid, display, wm_wait_time);
                 }
-                LOG(LOG_LEVEL_INFO, 
+                LOG(LOG_LEVEL_INFO,
                     "Calling auth_stop_session and auth_end from pid %d",
                     g_getpid());
                 auth_stop_session(data);
                 auth_end(data);
 
                 LOG(LOG_LEVEL_INFO,
-                    "Terminating X server (pid %d) on display %d", 
+                    "Terminating X server (pid %d) on display %d",
                     display_pid, display);
                 g_sigterm(display_pid);
 
@@ -898,7 +898,7 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
                 LOG(LOG_LEVEL_INFO,
                     "X server on display %d (pid %d) returned exit code %d "
                     "and signal number %d",
-                    display, display_pid, xserver_exit_status.exit_code, 
+                    display, display_pid, xserver_exit_status.exit_code,
                     xserver_exit_status.signal_no);
 
                 chansrv_exit_status = g_waitpid_status(chansrv_pid);
@@ -987,7 +987,7 @@ session_reconnect_fork(int display, char *username, long data)
             /* should not get here */
             LOG(LOG_LEVEL_ERROR,
                 "Error starting session reconnection script on display %d: %s",
-                display, g_cfg->reconnect_sh);     
+                display, g_cfg->reconnect_sh);
         }
         else
         {
@@ -1057,8 +1057,8 @@ session_kill(int pid)
         if (tmp->item->pid == pid)
         {
             /* deleting the session */
-            LOG(LOG_LEVEL_INFO, 
-                "++ terminated session:  username %s, display :%d.0, session_pid %d, ip %s", 
+            LOG(LOG_LEVEL_INFO,
+                "++ terminated session:  username %s, display :%d.0, session_pid %d, ip %s",
                 tmp->item->name, tmp->item->display, tmp->item->pid, tmp->item->client_ip);
             g_free(tmp->item);
 

--- a/sesman/session.h
+++ b/sesman/session.h
@@ -48,41 +48,41 @@
 
 struct session_date
 {
-  tui16 year;
-  tui8  month;
-  tui8  day;
-  tui8  hour;
-  tui8  minute;
+    tui16 year;
+    tui8  month;
+    tui8  day;
+    tui8  hour;
+    tui8  minute;
 };
 
 #define zero_time(s) { (s)->year=0; (s)->month=0; (s)->day=0; (s)->hour=0; (s)->minute=0; }
 
 struct session_item
 {
-  char name[256];
-  int pid; /* pid of sesman waiting for wm to end */
-  int display;
-  int width;
-  int height;
-  int bpp;
-  long data;
+    char name[256];
+    int pid; /* pid of sesman waiting for wm to end */
+    int display;
+    int width;
+    int height;
+    int bpp;
+    long data;
 
-  /* status info */
-  unsigned char status;
-  unsigned char type;
+    /* status info */
+    unsigned char status;
+    unsigned char type;
 
-  /* time data  */
-  struct session_date connect_time;
-  struct session_date disconnect_time;
-  struct session_date idle_time;
-  char client_ip[256];
-  tui8 guid[16];
+    /* time data  */
+    struct session_date connect_time;
+    struct session_date disconnect_time;
+    struct session_date idle_time;
+    char client_ip[256];
+    tui8 guid[16];
 };
 
 struct session_chain
 {
-  struct session_chain* next;
-  struct session_item* item;
+    struct session_chain *next;
+    struct session_item *item;
 };
 
 /**
@@ -91,11 +91,11 @@ struct session_chain
  * @return session data or 0
  *
  */
-struct session_item*
+struct session_item *
 session_get_bydata(const char *name, int width, int height, int bpp, int type,
                    const char *client_ip);
 #ifndef session_find_item
-  #define session_find_item(a, b, c, d, e, f) session_get_bydata(a, b, c, d, e, f);
+#define session_find_item(a, b, c, d, e, f) session_get_bydata(a, b, c, d, e, f);
 #endif
 
 /**
@@ -137,7 +137,7 @@ session_sigkill_all(void);
  * @return a pointer to the session descriptor on success, NULL otherwise
  *
  */
-struct session_item*
+struct session_item *
 session_get_bypid(int pid);
 
 /**
@@ -147,7 +147,7 @@ session_get_bypid(int pid);
  * @return a pointer to the session descriptor on success, NULL otherwise
  *
  */
-struct SCP_DISCONNECTED_SESSION*
+struct SCP_DISCONNECTED_SESSION *
 session_get_byuser(const char *user, int *cnt, unsigned char flags);
 
 /**

--- a/sesman/sig.h
+++ b/sesman/sig.h
@@ -59,7 +59,7 @@ sig_sesman_session_end(int sig);
  * @brief signal handling thread
  *
  */
-void*
-sig_handler_thread(void* arg);
+void *
+sig_handler_thread(void *arg);
 
 #endif

--- a/sesman/tools/sesrun.c
+++ b/sesman/tools/sesrun.c
@@ -220,8 +220,8 @@ parse_geometry_string(const char *geom_str, struct session_params *sp)
     }
 
     if (sep_count != 1 || other_count > 0 ||
-        sepp == geom_str ||  /* Separator at start of string */
-        sepp == (p - 1) )    /* Separator at end of string */
+            sepp == geom_str ||  /* Separator at start of string */
+            sepp == (p - 1) )    /* Separator at end of string */
     {
         LOG(LOG_LEVEL_ERROR, "Invalid geometry string '%s'", geom_str);
     }

--- a/sesman/tools/tcp.h
+++ b/sesman/tools/tcp.h
@@ -37,7 +37,7 @@
  *
  */
 int
-tcp_force_recv(int sck, char* data, int len);
+tcp_force_recv(int sck, char *data, int len);
 
 /**
  *
@@ -49,7 +49,7 @@ tcp_force_recv(int sck, char* data, int len);
  *
  */
 int
-tcp_force_send(int sck, char* data, int len);
+tcp_force_send(int sck, char *data, int len);
 
 /**
  *
@@ -61,6 +61,6 @@ tcp_force_send(int sck, char* data, int len);
  *
  */
 int
-tcp_bind(int sck, char* addr, char* port);
+tcp_bind(int sck, char *addr, char *port);
 
 #endif

--- a/tcutils/mainwindow.h
+++ b/tcutils/mainwindow.h
@@ -17,41 +17,42 @@
 
 #include "utils.h"
 
-namespace Ui {
-class MainWindow;
+namespace Ui
+{
+    class MainWindow;
 }
 
 class MainWindow : public QMainWindow
 {
-    Q_OBJECT
+        Q_OBJECT
 
-public:
-    explicit MainWindow(QWidget *parent = 0);
-    ~MainWindow();
+    public:
+        explicit MainWindow(QWidget *parent = 0);
+        ~MainWindow();
 
-private:
-    Ui::MainWindow  *ui;
-    void            *wtsChannel;
-    QSystemTrayIcon *trayIcon;
-    QMenu           *trayMenu;
-    bool             okToQuit;
-    QRect            savedGeometry;
-    QStatusBar      *statusBar;
+    private:
+        Ui::MainWindow  *ui;
+        void            *wtsChannel;
+        QSystemTrayIcon *trayIcon;
+        QMenu           *trayMenu;
+        bool             okToQuit;
+        QRect            savedGeometry;
+        QStatusBar      *statusBar;
 
-    QList<QListWidgetItem *> itemList;
+        QList<QListWidgetItem *> itemList;
 
-    void setupSystemTray();
-    int  initWtsChannel();
-    int  deinitWtsChannel();
-    void setStatusMsg(QString msg);
-    void closeEvent(QCloseEvent * event);
+        void setupSystemTray();
+        int  initWtsChannel();
+        int  deinitWtsChannel();
+        void setStatusMsg(QString msg);
+        void closeEvent(QCloseEvent *event);
 
-private slots:
-    void onBtnRefreshClicked();
-    void onBtnUnmountClicked();
-    void onActionQuit();
-    void onActionLaunch();
-    void onSystemTrayClicked(QSystemTrayIcon::ActivationReason);
+    private slots:
+        void onBtnRefreshClicked();
+        void onBtnUnmountClicked();
+        void onActionQuit();
+        void onActionLaunch();
+        void onSystemTrayClicked(QSystemTrayIcon::ActivationReason);
 };
 
 #endif // MAINWINDOW_H

--- a/tcutils/utils.h
+++ b/tcutils/utils.h
@@ -14,111 +14,111 @@
 
 typedef struct stream
 {
-    char* data;    /* holds stream data           */
-    char* pos;     /* current read/write position */
+    char *data;    /* holds stream data           */
+    char *pos;     /* current read/write position */
     int   size;    /* number of bytes in data     */
 } STREAM;
 
 #define qstream_new(_s, _size)                 \
-do                                             \
-{                                              \
-    (_s).data = (char *) malloc(_size);        \
-    (_s).pos = (_s).data;                      \
-    (_s).size = (_size);                       \
-}                                              \
-while (0)
+    do                                             \
+    {                                              \
+        (_s).data = (char *) malloc(_size);        \
+        (_s).pos = (_s).data;                      \
+        (_s).size = (_size);                       \
+    }                                              \
+    while (0)
 
 #define qstream_new_zero(_s, _size)            \
-do                                             \
-{                                              \
-    (_s).data = (char *) calloc((_size), 1);   \
-    (_s).pos = (_s).data;                      \
-    (_s).size = (_size);                       \
-}                                              \
-while (0)
+    do                                             \
+    {                                              \
+        (_s).data = (char *) calloc((_size), 1);   \
+        (_s).pos = (_s).data;                      \
+        (_s).size = (_size);                       \
+    }                                              \
+    while (0)
 
 #define qstream_free(_s)              \
-do                                    \
-{                                     \
-    if ((_s)->data)                   \
-        free((_s)->data);             \
-}                                     \
-while (0)
+    do                                    \
+    {                                     \
+        if ((_s)->data)                   \
+            free((_s)->data);             \
+    }                                     \
+    while (0)
 
 #define qstream_set_pos(_s, _p)       \
-do                                    \
-{                                     \
-    (_s)->pos = (_s)->data + (_p);    \
-}                                     \
-while (0)
+    do                                    \
+    {                                     \
+        (_s)->pos = (_s)->data + (_p);    \
+    }                                     \
+    while (0)
 
 #define qstream_inc_pos(_s, _v)       \
-do                                    \
-{                                     \
-    (_s)->pos += (_v);                \
-}                                     \
-while (0)
+    do                                    \
+    {                                     \
+        (_s)->pos += (_v);                \
+    }                                     \
+    while (0)
 
 #define qstream_rd_u8(_s, _v)                \
-do                                           \
-{                                            \
-    (_v) = *((unsigned char *) ((_s)->pos)); \
-    (_s)->pos++;                             \
-}                                            \
-while (0)
+    do                                           \
+    {                                            \
+        (_v) = *((unsigned char *) ((_s)->pos)); \
+        (_s)->pos++;                             \
+    }                                            \
+    while (0)
 
 #define qstream_rd_u16(_s, _v)                        \
-do                                                    \
-{                                                     \
-    (_v) = (unsigned short)                           \
-    (                                                 \
-        (*((unsigned char *) ((_s)->pos + 0)) << 0) | \
-        (*((unsigned char *) ((_s)->pos + 1)) << 8)   \
-    );                                                \
-    (_s)->pos += 2;                                   \
-} while (0)
+    do                                                    \
+    {                                                     \
+        (_v) = (unsigned short)                           \
+               (                                                 \
+                       (*((unsigned char *) ((_s)->pos + 0)) << 0) | \
+                       (*((unsigned char *) ((_s)->pos + 1)) << 8)   \
+               );                                                \
+        (_s)->pos += 2;                                   \
+    } while (0)
 
 #define qstream_rd_u32(_s, _v)                          \
-do                                                      \
-{                                                       \
-    (_v) = (unsigned int)                               \
-    (                                                   \
-        (*((unsigned char *) ((_s)->pos + 0)) << 0)  |  \
-        (*((unsigned char *) ((_s)->pos + 1)) << 8)  |  \
-        (*((unsigned char *) ((_s)->pos + 2)) << 16) |  \
-        (*((unsigned char *) ((_s)->pos + 3)) << 24)    \
-    );                                                  \
-    (_s)->pos += 4;                                     \
-} while (0)
+    do                                                      \
+    {                                                       \
+        (_v) = (unsigned int)                               \
+               (                                                   \
+                       (*((unsigned char *) ((_s)->pos + 0)) << 0)  |  \
+                       (*((unsigned char *) ((_s)->pos + 1)) << 8)  |  \
+                       (*((unsigned char *) ((_s)->pos + 2)) << 16) |  \
+                       (*((unsigned char *) ((_s)->pos + 3)) << 24)    \
+               );                                                  \
+        (_s)->pos += 4;                                     \
+    } while (0)
 
 #define qstream_wr_u8(_s, _v)                           \
-do                                                      \
-{                                                       \
-    *((_s)->pos) = (unsigned char) (_v);                \
-    (_s)->pos++;                                        \
-} while (0)
+    do                                                      \
+    {                                                       \
+        *((_s)->pos) = (unsigned char) (_v);                \
+        (_s)->pos++;                                        \
+    } while (0)
 
 #define qstream_wr_u16(_s, _v)                          \
-do                                                      \
-{                                                       \
-    *((_s)->pos) = (unsigned char) ((_v) >> 0);         \
-    (_s)->pos++;                                        \
-    *((_s)->pos) = (unsigned char) ((_v) >> 8);         \
-    (_s)->pos++;                                        \
-} while (0)
+    do                                                      \
+    {                                                       \
+        *((_s)->pos) = (unsigned char) ((_v) >> 0);         \
+        (_s)->pos++;                                        \
+        *((_s)->pos) = (unsigned char) ((_v) >> 8);         \
+        (_s)->pos++;                                        \
+    } while (0)
 
 #define qstream_wr_u32(_s, _v)                          \
-do                                                      \
-{                                                       \
-  *((_s)->pos) = (unsigned char) ((_v) >> 0);           \
-  (_s)->pos++;                                          \
-  *((_s)->pos) = (unsigned char) ((_v) >> 8);           \
-  (_s)->pos++;                                          \
-  *((_s)->pos) = (unsigned char) ((_v) >> 16);          \
-  (_s)->pos++;                                          \
-  *((_s)->pos) = (unsigned char) ((_v) >> 24);          \
-  (_s)->pos++;                                          \
-} while (0)
+    do                                                      \
+    {                                                       \
+        *((_s)->pos) = (unsigned char) ((_v) >> 0);           \
+        (_s)->pos++;                                          \
+        *((_s)->pos) = (unsigned char) ((_v) >> 8);           \
+        (_s)->pos++;                                          \
+        *((_s)->pos) = (unsigned char) ((_v) >> 16);          \
+        (_s)->pos++;                                          \
+        *((_s)->pos) = (unsigned char) ((_v) >> 24);          \
+        (_s)->pos++;                                          \
+    } while (0)
 
 /* list of commands we support; this list should match the one in */
 /* NeutrinoRDP channels/tcutils/tcutils_main.h                    */
@@ -141,10 +141,10 @@ enum TCU_UMOUNT_ERROR
 
 class Utils
 {
-public:
-    Utils();
-    static int getMountList(void *wtsChannel, QList<QListWidgetItem *> *itemList);
-    static int unmountDevice(void *wtsChannel, QString device, QStatusBar *statusBar);
+    public:
+        Utils();
+        static int getMountList(void *wtsChannel, QList<QListWidgetItem *> *itemList);
+        static int unmountDevice(void *wtsChannel, QString device, QStatusBar *statusBar);
 };
 
 #endif // UTILS_H

--- a/tests/common/test_string_calls.c
+++ b/tests/common/test_string_calls.c
@@ -199,8 +199,8 @@ START_TEST(test_strnjoin__when_always__then_doesnt_write_beyond_end_of_destinati
 {
     /* setup */
 
-    const char *src[] = { "a","b","c"};
-    char result[5+1+1]; /* a-b-c + term null + guard value */
+    const char *src[] = { "a", "b", "c"};
+    char result[5 + 1 + 1]; /* a-b-c + term null + guard value */
 
     /* test */
 

--- a/vnc/vnc.h
+++ b/vnc/vnc.h
@@ -78,9 +78,9 @@ struct vnc
     int (*mod_suppress_output)(struct vnc *v, int suppress,
                                int left, int top, int right, int bottom);
     int (*mod_server_monitor_resize)(struct vnc *v,
-                               int width, int height);
+                                     int width, int height);
     int (*mod_server_monitor_full_invalidate)(struct vnc *v,
-                               int width, int height);
+            int width, int height);
     int (*mod_server_version_message)(struct vnc *v);
     tintptr mod_dumby[100 - 14]; /* align, 100 minus the number of mod
                                   functions above */

--- a/vrplayer/decoder.h
+++ b/vrplayer/decoder.h
@@ -19,21 +19,21 @@
 
 class Decoder : public QObject
 {
-    Q_OBJECT
-public:
-    explicit Decoder(QObject *parent = 0);
-    int init(QString filename);
-    //int deinit();
-    //int setWindow(QRectangle rect);
+        Q_OBJECT
+    public:
+        explicit Decoder(QObject *parent = 0);
+        int init(QString filename);
+        //int deinit();
+        //int setWindow(QRectangle rect);
 
-private:
-    void *channel;
-    QRect mainWindowGeometry;
+    private:
+        void *channel;
+        QRect mainWindowGeometry;
 
-signals:
+    signals:
 
-public slots:
-    void onGeometryChanged(QRect *geometry);
+    public slots:
+        void onGeometryChanged(QRect *geometry);
 };
 
 #endif // DECODER_H

--- a/vrplayer/demuxmedia.h
+++ b/vrplayer/demuxmedia.h
@@ -22,8 +22,8 @@
 /* ffmpeg related stuff */
 extern "C"
 {
-    #include <libavformat/avformat.h>
-    #include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavcodec/avcodec.h>
 }
 
 #define VCR_PLAY        1
@@ -34,42 +34,42 @@ extern "C"
 
 class DemuxMedia : public QObject
 {
-    Q_OBJECT
+        Q_OBJECT
 
-public:
-    explicit DemuxMedia(QObject *parent = 0, QQueue<MediaPacket *> *videoQueue = 0,
-                        void *channel = 0, int stream_id = 101);
+    public:
+        explicit DemuxMedia(QObject *parent = 0, QQueue<MediaPacket *> *videoQueue = 0,
+                            void *channel = 0, int stream_id = 101);
 
-    void setVcrOp(int op);
-    int clear();
+        void setVcrOp(int op);
+        int clear();
 
-public slots:
-    void       startDemuxing();
-    void       onMediaSeek(int value);
+    public slots:
+        void       startDemuxing();
+        void       onMediaSeek(int value);
 
-private:
-    QMutex     vcrMutex;
-    int        vcrFlag;
-    void      *channel;
-    int        stream_id;
-    QMutex     sendMutex;
-    QMutex     posMutex;
-    int64_t    elapsedTime; /* elapsed time in usecs since play started */
-    int64_t    pausedTime;  /* time at which stream was paused          */
-    int64_t    la_seekPos;  /* locked access; must hold posMutex        */
-    bool       isStopped;
+    private:
+        QMutex     vcrMutex;
+        int        vcrFlag;
+        void      *channel;
+        int        stream_id;
+        QMutex     sendMutex;
+        QMutex     posMutex;
+        int64_t    elapsedTime; /* elapsed time in usecs since play started */
+        int64_t    pausedTime;  /* time at which stream was paused          */
+        int64_t    la_seekPos;  /* locked access; must hold posMutex        */
+        bool       isStopped;
 
-    QQueue<MediaPacket *> *videoQueue;
-    PlayVideo             *playVideo;
-    QThread               *playVideoThread;
+        QQueue<MediaPacket *> *videoQueue;
+        PlayVideo             *playVideo;
+        QThread               *playVideoThread;
 
-    void updateMediaPos();
+        void updateMediaPos();
 
-signals:
-    void onMediaRestarted();
+    signals:
+        void onMediaRestarted();
 
-signals:
-    void onElapsedtime(int val); /* in hundredth of a sec */
+    signals:
+        void onElapsedtime(int val); /* in hundredth of a sec */
 
 };
 

--- a/vrplayer/dlgabout.h
+++ b/vrplayer/dlgabout.h
@@ -3,23 +3,24 @@
 
 #include <QDialog>
 
-namespace Ui {
-class DlgAbout;
+namespace Ui
+{
+    class DlgAbout;
 }
 
 class DlgAbout : public QDialog
 {
-    Q_OBJECT
-    
-public:
-    explicit DlgAbout(QWidget *parent = 0);
-    ~DlgAbout();
-    
-private:
-    Ui::DlgAbout *ui;
+        Q_OBJECT
 
-private slots:
-    void onOk();
+    public:
+        explicit DlgAbout(QWidget *parent = 0);
+        ~DlgAbout();
+
+    private:
+        Ui::DlgAbout *ui;
+
+    private slots:
+        void onOk();
 };
 
 #endif // DLGABOUT_H

--- a/vrplayer/mainwindow.h
+++ b/vrplayer/mainwindow.h
@@ -38,8 +38,8 @@
 /* ffmpeg related stuff */
 extern "C"
 {
-    #include <libavformat/avformat.h>
-    #include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavcodec/avcodec.h>
 }
 
 #define VCR_PLAY        1
@@ -55,78 +55,78 @@ namespace Ui
 
 class MainWindow : public QMainWindow
 {
-    Q_OBJECT
+        Q_OBJECT
 
-public:
-    explicit MainWindow(QWidget *parent = 0);
-    ~MainWindow();
+    public:
+        explicit MainWindow(QWidget *parent = 0);
+        ~MainWindow();
 
-signals:
-    void onGeometryChanged(int x, int y, int width, int height);
+    signals:
+        void onGeometryChanged(int x, int y, int width, int height);
 
-public slots:
-    void onSliderValueChanged(int value);
+    public slots:
+        void onSliderValueChanged(int value);
 
-private slots:
-    void on_actionOpen_Media_File_triggered();
-    void on_actionExit_triggered();
+    private slots:
+        void on_actionOpen_Media_File_triggered();
+        void on_actionExit_triggered();
 
-    void onBtnPlayClicked(bool flag);
-    void onBtnRewindClicked(bool flag);
-    void onBtnStopClicked(bool flag);
+        void onBtnPlayClicked(bool flag);
+        void onBtnRewindClicked(bool flag);
+        void onBtnStopClicked(bool flag);
 
-    void onMediaDurationInSeconds(int duration);
-    void onElapsedTime(int secs);
-    void onSliderActionTriggered(int value);
-    void onMoveCompleted();
+        void onMediaDurationInSeconds(int duration);
+        void onElapsedTime(int secs);
+        void onSliderActionTriggered(int value);
+        void onMoveCompleted();
 
-    void on_actionAbout_triggered();
+        void on_actionAbout_triggered();
 
-    void onVolSliderValueChanged(int value);
+        void onVolSliderValueChanged(int value);
 
-protected:
-    void resizeEvent(QResizeEvent *e);
-    void closeEvent(QCloseEvent *e);
-    void moveEvent(QMoveEvent *e);
+    protected:
+        void resizeEvent(QResizeEvent *e);
+        void closeEvent(QCloseEvent *e);
+        void moveEvent(QMoveEvent *e);
 
-private:
-    Ui::MainWindow *ui;
+    private:
+        Ui::MainWindow *ui;
 
-    /* for UI */
-    QLabel        *lblCurrentPos;
-    QLabel        *lblDuration;
-    QLabel        *lblVideo;
-    QHBoxLayout   *hboxLayoutTop;
-    QHBoxLayout   *hboxLayoutMiddle;
-    QHBoxLayout   *hboxLayoutBottom;
-    QVBoxLayout   *vboxLayout;
-    QPushButton   *btnPlay;
-    QPushButton   *btnStop;
-    QPushButton   *btnRewind;
-    QSlider       *slider;
-    QSlider       *volSlider;
-    QWidget       *window;
-    bool           acceptSliderMove;
-    QTimer        *moveResizeTimer;
+        /* for UI */
+        QLabel        *lblCurrentPos;
+        QLabel        *lblDuration;
+        QLabel        *lblVideo;
+        QHBoxLayout   *hboxLayoutTop;
+        QHBoxLayout   *hboxLayoutMiddle;
+        QHBoxLayout   *hboxLayoutBottom;
+        QVBoxLayout   *vboxLayout;
+        QPushButton   *btnPlay;
+        QPushButton   *btnStop;
+        QPushButton   *btnRewind;
+        QSlider       *slider;
+        QSlider       *volSlider;
+        QWidget       *window;
+        bool           acceptSliderMove;
+        QTimer        *moveResizeTimer;
 
-    /* private stuff */
-    OurInterface  *interface;
-    //PlayVideo     *playVideo;
-    DemuxMedia    *demuxMedia;
-    QString        filename;
-    bool           oneTimeInitSuccess;
-    bool           remoteClientInited;
-    void          *channel;
-    int            stream_id;
-    int64_t        elapsedTime; /* elapsed time in usecs since play started */
-    int            vcrFlag;
-    bool           gotMediaOnCmdline;
+        /* private stuff */
+        OurInterface  *interface;
+        //PlayVideo     *playVideo;
+        DemuxMedia    *demuxMedia;
+        QString        filename;
+        bool           oneTimeInitSuccess;
+        bool           remoteClientInited;
+        void          *channel;
+        int            stream_id;
+        int64_t        elapsedTime; /* elapsed time in usecs since play started */
+        int            vcrFlag;
+        bool           gotMediaOnCmdline;
 
-    /* private methods */
-    void setupUI();
-    void openMediaFile();
-    void getVdoGeometry(QRect *rect);
-    void clearDisplay();
+        /* private methods */
+        void setupUI();
+        void openMediaFile();
+        void getVdoGeometry(QRect *rect);
+        void clearDisplay();
 };
 
 #endif // MAINWINDOW_H

--- a/vrplayer/mediapacket.h
+++ b/vrplayer/mediapacket.h
@@ -3,12 +3,12 @@
 
 class MediaPacket
 {
-public:
-    MediaPacket();
+    public:
+        MediaPacket();
 
-    void *av_pkt;
-    int   delay_in_us;
-    int   seq;
+        void *av_pkt;
+        int   delay_in_us;
+        int   seq;
 };
 
 #endif // MEDIAPACKET_H

--- a/vrplayer/ourinterface.h
+++ b/vrplayer/ourinterface.h
@@ -21,57 +21,57 @@
 /* ffmpeg related stuff */
 extern "C"
 {
-    #include <libavformat/avformat.h>
-    #include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavcodec/avcodec.h>
 }
 
 class OurInterface : public QObject
 {
-    Q_OBJECT
+        Q_OBJECT
 
-public:
-    explicit OurInterface(QObject *parent = 0);
+    public:
+        explicit OurInterface(QObject *parent = 0);
 
-    /* public methods */
-    int  oneTimeInit();
-    void oneTimeDeinit();
-    int initRemoteClient();
-    void deInitRemoteClient();
-    int  sendGeometry(QRect rect);
-    void setFilename(QString filename);
-    void playMedia();
-    //PlayVideo *getPlayVideoInstance();
-    DemuxMedia *getDemuxMediaInstance();
-    void setVcrOp(int op);
-    int setVolume(int volume);
+        /* public methods */
+        int  oneTimeInit();
+        void oneTimeDeinit();
+        int initRemoteClient();
+        void deInitRemoteClient();
+        int  sendGeometry(QRect rect);
+        void setFilename(QString filename);
+        void playMedia();
+        //PlayVideo *getPlayVideoInstance();
+        DemuxMedia *getDemuxMediaInstance();
+        void setVcrOp(int op);
+        int setVolume(int volume);
 
-public slots:
-    void onGeometryChanged(int x, int y, int width, int height);
+    public slots:
+        void onGeometryChanged(int x, int y, int width, int height);
 
-signals:
-    void on_ErrorMsg(QString title, QString msg);
-    void onMediaDurationInSeconds(int duration);
+    signals:
+        void on_ErrorMsg(QString title, QString msg);
+        void onMediaDurationInSeconds(int duration);
 
-private:
+    private:
 
-    /* private stuff */
+        /* private stuff */
 
-    QQueue<MediaPacket *> videoQueue;
+        QQueue<MediaPacket *> videoQueue;
 
-    DemuxMedia     *demuxMedia;
-    QThread        *demuxMediaThread;
-    //PlayVideo      *playVideo;
-    QString         filename;
-    void           *channel;
-    int             stream_id;
-    QRect           savedGeometry;
+        DemuxMedia     *demuxMedia;
+        QThread        *demuxMediaThread;
+        //PlayVideo      *playVideo;
+        QString         filename;
+        void           *channel;
+        int             stream_id;
+        QRect           savedGeometry;
 
-    /* private methods */
-    int  openVirtualChannel();
-    int  closeVirtualChannel();
-    int  sendMetadataFile();
-    int  sendVideoFormat();
-    int  sendAudioFormat();
+        /* private methods */
+        int  openVirtualChannel();
+        int  closeVirtualChannel();
+        int  sendMetadataFile();
+        int  sendVideoFormat();
+        int  sendAudioFormat();
 };
 
 #endif // INTERFACE_H

--- a/vrplayer/playaudio.h
+++ b/vrplayer/playaudio.h
@@ -19,8 +19,8 @@
 /* ffmpeg related stuff */
 extern "C"
 {
-    #include <libavformat/avformat.h>
-    #include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavcodec/avcodec.h>
 }
 
 #define VCR_PLAY        1
@@ -31,29 +31,29 @@ extern "C"
 
 class PlayAudio : public QObject
 {
-    Q_OBJECT
+        Q_OBJECT
 
-public:
-    explicit PlayAudio(QObject *parent = 0,
-                       QQueue<MediaPacket *> *audioQueue = 0,
-                       QMutex *sendMutex = 0,
-                       void *channel = 0,
-                       int stream_id = 101);
+    public:
+        explicit PlayAudio(QObject *parent = 0,
+                           QQueue<MediaPacket *> *audioQueue = 0,
+                           QMutex *sendMutex = 0,
+                           void *channel = 0,
+                           int stream_id = 101);
 
-    void setVcrOp(int op);
+        void setVcrOp(int op);
 
-public slots:
-    void play();
+    public slots:
+        void play();
 
-private:
-    QQueue<MediaPacket *> *audioQueue;
-    QMutex                *sendMutex;
-    QMutex                 vcrMutex;
-    int                    vcrFlag;
-    void                  *channel;
-    int                    stream_id;
+    private:
+        QQueue<MediaPacket *> *audioQueue;
+        QMutex                *sendMutex;
+        QMutex                 vcrMutex;
+        int                    vcrFlag;
+        void                  *channel;
+        int                    stream_id;
 
-    void clearAudioQ();
+        void clearAudioQ();
 };
 
 #endif // PLAYAUDIO_H

--- a/vrplayer/playvideo.h
+++ b/vrplayer/playvideo.h
@@ -20,8 +20,8 @@
 /* ffmpeg related stuff */
 extern "C"
 {
-    #include <libavformat/avformat.h>
-    #include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavcodec/avcodec.h>
 }
 
 #define VCR_PLAY        1
@@ -32,43 +32,43 @@ extern "C"
 
 class PlayVideo : public QObject
 {
-    Q_OBJECT
+        Q_OBJECT
 
-public:
-    explicit PlayVideo(QObject *parent = 0,
-                       QQueue<MediaPacket *> *videoQueue = 0,
-                       QMutex *sendMutex = 0,
-                       void *channel = 0,
-                       int stream_id = 101,
-                       int fps = 24);
+    public:
+        explicit PlayVideo(QObject *parent = 0,
+                           QQueue<MediaPacket *> *videoQueue = 0,
+                           QMutex *sendMutex = 0,
+                           void *channel = 0,
+                           int stream_id = 101,
+                           int fps = 24);
 
-    //void onMediaSeek(int value);
-    //void setVcrOp(int op);
-    //void onMediaRestarted();
+        //void onMediaSeek(int value);
+        //void setVcrOp(int op);
+        //void onMediaRestarted();
 
-public slots:
-    void play();
+    public slots:
+        void play();
 
-//signals:
-//    void onElapsedtime(int val); /* in hundredth of a sec */
+        //signals:
+        //    void onElapsedtime(int val); /* in hundredth of a sec */
 
-private:
-    QQueue<MediaPacket *> *videoQueue;
+    private:
+        QQueue<MediaPacket *> *videoQueue;
 
-//    int       vcrFlag;
-//    QMutex    vcrMutex;
-    QMutex   *sendMutex;
-//    QMutex    posMutex;
-//    int64_t   la_seekPos;  /* locked access; must hold posMutex */
-    void     *channel;
-    int       stream_id;
-    int       fps;
-//    int64_t   elapsedTime; /* elapsed time in usecs since play started */
-//    int64_t   pausedTime;  /* time at which stream was paused          */
-//    bool      isStopped;
+        //    int       vcrFlag;
+        //    QMutex    vcrMutex;
+        QMutex   *sendMutex;
+        //    QMutex    posMutex;
+        //    int64_t   la_seekPos;  /* locked access; must hold posMutex */
+        void     *channel;
+        int       stream_id;
+        int       fps;
+        //    int64_t   elapsedTime; /* elapsed time in usecs since play started */
+        //    int64_t   pausedTime;  /* time at which stream was paused          */
+        //    bool      isStopped;
 
-//    void updateMediaPos();
-//    void clearVideoQ();
+        //    void updateMediaPos();
+        //    void clearVideoQ();
 };
 
 #endif // PLAYVIDEO_H

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -1076,7 +1076,7 @@ dynamic_monitor_data(intptr_t id, int chan_id, char *data, int bytes)
     in_uint32_le(s, msg_type);
     in_uint32_le(s, msg_length);
     LOG(LOG_LEVEL_DEBUG, "dynamic_monitor_data: msg_type %d msg_length %d",
-           msg_type, msg_length);
+        msg_type, msg_length);
 
     rect.left = 8192;
     rect.top = 8192;
@@ -1088,7 +1088,7 @@ dynamic_monitor_data(intptr_t id, int chan_id, char *data, int bytes)
         in_uint32_le(s, MonitorLayoutSize);
         in_uint32_le(s, NumMonitor);
         LOG(LOG_LEVEL_DEBUG, "  MonitorLayoutSize %d NumMonitor %d",
-               MonitorLayoutSize, NumMonitor);
+            MonitorLayoutSize, NumMonitor);
         for (monitor_index = 0; monitor_index < NumMonitor; monitor_index++)
         {
             monitor_layout = monitor_layouts + monitor_index;
@@ -1103,13 +1103,13 @@ dynamic_monitor_data(intptr_t id, int chan_id, char *data, int bytes)
             in_uint32_le(s, monitor_layout->desktop_scale_factor);
             in_uint32_le(s, monitor_layout->device_scale_factor);
             LOG_DEVEL(LOG_LEVEL_DEBUG, "    Flags 0x%8.8x Left %d Top %d "
-                   "Width %d Height %d PhysicalWidth %d PhysicalHeight %d "
-                   "Orientation %d DesktopScaleFactor %d DeviceScaleFactor %d",
-                   monitor_layout->flags, monitor_layout->left, monitor_layout->top,
-                   monitor_layout->width, monitor_layout->height,
-                   monitor_layout->physical_width, monitor_layout->physical_height,
-                   monitor_layout->orientation, monitor_layout->desktop_scale_factor,
-                   monitor_layout->device_scale_factor);
+                      "Width %d Height %d PhysicalWidth %d PhysicalHeight %d "
+                      "Orientation %d DesktopScaleFactor %d DeviceScaleFactor %d",
+                      monitor_layout->flags, monitor_layout->left, monitor_layout->top,
+                      monitor_layout->width, monitor_layout->height,
+                      monitor_layout->physical_width, monitor_layout->physical_height,
+                      monitor_layout->orientation, monitor_layout->desktop_scale_factor,
+                      monitor_layout->device_scale_factor);
 
             rect.left = MIN(monitor_layout->left, rect.left);
             rect.top = MIN(monitor_layout->top, rect.top);
@@ -1133,8 +1133,9 @@ dynamic_monitor_data(intptr_t id, int chan_id, char *data, int bytes)
         /* redraw */
         xrdp_bitmap_invalidate(wm->screen, 0);
 
-        struct xrdp_mod* v = wm->mm->mod;
-        if (v != 0) {
+        struct xrdp_mod *v = wm->mm->mod;
+        if (v != 0)
+        {
             v->mod_server_version_message(v);
             v->mod_server_monitor_resize(v, session_width, session_height);
             v->mod_server_monitor_full_invalidate(v, session_width, session_height);

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -53,11 +53,11 @@ struct xrdp_mod
     int (*mod_frame_ack)(struct xrdp_mod *v, int flags, int frame_id);
     int (*mod_suppress_output)(struct xrdp_mod *v, int suppress,
                                int left, int top, int right, int bottom);
-    int (*mod_server_monitor_resize)(struct xrdp_mod* v,
-                               int width, int height);
-    int (*mod_server_monitor_full_invalidate)(struct xrdp_mod* v,
-                               int width, int height);
-    int (*mod_server_version_message)(struct xrdp_mod* v);
+    int (*mod_server_monitor_resize)(struct xrdp_mod *v,
+                                     int width, int height);
+    int (*mod_server_monitor_full_invalidate)(struct xrdp_mod *v,
+            int width, int height);
+    int (*mod_server_version_message)(struct xrdp_mod *v);
     tintptr mod_dumby[100 - 14]; /* align, 100 minus the number of mod
                                   functions above */
     /* server functions */

--- a/xrdpvr/xrdpvr.c
+++ b/xrdpvr/xrdpvr.c
@@ -216,19 +216,19 @@ xrdpvr_play_media(void *channel, int stream_id, char *filename)
     for (i = 0; i < g_psi.p_format_ctx->nb_streams; i++)
     {
         if (g_psi.p_format_ctx->streams[i]->codec->codec_type ==
-                                                     CODEC_TYPE_VIDEO &&
-            g_psi.p_format_ctx->streams[i]->codec->codec_id ==
-                                                     CODEC_ID_H264 &&
-            g_video_index < 0)
+                CODEC_TYPE_VIDEO &&
+                g_psi.p_format_ctx->streams[i]->codec->codec_id ==
+                CODEC_ID_H264 &&
+                g_video_index < 0)
         {
             g_video_index = i;
         }
 
         if (g_psi.p_format_ctx->streams[i]->codec->codec_type ==
-                                                     CODEC_TYPE_AUDIO &&
-            g_psi.p_format_ctx->streams[i]->codec->codec_id ==
-                                                     CODEC_ID_AAC &&
-            g_audio_index < 0)
+                CODEC_TYPE_AUDIO &&
+                g_psi.p_format_ctx->streams[i]->codec->codec_id ==
+                CODEC_ID_AAC &&
+                g_audio_index < 0)
         {
             g_audio_index = i;
         }
@@ -252,7 +252,7 @@ xrdpvr_play_media(void *channel, int stream_id, char *filename)
 
     /* find decoder for audio stream */
     g_psi.p_audio_codec =
-           avcodec_find_decoder(g_psi.p_audio_codec_ctx->codec_id);
+        avcodec_find_decoder(g_psi.p_audio_codec_ctx->codec_id);
 
     if (g_psi.p_audio_codec == NULL)
     {
@@ -261,7 +261,7 @@ xrdpvr_play_media(void *channel, int stream_id, char *filename)
 
     /* find decoder for video stream */
     g_psi.p_video_codec =
-             avcodec_find_decoder(g_psi.p_video_codec_ctx->codec_id);
+        avcodec_find_decoder(g_psi.p_video_codec_ctx->codec_id);
 
     if (g_psi.p_video_codec == NULL)
     {
@@ -337,7 +337,9 @@ xrdpvr_get_frame(void **av_pkt_ret, int *is_video_frame, int *delay_in_us)
     //printf("xrdpvr_get_frame:\n");
     /* alloc an AVPacket */
     if ((av_pkt = (AVPacket *) malloc(sizeof(AVPacket))) == NULL)
+    {
         return -1;
+    }
 
     /* read one frame into AVPacket */
     if (av_read_frame(g_psi.p_format_ctx, av_pkt) < 0)
@@ -491,7 +493,7 @@ xrdpvr_play_frame(void *channel, int stream_id, int *videoTimeout,
         bsfc = g_psi.bsfc;
         while (bsfc != 0)
         {
-            new_pkt= av_pkt;
+            new_pkt = av_pkt;
             error = av_bitstream_filter_filter(bsfc, g_psi.p_video_codec_ctx, 0,
                                                &new_pkt.data, &new_pkt.size,
                                                av_pkt.data, av_pkt.size,
@@ -552,11 +554,11 @@ xrdpvr_seek_media(int64_t pos, int backward)
 
     seek_target = av_rescale_q(pos * AV_TIME_BASE,
                                AV_TIME_BASE_Q,
-                      g_psi.p_format_ctx->streams[g_video_index]->time_base);
+                               g_psi.p_format_ctx->streams[g_video_index]->time_base);
 
 
     if (av_seek_frame(g_psi.p_format_ctx, g_video_index, seek_target,
-                     seek_flag) < 0)
+                      seek_flag) < 0)
     {
         printf("media seek error\n");
         return -1;
@@ -801,7 +803,7 @@ xrdpvr_create_metadata_file(void *channel, char *filename)
     int     len;
     int     fd;
 
-    if ((fd = open(filename , O_RDONLY)) < 0)
+    if ((fd = open(filename, O_RDONLY)) < 0)
     {
         return -1;
     }

--- a/xup/xup.c
+++ b/xup/xup.c
@@ -1305,8 +1305,8 @@ send_server_monitor_resize(struct mod *mod, struct stream *s, int width, int hei
     out_uint32_le(s, len);
     int rv = lib_send_copy(mod, s);
     LOG_DEVEL(LOG_LEVEL_DEBUG, "send_server_monitor_resize: sent resize message with following properties to xorgxrdp backend "
-        "width=%d, height=%d, bpp=%d, return value=%d",
-        width, height, bpp, rv);
+              "width=%d, height=%d, bpp=%d, return value=%d",
+              width, height, bpp, rv);
     return rv;
 }
 
@@ -1332,8 +1332,8 @@ send_server_monitor_full_invalidate(struct mod *mod, struct stream *s, int width
     out_uint32_le(s, len);
     int rv = lib_send_copy(mod, s);
     LOG_DEVEL(LOG_LEVEL_DEBUG, "send_server_monitor_full_invalidate: sent invalidate message with following properties to xorgxrdp backend "
-        "width=%d, height=%d, return value=%d",
-        width, height, rv);
+              "width=%d, height=%d, return value=%d",
+              width, height, rv);
     return rv;
 }
 

--- a/xup/xup.h
+++ b/xup/xup.h
@@ -51,11 +51,11 @@ struct mod
     int (*mod_frame_ack)(struct mod *v, int flags, int frame_id);
     int (*mod_suppress_output)(struct mod *v, int suppress,
                                int left, int top, int right, int bottom);
-    int (*mod_server_monitor_resize)(struct mod* v,
-                               int width, int height);
-    int (*mod_server_monitor_full_invalidate)(struct mod* v,
-                               int width, int height);
-    int (*mod_server_version_message)(struct mod* v);
+    int (*mod_server_monitor_resize)(struct mod *v,
+                                     int width, int height);
+    int (*mod_server_monitor_full_invalidate)(struct mod *v,
+            int width, int height);
+    int (*mod_server_version_message)(struct mod *v);
     tintptr mod_dumby[100 - 14]; /* align, 100 minus the number of mod
                                  functions above */
     /* server functions */


### PR DESCRIPTION
Add checking the code formatting with astyle during CI builds

Example build with the code formatting failed: https://github.com/aquesnel/xrdp/runs/2535294459
Example build with the code formatting succeeded: https://github.com/neutrinolabs/xrdp/pull/1879/checks?check_run_id=2535309754

Note: the i386 builds are likely failing because of a change to the github actions runner images: https://github.com/actions/virtual-environments/issues/3339 That issue says that it should be resolved next week but the github actions team.