### PR TITLE
Bump cppcheck version to 2.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
       CC: gcc
       # This is required to use a version of cppcheck other than that
       # supplied with the operating system
-      CPPCHECK_VER: 2.5
+      CPPCHECK_VER: 2.6
       CPPCHECK_REPO: https://github.com/danmar/cppcheck.git
     steps:
       # This is currently the only way to get a version into

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -2191,9 +2191,6 @@ getPAMError(const int pamError, char *text, int text_bytes)
             return "Error connecting to PAM";
         case 32 + 3:
             return "Username okey but group problem";
-        default:
-            g_snprintf(text, text_bytes, "Not defined PAM error:%d", pamError);
-            return text;
 #elif defined(OPENPAM)
         case PAM_SUCCESS: /* 0 */
             return "Success";
@@ -2255,10 +2252,10 @@ getPAMError(const int pamError, char *text, int text_bytes)
             return "Module is unknown";
         case PAM_DOMAIN_UNKNOWN: /* 29 */
             return "Unknown authentication domain";
+#endif
         default:
             g_snprintf(text, text_bytes, "Not defined PAM error:%d", pamError);
             return text;
-#endif
     }
 }
 
@@ -2309,8 +2306,6 @@ getPAMAdditionalErrorInfo(const int pamError, struct xrdp_mm *self)
             {
                 return "Authentication error - Verify that user/password is valid";
             }
-        default:
-            return "No expected error";
 #elif defined(OPENPAM)
         case PAM_SUCCESS: /* 0 */
             return NULL;
@@ -2351,9 +2346,9 @@ getPAMAdditionalErrorInfo(const int pamError, struct xrdp_mm *self)
             {
                 return "Authentication error - Verify that user/password is valid";
             }
+#endif
         default:
             return "No expected error";
-#endif
     }
 }
 #endif


### PR DESCRIPTION
Update to latest cppcheck for CI.

The modification to `xrdp_mm.c` avoids these errors which don't appear with cppcheck 2.5:-

```
xrdp/xrdp_mm.c:2130:5: error: Found a exit path from function with non-void return type that has missing return statement [missingReturn]
    {
    ^
xrdp/xrdp_mm.c:2269:5: error: Found a exit path from function with non-void return type that has missing return statement [missingReturn]
    {
    ^
```

The errors relate to the functions `getPAMError()` and `getPAMAdditionalErrorInfo()`. If the system is built on a PAM stack which isn't [linux-pam](http://www.linux-pam.org/), or [OpenPAM](https://www.openpam.org/), these functions are defined without return values.

The change simply moves the default case for the switch outside the conditional blocks for each stack.

In the longer term, these functions probably need moving into sesman, but I think that needs to wait for #1961