### PR TITLE
Clipboard fixes

### DIFF
--- a/sesman/chansrv/clipboard_common.h
+++ b/sesman/chansrv/clipboard_common.h
@@ -77,7 +77,7 @@ struct clip_file_desc /* CLIPRDR_FILEDESCRIPTOR */
     tui32 lastWriteTimeHigh;
     tui32 fileSizeHigh;
     tui32 fileSizeLow;
-    char cFileName[256];
+    char cFileName[260 * 4]; /* Allow each UCS-16 char to become 32 bits */
 };
 
 int clipboard_out_unicode(struct stream *s, const char *text,

--- a/sesman/chansrv/clipboard_file.c
+++ b/sesman/chansrv/clipboard_file.c
@@ -600,7 +600,7 @@ clipboard_c2s_in_files(struct stream *s, char *file_list)
     int lindex;
     int str_len;
     int file_count;
-    struct clip_file_desc *cfd;
+    struct clip_file_desc cfd;
     char *ptr;
 
     if (!s_check_rem(s, 4))
@@ -616,22 +616,20 @@ clipboard_c2s_in_files(struct stream *s, char *file_list)
     }
     xfuse_clear_clip_dir();
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_c2s_in_files: cItems %d", cItems);
-    cfd = (struct clip_file_desc *)
-          g_malloc(sizeof(struct clip_file_desc), 0);
     file_count = 0;
     ptr = file_list;
     for (lindex = 0; lindex < cItems; lindex++)
     {
-        g_memset(cfd, 0, sizeof(struct clip_file_desc));
-        clipboard_c2s_in_file_info(s, cfd);
-        if ((g_pos(cfd->cFileName, "\\") >= 0) ||
-                (cfd->fileAttributes & CB_FILE_ATTRIBUTE_DIRECTORY))
+        g_memset(&cfd, 0, sizeof(struct clip_file_desc));
+        clipboard_c2s_in_file_info(s, &cfd);
+        if ((g_pos(cfd.cFileName, "\\") >= 0) ||
+                (cfd.fileAttributes & CB_FILE_ATTRIBUTE_DIRECTORY))
         {
             LOG_DEVEL(LOG_LEVEL_ERROR, "clipboard_c2s_in_files: skipping directory not "
-                      "supported [%s]", cfd->cFileName);
+                      "supported [%s]", cfd.cFileName);
             continue;
         }
-        if (xfuse_add_clip_dir_item(cfd->cFileName, 0, cfd->fileSizeLow, lindex) == -1)
+        if (xfuse_add_clip_dir_item(cfd.cFileName, 0, cfd.fileSizeLow, lindex) == -1)
         {
             LOG_DEVEL(LOG_LEVEL_ERROR, "clipboard_c2s_in_files: failed to add clip dir item");
             continue;
@@ -654,11 +652,10 @@ clipboard_c2s_in_files(struct stream *s, char *file_list)
         *ptr = '/';
         ptr++;
 
-        str_len = g_strlen(cfd->cFileName);
-        g_strcpy(ptr, cfd->cFileName);
+        str_len = g_strlen(cfd.cFileName);
+        g_strcpy(ptr, cfd.cFileName);
         ptr += str_len;
     }
     *ptr = 0;
-    g_free(cfd);
     return 0;
 }

--- a/sesman/chansrv/clipboard_file.c
+++ b/sesman/chansrv/clipboard_file.c
@@ -575,7 +575,7 @@ clipboard_c2s_in_file_info(struct stream *s, struct clip_file_desc *cfd)
     in_uint32_le(s, cfd->lastWriteTimeHigh);
     in_uint32_le(s, cfd->fileSizeHigh);
     in_uint32_le(s, cfd->fileSizeLow);
-    num_chars = 256;
+    num_chars = sizeof(cfd->cFileName);
     clipboard_in_unicode(s, cfd->cFileName, &num_chars);
     ex_bytes = 512 - num_chars * 2;
     ex_bytes -= 2;

--- a/sesman/chansrv/clipboard_file.c
+++ b/sesman/chansrv/clipboard_file.c
@@ -565,6 +565,7 @@ static int
 clipboard_c2s_in_file_info(struct stream *s, struct clip_file_desc *cfd)
 {
     int num_chars;
+    int filename_bytes;
     int ex_bytes;
 
     in_uint32_le(s, cfd->flags);
@@ -576,11 +577,9 @@ clipboard_c2s_in_file_info(struct stream *s, struct clip_file_desc *cfd)
     in_uint32_le(s, cfd->fileSizeHigh);
     in_uint32_le(s, cfd->fileSizeLow);
     num_chars = sizeof(cfd->cFileName);
-    clipboard_in_unicode(s, cfd->cFileName, &num_chars);
-    ex_bytes = 512 - num_chars * 2;
-    ex_bytes -= 2;
+    filename_bytes = clipboard_in_unicode(s, cfd->cFileName, &num_chars);
+    ex_bytes = 520 - filename_bytes;
     in_uint8s(s, ex_bytes);
-    in_uint8s(s, 8); /* pad */
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_c2s_in_file_info:");
     LOG_DEVEL(LOG_LEVEL_DEBUG, "  flags 0x%8.8x", cfd->flags);
     LOG_DEVEL(LOG_LEVEL_DEBUG, "  fileAttributes 0x%8.8x", cfd->fileAttributes);


### PR DESCRIPTION
Fixes #1992 

There are a few other improvements in this area too, all as separate commits. In order:-

- The [struct clip_file_desc in clipboard_common.h](https://github.com/neutrinolabs/xrdp/blob/3e5948f52ea6930439715e258817d7c5e7c37dde/sesman/chansrv/clipboard_common.h#L72-L81) is meant to hold the data sent in a [CLIPRDR_FILEDESCRIPTOR](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeclip/a765d784-2b39-4b88-9faa-88f8666f9c35). The filename is 260 Unicode characters. Since each filename could occupy up to 4 bytes, the allocated space for the cFileName member is too small.
- (See #1992). The logic to skip the padding at the end of a CLIPRDR_FILEDESCRIPTOR is wrong, and only works for simple (i.e. European) filenames.
- An unnecessary malloc/free pair is removed by using a stack variable instead.
- A check is added that the buffer containing a CLIPRDR_FILEDESCRIPTOR has enough data before the structure is read.