### PR TITLE
Use text strings for security level logging at ISO layer

### DIFF
--- a/common/string_calls.h
+++ b/common/string_calls.h
@@ -38,6 +38,21 @@ struct info_string_tag
 #define INFO_STRING_END_OF_LIST { '\0', NULL }
 
 /**
+ * Map a bitmask to a string value
+ *
+ *
+ * This structure is used by g_bitmask_to_str() to specify the
+ * string for each bit in the bitmask
+ */
+struct bitmask_string
+{
+    int mask;
+    const char *str;
+};
+
+#define BITMASK_STRING_END_OF_LIST { 0, NULL }
+
+/**
  * Processes a format string for general info
  *
  * @param[out] dest Destination buffer
@@ -139,6 +154,25 @@ g_bytes_to_hexdump(const char *src, int len);
  */
 int
 g_get_display_num_from_display(const char *display_text);
+
+/**
+ * Converts a bitmask into a string for output purposes
+ *
+ * @param bitmask Bitmask to convert
+ * @param bitdefs Definitions for strings for bits
+ * @param delim Delimiter to use between strings
+ * @param buff Output buff
+ * @param bufflen Length of buff, including terminator '`\0'
+ *
+ * @return Total length excluding terminator which would be written, as
+ *         in snprintf(). Can be used to check for overflow
+ *
+ * @note Any undefined bits in the bitmask are appended to the output as
+ *       a hexadecimal constant.
+ */
+int
+g_bitmask_to_str(int bitmask, const struct bitmask_string[],
+                 char delim, char *buff, int bufflen);
 
 int      g_strlen(const char *text);
 const char *g_strchr(const char *text, int c);

--- a/tests/common/test_string_calls.c
+++ b/tests/common/test_string_calls.c
@@ -214,11 +214,122 @@ START_TEST(test_strnjoin__when_always__then_doesnt_write_beyond_end_of_destinati
 END_TEST
 
 /******************************************************************************/
+START_TEST(test_bm2str__no_bits_defined)
+{
+    int rv;
+    char buff[64];
+
+    static const struct bitmask_string bits[] =
+    {
+        BITMASK_STRING_END_OF_LIST
+    };
+
+    rv = g_bitmask_to_str(0xffff, bits, ',', buff, sizeof(buff));
+
+    ck_assert_str_eq(buff, "0xffff");
+    ck_assert_int_eq(rv, 6);
+}
+END_TEST
+
+START_TEST(test_bm2str__all_bits_defined)
+{
+    int rv;
+    char buff[64];
+
+    static const struct bitmask_string bits[] =
+    {
+        {1 << 0, "BIT_0"},
+        {1 << 1, "BIT_1"},
+        {1 << 6, "BIT_6"},
+        {1 << 7, "BIT_7"},
+        BITMASK_STRING_END_OF_LIST
+    };
+
+    int bitmask = 1 << 0 | 1 << 1 | 1 << 6 | 1 << 7;
+
+    rv = g_bitmask_to_str(bitmask, bits, '|', buff, sizeof(buff));
+
+    ck_assert_str_eq(buff, "BIT_0|BIT_1|BIT_6|BIT_7");
+    ck_assert_int_eq(rv, (6 * 4) - 1);
+}
+END_TEST
+
+START_TEST(test_bm2str__some_bits_undefined)
+{
+    int rv;
+    char buff[64];
+
+    static const struct bitmask_string bits[] =
+    {
+        {1 << 0, "BIT_0"},
+        {1 << 1, "BIT_1"},
+        {1 << 6, "BIT_6"},
+        {1 << 7, "BIT_7"},
+        BITMASK_STRING_END_OF_LIST
+    };
+
+    int bitmask = 1 << 0 | 1 << 1 | 1 << 16;
+
+    rv = g_bitmask_to_str(bitmask, bits, ':', buff, sizeof(buff));
+
+    ck_assert_str_eq(buff, "BIT_0:BIT_1:0x10000");
+    ck_assert_int_eq(rv, (6 * 2) + 7);
+}
+END_TEST
+
+START_TEST(test_bm2str__overflow_all_bits_defined)
+{
+    int rv;
+    char buff[10];
+
+    static const struct bitmask_string bits[] =
+    {
+        {1 << 0, "BIT_0"},
+        {1 << 1, "BIT_1"},
+        {1 << 6, "BIT_6"},
+        {1 << 7, "BIT_7"},
+        BITMASK_STRING_END_OF_LIST
+    };
+
+    int bitmask = 1 << 0 | 1 << 1 | 1 << 6 | 1 << 7;
+
+    rv = g_bitmask_to_str(bitmask, bits, '+', buff, sizeof(buff));
+
+    ck_assert_str_eq(buff, "BIT_0+BIT");
+    ck_assert_int_eq(rv, (4 * 6) - 1);
+}
+END_TEST
+
+START_TEST(test_bm2str__overflow_some_bits_undefined)
+{
+    int rv;
+    char buff[16];
+
+    static const struct bitmask_string bits[] =
+    {
+        {1 << 0, "BIT_0"},
+        {1 << 1, "BIT_1"},
+        {1 << 6, "BIT_6"},
+        {1 << 7, "BIT_7"},
+        BITMASK_STRING_END_OF_LIST
+    };
+
+    int bitmask = 1 << 0 | 1 << 1 | 1 << 16;
+
+    rv = g_bitmask_to_str(bitmask, bits, '#', buff, sizeof(buff));
+
+    ck_assert_str_eq(buff, "BIT_0#BIT_1#0x1");
+    ck_assert_int_eq(rv, (6 * 2) + 7);
+}
+END_TEST
+
+/******************************************************************************/
 Suite *
 make_suite_test_string(void)
 {
     Suite *s;
     TCase *tc_strnjoin;
+    TCase *tc_bm2str;
 
     s = suite_create("String");
 
@@ -235,6 +346,14 @@ make_suite_test_string(void)
     tcase_add_test(tc_strnjoin, test_strnjoin__when_destination_is_shorter_than_src_plus_joiner__returns_partial_joined_string);
     tcase_add_test(tc_strnjoin, test_strnjoin__when_destination_has_contents__returns_joined_string_with_content_overwritten);
     tcase_add_test(tc_strnjoin, test_strnjoin__when_always__then_doesnt_write_beyond_end_of_destination);
+
+    tc_bm2str = tcase_create("bm2str");
+    suite_add_tcase(s, tc_bm2str);
+    tcase_add_test(tc_bm2str, test_bm2str__no_bits_defined);
+    tcase_add_test(tc_bm2str, test_bm2str__all_bits_defined);
+    tcase_add_test(tc_bm2str, test_bm2str__some_bits_undefined);
+    tcase_add_test(tc_bm2str, test_bm2str__overflow_all_bits_defined);
+    tcase_add_test(tc_bm2str, test_bm2str__overflow_some_bits_undefined);
 
     return s;
 }


### PR DESCRIPTION
Fixes #1974 

Can be merged after v0.9.17 (if people are happy with the code, that is).