### PR TITLE
Moved g_initgroups() call to before auth_start_session()

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -2875,12 +2875,18 @@ g_setgid(int pid)
 /* returns error, zero is success, non zero is error */
 /* does not work in win32 */
 int
-g_initgroups(const char *user, int gid)
+g_initgroups(const char *username)
 {
 #if defined(_WIN32)
     return 0;
 #else
-    return initgroups(user, gid);
+    int gid;
+    int error = g_getuser_info(username, &gid, NULL, NULL, NULL, NULL);
+    if (error == 0)
+    {
+        error = initgroups(username, gid);
+    }
+    return error;
 #endif
 }
 

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -159,7 +159,7 @@ void     g_signal_pipe(void (*func)(int));
 void     g_signal_usr1(void (*func)(int));
 int      g_fork(void);
 int      g_setgid(int pid);
-int      g_initgroups(const char *user, int gid);
+int      g_initgroups(const char *user);
 int      g_getuid(void);
 int      g_getgid(void);
 int      g_setuid(int pid);

--- a/sesman/env.c
+++ b/sesman/env.c
@@ -112,12 +112,10 @@ env_set_user(const char *username, char **passwd_file, int display,
     if (error == 0)
     {
         g_rm_temp_dir();
+        /*
+         * Set the primary group. Note that secondary groups should already
+         * have been set */
         error = g_setgid(pw_gid);
-
-        if (error == 0)
-        {
-            error = g_initgroups(username, pw_gid);
-        }
 
         if (error == 0)
         {

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -525,6 +525,16 @@ session_start(long data,
         g_delete_wait_obj(g_sigchld_event);
         g_delete_wait_obj(g_term_event);
 
+        /* Set the secondary groups before starting the session to prevent
+         * problems on PAM-based systems (see pam_setcred(3)) */
+        if (g_initgroups(s->username) != 0)
+        {
+            LOG(LOG_LEVEL_ERROR,
+                "Failed to initialise secondary groups for %s: %s",
+                s->username, g_get_strerror());
+            g_exit(1);
+        }
+
         auth_start_session(data, display);
         sesman_close_all();
         g_sprintf(geometry, "%dx%d", s->width, s->height);


### PR DESCRIPTION
Fixes #1978 

Tested on FreeBSD 13 and Ubuntu 20.04. Note that `pam_group` has a different function on these two operating systems:-
- On FreeBSD, `pam_group` is used to allow or deny access based on group membership
- On Ubuntu, `pam_group` is used to confer access to secondary groups (which is what #1978 is about)

The FreeBSD testing consisted of adding this line to `/etc/pam.d/xrdp-sesman`:-

```
auth	required	pam_group.so		luser group=games
```

with this line in place, only users in the `games` group could log in to xrdp.

The Ubuntu testing added this line to `/etc/security/group.conf`:-

```
*;*;*;Al0000-2400;floppy
```

with this line in place, users logging in to xrdp were added to the `floppy` group.