### PR TITLE
Bumped cppcheck version to 2.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
       CC: gcc
       # This is required to use a version of cppcheck other than that
       # supplied with the operating system
-      CPPCHECK_VER: 2.4
+      CPPCHECK_VER: 2.5
       CPPCHECK_REPO: https://github.com/danmar/cppcheck.git
     steps:
       # This is currently the only way to get a version into

--- a/tcutils/utils.h
+++ b/tcutils/utils.h
@@ -17,6 +17,8 @@ typedef struct stream
     char *data;    /* holds stream data           */
     char *pos;     /* current read/write position */
     int   size;    /* number of bytes in data     */
+
+    stream() : data(0), pos(0), size(0) {}
 } STREAM;
 
 #define qstream_new(_s, _size)                 \


### PR DESCRIPTION
Small change to bump cppcheck to version 2.5

A small change is also needed to `tcutils/utils.h` to prevent these warnings:-

```
utils.cpp:25:5: error: Uninitialized struct member: s.pos [uninitStructMember]
    qstream_new(s, 1024 * 8);
    ^
utils.cpp:25:5: error: Uninitialized struct member: s.size [uninitStructMember]
    qstream_new(s, 1024 * 8);
    ^
utils.cpp:111:5: error: Uninitialized struct member: s.pos [uninitStructMember]
    qstream_new(s, 1024);
    ^
utils.cpp:111:5: error: Uninitialized struct member: s.size [uninitStructMember]
    qstream_new(s, 1024);
    ^
```

I've managed to verify that the change I've made to tcutils will build on older systems - it doesn't build with our current CI.

The tcutils stuff is based on Qt4 and hence defunct. It's in C++, but doesn't make particularly good use of that language.


Ideally we'd update this utility for Qt5 compatibility, and also improve the C++ usage. I'm personally not that keen on learning all about Qt5 to do this however, given that this utility seems to be more of an example than anything useful.

We seem to have three choices here:-
- Leave this PR as is, and ignore tcutils for now on the grounds it may be useful later.
- Update tcutils to Qt5 (and presumably maintain it)
- Remove the utility entirely.

Thoughts?