### PR TITLE
Removed extra space which is breaking new astyle check

### DIFF
--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -182,7 +182,7 @@ lxrdp_connect(struct mod *mod)
         }
 
 #endif
-        LOG(LOG_LEVEL_ERROR, "NeutrinoRDP proxy connection: status [Failed]," 
+        LOG(LOG_LEVEL_ERROR, "NeutrinoRDP proxy connection: status [Failed],"
             " RDP client [%s:%s], RDP server [%s:%d], RDP server username [%s],"
             " xrdp pamusername [%s], xrdp process id [%d]",
             mod->client_info.client_addr,


### PR DESCRIPTION
Companion to #1879. This was introduced by #1875 and I didn't spot it at the time.

My CI builds are intermittently failing ATM in the package install phase with an error like this:-

```
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/p/pam/libpam0g-dev_1.3.1-5ubuntu4.1_amd64.deb  404  Not Found [IP: 52.154.174.208 80]
```

I'm going to ignore this for now.