### PR TITLE
Parse DEVICE_ANNOUNCE header correctly

### DIFF
--- a/common/parse.h
+++ b/common/parse.h
@@ -498,6 +498,8 @@ parser_stream_overflow_check(const struct stream *s, int n, int is_out,
  *****************************************************************************/
 #define xstream_free(_s) free_stream(_s)
 
+#define xstream_skip_u8(_s, _n)       in_uint8s(_s, _n)
+
 #define xstream_rd_u8(_s, _var)       in_uint8(_s, _var)
 #define xstream_rd_u16_le(_s, _var)   in_uint16_le(_s, _var)
 #define xstream_rd_u32_le(_s, _var)   in_uint32_le(_s, _var)

--- a/sesman/chansrv/devredir.c
+++ b/sesman/chansrv/devredir.c
@@ -827,7 +827,7 @@ devredir_proc_client_devlist_announce_req(struct stream *s)
                                       device_data_len);
                 }
 
-                LOG(LOG_LEVEL_INFO, "detected remote drive %s",
+                LOG(LOG_LEVEL_INFO, "Detected remote drive '%s'",
                     preferred_dos_name);
 
                 LOG_DEVEL(LOG_LEVEL_DEBUG,
@@ -868,8 +868,7 @@ devredir_proc_client_devlist_announce_req(struct stream *s)
                     /* default */ "unknown device";
 
                 xstream_skip_u8(s, device_data_len);
-                LOG(LOG_LEVEL_INFO, "Remote %s '%s' is not supported"
-                    " and will be ignored",
+                LOG(LOG_LEVEL_INFO, "Detected remote %s '%s' (not supported)",
                     description, preferred_dos_name);
                 LOG_DEVEL(LOG_LEVEL_DEBUG,
                           "description=%s dosname=%s device_id=0x%x",


### PR DESCRIPTION
Fixes #327 

The DEVICE_ANNOUNCE header in [[MS-RDPEFS] 2.2.1.3](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/32e34332-774b-4ead-8c9d-5d64720d6bf9) has DeviceDataLength and DeviceData fields. These fields are only parsed correctly for devices of type RDPDR_DTYP_FILESYSTEM

For all other device types, the fields are not read and skipped, but are left sitting in the buffer.

Consequently, when a [DR_DEVICELIST_ANNOUNCE](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/d8b2bc1c-0207-4c15-abe3-62eaa2afcaf1) message is received with a printer before the filesystem drives, chansrv gets out of sync and fails to parse the filesystem drives correctly.

This PR skips the DeviceDataLength and DeviceData fields correctly for all device types.

Incidentally, I'm not aware of why devredir.c uses xstream macros from parse.h rather than the more usual ones. I've added another xstream macro `xstream_skip_u8` to allow a number of bytes in the data stream to be skipped.

As I submit this, the CI for 32-bit builds is still broken.