### PR TITLE
Log a message for failed logins

### DIFF
--- a/sesman/scp_v0.c
+++ b/sesman/scp_v0.c
@@ -157,6 +157,8 @@ scp_v0_process(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
     }
     else
     {
+        LOG(LOG_LEVEL_INFO, "Username or password error for user: %s",
+            s->username);
         scp_v0s_deny_connection(c);
     }
     if (do_auth_end)


### PR DESCRIPTION
Fixes #1724 and #1946

Apologies for dropping this one. I was hoping to pick it up as a rework of the SCP code, but this is a much larger job than I first realised.

The following message is now logged as in sesman.log for unrecognised users or invalid passwords:-

```
Username or password error for user: <user>
```

This is very much a quick fix. If preferred. I can add more detailed logging to the PAM code, or I could pull the existing PAM detail from `xrdp/xrdp_mm.c` into some sort of library module and use it to generate extra info in sesman.

Thoughts?