### PR TITLE
CI: Update package lists before adding packages

### DIFF
--- a/scripts/install_astyle_dependencies_with_apt.sh
+++ b/scripts/install_astyle_dependencies_with_apt.sh
@@ -3,4 +3,5 @@ set -eufx
 
 PACKAGES="subversion cmake"
         
+apt-get update
 apt-get -yq --no-install-suggests --no-install-recommends install $PACKAGES

--- a/scripts/install_cppcheck_dependencies_with_apt.sh
+++ b/scripts/install_cppcheck_dependencies_with_apt.sh
@@ -3,4 +3,5 @@ set -eufx
 
 PACKAGES="libz3-dev z3"
         
+apt-get update
 apt-get -yq --no-install-suggests --no-install-recommends install $PACKAGES

--- a/scripts/install_xrdp_build_dependencies_with_apt.sh
+++ b/scripts/install_xrdp_build_dependencies_with_apt.sh
@@ -89,6 +89,7 @@ in
         ;;
 esac
 
+apt-get update
 apt-get -yq \
     --no-install-suggests \
     --no-install-recommends \


### PR DESCRIPTION
CI is currently failing (2021-05-28)

We need to update the package lists before installing build dependencies. The clue was that the 32-bit stuff was OK. so I worked back from there.

I've used the older style `apt-get update` rather than `apt update` for consistency.