### PR TITLE
Some copy-paste tidyups + Nautilus 3 compatibility

### DIFF
--- a/docs/man/sesman.ini.5.in
+++ b/docs/man/sesman.ini.5.in
@@ -290,6 +290,14 @@ features:-
 .P
 -  copying-and-pasting of files
 .RE
+.TP
+\fBUseNautilus3FlistFormat\fR=\fI[false|true]\fR
+Defaults to \fIfalse\fR.
+Set to \fItrue\fR to make file copy-paste compatible with Nautilus from
+GNOME 3 versions later than 3.29.92. Do not use this for any other reason.
+
+This setting will be removed in a later version of xrdp, when GNOME 3 is
+no longer supported.
 
 .SH "SESSIONS VARIABLES"
 All entries in the \fB[SessionVariables]\fR section are set as

--- a/sesman/chansrv/chansrv_config.c
+++ b/sesman/chansrv/chansrv_config.c
@@ -39,7 +39,7 @@
 #define DEFAULT_ENABLE_FUSE_MOUNT           1
 #define DEFAULT_FUSE_MOUNT_NAME             "xrdp-client"
 #define DEFAULT_FILE_UMASK                  077
-
+#define DEFAULT_USE_NAUTILUS3_FLIST_FORMAT  0
 /**
  * Type used for passing a logging function about
  */
@@ -161,7 +161,7 @@ read_config_chansrv(log_func_t logmsg,
         {
             cfg->enable_fuse_mount = g_text2bool(value);
         }
-        if (g_strcasecmp(name, "FuseMountName") == 0)
+        else if (g_strcasecmp(name, "FuseMountName") == 0)
         {
             g_free(cfg->fuse_mount_name);
             cfg->fuse_mount_name = g_strdup(value);
@@ -175,6 +175,10 @@ read_config_chansrv(log_func_t logmsg,
         else if (g_strcasecmp(name, "FileUmask") == 0)
         {
             cfg->file_umask = strtol(value, NULL, 0);
+        }
+        else if (g_strcasecmp(name, "UseNautilus3FlistFormat") == 0)
+        {
+            cfg->use_nautilus3_flist_format = g_text2bool(value);
         }
     }
 
@@ -206,6 +210,7 @@ new_config(void)
         cfg->restrict_outbound_clipboard = DEFAULT_RESTRICT_OUTBOUND_CLIPBOARD;
         cfg->fuse_mount_name = fuse_mount_name;
         cfg->file_umask = DEFAULT_FILE_UMASK;
+        cfg->use_nautilus3_flist_format = DEFAULT_USE_NAUTILUS3_FLIST_FORMAT;
     }
 
     return cfg;
@@ -290,6 +295,8 @@ config_dump(struct config_chansrv *config)
               g_bool2text(config->enable_fuse_mount));
     g_writeln("    FuseMountName:             %s", config->fuse_mount_name);
     g_writeln("    FileMask:                  0%o", config->file_umask);
+    g_writeln("    Nautilus 3 Flist Format:   %s",
+              g_bool2text(config->use_nautilus3_flist_format));
 }
 
 /******************************************************************************/

--- a/sesman/chansrv/chansrv_config.h
+++ b/sesman/chansrv/chansrv_config.h
@@ -36,6 +36,9 @@ struct config_chansrv
     char *fuse_mount_name;
     /** FileUmask from sesman.ini */
     mode_t file_umask;
+
+    /** Whether to use nautilus3-compatible file lists for the clipboard */
+    int use_nautilus3_flist_format;
 };
 
 

