### PR TITLE
neutrinordp: Allow users or administrators to configure the mstsc experience settings.

### DIFF
--- a/neutrinordp/xrdp-neutrinordp.h
+++ b/neutrinordp/xrdp-neutrinordp.h
@@ -217,4 +217,8 @@ struct mod
     struct brush_item brush_cache[64];
     struct pointer_item pointer_cache[32];
     char pamusername[255];
+
+    int allow_client_experiencesettings;
+    int perf_settings_override_mask; /* Performance bits overridden in ini file */
+    int perf_settings_values_mask; /* Values of overridden performance bits */
 };

--- a/xrdp/xrdp.ini.in
+++ b/xrdp/xrdp.ini.in
@@ -258,6 +258,23 @@ password=ask
 ; Currently NeutrinoRDP doesn't support dynamic resizing. Uncomment
 ; this line if you're using a client which does.
 #enable_dynamic_resizing=false
+; By default, performance settings requested by the RDP client are ignored
+; and chosen by NeutrinoRDP. Uncomment this line to allow the user to
+; select performance settings in the RDP client.
+#perf.allow_client_experiencesettings=true
+; Override any experience setting by uncommenting one or more of the
+; following lines.
+#perf.wallpaper=false
+#perf.font_smoothing=false
+#perf.desktop_composition=false
+#perf.full_window_drag=false
+#perf.menu_anims=false
+#perf.themes=false
+#perf.cursor_blink=false
+; By default NeutrinoRDP supports cursor shadows. If this is giving
+; you problems (e.g. cursor is a black rectangle) try disabling cursor
+; shadows by uncommenting the following line.
+#perf.cursor_shadow=false
 
 ; You can override the common channel settings for each session type
 #channel.rdpdr=true


### PR DESCRIPTION
Hi.

I am connecting to remote Windows 10 Pro with NeutrinoRDP Proxy.
I have found that when I have mouse cursor shadow enabled, the mouse cursor turns into a black square.

This is similar to what was reported in FreeRDP [issue 5337](https://github.com/FreeRDP/FreeRDP/issues/5337#).
The workaround is to disable the option to `Enable pointer shadow` in the mouse properties of the remote Windows.

I have confirmed that the same can be done with the `xrdp-neutrinordp.c` function `lfreerdp_pre_connect()`.
b8ec98a

Best regards.