### PR TITLE
Add missing rfb.c to the VNC module makefile

### DIFF
--- a/vnc/Makefile.am
+++ b/vnc/Makefile.am
@@ -11,9 +11,10 @@ module_LTLIBRARIES = \
 libvnc_la_SOURCES = \
   vnc.c \
   vnc_clip.c \
-  rfb.h \
+  rfb.c \
   vnc.h \
-  vnc_clip.h
+  vnc_clip.h \
+  rfb.h
 
 libvnc_la_LIBADD = \
   $(top_builddir)/common/libcommon.la


### PR DESCRIPTION
Fixes #1986 

Follow-on to #1989 - this additional change was missed. This has now been fully tested by compiling xrdp with `CFLAGS="-Wl,-z,now"`