### PR TITLE
Actively prevent user from specifying --enable-xrdpdebug

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
             arch: amd64
             os: ubuntu-latest
             name_extra: and DEBUG
-            CONF_FLAGS_EXTRA: "--enable-xrdpdebug"
+            CONF_FLAGS_EXTRA: "--enable-devel-all"
 
           # Maximal 32-bit arch builds
           - CC: gcc

--- a/configure.ac
+++ b/configure.ac
@@ -166,6 +166,14 @@ AC_ARG_ENABLE(rdpsndaudin, AS_HELP_STRING([--enable-rdpsndaudin],
               [], [enable_rdpsndaudin=no])
 AM_CONDITIONAL(XRDP_RDPSNDAUDIN, [test x$enable_rdpsndaudin = xyes])
 
+# Obsolete options
+AC_ARG_ENABLE(xrdpdebug, AS_HELP_STRING([--enable-xrdpdebug],
+              [This option is no longer supported - use --enable-devel-all]))
+
+if test "x$enable_xrdpdebug" != x; then
+  AC_MSG_ERROR([--enable-xrdpdebug must be replaced with one or more --enable-devel-* options])
+fi
+
 # configure compiler options and CFLAGS
 AX_GCC_FUNC_ATTRIBUTE([format])
 AX_TYPE_SOCKLEN_T


### PR DESCRIPTION
I noticed yesterday that one of the CI jobs was still using `--enable-xrdpdebug` instead of the more general `--enable-devel-all` option (see #1887)

This minor PR addresses that and makes `--enable-xrdpdebug` an error to inform developers of the change.