### PR TITLE
Move scp to standard transport

### DIFF
--- a/common/trans.c
+++ b/common/trans.c
@@ -814,7 +814,7 @@ trans_connect(struct trans *self, const char *server, const char *port,
  * @return 0 on success, 1 on failure
  */
 int
-trans_listen_address(struct trans *self, char *port, const char *address)
+trans_listen_address(struct trans *self, const char *port, const char *address)
 {
     if (self->sck != 0)
     {
@@ -929,7 +929,7 @@ trans_listen_address(struct trans *self, char *port, const char *address)
 
 /*****************************************************************************/
 int
-trans_listen(struct trans *self, char *port)
+trans_listen(struct trans *self, const char *port)
 {
     return trans_listen_address(self, port, "0.0.0.0");
 }

--- a/common/trans.h
+++ b/common/trans.h
@@ -148,9 +148,9 @@ int
 trans_connect(struct trans *self, const char *server, const char *port,
               int timeout);
 int
-trans_listen_address(struct trans *self, char *port, const char *address);
+trans_listen_address(struct trans *self, const char *port, const char *address);
 int
-trans_listen(struct trans *self, char *port);
+trans_listen(struct trans *self, const char *port);
 struct stream *
 trans_get_in_s(struct trans *self);
 struct stream *

--- a/sesman/env.c
+++ b/sesman/env.c
@@ -143,7 +143,8 @@ env_set_user(const char *username, char **passwd_file, int display,
             g_sprintf(text, ":%d.0", display);
             g_setenv("DISPLAY", text, 1);
             g_setenv("XRDP_SESSION", "1", 1);
-            /* XRDP_SOCKET_PATH should be set even here, chansrv uses this */
+            /* XRDP_SOCKET_PATH should be set even here. It's used by
+             * xorgxrdp and the pulseaudio plugin */
             g_setenv("XRDP_SOCKET_PATH", XRDP_SOCKET_PATH, 1);
             /* pulse sink socket */
             g_snprintf(text, sizeof(text) - 1, CHANSRV_PORT_OUT_BASE_STR, display);

--- a/sesman/libscp/libscp_commands.h
+++ b/sesman/libscp/libscp_commands.h
@@ -29,7 +29,27 @@
 
 #include "libscp_commands_mng.h"
 
-#define SCP_CMD_LOGIN        0x0001
-#define SCP_CMD_CONN_ERROR   0xFFFF
+/* Message numbers
+ * SCP_CMD_* are client to server, SCP_REPLY_* are server to client */
+
+/* Login sequence */
+#define SCP_CMD_LOGIN                   1
+#define SCP_REPLY_LOGIN_DENIED          2
+#define SCP_REPLY_REREQUEST_CREDS       3
+#define SCP_CMD_RESEND_CREDS            4
+#define SCP_REPLY_CHANGE_PASSWD        20
+#define SCP_REPLY_NEW_SESSION          30
+#define SCP_REPLY_USER_SESSIONS_EXIST  40
+
+/* List sessions */
+#define SCP_CMD_GET_SESSION_LIST       41
+#define SCP_REPLY_SESSIONS_INFO        42
+#define SCP_CMD_SELECT_SESSION         43
+#define SCP_CMD_SELECT_SESSION_CANCEL  44
+
+/* Other */
+#define SCP_CMD_FORCE_NEW_CONN         45
+#define SCP_REPLY_SESSION_RECONNECTED  46
+#define SCP_REPLY_CMD_CONN_ERROR       0xFFFF
 
 #endif

--- a/sesman/libscp/libscp_connection.c
+++ b/sesman/libscp/libscp_connection.c
@@ -32,32 +32,14 @@
 
 //extern struct log_config* s_log;
 
-struct SCP_CONNECTION *
-scp_connection_create(int sck)
+struct trans *
+scp_trans_create(int sck)
 {
-    struct SCP_CONNECTION *conn;
-
-    conn = g_new(struct SCP_CONNECTION, 1);
-
-    if (0 == conn)
+    struct trans *result = trans_create(TRANS_MODE_TCP, 8192, 8192);
+    if (result != NULL)
     {
-        LOG(LOG_LEVEL_ERROR, "[connection:%d] connection create: malloc error", __LINE__);
-        return 0;
+        result->sck = sck;
     }
 
-    conn->in_sck = sck;
-    make_stream(conn->in_s);
-    init_stream(conn->in_s, 8196);
-    make_stream(conn->out_s);
-    init_stream(conn->out_s, 8196);
-
-    return conn;
-}
-
-void
-scp_connection_destroy(struct SCP_CONNECTION *c)
-{
-    free_stream(c->in_s);
-    free_stream(c->out_s);
-    g_free(c);
+    return result;
 }

--- a/sesman/libscp/libscp_connection.h
+++ b/sesman/libscp/libscp_connection.h
@@ -31,22 +31,18 @@
 
 /**
  *
- * @brief creates a new connection
+ * @brief creates a new SCP transport object
  * @param sck the connection socket
  *
- * @return a struct SCP_CONNECTION* object on success, NULL otherwise
+ * This is a convenience function which calls trans_create() with the
+ * correct parameters.
+ *
+ * Returned object can be freed with trans_delete()
+ *
+ * @return a struct trans* object on success, NULL otherwise
  *
  */
-struct SCP_CONNECTION *
-scp_connection_create(int sck);
-
-/**
- *
- * @brief destroys a struct SCP_CONNECTION* object
- * @param c the object to be destroyed
- *
- */
-void
-scp_connection_destroy(struct SCP_CONNECTION *c);
+struct trans *
+scp_trans_create(int sck);
 
 #endif

--- a/sesman/libscp/libscp_session.c
+++ b/sesman/libscp/libscp_session.c
@@ -78,14 +78,6 @@ scp_session_set_type(struct SCP_SESSION *s, tui8 type)
 
         case SCP_SESSION_TYPE_MANAGE:
             s->type = SCP_SESSION_TYPE_MANAGE;
-            s->mng = (struct SCP_MNG_DATA *)g_malloc(sizeof(struct SCP_MNG_DATA), 1);
-
-            if (NULL == s->mng)
-            {
-                LOG(LOG_LEVEL_ERROR, "[session:%d] set_type: internal error", __LINE__);
-                return 1;
-            }
-
             break;
 
         default:
@@ -439,14 +431,55 @@ scp_session_set_guid(struct SCP_SESSION *s, const tui8 *guid)
 void
 scp_session_destroy(struct SCP_SESSION *s)
 {
-    g_free(s->username);
-    g_free(s->password);
-    g_free(s->hostname);
-    g_free(s->domain);
-    g_free(s->program);
-    g_free(s->directory);
-    g_free(s->client_ip);
-    g_free(s->errstr);
-    g_free(s->mng);
-    g_free(s);
+    if (s != NULL)
+    {
+        g_free(s->username);
+        g_free(s->password);
+        g_free(s->hostname);
+        g_free(s->domain);
+        g_free(s->program);
+        g_free(s->directory);
+        g_free(s->client_ip);
+        g_free(s->errstr);
+        g_free(s);
+    }
+}
+
+/*******************************************************************/
+struct SCP_SESSION *
+scp_session_clone(const struct SCP_SESSION *s)
+{
+    struct SCP_SESSION *result = NULL;
+
+    if (s != NULL && (result = g_new(struct SCP_SESSION, 1)) != NULL)
+    {
+        /* Duplicate all the scalar variables */
+        g_memcpy(result, s, sizeof(*s));
+
+        /* Now duplicate all the strings */
+        result->username = g_strdup(s->username);
+        result->password = g_strdup(s->password);
+        result->hostname = g_strdup(s->hostname);
+        result->errstr = g_strdup(s->errstr);
+        result->domain = g_strdup(s->domain);
+        result->program = g_strdup(s->program);
+        result->directory = g_strdup(s->directory);
+        result->client_ip = g_strdup(s->client_ip);
+
+        /* Did all the string copies succeed? */
+        if ((s->username != NULL && result->username == NULL) ||
+                (s->password != NULL && result->password == NULL) ||
+                (s->hostname != NULL && result->hostname == NULL) ||
+                (s->errstr != NULL && result->errstr == NULL) ||
+                (s->domain != NULL && result->domain == NULL) ||
+                (s->program != NULL && result->program == NULL) ||
+                (s->directory != NULL && result->directory == NULL) ||
+                (s->client_ip != NULL && result->client_ip == NULL))
+        {
+            scp_session_destroy(result);
+            result = NULL;
+        }
+    }
+
+    return result;
 }

--- a/sesman/libscp/libscp_session.h
+++ b/sesman/libscp/libscp_session.h
@@ -40,6 +40,14 @@
 struct SCP_SESSION *
 scp_session_create(void);
 
+/*
+ * Makes a copy of a struct SCP_SESSION object
+ * @param s Object to clone
+ * @return a copy of s, or NULL if no memory
+ */
+struct SCP_SESSION *
+scp_session_clone(const struct SCP_SESSION *s);
+
 int
 scp_session_set_type(struct SCP_SESSION *s, tui8 type);
 

--- a/sesman/libscp/libscp_types.h
+++ b/sesman/libscp/libscp_types.h
@@ -94,6 +94,11 @@ struct SCP_SESSION
     char *directory;
     char *client_ip;
     tui8 guid[16];
+    /* added for state */
+    int current_cmd;
+    int return_sid;
+    int retries;
+    int current_try;
 };
 
 struct SCP_DISCONNECTED_SESSION

--- a/sesman/libscp/libscp_types.h
+++ b/sesman/libscp/libscp_types.h
@@ -31,6 +31,7 @@
 #include "parse.h"
 #include "arch.h"
 #include "log.h"
+#include "trans.h"
 
 #define SCP_SID      tui32
 #define SCP_DISPLAY  tui16

--- a/sesman/libscp/libscp_types.h
+++ b/sesman/libscp/libscp_types.h
@@ -64,13 +64,6 @@
    exhaustion attempts (CVE-2020-4044) */
 #define SCP_MAX_MESSAGE_SIZE 8192
 
-struct SCP_CONNECTION
-{
-    int in_sck;
-    struct stream *in_s;
-    struct stream *out_s;
-};
-
 struct SCP_SESSION
 {
     tui8  type;

--- a/sesman/libscp/libscp_types.h
+++ b/sesman/libscp/libscp_types.h
@@ -81,7 +81,6 @@ struct SCP_SESSION
     tui8  ipv6addr[16];
     SCP_DISPLAY display;
     char *errstr;
-    struct SCP_MNG_DATA *mng;
     char *domain;
     char *program;
     char *directory;

--- a/sesman/libscp/libscp_v0.c
+++ b/sesman/libscp/libscp_v0.c
@@ -244,7 +244,7 @@ scp_v0s_init_session(struct trans *atrans, struct SCP_SESSION *session)
 
     if (!s_check_rem(in_s, 6))
     {
-        return SCP_SERVER_STATE_INTERNAL_ERR;
+        return SCP_SERVER_STATE_SIZE_ERR;
     }
     in_uint8s(in_s, 4); /* size */
     in_uint16_be(in_s, code);
@@ -310,6 +310,7 @@ scp_v0s_init_session(struct trans *atrans, struct SCP_SESSION *session)
             {
                 return SCP_SERVER_STATE_SIZE_ERR;
             }
+
             if (buf[0] != '\0')
             {
                 scp_session_set_domain(session, buf);

--- a/sesman/libscp/libscp_v0.h
+++ b/sesman/libscp/libscp_v0.h
@@ -29,6 +29,9 @@
 
 #include "libscp.h"
 
+/*TODO : Replace this (unused) function with something that can be used
+ * by xrdp_mm.c and sesrun.c */
+#if 0
 /* client API */
 /**
  *
@@ -40,6 +43,7 @@
  */
 enum SCP_CLIENT_STATES_E
 scp_v0c_connect(struct SCP_CONNECTION *c, struct SCP_SESSION *s);
+#endif
 
 /* server API */
 /**

--- a/sesman/libscp/libscp_v0.h
+++ b/sesman/libscp/libscp_v0.h
@@ -54,7 +54,7 @@ scp_v0c_connect(struct SCP_CONNECTION *c, struct SCP_SESSION *s);
  *
  */
 enum SCP_SERVER_STATES_E
-scp_v0s_accept(struct trans *atrans, struct SCP_SESSION **s);
+scp_v0s_accept(struct trans *atrans, struct SCP_SESSION *s);
 
 /**
  *

--- a/sesman/libscp/libscp_v0.h
+++ b/sesman/libscp/libscp_v0.h
@@ -45,40 +45,38 @@ scp_v0c_connect(struct SCP_CONNECTION *c, struct SCP_SESSION *s);
 /**
  *
  * @brief processes the stream using scp version 0
- * @param c connection descriptor
+ * @param atrans connection trans
  * @param s session descriptor
- * @param skipVchk if set to !0 skips the version control (to be used after
- *                 scp_vXs_accept() )
  *
  */
 enum SCP_SERVER_STATES_E
-scp_v0s_accept(struct SCP_CONNECTION *c, struct SCP_SESSION **s, int skipVchk);
+scp_v0s_accept(struct trans *atrans, struct SCP_SESSION **s);
 
 /**
  *
  * @brief allows the connection to TS, returning the display port
- * @param c connection descriptor
+ * @param atrans connection trans
  *
  */
 enum SCP_SERVER_STATES_E
-scp_v0s_allow_connection(struct SCP_CONNECTION *c, SCP_DISPLAY d, const tui8 *guid);
+scp_v0s_allow_connection(struct trans *atrans, SCP_DISPLAY d, const tui8 *guid);
 
 /**
  *
  * @brief denies the connection to TS
- * @param c connection descriptor
+ * @param atrans connection trans
  *
  */
 enum SCP_SERVER_STATES_E
-scp_v0s_deny_connection(struct SCP_CONNECTION *c);
+scp_v0s_deny_connection(struct trans *atrans);
 
 /**
  * @brief send reply to an authentication request
- * @param c connection descriptor
+ * @param atrans connection trans
  * @param value the reply code 0 means ok
  * @return
  */
 enum SCP_SERVER_STATES_E
-scp_v0s_replyauthentication(struct SCP_CONNECTION *c, unsigned short int value);
+scp_v0s_replyauthentication(struct trans *atrans, unsigned short int value);
 
 #endif

--- a/sesman/libscp/libscp_v1c.c
+++ b/sesman/libscp/libscp_v1c.c
@@ -35,18 +35,16 @@
 #include <stdio.h>
 
 static enum SCP_CLIENT_STATES_E
-_scp_v1c_check_response(struct SCP_CONNECTION *c, struct SCP_SESSION *s);
+_scp_v1c_check_response(struct trans *t, struct SCP_SESSION *s);
 
 /* client API */
 /* 001 */
 enum SCP_CLIENT_STATES_E
-scp_v1c_connect(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
+scp_v1c_connect(struct trans *t, struct SCP_SESSION *s)
 {
     tui8 sz;
-    tui32 size;
-
-    init_stream(c->out_s, c->out_s->size);
-    init_stream(c->in_s, c->in_s->size);
+    int size;
+    struct stream *out_s = t->out_s;
 
     size = (19 + 17 + 4 + g_strlen(s->hostname) + g_strlen(s->username) +
             g_strlen(s->password));
@@ -60,94 +58,100 @@ scp_v1c_connect(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
         size = size + 16;
     }
 
+    init_stream(out_s, size);
+
     /* sending request */
 
     /* header */
-    out_uint32_be(c->out_s, 1); /* version */
-    out_uint32_be(c->out_s, size);
-    out_uint16_be(c->out_s, SCP_COMMAND_SET_DEFAULT);
-    out_uint16_be(c->out_s, 1);
+    out_uint32_be(out_s, 1); /* version */
+    out_uint32_be(out_s, size);
+    out_uint16_be(out_s, SCP_COMMAND_SET_DEFAULT);
+    out_uint16_be(out_s, 1);
 
     /* body */
-    out_uint8(c->out_s, s->type);
-    out_uint16_be(c->out_s, s->height);
-    out_uint16_be(c->out_s, s->width);
-    out_uint8(c->out_s, s->bpp);
-    out_uint8(c->out_s, s->rsr);
-    out_uint8p(c->out_s, s->locale, 17);
-    out_uint8(c->out_s, s->addr_type);
+    out_uint8(out_s, s->type);
+    out_uint16_be(out_s, s->height);
+    out_uint16_be(out_s, s->width);
+    out_uint8(out_s, s->bpp);
+    out_uint8(out_s, s->rsr);
+    out_uint8p(out_s, s->locale, 17);
+    out_uint8(out_s, s->addr_type);
 
     if (s->addr_type == SCP_ADDRESS_TYPE_IPV4)
     {
-        out_uint32_be(c->out_s, s->ipv4addr);
+        out_uint32_be(out_s, s->ipv4addr);
     }
     else if (s->addr_type == SCP_ADDRESS_TYPE_IPV6)
     {
-        out_uint8p(c->out_s, s->ipv6addr, 16);
+        out_uint8p(out_s, s->ipv6addr, 16);
     }
 
     sz = g_strlen(s->hostname);
-    out_uint8(c->out_s, sz);
-    out_uint8p(c->out_s, s->hostname, sz);
+    out_uint8(out_s, sz);
+    out_uint8p(out_s, s->hostname, sz);
     sz = g_strlen(s->username);
-    out_uint8(c->out_s, sz);
-    out_uint8p(c->out_s, s->username, sz);
+    out_uint8(out_s, sz);
+    out_uint8p(out_s, s->username, sz);
     sz = g_strlen(s->password);
-    out_uint8(c->out_s, sz);
-    out_uint8p(c->out_s, s->password, sz);
+    out_uint8(out_s, sz);
+    out_uint8p(out_s, s->password, sz);
+    s_mark_end(out_s);
 
-    if (0 != scp_tcp_force_send(c->in_sck, c->out_s->data, size))
+    if (0 != trans_force_write(t))
     {
         return SCP_CLIENT_STATE_NETWORK_ERR;
     }
 
     /* wait for response */
-    return _scp_v1c_check_response(c, s);
+    return _scp_v1c_check_response(t, s);
 }
 
 /* 004 */
 enum SCP_CLIENT_STATES_E
-scp_v1c_resend_credentials(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
+scp_v1c_resend_credentials(struct trans *t, struct SCP_SESSION *s)
 {
+    struct stream *out_s = t->out_s;
     tui8 sz;
-    tui32 size;
-
-    init_stream(c->out_s, c->out_s->size);
-    init_stream(c->in_s, c->in_s->size);
+    int size;
 
     size = 12 + 2 + g_strlen(s->username) + g_strlen(s->password);
 
+    init_stream(out_s, size);
+
     /* sending request */
     /* header */
-    out_uint32_be(c->out_s, 1); /* version */
-    out_uint32_be(c->out_s, size);
-    out_uint16_be(c->out_s, SCP_COMMAND_SET_DEFAULT);
-    out_uint16_be(c->out_s, 4);
+    out_uint32_be(out_s, 1); /* version */
+    out_uint32_be(out_s, size);
+    out_uint16_be(out_s, SCP_COMMAND_SET_DEFAULT);
+    out_uint16_be(out_s, 4);
 
     /* body */
     sz = g_strlen(s->username);
-    out_uint8(c->out_s, sz);
-    out_uint8p(c->out_s, s->username, sz);
+    out_uint8(out_s, sz);
+    out_uint8p(out_s, s->username, sz);
     sz = g_strlen(s->password);
-    out_uint8(c->out_s, sz);
-    out_uint8p(c->out_s, s->password, sz);
+    out_uint8(out_s, sz);
+    out_uint8p(out_s, s->password, sz);
+    s_mark_end(out_s);
 
-    if (0 != scp_tcp_force_send(c->in_sck, c->out_s->data, size))
+    if (0 != trans_force_write(t))
     {
         return SCP_CLIENT_STATE_NETWORK_ERR;
     }
 
     /* wait for response */
-    return _scp_v1c_check_response(c, s);
+    return _scp_v1c_check_response(t, s);
 }
 
 /* 041 */
 enum SCP_CLIENT_STATES_E
-scp_v1c_get_session_list(struct SCP_CONNECTION *c, int *scount,
+scp_v1c_get_session_list(struct trans *t, int *scount,
                          struct SCP_DISCONNECTED_SESSION **s)
 {
+    struct stream *in_s = t->in_s;
+    struct stream *out_s = t->out_s;
     tui32 version = 1;
-    tui32 size = 12;
+    int size = 12;
     tui16 cmd = 41;
     tui32 sescnt = 0;    /* total session number */
     tui32 sestmp = 0;    /* additional total session number */
@@ -158,15 +162,16 @@ scp_v1c_get_session_list(struct SCP_CONNECTION *c, int *scount,
     int idx;
     struct SCP_DISCONNECTED_SESSION *ds = 0;
 
-    init_stream(c->out_s, c->out_s->size);
+    init_stream(out_s, 64);
 
     /* we request session list */
-    out_uint32_be(c->out_s, version);                 /* version */
-    out_uint32_be(c->out_s, size);                    /* size    */
-    out_uint16_be(c->out_s, SCP_COMMAND_SET_DEFAULT); /* cmdset  */
-    out_uint16_be(c->out_s, cmd);                     /* cmd     */
+    out_uint32_be(out_s, version);                 /* version */
+    out_uint32_be(out_s, size);                    /* size    */
+    out_uint16_be(out_s, SCP_COMMAND_SET_DEFAULT); /* cmdset  */
+    out_uint16_be(out_s, cmd);                     /* cmd     */
+    s_mark_end(out_s);
 
-    if (0 != scp_tcp_force_send(c->in_sck, c->out_s->data, size))
+    if (0 != trans_force_write(t))
     {
         return SCP_CLIENT_STATE_NETWORK_ERR;
     }
@@ -174,15 +179,15 @@ scp_v1c_get_session_list(struct SCP_CONNECTION *c, int *scount,
     do
     {
         /* then we wait for server response */
-        init_stream(c->in_s, c->in_s->size);
+        init_stream(in_s, 8);
 
-        if (0 != scp_tcp_force_recv(c->in_sck, c->in_s->data, 8))
+        if (0 != trans_force_read(t, 8))
         {
             g_free(ds);
             return SCP_CLIENT_STATE_NETWORK_ERR;
         }
 
-        in_uint32_be(c->in_s, version);
+        in_uint32_be(t->in_s, version);
 
         if (version != 1)
         {
@@ -190,7 +195,7 @@ scp_v1c_get_session_list(struct SCP_CONNECTION *c, int *scount,
             return SCP_CLIENT_STATE_VERSION_ERR;
         }
 
-        in_uint32_be(c->in_s, size);
+        in_uint32_be(t->in_s, size);
 
         if (size < 12)
         {
@@ -198,15 +203,15 @@ scp_v1c_get_session_list(struct SCP_CONNECTION *c, int *scount,
             return SCP_CLIENT_STATE_SIZE_ERR;
         }
 
-        init_stream(c->in_s, c->in_s->size);
+        init_stream(t->in_s, size - 8);
 
-        if (0 != scp_tcp_force_recv(c->in_sck, c->in_s->data, size - 8))
+        if (0 != trans_force_read(t, size - 8))
         {
             g_free(ds);
             return SCP_CLIENT_STATE_NETWORK_ERR;
         }
 
-        in_uint16_be(c->in_s, cmd);
+        in_uint16_be(in_s, cmd);
 
         if (cmd != SCP_COMMAND_SET_DEFAULT)
         {
@@ -214,7 +219,7 @@ scp_v1c_get_session_list(struct SCP_CONNECTION *c, int *scount,
             return SCP_CLIENT_STATE_SEQUENCE_ERR;
         }
 
-        in_uint16_be(c->in_s, cmd);
+        in_uint16_be(in_s, cmd);
 
         if (cmd != 42)
         {
@@ -225,7 +230,7 @@ scp_v1c_get_session_list(struct SCP_CONNECTION *c, int *scount,
         if (firstpkt)
         {
             firstpkt = 0;
-            in_uint32_be(c->in_s, sescnt);
+            in_uint32_be(in_s, sescnt);
             sestmp = sescnt;
 
             ds = g_new(struct SCP_DISCONNECTED_SESSION, sescnt);
@@ -237,37 +242,37 @@ scp_v1c_get_session_list(struct SCP_CONNECTION *c, int *scount,
         }
         else
         {
-            in_uint32_be(c->in_s, sestmp);
+            in_uint32_be(in_s, sestmp);
         }
 
-        in_uint8(c->in_s, continued);
-        in_uint8(c->in_s, pktcnt);
+        in_uint8(in_s, continued);
+        in_uint8(in_s, pktcnt);
 
         for (idx = 0; idx < pktcnt; idx++)
         {
-            in_uint32_be(c->in_s, (ds[totalcnt]).SID); /* session id */
-            in_uint8(c->in_s, (ds[totalcnt]).type);
-            in_uint16_be(c->in_s, (ds[totalcnt]).height);
-            in_uint16_be(c->in_s, (ds[totalcnt]).width);
-            in_uint8(c->in_s, (ds[totalcnt]).bpp);
-            in_uint8(c->in_s, (ds[totalcnt]).idle_days);
-            in_uint8(c->in_s, (ds[totalcnt]).idle_hours);
-            in_uint8(c->in_s, (ds[totalcnt]).idle_minutes);
+            in_uint32_be(in_s, (ds[totalcnt]).SID); /* session id */
+            in_uint8(in_s, (ds[totalcnt]).type);
+            in_uint16_be(in_s, (ds[totalcnt]).height);
+            in_uint16_be(in_s, (ds[totalcnt]).width);
+            in_uint8(in_s, (ds[totalcnt]).bpp);
+            in_uint8(in_s, (ds[totalcnt]).idle_days);
+            in_uint8(in_s, (ds[totalcnt]).idle_hours);
+            in_uint8(in_s, (ds[totalcnt]).idle_minutes);
 
-            in_uint16_be(c->in_s, (ds[totalcnt]).conn_year);
-            in_uint8(c->in_s, (ds[totalcnt]).conn_month);
-            in_uint8(c->in_s, (ds[totalcnt]).conn_day);
-            in_uint8(c->in_s, (ds[totalcnt]).conn_hour);
-            in_uint8(c->in_s, (ds[totalcnt]).conn_minute);
-            in_uint8(c->in_s, (ds[totalcnt]).addr_type);
+            in_uint16_be(in_s, (ds[totalcnt]).conn_year);
+            in_uint8(in_s, (ds[totalcnt]).conn_month);
+            in_uint8(in_s, (ds[totalcnt]).conn_day);
+            in_uint8(in_s, (ds[totalcnt]).conn_hour);
+            in_uint8(in_s, (ds[totalcnt]).conn_minute);
+            in_uint8(in_s, (ds[totalcnt]).addr_type);
 
             if ((ds[totalcnt]).addr_type == SCP_ADDRESS_TYPE_IPV4)
             {
-                in_uint32_be(c->in_s, (ds[totalcnt]).ipv4addr);
+                in_uint32_be(in_s, (ds[totalcnt]).ipv4addr);
             }
             else if ((ds[totalcnt]).addr_type == SCP_ADDRESS_TYPE_IPV6)
             {
-                in_uint8a(c->in_s, (ds[totalcnt]).ipv6addr, 16);
+                in_uint8a(in_s, (ds[totalcnt]).ipv6addr, 16);
             }
 
             totalcnt++;
@@ -285,66 +290,69 @@ scp_v1c_get_session_list(struct SCP_CONNECTION *c, int *scount,
 
 /* 043 */
 enum SCP_CLIENT_STATES_E
-scp_v1c_select_session(struct SCP_CONNECTION *c, struct SCP_SESSION *s,
+scp_v1c_select_session(struct trans *t, struct SCP_SESSION *s,
                        SCP_SID sid)
 {
+    struct stream *in_s = t->in_s;
+    struct stream *out_s = t->out_s;
     tui32 version = 1;
-    tui32 size = 16;
+    int size = 16;
     tui16 cmd = 43;
 
-    init_stream(c->out_s, c->out_s->size);
+    init_stream(out_s, 64);
 
     /* sending our selection */
-    out_uint32_be(c->out_s, version);                 /* version */
-    out_uint32_be(c->out_s, size);                    /* size    */
-    out_uint16_be(c->out_s, SCP_COMMAND_SET_DEFAULT); /* cmdset  */
-    out_uint16_be(c->out_s, cmd);                     /* cmd     */
+    out_uint32_be(out_s, version);                 /* version */
+    out_uint32_be(out_s, size);                    /* size    */
+    out_uint16_be(out_s, SCP_COMMAND_SET_DEFAULT); /* cmdset  */
+    out_uint16_be(out_s, cmd);                     /* cmd     */
 
-    out_uint32_be(c->out_s, sid);
+    out_uint32_be(out_s, sid);
+    s_mark_end(out_s);
 
-    if (0 != scp_tcp_force_send(c->in_sck, c->out_s->data, size))
+    if (0 != trans_force_write(t))
     {
         return SCP_CLIENT_STATE_NETWORK_ERR;
     }
 
     /* waiting for response.... */
-    init_stream(c->in_s, c->in_s->size);
+    init_stream(in_s, 8);
 
-    if (0 != scp_tcp_force_recv(c->in_sck, c->in_s->data, 8))
+    if (0 != trans_force_read(t, 8))
     {
         return SCP_CLIENT_STATE_NETWORK_ERR;
     }
 
-    in_uint32_be(c->in_s, version);
+    in_uint32_be(in_s, version);
 
     if (version != 1)
     {
         return SCP_CLIENT_STATE_VERSION_ERR;
     }
 
-    in_uint32_be(c->in_s, size);
+    in_uint32_be(in_s, size);
 
     if (size < 12)
     {
         return SCP_CLIENT_STATE_SIZE_ERR;
     }
 
-    init_stream(c->in_s, c->in_s->size);
+    init_stream(in_s, size - 8);
 
     /* read the rest of the packet */
-    if (0 != scp_tcp_force_recv(c->in_sck, c->in_s->data, size - 8))
+    if (0 != trans_force_read(t, size - 8))
     {
         return SCP_CLIENT_STATE_NETWORK_ERR;
     }
 
-    in_uint16_be(c->in_s, cmd);
+    in_uint16_be(in_s, cmd);
 
     if (cmd != SCP_COMMAND_SET_DEFAULT)
     {
         return SCP_CLIENT_STATE_SEQUENCE_ERR;
     }
 
-    in_uint16_be(c->in_s, cmd);
+    in_uint16_be(in_s, cmd);
 
     if (cmd != 46)
     {
@@ -352,7 +360,7 @@ scp_v1c_select_session(struct SCP_CONNECTION *c, struct SCP_SESSION *s,
     }
 
     /* session display */
-    in_uint16_be(c->in_s, (s->display));
+    in_uint16_be(in_s, (s->display));
     /*we don't need to return any data other than the display */
     /*because we already sent that                            */
 
@@ -361,21 +369,23 @@ scp_v1c_select_session(struct SCP_CONNECTION *c, struct SCP_SESSION *s,
 
 /* 044 */
 enum SCP_CLIENT_STATES_E
-scp_v1c_select_session_cancel(struct SCP_CONNECTION *c)
+scp_v1c_select_session_cancel(struct trans *t)
 {
+    struct stream *out_s = t->out_s;
     tui32 version = 1;
     tui32 size = 12;
     tui16 cmd = 44;
 
-    init_stream(c->out_s, c->out_s->size);
+    init_stream(out_s, 64);
 
     /* sending our selection */
-    out_uint32_be(c->out_s, version);                 /* version */
-    out_uint32_be(c->out_s, size);                    /* size    */
-    out_uint16_be(c->out_s, SCP_COMMAND_SET_DEFAULT); /* cmdset  */
-    out_uint16_be(c->out_s, cmd);                     /* cmd     */
+    out_uint32_be(out_s, version);                 /* version */
+    out_uint32_be(out_s, size);                    /* size    */
+    out_uint16_be(out_s, SCP_COMMAND_SET_DEFAULT); /* cmdset  */
+    out_uint16_be(out_s, cmd);                     /* cmd     */
+    s_mark_end(out_s);
 
-    if (0 != scp_tcp_force_send(c->in_sck, c->out_s->data, size))
+    if (0 != trans_force_write(t))
     {
         return SCP_CLIENT_STATE_NETWORK_ERR;
     }
@@ -384,49 +394,50 @@ scp_v1c_select_session_cancel(struct SCP_CONNECTION *c)
 }
 
 static enum SCP_CLIENT_STATES_E
-_scp_v1c_check_response(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
+_scp_v1c_check_response(struct trans *t, struct SCP_SESSION *s)
 {
+    struct stream *in_s = t->in_s;
     tui32 version;
-    tui32 size;
+    int size;
     tui16 cmd;
     tui16 dim;
 
-    init_stream(c->in_s, c->in_s->size);
+    init_stream(in_s, 64);
 
-    if (0 != scp_tcp_force_recv(c->in_sck, c->in_s->data, 8))
+    if (0 != trans_force_read(t, 8))
     {
         return SCP_CLIENT_STATE_NETWORK_ERR;
     }
 
-    in_uint32_be(c->in_s, version);
+    in_uint32_be(in_s, version);
 
     if (version != 1)
     {
         return SCP_CLIENT_STATE_VERSION_ERR;
     }
 
-    in_uint32_be(c->in_s, size);
+    in_uint32_be(in_s, size);
 
-    init_stream(c->in_s, c->in_s->size);
+    init_stream(in_s, size - 8);
 
     /* read the rest of the packet */
-    if (0 != scp_tcp_force_recv(c->in_sck, c->in_s->data, size - 8))
+    if (0 != trans_force_read(t, size - 8))
     {
         return SCP_CLIENT_STATE_NETWORK_ERR;
     }
 
-    in_uint16_be(c->in_s, cmd);
+    in_uint16_be(in_s, cmd);
 
     if (cmd != SCP_COMMAND_SET_DEFAULT)
     {
         return SCP_CLIENT_STATE_SEQUENCE_ERR;
     }
 
-    in_uint16_be(c->in_s, cmd);
+    in_uint16_be(in_s, cmd);
 
     if (cmd == 2) /* connection denied */
     {
-        in_uint16_be(c->in_s, dim);
+        in_uint16_be(in_s, dim);
 
         if (s->errstr != 0)
         {
@@ -440,14 +451,14 @@ _scp_v1c_check_response(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
             return SCP_CLIENT_STATE_INTERNAL_ERR;
         }
 
-        in_uint8a(c->in_s, s->errstr, dim);
+        in_uint8a(in_s, s->errstr, dim);
         (s->errstr)[dim] = '\0';
 
         return SCP_CLIENT_STATE_CONNECTION_DENIED;
     }
     else if (cmd == 3) /* resend usr/pwd */
     {
-        in_uint16_be(c->in_s, dim);
+        in_uint16_be(in_s, dim);
 
         if (s->errstr != 0)
         {
@@ -461,14 +472,14 @@ _scp_v1c_check_response(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
             return SCP_CLIENT_STATE_INTERNAL_ERR;
         }
 
-        in_uint8a(c->in_s, s->errstr, dim);
+        in_uint8a(in_s, s->errstr, dim);
         (s->errstr)[dim] = '\0';
 
         return SCP_CLIENT_STATE_RESEND_CREDENTIALS;
     }
     else if (cmd == 20) /* password change */
     {
-        in_uint16_be(c->in_s, dim);
+        in_uint16_be(in_s, dim);
 
         if (s->errstr != 0)
         {
@@ -482,14 +493,14 @@ _scp_v1c_check_response(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
             return SCP_CLIENT_STATE_INTERNAL_ERR;
         }
 
-        in_uint8a(c->in_s, s->errstr, dim);
+        in_uint8a(in_s, s->errstr, dim);
         (s->errstr)[dim] = '\0';
 
         return SCP_CLIENT_STATE_PWD_CHANGE_REQ;
     }
     else if (cmd == 30) /* display */
     {
-        in_uint16_be(c->in_s, s->display);
+        in_uint16_be(in_s, s->display);
 
         return SCP_CLIENT_STATE_OK;
     }

--- a/sesman/libscp/libscp_v1c.h
+++ b/sesman/libscp/libscp_v1c.h
@@ -32,32 +32,32 @@
 /* client API */
 /* 001 */
 enum SCP_CLIENT_STATES_E
-scp_v1c_connect(struct SCP_CONNECTION *c, struct SCP_SESSION *s);
+scp_v1c_connect(struct trans *t, struct SCP_SESSION *s);
 
 /* 004 */
 enum SCP_CLIENT_STATES_E
-scp_v1c_resend_credentials(struct SCP_CONNECTION *c, struct SCP_SESSION *s);
+scp_v1c_resend_credentials(struct trans *t, struct SCP_SESSION *s);
 
 /* 021 */
 enum SCP_CLIENT_STATES_E
-scp_v1c_pwd_change(struct SCP_CONNECTION *c, char *newpass);
+scp_v1c_pwd_change(struct trans *t, char *newpass);
 
 /* 022 */
 enum SCP_CLIENT_STATES_E
-scp_v1c_pwd_change_cancel(struct SCP_CONNECTION *c);
+scp_v1c_pwd_change_cancel(struct trans *t);
 
 /* 041 */
 enum SCP_CLIENT_STATES_E
-scp_v1c_get_session_list(struct SCP_CONNECTION *c, int *scount,
+scp_v1c_get_session_list(struct trans *t, int *scount,
                          struct SCP_DISCONNECTED_SESSION **s);
 
 /* 043 */
 enum SCP_CLIENT_STATES_E
-scp_v1c_select_session(struct SCP_CONNECTION *c, struct SCP_SESSION *s,
+scp_v1c_select_session(struct trans *t, struct SCP_SESSION *s,
                        SCP_SID sid);
 
 /* 044 */
 enum SCP_CLIENT_STATES_E
-scp_v1c_select_session_cancel(struct SCP_CONNECTION *c);
+scp_v1c_select_session_cancel(struct trans *t);
 
 #endif

--- a/sesman/libscp/libscp_v1c_mng.c
+++ b/sesman/libscp/libscp_v1c_mng.c
@@ -95,6 +95,7 @@ scp_v1c_mng_connect(struct trans *t, struct SCP_SESSION *s)
     sz = g_strlen(s->hostname);
     out_uint8(out_s, sz);
     out_uint8p(out_s, s->hostname, sz);
+    s_mark_end(out_s);
 
     if (0 != trans_force_write(t))
     {

--- a/sesman/libscp/libscp_v1c_mng.h
+++ b/sesman/libscp/libscp_v1c_mng.h
@@ -32,7 +32,7 @@
 /* client API */
 /* 001 */
 enum SCP_CLIENT_STATES_E
-scp_v1c_mng_connect(struct SCP_CONNECTION *c, struct SCP_SESSION *s);
+scp_v1c_mng_connect(struct trans *t, struct SCP_SESSION *s);
 
 /* 004 * /
 enum SCP_CLIENT_STATES_E
@@ -49,7 +49,7 @@ scp_v1c_pwd_change_cancel(struct SCP_CONNECTION* c);
 
 /* 041 */
 enum SCP_CLIENT_STATES_E
-scp_v1c_mng_get_session_list(struct SCP_CONNECTION *c, int *scount,
+scp_v1c_mng_get_session_list(struct trans *t, int *scount,
                              struct SCP_DISCONNECTED_SESSION **s);
 
 #endif

--- a/sesman/libscp/libscp_v1s.h
+++ b/sesman/libscp/libscp_v1s.h
@@ -46,6 +46,18 @@ scp_v1s_accept(struct SCP_CONNECTION *c, struct SCP_SESSION **s, int skipVchk);
 
 /**
  *
+ * @brief processes the stream using scp version 1
+ * @param trans connection trans
+ * @param s pointer to session descriptor pointer
+ *
+ * this function places in *s the address of a newly allocated SCP_SESSION structure
+ * that should be free()d
+ */
+enum SCP_SERVER_STATES_E
+scp_v1s_accept_msg(struct trans *atrans, struct SCP_SESSION **s);
+
+/**
+ *
  * @brief denies connection to sesman
  * @param c connection descriptor
  * @param reason pointer to a string containing the reason for denying connection

--- a/sesman/libscp/libscp_v1s.h
+++ b/sesman/libscp/libscp_v1s.h
@@ -33,20 +33,6 @@
 /**
  *
  * @brief processes the stream using scp version 1
- * @param c connection descriptor
- * @param s pointer to session descriptor pointer
- * @param skipVchk if set to !0 skips the version control (to be used after
- *                 scp_vXs_accept() )
- *
- * this function places in *s the address of a newly allocated SCP_SESSION structure
- * that should be free()d
- */
-enum SCP_SERVER_STATES_E
-scp_v1s_accept(struct SCP_CONNECTION *c, struct SCP_SESSION **s, int skipVchk);
-
-/**
- *
- * @brief processes the stream using scp version 1
  * @param trans connection trans
  * @param s pointer to session descriptor pointer
  *
@@ -54,7 +40,7 @@ scp_v1s_accept(struct SCP_CONNECTION *c, struct SCP_SESSION **s, int skipVchk);
  * that should be free()d
  */
 enum SCP_SERVER_STATES_E
-scp_v1s_accept_msg(struct trans *atrans, struct SCP_SESSION **s);
+scp_v1s_accept(struct trans *t, struct SCP_SESSION **s);
 
 /**
  *
@@ -65,35 +51,47 @@ scp_v1s_accept_msg(struct trans *atrans, struct SCP_SESSION **s);
  */
 /* 002 */
 enum SCP_SERVER_STATES_E
-scp_v1s_deny_connection(struct SCP_CONNECTION *c, const char *reason);
+scp_v1s_deny_connection(struct trans *t, const char *reason);
 
 enum SCP_SERVER_STATES_E
-scp_v1s_request_password(struct SCP_CONNECTION *c, struct SCP_SESSION *s,
+scp_v1s_request_password(struct trans *t, struct SCP_SESSION *s,
                          const char *reason);
+
+enum SCP_SERVER_STATES_E
+scp_v1s_accept_password_reply(int cmd, struct trans *t);
+
+enum SCP_SERVER_STATES_E
+scp_v1s_accept_list_sessions_reply(int cmd, struct trans *t);
 
 /* 020 */
 enum SCP_SERVER_STATES_E
-scp_v1s_request_pwd_change(struct SCP_CONNECTION *c, char *reason, char *npw);
+scp_v1s_request_pwd_change(struct trans *t, char *reason, char *npw);
 
 /* 023 */
 enum SCP_SERVER_STATES_E
-scp_v1s_pwd_change_error(struct SCP_CONNECTION *c, char *error, int retry, char *npw);
+scp_v1s_pwd_change_error(struct trans *t, char *error, int retry, char *npw);
 
 /* 030 */
 enum SCP_SERVER_STATES_E
-scp_v1s_connect_new_session(struct SCP_CONNECTION *c, SCP_DISPLAY d);
+scp_v1s_connect_new_session(struct trans *t, SCP_DISPLAY d);
 
 /* 032 */
 enum SCP_SERVER_STATES_E
-scp_v1s_connection_error(struct SCP_CONNECTION *c, const char *error);
+scp_v1s_connection_error(struct trans *t, const char *error);
 
 /* 040 */
 enum SCP_SERVER_STATES_E
 scp_v1s_list_sessions(struct SCP_CONNECTION *c, int sescnt,
                       struct SCP_DISCONNECTED_SESSION *ds, SCP_SID *sid);
 
+enum SCP_SERVER_STATES_E
+scp_v1s_list_sessions40(struct trans *t);
+
+enum SCP_SERVER_STATES_E
+scp_v1s_list_sessions42(struct trans *t, int sescnt, struct SCP_DISCONNECTED_SESSION *ds);
+
 /* 046 was: 031 struct SCP_DISCONNECTED_SESSION* ds, */
 enum SCP_SERVER_STATES_E
-scp_v1s_reconnect_session(struct SCP_CONNECTION *c, SCP_DISPLAY d);
+scp_v1s_reconnect_session(struct trans *t, SCP_DISPLAY d);
 
 #endif

--- a/sesman/libscp/libscp_v1s.h
+++ b/sesman/libscp/libscp_v1s.h
@@ -80,9 +80,11 @@ enum SCP_SERVER_STATES_E
 scp_v1s_connection_error(struct trans *t, const char *error);
 
 /* 040 */
+#if 0
 enum SCP_SERVER_STATES_E
 scp_v1s_list_sessions(struct SCP_CONNECTION *c, int sescnt,
                       struct SCP_DISCONNECTED_SESSION *ds, SCP_SID *sid);
+#endif
 
 enum SCP_SERVER_STATES_E
 scp_v1s_list_sessions40(struct trans *t);

--- a/sesman/libscp/libscp_v1s.h
+++ b/sesman/libscp/libscp_v1s.h
@@ -40,7 +40,7 @@
  * that should be free()d
  */
 enum SCP_SERVER_STATES_E
-scp_v1s_accept(struct trans *t, struct SCP_SESSION **s);
+scp_v1s_accept(struct trans *t, struct SCP_SESSION *s);
 
 /**
  *
@@ -58,7 +58,7 @@ scp_v1s_request_password(struct trans *t, struct SCP_SESSION *s,
                          const char *reason);
 
 enum SCP_SERVER_STATES_E
-scp_v1s_accept_password_reply(int cmd, struct trans *t);
+scp_v1s_accept_password_reply(struct trans *t, struct SCP_SESSION *s);
 
 enum SCP_SERVER_STATES_E
 scp_v1s_accept_list_sessions_reply(int cmd, struct trans *t);

--- a/sesman/libscp/libscp_v1s_mng.h
+++ b/sesman/libscp/libscp_v1s_mng.h
@@ -33,18 +33,6 @@
 /**
  *
  * @brief processes the stream using scp version 1
- * @param c connection descriptor
- * @param s pointer to session descriptor pointer
- *
- * this function places in *s the address of a newly allocated SCP_SESSION structure
- * that should be free()d
- */
-enum SCP_SERVER_STATES_E
-scp_v1s_mng_accept(struct SCP_CONNECTION *c, struct SCP_SESSION **s);
-
-/**
- *
- * @brief processes the stream using scp version 1
  * @param atrans connection descriptor
  * @param s pointer to session descriptor pointer
  *
@@ -52,7 +40,7 @@ scp_v1s_mng_accept(struct SCP_CONNECTION *c, struct SCP_SESSION **s);
  * that should be free()d
  */
 enum SCP_SERVER_STATES_E
-scp_v1s_mng_accept_msg(struct trans *atrans, struct SCP_SESSION **s);
+scp_v1s_mng_accept(struct trans *atrans, struct SCP_SESSION **s);
 
 /**
  *

--- a/sesman/libscp/libscp_v1s_mng.h
+++ b/sesman/libscp/libscp_v1s_mng.h
@@ -50,7 +50,7 @@ scp_v1s_mng_accept(struct trans *atrans, struct SCP_SESSION **s);
  */
 /* 002 */
 enum SCP_SERVER_STATES_E
-scp_v1s_mng_allow_connection(struct SCP_CONNECTION *c, struct SCP_SESSION *s);
+scp_v1s_mng_allow_connection(struct trans *atrans, struct SCP_SESSION *s);
 
 /**
  *
@@ -61,7 +61,7 @@ scp_v1s_mng_allow_connection(struct SCP_CONNECTION *c, struct SCP_SESSION *s);
  */
 /* 003 */
 enum SCP_SERVER_STATES_E
-scp_v1s_mng_deny_connection(struct SCP_CONNECTION *c, const char *reason);
+scp_v1s_mng_deny_connection(struct trans *atrans, const char *reason);
 
 /**
  *
@@ -71,7 +71,7 @@ scp_v1s_mng_deny_connection(struct SCP_CONNECTION *c, const char *reason);
  */
 /* 006 */
 enum SCP_SERVER_STATES_E
-scp_v1s_mng_list_sessions(struct SCP_CONNECTION *c, struct SCP_SESSION *s,
+scp_v1s_mng_list_sessions(struct trans *atrans, struct SCP_SESSION *s,
                           int sescnt, struct SCP_DISCONNECTED_SESSION *ds);
 //                           SCP_SID* sid);
 

--- a/sesman/libscp/libscp_v1s_mng.h
+++ b/sesman/libscp/libscp_v1s_mng.h
@@ -44,6 +44,18 @@ scp_v1s_mng_accept(struct SCP_CONNECTION *c, struct SCP_SESSION **s);
 
 /**
  *
+ * @brief processes the stream using scp version 1
+ * @param atrans connection descriptor
+ * @param s pointer to session descriptor pointer
+ *
+ * this function places in *s the address of a newly allocated SCP_SESSION structure
+ * that should be free()d
+ */
+enum SCP_SERVER_STATES_E
+scp_v1s_mng_accept_msg(struct trans *atrans, struct SCP_SESSION **s);
+
+/**
+ *
  * @brief allows connection to sesman
  * @param c connection descriptor
  *

--- a/sesman/libscp/libscp_v1s_mng.h
+++ b/sesman/libscp/libscp_v1s_mng.h
@@ -34,13 +34,10 @@
  *
  * @brief processes the stream using scp version 1
  * @param atrans connection descriptor
- * @param s pointer to session descriptor pointer
- *
- * this function places in *s the address of a newly allocated SCP_SESSION structure
- * that should be free()d
+ * @param s session descriptor pointer
  */
 enum SCP_SERVER_STATES_E
-scp_v1s_mng_accept(struct trans *atrans, struct SCP_SESSION **s);
+scp_v1s_mng_accept(struct trans *atrans, struct SCP_SESSION *s);
 
 /**
  *

--- a/sesman/libscp/libscp_vX.c
+++ b/sesman/libscp/libscp_vX.c
@@ -49,7 +49,7 @@ scp_vXs_accept(struct trans *atrans, struct SCP_SESSION **s)
     }
     else if (version == 1)
     {
-        return scp_v1s_accept_msg(atrans, s);
+        return scp_v1s_accept(atrans, s);
     }
     return SCP_SERVER_STATE_VERSION_ERR;
 }

--- a/sesman/libscp/libscp_vX.c
+++ b/sesman/libscp/libscp_vX.c
@@ -32,7 +32,7 @@
 
 /******************************************************************************/
 enum SCP_SERVER_STATES_E
-scp_vXs_accept(struct trans *atrans, struct SCP_SESSION **s)
+scp_vXs_accept(struct trans *atrans, struct SCP_SESSION *s)
 {
     struct stream *in_s;
     int version;

--- a/sesman/libscp/libscp_vX.c
+++ b/sesman/libscp/libscp_vX.c
@@ -30,28 +30,26 @@
 
 #include "libscp_vX.h"
 
-/* server API */
-enum SCP_SERVER_STATES_E scp_vXs_accept(struct SCP_CONNECTION *c, struct SCP_SESSION **s)
+/******************************************************************************/
+enum SCP_SERVER_STATES_E
+scp_vXs_accept(struct trans *atrans, struct SCP_SESSION **s)
 {
-    tui32 version;
+    struct stream *in_s;
+    int version;
 
-    /* reading version and packet size */
-    if (0 != scp_tcp_force_recv(c->in_sck, c->in_s->data, 8))
+    in_s = atrans->in_s;
+    if (!s_check_rem(in_s, 4))
     {
-        return SCP_SERVER_STATE_NETWORK_ERR;
+        return SCP_SERVER_STATE_INTERNAL_ERR;
     }
-    c->in_s->end = c->in_s->data + 8;
-
-    in_uint32_be(c->in_s, version);
-
+    in_uint32_be(in_s, version);
     if (version == 0)
     {
-        return scp_v0s_accept(c, s, 1);
+        return scp_v0s_accept(atrans, s);
     }
     else if (version == 1)
     {
-        return scp_v1s_accept(c, s, 1);
+        return scp_v1s_accept_msg(atrans, s);
     }
-
     return SCP_SERVER_STATE_VERSION_ERR;
 }

--- a/sesman/libscp/libscp_vX.h
+++ b/sesman/libscp/libscp_vX.h
@@ -36,12 +36,13 @@
 /**
  *
  * @brief version neutral server accept function
- * @param c connection descriptor
+ * @param atrans connection trans
  * @param s session descriptor pointer address.
  *          it will return a newly allocated descriptor.
  *          It this memory needs to be g_free()d
  *
  */
-enum SCP_SERVER_STATES_E scp_vXs_accept(struct SCP_CONNECTION *c, struct SCP_SESSION **s);
+enum SCP_SERVER_STATES_E
+scp_vXs_accept(struct trans *atrans, struct SCP_SESSION **s);
 
 #endif

--- a/sesman/libscp/libscp_vX.h
+++ b/sesman/libscp/libscp_vX.h
@@ -37,12 +37,10 @@
  *
  * @brief version neutral server accept function
  * @param atrans connection trans
- * @param s session descriptor pointer address.
- *          it will return a newly allocated descriptor.
- *          It this memory needs to be g_free()d
+ * @param s session descriptor
  *
  */
 enum SCP_SERVER_STATES_E
-scp_vXs_accept(struct trans *atrans, struct SCP_SESSION **s);
+scp_vXs_accept(struct trans *atrans, struct SCP_SESSION *s);
 
 #endif

--- a/sesman/notes.txt
+++ b/sesman/notes.txt
@@ -1,3 +1,11 @@
+************************************************************
+** Notes on the current version of the SCP protocol used  **
+** to communicate with sesman                             **
+**                                                        **
+** This information is for internal documentational use   **
+** only. It may be incomplete. The SCP protocol is        **
+** internal, and may change for even minor releases.      **
+************************************************************
 
 
 message header

--- a/sesman/notes.txt
+++ b/sesman/notes.txt
@@ -1,0 +1,58 @@
+
+
+message header
+version     4       - version, 0 or 1
+size        4       - size of PDU including header
+cmdset      2       - 0
+
+version 0
+cmdset 2 bytes
+    0   - Xvnc                              client to server
+    3   - response to 0, 10, or 20          server to client
+    4   - SCP_GW_AUTHENTICATION             client to server
+    10  - X11rdp                            client to server
+    20  - Xorg                              client to server
+
+version 1
+cmdset 2 bytes
+    0   - SCP_COMMAND_SET_DEFAULT
+    1   - SCP_COMMAND_SET_MANAGE
+    2   - SCP_COMMAND_SET_RSR
+
+SCP_COMMAND_SET_DEFAULT
+cmd 2 bytes
+    1       - main                          client to server
+    3       - password request              server to client
+    4       - password reply                client to server
+    30      - connect new session
+    40      - list all sessions             server to client
+    41      - list all sessions response    client to server
+    42      - list all sessions             server to client
+    43      - list all sessions response    client to server
+    44      - list all sessions response    client to server
+    45      -                               client to server
+    46      - reconnect session
+    0xFFFF  - SCP_CMD_CONN_ERROR
+
+SCP_COMMAND_SET_MANAGE
+cmd 2 bytes
+    1       - manager login
+    2       - SCP_CMD_MNG_LOGIN_ALLOW
+
+v0
+scp_process                         scp.c
+    scp_vXs_accept                  libscp_vX.c
+        scp_v0s_accept              libscp_v0.c
+    scp_v0_process                  scp_v0.c
+        session_start               session.c
+
+v1
+scp_process                         scp.c
+    scp_vXs_accept                  libscp_vX.c
+        scp_v1s_accept              libscp_v1s.c
+            scp_v1s_mng_accept      libscp_v1s_mng.c
+    scp_v1_process                  scp_v1.c
+        scp_v1s_request_password    libscp_v1s.c
+    or
+    scp_v1_mng_process              scp_v1_mng.c
+

--- a/sesman/scp.c
+++ b/sesman/scp.c
@@ -39,10 +39,12 @@ extern struct config_sesman *g_cfg; /* in sesman.c */
 enum SCP_SERVER_STATES_E
 scp_process(struct trans *t)
 {
+    enum SCP_SERVER_STATES_E result;
     struct SCP_SESSION *sdata;
 
     sdata = NULL;
-    switch (scp_vXs_accept(t, &sdata))
+    result = scp_vXs_accept(t, &sdata);
+    switch (result)
     {
         case SCP_SERVER_STATE_OK:
             if (sdata->version == 0)
@@ -83,8 +85,9 @@ scp_process(struct trans *t)
             break;
         default:
             LOG(LOG_LEVEL_ALWAYS, "unknown return from scp_vXs_accept()");
+            result = SCP_SERVER_STATE_INTERNAL_ERR;
             break;
     }
-    return 0;
+    return result;
 }
 

--- a/sesman/scp.c
+++ b/sesman/scp.c
@@ -51,19 +51,19 @@ scp_process(struct trans *t)
             {
                 /* starts processing an scp v0 connection */
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "accept ok, go on with scp v0");
-                scp_v0_process(t, sdata);
+                result = scp_v0_process(t, sdata);
             }
             else
             {
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "accept ok, go on with scp v1");
-                scp_v1_process(t, sdata);
+                result = scp_v1_process(t, sdata);
             }
             break;
         case SCP_SERVER_STATE_START_MANAGE:
             /* starting a management session */
             LOG(LOG_LEVEL_INFO,
                 "starting a sesman management session...");
-            scp_v1_mng_process_msg(t, sdata);
+            result = scp_v1_mng_process_msg(t, sdata);
             break;
         case SCP_SERVER_STATE_VERSION_ERR:
         case SCP_SERVER_STATE_SIZE_ERR:

--- a/sesman/scp.c
+++ b/sesman/scp.c
@@ -36,25 +36,25 @@
 extern struct config_sesman *g_cfg; /* in sesman.c */
 
 /******************************************************************************/
-int
-scp_process(struct trans *atrans)
+enum SCP_SERVER_STATES_E
+scp_process(struct trans *t)
 {
     struct SCP_SESSION *sdata;
 
     sdata = NULL;
-    switch (scp_vXs_accept(atrans, &sdata))
+    switch (scp_vXs_accept(t, &sdata))
     {
         case SCP_SERVER_STATE_OK:
             if (sdata->version == 0)
             {
                 /* starts processing an scp v0 connection */
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "accept ok, go on with scp v0");
-                scp_v0_process(atrans, sdata);
+                scp_v0_process(t, sdata);
             }
             else
             {
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "accept ok, go on with scp v1");
-                scp_v1_process_msg(atrans, sdata);
+                scp_v1_process(t, sdata);
             }
             break;
         case SCP_SERVER_STATE_START_MANAGE:

--- a/sesman/scp.c
+++ b/sesman/scp.c
@@ -37,13 +37,9 @@ extern struct config_sesman *g_cfg; /* in sesman.c */
 
 /******************************************************************************/
 enum SCP_SERVER_STATES_E
-scp_process(struct trans *t)
+scp_process(struct trans *t, struct SCP_SESSION *sdata)
 {
-    enum SCP_SERVER_STATES_E result;
-    struct SCP_SESSION *sdata;
-
-    sdata = NULL;
-    result = scp_vXs_accept(t, &sdata);
+    enum SCP_SERVER_STATES_E result = scp_vXs_accept(t, sdata);
     switch (result)
     {
         case SCP_SERVER_STATE_OK:
@@ -88,6 +84,7 @@ scp_process(struct trans *t)
             result = SCP_SERVER_STATE_INTERNAL_ERR;
             break;
     }
+
     return result;
 }
 

--- a/sesman/scp.h
+++ b/sesman/scp.h
@@ -36,10 +36,10 @@
  * @brief Starts a an scp protocol thread.
  *        Starts a an scp protocol thread.
  *        But does only version control....
- * @param socket the connection socket
+ * @param atrans the connection trans
  *
  */
-void *
-scp_process_start(void *sck);
+int
+scp_process(struct trans *atrans);
 
 #endif

--- a/sesman/scp.h
+++ b/sesman/scp.h
@@ -39,7 +39,7 @@
  * @param atrans the connection trans
  *
  */
-int
-scp_process(struct trans *atrans);
+enum SCP_SERVER_STATES_E
+scp_process(struct trans *t);
 
 #endif

--- a/sesman/scp.h
+++ b/sesman/scp.h
@@ -40,6 +40,6 @@
  *
  */
 enum SCP_SERVER_STATES_E
-scp_process(struct trans *t);
+scp_process(struct trans *t, struct SCP_SESSION *s);
 
 #endif

--- a/sesman/scp_v0.c
+++ b/sesman/scp_v0.c
@@ -33,8 +33,8 @@
 extern struct config_sesman *g_cfg; /* in sesman.c */
 
 /******************************************************************************/
-void
-scp_v0_process(struct trans *atrans, struct SCP_SESSION *s)
+enum SCP_SERVER_STATES_E
+scp_v0_process(struct trans *t, struct SCP_SESSION *s)
 {
     int display = 0;
     tbus data;
@@ -53,14 +53,14 @@ scp_v0_process(struct trans *atrans, struct SCP_SESSION *s)
             if (1 == access_login_allowed(s->username))
             {
                 /* the user is member of the correct groups. */
-                scp_v0s_replyauthentication(atrans, errorcode);
+                scp_v0s_replyauthentication(t, errorcode);
                 LOG(LOG_LEVEL_INFO, "Access permitted for user: %s",
                     s->username);
                 /* g_writeln("Connection allowed"); */
             }
             else
             {
-                scp_v0s_replyauthentication(atrans, 32 + 3); /* all first 32 are reserved for PAM errors */
+                scp_v0s_replyauthentication(t, 32 + 3); /* all first 32 are reserved for PAM errors */
                 LOG(LOG_LEVEL_INFO, "Username okay but group problem for "
                     "user: %s", s->username);
                 /* g_writeln("user password ok, but group problem"); */
@@ -71,7 +71,7 @@ scp_v0_process(struct trans *atrans, struct SCP_SESSION *s)
             /* g_writeln("username or password error"); */
             LOG(LOG_LEVEL_INFO, "Username or password error for user: %s",
                 s->username);
-            scp_v0s_replyauthentication(atrans, errorcode);
+            scp_v0s_replyauthentication(t, errorcode);
         }
     }
     else if (data)
@@ -148,21 +148,22 @@ scp_v0_process(struct trans *atrans, struct SCP_SESSION *s)
 
         if (display == 0)
         {
-            scp_v0s_deny_connection(atrans);
+            scp_v0s_deny_connection(t);
         }
         else
         {
-            scp_v0s_allow_connection(atrans, display, s->guid);
+            scp_v0s_allow_connection(t, display, s->guid);
         }
     }
     else
     {
         LOG(LOG_LEVEL_INFO, "Username or password error for user: %s",
             s->username);
-        scp_v0s_deny_connection(atrans);
+        scp_v0s_deny_connection(t);
     }
     if (do_auth_end)
     {
         auth_end(data);
     }
+    return SCP_SERVER_STATE_END;
 }

--- a/sesman/scp_v0.c
+++ b/sesman/scp_v0.c
@@ -34,7 +34,7 @@ extern struct config_sesman *g_cfg; /* in sesman.c */
 
 /******************************************************************************/
 void
-scp_v0_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
+scp_v0_process(struct trans *atrans, struct SCP_SESSION *s)
 {
     int display = 0;
     tbus data;
@@ -53,15 +53,15 @@ scp_v0_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
             if (1 == access_login_allowed(s->username))
             {
                 /* the user is member of the correct groups. */
-                scp_v0s_replyauthentication(c, errorcode);
+                scp_v0s_replyauthentication(atrans, errorcode);
                 LOG(LOG_LEVEL_INFO, "Access permitted for user: %s",
                     s->username);
                 /* g_writeln("Connection allowed"); */
             }
             else
             {
-                scp_v0s_replyauthentication(c, 32 + 3); /* all first 32 are reserved for PAM errors */
-                LOG(LOG_LEVEL_INFO, "Username okey but group problem for "
+                scp_v0s_replyauthentication(atrans, 32 + 3); /* all first 32 are reserved for PAM errors */
+                LOG(LOG_LEVEL_INFO, "Username okay but group problem for "
                     "user: %s", s->username);
                 /* g_writeln("user password ok, but group problem"); */
             }
@@ -71,7 +71,7 @@ scp_v0_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
             /* g_writeln("username or password error"); */
             LOG(LOG_LEVEL_INFO, "Username or password error for user: %s",
                 s->username);
-            scp_v0s_replyauthentication(c, errorcode);
+            scp_v0s_replyauthentication(atrans, errorcode);
         }
     }
     else if (data)
@@ -123,18 +123,18 @@ scp_v0_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
                 if (SCP_SESSION_TYPE_XVNC == s->type)
                 {
                     LOG( LOG_LEVEL_INFO, "starting Xvnc session...");
-                    display = session_start(data, SESMAN_SESSION_TYPE_XVNC, c, s);
+                    display = session_start(data, SESMAN_SESSION_TYPE_XVNC, s);
                 }
                 else if (SCP_SESSION_TYPE_XRDP == s->type)
                 {
                     LOG(LOG_LEVEL_INFO, "starting X11rdp session...");
-                    display = session_start(data, SESMAN_SESSION_TYPE_XRDP, c, s);
+                    display = session_start(data, SESMAN_SESSION_TYPE_XRDP, s);
                 }
                 else if (SCP_SESSION_TYPE_XORG == s->type)
                 {
                     /* type is SCP_SESSION_TYPE_XORG */
                     LOG(LOG_LEVEL_INFO, "starting Xorg session...");
-                    display = session_start(data, SESMAN_SESSION_TYPE_XORG, c, s);
+                    display = session_start(data, SESMAN_SESSION_TYPE_XORG, s);
                 }
                 /* if the session started up ok, auth_end will be called on
                    sig child */
@@ -148,18 +148,18 @@ scp_v0_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
 
         if (display == 0)
         {
-            scp_v0s_deny_connection(c);
+            scp_v0s_deny_connection(atrans);
         }
         else
         {
-            scp_v0s_allow_connection(c, display, s->guid);
+            scp_v0s_allow_connection(atrans, display, s->guid);
         }
     }
     else
     {
         LOG(LOG_LEVEL_INFO, "Username or password error for user: %s",
             s->username);
-        scp_v0s_deny_connection(c);
+        scp_v0s_deny_connection(atrans);
     }
     if (do_auth_end)
     {

--- a/sesman/scp_v0.h
+++ b/sesman/scp_v0.h
@@ -29,7 +29,7 @@
 
 #include "libscp.h"
 
-void
-scp_v0_process(struct trans *atrans, struct SCP_SESSION *s);
+enum SCP_SERVER_STATES_E
+scp_v0_process(struct trans *t, struct SCP_SESSION *s);
 
 #endif

--- a/sesman/scp_v0.h
+++ b/sesman/scp_v0.h
@@ -29,15 +29,7 @@
 
 #include "libscp.h"
 
-/**
- *
- * @brief processes the stream using scp version 0
- * @param in_sck connection socket
- * @param in_s input stream
- * @param out_s output stream
- *
- */
 void
-scp_v0_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s);
+scp_v0_process(struct trans *atrans, struct SCP_SESSION *s);
 
 #endif

--- a/sesman/scp_v1.c
+++ b/sesman/scp_v1.c
@@ -191,7 +191,7 @@ scp_v1_process41(struct trans *t, struct SCP_SESSION *s)
     e = scp_v1s_list_sessions42(t, scount, slist);
     if (SCP_SERVER_STATE_OK != e)
     {
-        LOG(LOG_LEVEL_ERROR, "scp_v1s_list_sessions42 failed");
+        LOG(LOG_LEVEL_WARNING, "scp_v1s_list_sessions42 failed");
     }
 
     return SCP_SERVER_STATE_OK;
@@ -209,7 +209,7 @@ scp_v1_process43(struct trans *t, struct SCP_SESSION *s)
     if (0 == sitem)
     {
         e = scp_v1s_connection_error(t, "Internal error");
-        LOG(LOG_LEVEL_INFO, "Cannot find session item on the chain");
+        LOG(LOG_LEVEL_INFO, "No session exists with PID %d", s->return_sid);
     }
     else
     {
@@ -253,17 +253,17 @@ scp_v1_process(struct trans *t, struct SCP_SESSION *s)
     ; /* astyle 3.1 needs this, or the switch is badly formatted */
     switch (s->current_cmd)
     {
-        case 1:
+        case SCP_CMD_LOGIN:
             return scp_v1_process1(t, s);
-        case 4:
+        case SCP_CMD_RESEND_CREDS:
             return scp_v1_process4(t, s);
-        case 41:
+        case SCP_CMD_GET_SESSION_LIST:
             return scp_v1_process41(t, s);
-        case 43:
+        case SCP_CMD_SELECT_SESSION:
             return scp_v1_process43(t, s);
-        case 44:
+        case SCP_CMD_SELECT_SESSION_CANCEL:
             return scp_v1_process44(t, s);
-        case 45:
+        case SCP_CMD_FORCE_NEW_CONN:
             return scp_v1_process45(t, s);
     }
     return SCP_SERVER_STATE_END;

--- a/sesman/scp_v1.c
+++ b/sesman/scp_v1.c
@@ -127,17 +127,17 @@ scp_v1_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
         if (SCP_SESSION_TYPE_XVNC == s->type)
         {
             LOG(LOG_LEVEL_INFO, "starting Xvnc session...");
-            display = session_start(data, SESMAN_SESSION_TYPE_XVNC, c, s);
+            display = session_start(data, SESMAN_SESSION_TYPE_XVNC, s);
         }
         else if (SCP_SESSION_TYPE_XRDP == s->type)
         {
             LOG(LOG_LEVEL_INFO, "starting X11rdp session...");
-            display = session_start(data, SESMAN_SESSION_TYPE_XRDP, c, s);
+            display = session_start(data, SESMAN_SESSION_TYPE_XRDP, s);
         }
         else if (SCP_SESSION_TYPE_XORG == s->type)
         {
             LOG(LOG_LEVEL_INFO, "starting Xorg session...");
-            display = session_start(data, SESMAN_SESSION_TYPE_XORG, c, s);
+            display = session_start(data, SESMAN_SESSION_TYPE_XORG, s);
         }
         /* if the session started up ok, auth_end will be called on
            sig child */
@@ -213,6 +213,13 @@ scp_v1_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
         auth_end(data);
     }
     g_free(slist);
+}
+
+/******************************************************************************/
+void
+scp_v1_process_msg(struct trans *atrans, struct SCP_SESSION *s)
+{
+    // JAY TODO
 }
 
 static void parseCommonStates(enum SCP_SERVER_STATES_E e, const char *f)

--- a/sesman/scp_v1.c
+++ b/sesman/scp_v1.c
@@ -78,9 +78,9 @@ scp_v1_process1(struct trans *t, struct SCP_SESSION *s)
             scp_v1s_deny_connection(t, "Login failed");
             LOG(LOG_LEVEL_INFO, "Login failed for user %s. "
                 "Connection terminated", s->username);
-            return 1;
+            return SCP_SERVER_STATE_END;
         }
-        return 0;
+        return SCP_SERVER_STATE_OK;
     }
 
     /* testing if login is allowed*/
@@ -89,7 +89,7 @@ scp_v1_process1(struct trans *t, struct SCP_SESSION *s)
         scp_v1s_deny_connection(t, "Access to Terminal Server not allowed.");
         LOG(LOG_LEVEL_INFO, "User %s not allowed on TS. "
             "Connection terminated", s->username);
-        return 0;
+        return SCP_SERVER_STATE_END;
     }
 
     //check if we need password change
@@ -156,14 +156,14 @@ scp_v1_process1(struct trans *t, struct SCP_SESSION *s)
         auth_end(data);
     }
     g_free(slist);
-    return 0;
+    return SCP_SERVER_STATE_OK;
 }
 
 /******************************************************************************/
 static enum SCP_SERVER_STATES_E
 scp_v1_process4(struct trans *t, struct SCP_SESSION *s)
 {
-    return 0;
+    return SCP_SERVER_STATE_OK;
 }
 
 /******************************************************************************/
@@ -181,7 +181,7 @@ scp_v1_process41(struct trans *t, struct SCP_SESSION *s)
     if (scount == 0)
     {
         /* */
-        return 1;
+        return SCP_SERVER_STATE_END;
     }
 
     e = scp_v1s_list_sessions42(t, scount, slist);
@@ -190,7 +190,7 @@ scp_v1_process41(struct trans *t, struct SCP_SESSION *s)
         LOG(LOG_LEVEL_ERROR, "scp_v1s_list_sessions42 failed");
     }
 
-    return 0;
+    return SCP_SERVER_STATE_OK;
 }
 
 /******************************************************************************/

--- a/sesman/scp_v1.c
+++ b/sesman/scp_v1.c
@@ -49,8 +49,12 @@ scp_v1_process1(struct trans *t, struct SCP_SESSION *s)
     struct SCP_DISCONNECTED_SESSION *slist;
     bool_t do_auth_end = 1;
 
-    s->retries = g_cfg->sec.login_retry;
-    s->current_try = s->retries;
+    if (s->retries == 0)
+    {
+        /* First time in */
+        s->retries = g_cfg->sec.login_retry;
+        s->current_try = s->retries;
+    }
     data = auth_userpass(s->username, s->password, NULL);
     if (data == 0)
     {
@@ -246,10 +250,11 @@ scp_v1_process45(struct trans *t, struct SCP_SESSION *s)
 enum SCP_SERVER_STATES_E
 scp_v1_process(struct trans *t, struct SCP_SESSION *s)
 {
+    ; /* astyle 3.1 needs this, or the switch is badly formatted */
     switch (s->current_cmd)
     {
         case 1:
-                    return scp_v1_process1(t, s);
+            return scp_v1_process1(t, s);
         case 4:
             return scp_v1_process4(t, s);
         case 41:

--- a/sesman/scp_v1.h
+++ b/sesman/scp_v1.h
@@ -35,10 +35,7 @@
  * @param out_s output stream
  *
  */
-void
-scp_v1_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s);
-
-void
-scp_v1_process_msg(struct trans *atrans, struct SCP_SESSION *s);
+enum SCP_SERVER_STATES_E
+scp_v1_process(struct trans *t, struct SCP_SESSION *s);
 
 #endif

--- a/sesman/scp_v1.h
+++ b/sesman/scp_v1.h
@@ -38,4 +38,7 @@
 void
 scp_v1_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s);
 
+void
+scp_v1_process_msg(struct trans *atrans, struct SCP_SESSION *s);
+
 #endif

--- a/sesman/scp_v1_mng.c
+++ b/sesman/scp_v1_mng.c
@@ -104,6 +104,12 @@ scp_v1_mng_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
     auth_end(data);
 }
 
+void
+scp_v1_mng_process_msg(struct trans *atrans, struct SCP_SESSION *s)
+{
+    // JAY TODO
+}
+
 static void parseCommonStates(enum SCP_SERVER_STATES_E e, const char *f)
 {
     switch (e)

--- a/sesman/scp_v1_mng.c
+++ b/sesman/scp_v1_mng.c
@@ -37,8 +37,8 @@ extern struct config_sesman *g_cfg; /* in sesman.c */
 static void parseCommonStates(enum SCP_SERVER_STATES_E e, const char *f);
 
 /******************************************************************************/
-void
-scp_v1_mng_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
+enum SCP_SERVER_STATES_E
+scp_v1_mng_process_msg(struct trans *atrans, struct SCP_SESSION *s)
 {
     long data;
     enum SCP_SERVER_STATES_E e;
@@ -51,24 +51,24 @@ scp_v1_mng_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
 
     if (!data)
     {
-        scp_v1s_mng_deny_connection(c, "Login failed");
+        scp_v1s_mng_deny_connection(atrans, "Login failed");
         LOG(LOG_LEVEL_INFO,
             "[MNG] Login failed for user %s. Connection terminated", s->username);
         auth_end(data);
-        return;
+        return SCP_SERVER_STATE_END;
     }
 
     /* testing if login is allowed */
     if (0 == access_login_mng_allowed(s->username))
     {
-        scp_v1s_mng_deny_connection(c, "Access to Terminal Server not allowed.");
+        scp_v1s_mng_deny_connection(atrans, "Access to Terminal Server not allowed.");
         LOG(LOG_LEVEL_INFO,
             "[MNG] User %s not allowed on TS. Connection terminated", s->username);
         auth_end(data);
-        return;
+        return SCP_SERVER_STATE_END;
     }
 
-    e = scp_v1s_mng_allow_connection(c, s);
+    e = scp_v1s_mng_allow_connection(atrans, s);
 
     end = 1;
 
@@ -89,7 +89,7 @@ scp_v1_mng_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
                     LOG(LOG_LEVEL_INFO, "No sessions on Terminal Server");
                 }
 
-                e = scp_v1s_mng_list_sessions(c, s, scount, slist);
+                e = scp_v1s_mng_list_sessions(atrans, s, scount, slist);
                 g_free(slist);
                 break;
             default:
@@ -102,12 +102,7 @@ scp_v1_mng_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
 
     /* cleanup */
     auth_end(data);
-}
-
-void
-scp_v1_mng_process_msg(struct trans *atrans, struct SCP_SESSION *s)
-{
-    // JAY TODO
+    return SCP_SERVER_STATE_END;
 }
 
 static void parseCommonStates(enum SCP_SERVER_STATES_E e, const char *f)

--- a/sesman/scp_v1_mng.h
+++ b/sesman/scp_v1_mng.h
@@ -38,4 +38,7 @@
 void
 scp_v1_mng_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s);
 
+void
+scp_v1_mng_process_msg(struct trans *atrans, struct SCP_SESSION *s);
+
 #endif

--- a/sesman/scp_v1_mng.h
+++ b/sesman/scp_v1_mng.h
@@ -30,15 +30,11 @@
 /**
  *
  * @brief processes the stream using scp version 1
- * @param in_sck connection socket
- * @param in_s input stream
- * @param out_s output stream
+ * @param atrans incoming transport
+ * @param s incoming session details
  *
  */
-void
-scp_v1_mng_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s);
-
-void
+enum SCP_SERVER_STATES_E
 scp_v1_mng_process_msg(struct trans *atrans, struct SCP_SESSION *s);
 
 #endif

--- a/sesman/sesman.c
+++ b/sesman/sesman.c
@@ -230,7 +230,7 @@ sesman_data_in(struct trans *self)
     {
         /* prcess message */
         self->in_s->p = self->in_s->data;
-        if (scp_process(self) != 0)
+        if (scp_process(self) != SCP_SERVER_STATE_OK)
         {
             LOG(LOG_LEVEL_ERROR, "sesman_data_in: scp_process_msg failed");
             return 1;

--- a/sesman/sesman.c
+++ b/sesman/sesman.c
@@ -34,6 +34,14 @@
 #include "xrdp_configure_options.h"
 #include "string_calls.h"
 
+/**
+ * Maximum number of short-lived connections to sesman
+ *
+ * At the moment, all connections to sesman are short-lived. This may change
+ * in the future
+ */
+#define MAX_SHORT_LIVED_CONNECTIONS 16
+
 struct sesman_startup_params
 {
     const char *sesman_ini;
@@ -296,7 +304,7 @@ sesman_data_in(struct trans *self)
         /* reset for next message */
         self->header_size = 8;
         self->extra_flags = 0;
-        init_stream(self->in_s, 0);
+        init_stream(self->in_s, 0); /* Reset input stream pointers */
     }
     return 0;
 }
@@ -306,7 +314,7 @@ static int
 sesman_listen_conn_in(struct trans *self, struct trans *new_self)
 {
     struct sesman_con *sc;
-    if (g_con_list->count >= 16)
+    if (g_con_list->count >= MAX_SHORT_LIVED_CONNECTIONS)
     {
         LOG(LOG_LEVEL_ERROR, "sesman_data_in: error, too many "
             "connections, rejecting");

--- a/sesman/sesman.c
+++ b/sesman/sesman.c
@@ -197,7 +197,7 @@ sesman_close_all(void)
     int index;
     struct trans *con_trans;
 
-    log_message(LOG_LEVEL_DEBUG, "sesman_close_all:");
+    LOG_DEVEL(LOG_LEVEL_TRACE, "sesman_close_all:");
     trans_delete(g_list_trans);
     for (index = 0; index < g_con_list->count; index++)
     {
@@ -220,7 +220,7 @@ sesman_data_in(struct trans *self)
         in_uint32_be(self->in_s, size);
         if (size > self->in_s->size)
         {
-            log_message(LOG_LEVEL_ERROR, "sesman_data_in: bad message size");
+            LOG(LOG_LEVEL_ERROR, "sesman_data_in: bad message size");
             return 1;
         }
         self->header_size = size;
@@ -232,8 +232,7 @@ sesman_data_in(struct trans *self)
         self->in_s->p = self->in_s->data;
         if (scp_process(self) != 0)
         {
-            log_message(LOG_LEVEL_ERROR, "sesman_data_in: scp_process_msg "
-                        "failed");
+            LOG(LOG_LEVEL_ERROR, "sesman_data_in: scp_process_msg failed");
             return 1;
         }
         /* reset for next message */
@@ -258,8 +257,8 @@ sesman_listen_conn_in(struct trans *self, struct trans *new_self)
     }
     else
     {
-        log_message(LOG_LEVEL_ERROR, "sesman_data_in: error, too many "
-                    "connections, rejecting");
+        LOG(LOG_LEVEL_ERROR, "sesman_data_in: error, too many "
+            "connections, rejecting");
         trans_delete(new_self);
     }
     return 0;
@@ -287,13 +286,13 @@ sesman_main_loop(void)
     g_con_list = list_create();
     if (g_con_list == NULL)
     {
-        log_message(LOG_LEVEL_ERROR, "sesman_main_loop: list_create failed");
+        LOG(LOG_LEVEL_ERROR, "sesman_main_loop: list_create failed");
         return 1;
     }
     g_list_trans = trans_create(TRANS_MODE_TCP, 8192, 8192);
     if (g_list_trans == NULL)
     {
-        log_message(LOG_LEVEL_ERROR, "sesman_main_loop: trans_create failed");
+        LOG(LOG_LEVEL_ERROR, "sesman_main_loop: trans_create failed");
         list_delete(g_con_list);
         return 1;
     }
@@ -304,8 +303,8 @@ sesman_main_loop(void)
                                  g_cfg->listen_address);
     if (error != 0)
     {
-        log_message(LOG_LEVEL_ERROR, "sesman_main_loop: trans_listen_address "
-                    "failed");
+        LOG(LOG_LEVEL_ERROR, "sesman_main_loop: trans_listen_address "
+            "failed");
         trans_delete(g_list_trans);
         list_delete(g_con_list);
         return 1;
@@ -327,8 +326,8 @@ sesman_main_loop(void)
                                                wobjs, &wobjs_count, &timeout);
                 if (error != 0)
                 {
-                    log_message(LOG_LEVEL_ERROR, "sesman_main_loop: "
-                                "trans_get_wait_objs_rw failed");
+                    LOG(LOG_LEVEL_ERROR, "sesman_main_loop: "
+                        "trans_get_wait_objs_rw failed");
                     break;
                 }
             }
@@ -341,8 +340,8 @@ sesman_main_loop(void)
                                        wobjs, &wobjs_count, &timeout);
         if (error != 0)
         {
-            log_message(LOG_LEVEL_ERROR, "sesman_main_loop: "
-                        "trans_get_wait_objs_rw failed");
+            LOG(LOG_LEVEL_ERROR, "sesman_main_loop: "
+                "trans_get_wait_objs_rw failed");
             break;
         }
 
@@ -366,8 +365,8 @@ sesman_main_loop(void)
                 error = trans_check_wait_objs(con_trans);
                 if (error != 0)
                 {
-                    log_message(LOG_LEVEL_ERROR, "sesman_main_loop: "
-                                "trans_check_wait_objs failed, removing trans");
+                    LOG(LOG_LEVEL_ERROR, "sesman_main_loop: "
+                        "trans_check_wait_objs failed, removing trans");
                     trans_delete(con_trans);
                     list_remove_item(g_con_list, index);
                     index--;
@@ -378,8 +377,8 @@ sesman_main_loop(void)
         error = trans_check_wait_objs(g_list_trans);
         if (error != 0)
         {
-            log_message(LOG_LEVEL_ERROR, "sesman_main_loop: "
-                        "trans_check_wait_objs failed");
+            LOG(LOG_LEVEL_ERROR, "sesman_main_loop: "
+                "trans_check_wait_objs failed");
             break;
         }
     }

--- a/sesman/sesman.h
+++ b/sesman/sesman.h
@@ -41,6 +41,15 @@
 
 #include "libscp.h"
 
+/*
+ * Close all file descriptors used by sesman.
+ *
+ * This is generally used after forking, to make sure the
+ * file descriptors used by the main process are not disturbed
+ *
+ * This call will also release all trans and SCP_SESSION objects
+ * held by sesman
+ */
 int
 sesman_close_all(void);
 

--- a/sesman/sesman.h
+++ b/sesman/sesman.h
@@ -41,4 +41,7 @@
 
 #include "libscp.h"
 
+int
+sesman_close_all(void);
+
 #endif

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -49,7 +49,6 @@
 
 extern unsigned char g_fixedkey[8];
 extern struct config_sesman *g_cfg; /* in sesman.c */
-extern int g_sck; /* in sesman.c */
 struct session_chain *g_sessions;
 int g_session_count;
 
@@ -411,8 +410,7 @@ session_start_chansrv(char *username, int display)
 /******************************************************************************/
 /* called with the main thread */
 static int
-session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
-                   struct SCP_SESSION *s)
+session_start_fork(tbus data, tui8 type, struct SCP_SESSION *s)
 {
     int display = 0;
     int pid = 0;
@@ -496,8 +494,7 @@ session_start_fork(tbus data, tui8 type, struct SCP_CONNECTION *c,
             display, g_getpid());
         auth_start_session(data, display);
         g_delete_wait_obj(g_term_event);
-        g_tcp_close(g_sck);
-        g_tcp_close(c->in_sck);
+        sesman_close_all();
         g_sprintf(geometry, "%dx%d", s->width, s->height);
         g_sprintf(depth, "%d", s->bpp);
         g_sprintf(screen, ":%d", display);
@@ -1008,10 +1005,9 @@ session_reconnect_fork(int display, char *username, long data)
 /* called by a worker thread, ask the main thread to call session_sync_start
    and wait till done */
 int
-session_start(long data, tui8 type, struct SCP_CONNECTION *c,
-              struct SCP_SESSION *s)
+session_start(long data, tui8 type, struct SCP_SESSION *s)
 {
-    return session_start_fork(data, type, c, s);
+    return session_start_fork(data, type, s);
 }
 
 /******************************************************************************/

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -492,6 +492,15 @@ session_start_fork(tbus data, tui8 type, struct SCP_SESSION *s)
         LOG(LOG_LEVEL_INFO,
             "[session start] (display %d): calling auth_start_session from pid %d",
             display, g_getpid());
+
+        /* Clone the session object, as the passed-in copy will be
+         * deleted by sesman_close_all() */
+        if ((s = scp_session_clone(s)) == NULL)
+        {
+            LOG(LOG_LEVEL_ERROR,
+                "Failed to clone the session data - out of memory");
+            g_exit(1);
+        }
         auth_start_session(data, display);
         g_delete_wait_obj(g_term_event);
         sesman_close_all();

--- a/sesman/session.h
+++ b/sesman/session.h
@@ -105,8 +105,7 @@ session_get_bydata(const char *name, int width, int height, int bpp, int type,
  *
  */
 int
-session_start(long data, tui8 type, struct SCP_CONNECTION *c,
-              struct SCP_SESSION *s);
+session_start(long data, tui8 type, struct SCP_SESSION *s);
 
 int
 session_reconnect(int display, char *username, long data);

--- a/sesman/sig.c
+++ b/sesman/sig.c
@@ -32,7 +32,6 @@
 
 #include "sesman.h"
 
-extern int g_sck;
 extern int g_pid;
 extern struct config_sesman *g_cfg; /* in sesman.c */
 extern tbus g_term_event;

--- a/sesman/tools/sesadmin.c
+++ b/sesman/tools/sesadmin.c
@@ -38,8 +38,8 @@ char cmnd[257];
 char serv[257];
 char port[257];
 
-void cmndList(struct SCP_CONNECTION *c);
-void cmndKill(struct SCP_CONNECTION *c, struct SCP_SESSION *s);
+void cmndList(struct trans *t);
+void cmndKill(struct trans *t, struct SCP_SESSION *s);
 void cmndHelp(void);
 
 int inputSession(struct SCP_SESSION *s);
@@ -48,7 +48,7 @@ unsigned int menuSelect(unsigned int choices);
 int main(int argc, char **argv)
 {
     struct SCP_SESSION *s;
-    struct SCP_CONNECTION *c;
+    struct trans *t;
     enum SCP_CLIENT_STATES_E e;
     //int end;
     int idx;
@@ -136,7 +136,7 @@ int main(int argc, char **argv)
     }
 
     s = scp_session_create();
-    c = scp_connection_create(sock);
+    t = scp_trans_create(sock);
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "Connecting to %s:%s with user %s (%s)", serv, port, user, pass);
 
@@ -151,7 +151,7 @@ int main(int argc, char **argv)
     scp_session_set_username(s, user);
     scp_session_set_password(s, pass);
 
-    e = scp_v1c_mng_connect(c, s);
+    e = scp_v1c_mng_connect(t, s);
 
     if (SCP_CLIENT_STATE_OK != e)
     {
@@ -160,16 +160,16 @@ int main(int argc, char **argv)
 
     if (0 == g_strncmp(cmnd, "list", 5))
     {
-        cmndList(c);
+        cmndList(t);
     }
     else if (0 == g_strncmp(cmnd, "kill:", 5))
     {
-        cmndKill(c, s);
+        cmndKill(t, s);
     }
 
     g_tcp_close(sock);
     scp_session_destroy(s);
-    scp_connection_destroy(c);
+    trans_delete(t);
     log_end();
 
     return 0;
@@ -203,14 +203,14 @@ print_session(const struct SCP_DISCONNECTED_SESSION *s)
            s->conn_minute);
 }
 
-void cmndList(struct SCP_CONNECTION *c)
+void cmndList(struct trans *t)
 {
     struct SCP_DISCONNECTED_SESSION *dsl;
     enum SCP_CLIENT_STATES_E e;
     int scnt;
     int idx;
 
-    e = scp_v1c_mng_get_session_list(c, &scnt, &dsl);
+    e = scp_v1c_mng_get_session_list(t, &scnt, &dsl);
 
     if (e != SCP_CLIENT_STATE_LIST_OK)
     {
@@ -233,7 +233,7 @@ void cmndList(struct SCP_CONNECTION *c)
     g_free(dsl);
 }
 
-void cmndKill(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
+void cmndKill(struct trans *t, struct SCP_SESSION *s)
 {
 
 }

--- a/sesman/tools/sesadmin.c
+++ b/sesman/tools/sesadmin.c
@@ -140,9 +140,9 @@ int main(int argc, char **argv)
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "Connecting to %s:%s with user %s (%s)", serv, port, user, pass);
 
-    if (0 != g_tcp_connect(sock, serv, port))
+    if (0 != trans_connect(t, serv, port, 3000))
     {
-        LOG_DEVEL(LOG_LEVEL_DEBUG, "g_tcp_connect() error");
+        LOG(LOG_LEVEL_ERROR, "trans_connect() error");
         return 1;
     }
 
@@ -167,7 +167,6 @@ int main(int argc, char **argv)
         cmndKill(t, s);
     }
 
-    g_tcp_close(sock);
     scp_session_destroy(s);
     trans_delete(t);
     log_end();

--- a/sesman/tools/sesrun.c
+++ b/sesman/tools/sesrun.c
@@ -504,6 +504,7 @@ handle_scpv0_auth_reply(int sck)
         int data;
         int display;
 
+        in_s->end = in_s->data + 8;
         in_uint32_be(in_s, version);
         in_uint32_be(in_s, size);
         if (version == 0 && size >= 14)

--- a/sesman/tools/sestest.c
+++ b/sesman/tools/sestest.c
@@ -37,7 +37,7 @@ int main(int argc, char **argv)
 {
     char buf[256];
     struct SCP_SESSION *s;
-    struct SCP_CONNECTION *c;
+    struct trans *t;
     /*struct SCP_DISCONNECTED_SESSION ds;*/
     struct SCP_DISCONNECTED_SESSION *dsl;
     enum SCP_CLIENT_STATES_E e;
@@ -62,7 +62,7 @@ int main(int argc, char **argv)
     }
 
     s = scp_session_create();
-    c = scp_connection_create(sock);
+    t = scp_trans_create(sock);
 
     if (0 != g_tcp_connect(sock, "localhost", "3350"))
     {
@@ -105,7 +105,7 @@ int main(int argc, char **argv)
     s.errstr=0;*/
 
     end = 0;
-    e = scp_v1c_connect(c, s);
+    e = scp_v1c_connect(t, s);
 
     while (!end)
     {
@@ -117,7 +117,7 @@ int main(int argc, char **argv)
                 break;
             case SCP_CLIENT_STATE_SESSION_LIST:
                 g_printf("OK : session list needed\n");
-                e = scp_v1c_get_session_list(c, &scnt, &dsl);
+                e = scp_v1c_get_session_list(t, &scnt, &dsl);
                 break;
             case SCP_CLIENT_STATE_LIST_OK:
                 g_printf("OK : selecting a session:\n");
@@ -131,7 +131,7 @@ int main(int argc, char **argv)
                 }
 
                 sel = menuSelect(scnt);
-                e = scp_v1c_select_session(c, s, dsl[sel - 1].SID);
+                e = scp_v1c_select_session(t, s, dsl[sel - 1].SID);
                 g_printf("\n return: %d \n", e);
                 break;
             case SCP_CLIENT_STATE_RESEND_CREDENTIALS:
@@ -152,7 +152,7 @@ int main(int argc, char **argv)
                 }
 
                 scp_session_set_password(s, buf);
-                e = scp_v1c_resend_credentials(c, s);
+                e = scp_v1c_resend_credentials(t, s);
                 break;
             case SCP_CLIENT_STATE_CONNECTION_DENIED:
                 g_printf("ERR: connection denied: %s\n", s->errstr);
@@ -175,7 +175,7 @@ int main(int argc, char **argv)
 
     g_tcp_close(sock);
     scp_session_destroy(s);
-    scp_connection_destroy(c);
+    trans_delete(t);
     /*free_stream(c.in_s);
     free_stream(c.out_s);*/
 

--- a/sesman/tools/sestest.c
+++ b/sesman/tools/sestest.c
@@ -41,18 +41,17 @@ int main(int argc, char **argv)
     /*struct SCP_DISCONNECTED_SESSION ds;*/
     struct SCP_DISCONNECTED_SESSION *dsl;
     enum SCP_CLIENT_STATES_E e;
-    struct log_config log;
+    struct log_config *logging;
     int end;
     int scnt;
     int idx;
     int sel;
     int sock;
 
-    log.enable_syslog = 0;
-    log.log_level = LOG_LEVEL_DEBUG;
-    log.program_name = "sestest";
-    log.log_file = g_strdup("sestest.log");
-    log_start_from_param(&log);
+    logging = log_config_init_for_console(LOG_LEVEL_INFO, NULL);
+    log_start_from_param(logging);
+    log_config_free(logging);
+
     scp_init();
 
     sock = g_tcp_socket();
@@ -64,7 +63,7 @@ int main(int argc, char **argv)
     s = scp_session_create();
     t = scp_trans_create(sock);
 
-    if (0 != g_tcp_connect(sock, "localhost", "3350"))
+    if (0 != trans_connect(t, "localhost", "3350", 3000))
     {
         g_printf("error connecting");
         return 1;
@@ -173,11 +172,9 @@ int main(int argc, char **argv)
         }
     }
 
-    g_tcp_close(sock);
     scp_session_destroy(s);
     trans_delete(t);
-    /*free_stream(c.in_s);
-    free_stream(c.out_s);*/
+    log_end();
 
     return 0;
 }


### PR DESCRIPTION
The PR is based on part of #1602.

#1602 is in two parts:-
1. Move SCP away from using `struct SCP_CONNECTION` as a connection type to the more standard `struct trans` transport type used everywhere else
2. Add the capability to use UNIX domain sockets for SCP

Both of these are necessary moving forwards to modernise SCP. This PR focusses on the first half only.

I've taken @jsorg71's original commits and rebased them. I've then completely removed the `struct SCP_CONNECTION` to avoid confusion, and to ensure that the transition to `struct trans` is complete. This has entailed updating the utilities.

There's still a lot to do for SCP. This is only a start.