### PR TITLE
PAM module minor improvements

### DIFF
--- a/sesman/verify_user_pam.c
+++ b/sesman/verify_user_pam.c
@@ -93,7 +93,30 @@ msg_style_to_str(int msg_style, char *buff, unsigned int bufflen)
     return result;
 }
 
-/******************************************************************************/
+/***************************************************************************//**
+ * Provides the PAM conversation callback function
+ *
+ * At present, the main purpose of this function is to supply the
+ * user's password to the PAM stack, although some module logging is
+ * implemented here.
+ *
+ * @param[in] num_msg Count of messages in the msg array
+ * @param[in] msg Messages from the PAM stack to the application
+ * @param[out] resp Message replies from the application to the PAM stack
+ * @param[in] appdata_ptr Used to pass in a struct t_user_pass pointer
+ *
+ * @result PAM_SUCCESS if the messages were all processed successfully.
+ *
+ * @post If PAM_SUCCESS is returned, resp and its contents are allocated here
+ *       and must be freed by the caller
+ * @post If PAM_SUCCESS is not returned, resp is not allocated and must not
+ *       be not freed by the caller
+ *
+ * @note See pam_conv(3) for more information
+ * @note A basic example conversation function can be found in OSF RFC
+         86.0 (1995)
+ */
+
 static int
 verify_pam_conv(int num_msg, const struct pam_message **msg,
                 struct pam_response **resp, void *appdata_ptr)

--- a/sesman/verify_user_pam.c
+++ b/sesman/verify_user_pam.c
@@ -86,7 +86,7 @@ msg_style_to_str(int msg_style, char *buff, unsigned int bufflen)
             break;
 
         default:
-            snprintf(buff, bufflen, "UNKNOWN_0x%x", msg_style);
+            g_snprintf(buff, bufflen, "UNKNOWN_0x%x", msg_style);
             result = buff;
     }
 


### PR DESCRIPTION
This PR makes minor improvements to the PAM processing.

# General
- `g_printf()` calls for error conditions are replaced with `LOG()` calls.
- `PAM_USER` is now set for (e.g.) `pam_exec.so` - this addresses part of #1882 

# Conversion function
- More error logging/checking is added to the PAM conversion function
- The `PAM_ERROR_MSG` style (see [pam_conv(3)](https://linux.die.net/man/3/pam_conv) is now supported
- The `PAM_TEXT_INFO` style now logs the message rather than ignoring it completely.
- some potential memory leaks if the conv function fails have been removed.

The PAM_USER functionality was tested by adding this line to `/etc/pam.d/xrdp-sesman`:-

```
auth optional pam_exec.so log=/tmp/pam.log /usr/bin/env
```

After logging in, `/tmp/pam.log` contained:-
```
PAM_SERVICE=xrdp-sesman
PAM_USER=testuser
PAM_TTY=xrdp-sesman
PAM_TYPE=auth
```

Although the `PAM_ERROR_MSG` style could not easily be tested directly without writing a PAM module, the `pam_echo.so` was used to exercise the very similar `PAM_TEXT_INFO` style which now outputs to the sesman log.