### PR TITLE
Bump legacy OS to Ubuntu 18.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,19 +63,19 @@ jobs:
           - CC: gcc
             feature_set: max
             arch: i386
-            os: ubuntu-16.04
+            os: ubuntu-18.04
             name_extra: for 32-bit arch (legacy OS)
 
           - CC: g++
             feature_set: max
             arch: i386
-            os: ubuntu-16.04
+            os: ubuntu-18.04
             name_extra: for 32-bit arch (legacy OS)
 
           - CC: clang
             feature_set: max
             arch: i386
-            os: ubuntu-16.04
+            os: ubuntu-18.04
             name_extra: for 32-bit arch (legacy OS)
 
     name: ${{ matrix.feature_set }} features with ${{ matrix.CC }} ${{ matrix.name_extra }}


### PR DESCRIPTION
16.04 Ubuntu legacy builds are broken again in Github actions. I've just merged PR #1913 which was fine 3 days ago.

It's going to become harder to fix this over the next few months as GitHub actions are deprecating 16.04 - see actions/virtual-environments#3287

Anyone object to bumping the 'legacy' build platform to 18.04 now rather than waiting 3 months until September?