### PR TITLE
override keyboard infomation #1950 (1st)

### DIFF
--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -33,6 +33,14 @@ struct monitor_info
     int is_primary;
 };
 
+/* xrdp keyboard overrids */
+struct xrdp_keyboard_overrides
+{
+    int type;
+    int subtype;
+    int layout;
+};
+
 /**
  * Information about the xrdp client
  *
@@ -172,9 +180,12 @@ struct xrdp_client_info
 
     int enable_token_login;
     char domain_user_separator[16];
+
+    /* xrdp.override_* values */
+    struct xrdp_keyboard_overrides xrdp_keyboard_overrides;
 };
 
 /* yyyymmdd of last incompatible change to xrdp_client_info */
-#define CLIENT_INFO_CURRENT_VERSION 20210225
+#define CLIENT_INFO_CURRENT_VERSION 20210723
 
 #endif

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -50,6 +50,10 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
     char *tmp = NULL;
     int tmp_length = 0;
 
+    client_info->xrdp_keyboard_overrides.type = -1;
+    client_info->xrdp_keyboard_overrides.subtype = -1;
+    client_info->xrdp_keyboard_overrides.layout = -1;
+
     /* initialize (zero out) local variables: */
     items = list_create();
     items->auto_free = 1;

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -278,6 +278,18 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
         {
             g_strncpy(client_info->domain_user_separator, value, sizeof(client_info->domain_user_separator) - 1);
         }
+        else if (g_strcasecmp(item, "xrdp.override_keyboard_type") == 0)
+        {
+            client_info->xrdp_keyboard_overrides.type = g_atoix(value);
+        }
+        else if (g_strcasecmp(item, "xrdp.override_keyboard_subtype") == 0)
+        {
+            client_info->xrdp_keyboard_overrides.subtype = g_atoix(value);
+        }
+        else if (g_strcasecmp(item, "xrdp.override_keylayout") == 0)
+        {
+            client_info->xrdp_keyboard_overrides.layout = g_atoix(value);
+        }
     }
 
     list_delete(items);

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -383,20 +383,20 @@ xrdp_load_keyboard_layout(struct xrdp_client_info *client_info)
         client_info->keyboard_type, client_info->keyboard_subtype,
         client_info->keylayout);
 
-    if (ko->type != 0)
+    if (ko->type != -1)
     {
         LOG(LOG_LEVEL_INFO, "overrode keyboard_type 0x%02X"
             " with 0x%02X", client_info->keyboard_type, ko->type);
         client_info->keyboard_type = ko->type;
     }
-    if (ko->subtype != 0)
+    if (ko->subtype != -1)
     {
         LOG(LOG_LEVEL_INFO, "overrode keyboard_subtype 0x%02X"
             " with 0x%02X", client_info->keyboard_subtype,
             ko->subtype);
         client_info->keyboard_subtype = ko->subtype;
     }
-    if (ko->layout != 0)
+    if (ko->layout != -1)
     {
         LOG(LOG_LEVEL_INFO, "overrode keylayout 0x%08X"
             " with 0x%08X", client_info->keylayout, ko->layout);

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -374,9 +374,34 @@ xrdp_load_keyboard_layout(struct xrdp_client_info *client_info)
     char keyboard_cfg_file[256] = { 0 };
     char rdp_layout[256] = { 0 };
 
-    LOG(LOG_LEVEL_INFO, "xrdp_load_keyboard_layout: keyboard_type [%d] keyboard_subtype [%d]",
-        client_info->keyboard_type, client_info->keyboard_subtype);
+    const struct xrdp_keyboard_overrides *ko =
+            &client_info->xrdp_keyboard_overrides;
 
+    LOG(LOG_LEVEL_INFO, "xrdp_load_keyboard_layout: Keyboard information sent"
+        " by the RDP client, keyboard_type:[0x%02X], keyboard_subtype:[0x%02X],"
+        " keylayout:[0x%08X]",
+        client_info->keyboard_type, client_info->keyboard_subtype,
+        client_info->keylayout);
+
+    if (ko->type != 0)
+    {
+        LOG(LOG_LEVEL_INFO, "overrode keyboard_type 0x%02X"
+            " with 0x%02X", client_info->keyboard_type, ko->type);
+        client_info->keyboard_type = ko->type;
+    }
+    if (ko->subtype != 0)
+    {
+        LOG(LOG_LEVEL_INFO, "overrode keyboard_subtype 0x%02X"
+            " with 0x%02X", client_info->keyboard_subtype,
+            ko->subtype);
+        client_info->keyboard_subtype = ko->subtype;
+    }
+    if (ko->layout != 0)
+    {
+        LOG(LOG_LEVEL_INFO, "overrode keylayout 0x%08X"
+            " with 0x%08X", client_info->keylayout, ko->layout);
+        client_info->keylayout = ko->layout;
+    }
     /* infer model/variant */
     /* TODO specify different X11 keyboard models/variants */
     g_memset(client_info->model, 0, sizeof(client_info->model));

--- a/xrdp/xrdp.ini.in
+++ b/xrdp/xrdp.ini.in
@@ -63,6 +63,12 @@ ssl_protocols=TLSv1.2, TLSv1.3
 ; for example when the server is multi homed with SSSd
 #domain_user_separator=@
 
+; The following options will override the keyboard layout settings.
+; These options are for DEBUG and are not recommended for regular use.
+#xrdp.override_keyboard_type=0x04
+#xrdp.override_keyboard_subtype=0x01
+#xrdp.override_keylayout=0x00000409
+
 ; Section name to use for automatic login if the client sends username
 ; and password. If empty, the domain name sent by the client is used.
 ; If empty and no domain name is given, the first suitable section in


### PR DESCRIPTION
This is a PR for Discussions #1950.
In this discussion we are considering several issues.

This is the first one.

add an option to force the RDP Client to overwrite any keyboard information sent to it with the specified value for debugging purposes.

I welcome suggestions for corrections to redundant code or confusing comments.