--- a/sesman/chansrv/clipboard.c
+++ b/sesman/chansrv/clipboard.c
@@ -1244,7 +1244,28 @@ clipboard_process_data_response_for_file(struct stream *s,
     else if ((g_clip_c2s.type == XA_STRING) ||
              (g_clip_c2s.type == g_utf8_atom))
     {
-        rv = clipboard_c2s_in_files(s, g_clip_c2s.data, flist_size, "");
+        if (g_cfg->use_nautilus3_flist_format)
+        {
+            /*
+             * This file list format is only used by GNOME 3
+             * versions >= 3.29.92. It is not used by GNOME 4. Remove
+             * this workaround when GNOME 3 is no longer supported by
+             * long-term distros */
+#define LIST_PREFIX "x-special/nautilus-clipboard\ncopy\n"
+#define LIST_PREFIX_LEN (sizeof(LIST_PREFIX) - 1)
+            g_strcpy(g_clip_c2s.data, LIST_PREFIX);
+            rv = clipboard_c2s_in_files(s,
+                                        g_clip_c2s.data + LIST_PREFIX_LEN,
+                                        flist_size - LIST_PREFIX_LEN - 1,
+                                        "file://");
+            g_strcat(g_clip_c2s.data, "\n");
+#undef LIST_PREFIX_LEN
+#undef LIST_PREFIX
+        }
+        else
+        {
+            rv = clipboard_c2s_in_files(s, g_clip_c2s.data, flist_size, "");
+        }
     }
     else
     {

--- a/sesman/chansrv/clipboard_file.c
+++ b/sesman/chansrv/clipboard_file.c
@@ -598,7 +598,8 @@ clipboard_c2s_in_file_info(struct stream *s, struct clip_file_desc *cfd)
 
 /*****************************************************************************/
 int
-clipboard_c2s_in_files(struct stream *s, char *file_list, int file_list_size)
+clipboard_c2s_in_files(struct stream *s, char *file_list, int file_list_size,
+                       const char *fprefix)
 {
     int citems;
     int lindex;
@@ -607,7 +608,6 @@ clipboard_c2s_in_files(struct stream *s, char *file_list, int file_list_size)
     char *ptr;
     char *last; /* Last writeable char in buffer */
     int dropped_files = 0; /* # files we can't add to buffer */
-    const char *prefix = "file://";
 
     if (file_list_size < 1)
     {
@@ -655,7 +655,7 @@ clipboard_c2s_in_files(struct stream *s, char *file_list, int file_list_size)
 
         /* Room for this file? */
         str_len = (ptr == file_list) ? 0 : 1; /* Delimiter */
-        str_len += g_strlen(prefix);
+        str_len += g_strlen(fprefix); /* e.g. "file://" */
         str_len += g_strlen(g_fuse_clipboard_path);
         str_len += 1; /* '/' */
         str_len += g_strlen(cfd.cFileName);
@@ -677,8 +677,8 @@ clipboard_c2s_in_files(struct stream *s, char *file_list, int file_list_size)
             *ptr++ = '\n';
         }
 
-        str_len = g_strlen(prefix);
-        g_strcpy(ptr, prefix);
+        str_len = g_strlen(fprefix);
+        g_strcpy(ptr, fprefix);
         ptr += str_len;
 
         str_len = g_strlen(g_fuse_clipboard_path);

--- a/sesman/chansrv/clipboard_file.h
+++ b/sesman/chansrv/clipboard_file.h
@@ -30,8 +30,24 @@ clipboard_process_file_request(struct stream *s, int clip_msg_status,
 int
 clipboard_process_file_response(struct stream *s, int clip_msg_status,
                                 int clip_msg_len);
+/**
+ * Process a CLIPRDR_FILELIST - see [MS-RDPECLIP] 2.2.5.2.3
+ *
+ * Files in the list are added to the xfs filesystem in the clipboard
+ * directory. The filenames names are added to the 'file_list' for the user.
+ * Files are prefixed with 'file://<clipboard_dir>/' and separated by '\n'.
+ *
+ * If the list is not big enough, whole filenames are omitted, and a warning
+ * message is logged. This is not an error.
+ *
+ * @param s Input stream containing CLIPRDR_FILELIST
+ * @param file_list Output buffer for filenames
+ * @param file_list_size Size of buffer, including space for '\0'.
+ *
+ * @return Zero for success.
+ */
 int
-clipboard_c2s_in_files(struct stream *s, char *file_list);
+clipboard_c2s_in_files(struct stream *s, char *file_list, int file_list_size);
 
 int
 clipboard_request_file_size(int stream_id, int lindex);

--- a/sesman/chansrv/clipboard_file.h
+++ b/sesman/chansrv/clipboard_file.h
@@ -35,7 +35,7 @@ clipboard_process_file_response(struct stream *s, int clip_msg_status,
  *
  * Files in the list are added to the xfs filesystem in the clipboard
  * directory. The filenames names are added to the 'file_list' for the user.
- * Files are prefixed with 'file://<clipboard_dir>/' and separated by '\n'.
+ * Files are prefixed with '<fprefix><clipboard_dir>/' and separated by '\n'.
  *
  * If the list is not big enough, whole filenames are omitted, and a warning
  * message is logged. This is not an error.
@@ -43,11 +43,13 @@ clipboard_process_file_response(struct stream *s, int clip_msg_status,
  * @param s Input stream containing CLIPRDR_FILELIST
  * @param file_list Output buffer for filenames
  * @param file_list_size Size of buffer, including space for '\0'.
+ * @param fprefix Prefix for each file in the file list (e.g. "file://")
  *
  * @return Zero for success.
  */
 int
-clipboard_c2s_in_files(struct stream *s, char *file_list, int file_list_size);
+clipboard_c2s_in_files(struct stream *s, char *file_list, int file_list_size,
+                       const char *fprefix);
 
 int
 clipboard_request_file_size(int stream_id, int lindex);

--- a/sesman/sesman.ini.in
+++ b/sesman/sesman.ini.in
@@ -125,6 +125,10 @@ FuseMountName=thinclient_drives
 FileUmask=077
 ; Can be used to disable FUSE functionality - see sesman.ini(5)
 #EnableFuseMount=false
+; Uncomment this line only if you are using GNOME 3 versions 3.29.92
+; and up, and you wish to cut-paste files between Nautilus and Windows. Do
+; not use this setting for GNOME 4, or other file managers
+#UseNautilus3FlistFormat=true
 
 [ChansrvLogging]
 ; Note: one log file is created per display and the LogFile config value 


### PR DESCRIPTION
Fixes #1994 

The reader is referred to #1994 for some background behind this.

In this description "Nautilus 3" means versions of Nautilus supplied with GNOME 3 3.29.92 and later.

In the process of investigating that fault, we found that using `xclip` to query the clipboard for a STRING or UTF8_STRING when files were selected on the Windows side could hang. This PR fixes that by emulating the behaviour of Thunar or Nautilus 3 for such queries.

In all, there are three commits here:-
1) The first commit adds some memory buffer overflow checking to the clipboard code we're using for files. In particular, the function `clipboard_c2s_in_files()` now is passed the length of the buffer it has available to write to.
2) The second commit provides a default STRING or UTF8_STRING response to an X client requesting it when a file list is available.
3) The third commit adds a variable to `sesman.ini` which can be used to enable Nautilus 3 compatibility if required.

The intention is to revert the 3rd commit when there is no need to support Nautilus 3. I estimate this will be in about 3 years' time, but it may be more if RHEL 8 (and clones) do not migrate to GNOME 4.

It may be that we decide the third commit is too complicated and we wish to remove it. Even so, I believe the first two commits are worth adding to the codebase.