### PR TITLE
32-bit CI build process : Remove some 64-bit packages

### DIFF
--- a/scripts/install_xrdp_build_dependencies_with_apt.sh
+++ b/scripts/install_xrdp_build_dependencies_with_apt.sh
@@ -4,6 +4,39 @@ set -eufx
 FEATURE_SET=min
 ARCH=amd64
 
+# See apt.conf(5)
+DEBUG_OPTS=
+#DEBUG_OPTS="$DEBUG_OPTS -oDebug::pkgProblemResolver=1"
+
+# Given a list of i386 packages, this call makes sure the amd64 variants
+# of the development libraries are not installed
+remove_64bit_libdev_packages()
+{
+    flags=$-
+    set +x  ;# Disable tracing for this func
+    rlist=""
+    for p in $PACKAGES; do
+        # Identify packages starting with 'lib' and ending with '-dev:i386'
+        if [ "${p#lib}" != "$p" -a "${p%-dev:i386}" != "$p" ]; then
+            p64=${p%i386}amd64
+            if dpkg -s $p64 >/dev/null 2>&1 ; then
+                rlist="$rlist ${p%i386}amd64"
+            fi
+        fi
+    done
+    if [ -n "$rlist" ]; then
+        echo "** Some 64-bit development packages appear to clash with i386 packages"
+        echo "**$rlist"
+        apt-get remove $rlist || :
+    fi
+    # Restore tracing, if enabled on entry
+    set -$flags
+}
+
+# ----------------------------------------------------------------------------
+# M A I N
+# ----------------------------------------------------------------------------
+
 if [ $# -ge 1 ]; then
     FEATURE_SET="$1"
     shift
@@ -84,6 +117,7 @@ in
         dpkg --print-architecture
         dpkg --print-foreign-architectures
         apt-get update
+        remove_64bit_libdev_packages $PACKAGES
         ;;
     *)
         echo "unsupported architecture: $ARCH"
@@ -95,5 +129,6 @@ apt-get update
 apt-get -yq \
     --no-install-suggests \
     --no-install-recommends \
+    $DEBUG_OPTS \
     $APT_EXTRA_ARGS \
     install $PACKAGES


### PR DESCRIPTION
The 32-bit CI build process is [broken again](https://github.com/neutrinolabs/xrdp/actions/runs/1197593050).

The reason this time appears to be that the libtiff-dev:i386 package conflicts with the libtiff-dev:amd64 package. The exact reason for this isn't clear to me. At the time of writing, both i386 and amd64 packages appear to have the same version, namely `4.0.9-5ubuntu0.4`.

I've tried to come up with a more pro-active solution this time. What I've done, is for i386 builds where `libxxx-dev:i386` is installed, I've removed `libxxx-dev:amd64` beforehand. We shouldn't need any of these packages for a 32-bit build and removing them should greatly decrease the chances of a package version clash if the repos are out-of sync.