### PR TITLE
clipboard: log file transfer for the purpose of audit

### DIFF
--- a/sesman/chansrv/clipboard_file.c
+++ b/sesman/chansrv/clipboard_file.c
@@ -445,6 +445,10 @@ clipboard_send_file_data(int streamId, int lindex,
     rv = send_channel_data(g_cliprdr_chan_id, s->data, size);
     free_stream(s);
     g_file_close(fd);
+
+    /* Log who transferred which file via clipboard for the purpose of audit */
+    LOG(LOG_LEVEL_INFO, "S2C: Transfered a file: filename=%s, uid=%d", full_fn, g_getuid());
+
     return rv;
 }
 


### PR DESCRIPTION
Some customers want to record who took out which file from the xrdp server to the client via clipboard for the purpose of audit.


Note: chansrv logs are replaced with an empty file every time when chansrv is restarted on the same display number.  Syslog should be used instead to make the log non-volatile.