### PR TITLE
Fixed the ability to overwrite common channel settings.

### DIFF
--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -535,6 +535,13 @@ lxrdp_set_param(struct mod *mod, const char *name, const char *value)
     {
         /* Valid (but unused) parameters not logged */
     }
+    else if (g_strcmp(name, "channel.rdpdr") == 0 ||
+             g_strcmp(name, "channel.rdpsnd") == 0 ||
+             g_strcmp(name, "channel.cliprdr") == 0 ||
+             g_strcmp(name, "channel.drdynvc") == 0)
+    {
+        /* Valid (but unused) parameters not logged */
+    }
     else
     {
         LOG(LOG_LEVEL_WARNING, "lxrdp_set_param: unknown name [%s] value [%s]", name, value);

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -1797,7 +1797,6 @@ xrdp_mm_process_login_response(struct xrdp_mm *self, struct stream *s)
                 {
                     g_snprintf(port, 255, "%d", 7200 + display);
                 }
-                xrdp_mm_update_allowed_channels(self);
                 xrdp_mm_connect_chansrv(self, ip, port);
             }
         }
@@ -2491,6 +2490,8 @@ xrdp_mm_connect(struct xrdp_mm *self)
             }
         }
     }
+
+    xrdp_mm_update_allowed_channels(self);
 
 #ifdef USE_PAM
     if (use_pam_auth)


### PR DESCRIPTION
Hi.

I have found that I cannot override the common channel settings when using the NeutrinoRDP Proxy.

I tried to write the following in `xrdp.ini`.
```
[cliprdr-ture]
name=cliprdr-true
lib=libxrdpneutrinordp.so
ip=cliprdr-true-Windows
<snip>
channel.cliprdr=true

[cliprdr-false]
name=cliprdr-false
lib=libxrdpneutrinordp.so
ip=cliprdr-false-Windows
<snip>
channel.cliprdr=false
```

I did some trial and error and added three lines to `xrdp_mm.c`.
I also added the same process as #1872 to` xrdp-neutrinordp.c `because the log shows the error `lxrdp_set_param: unknown name`.

I tested the behavior and confirmed that `channel.cliprdr`, `channel.rdpsnd `and `channel.rdpdr `work fine.
However, I did not know how to test `channel.drdynvc`.

Best regards.
