### PR TITLE
Unify scpv0 code

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -48,8 +48,8 @@ SUBDIRS = \
   libxrdp \
   $(PAINTERDIR) \
   $(RFXCODECDIR) \
-  xrdp \
   sesman \
+  xrdp \
   keygen \
   docs \
   instfiles \

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -47,6 +47,8 @@ libcommon_la_SOURCES = \
   fifo.h \
   file.c \
   file.h \
+  guid.c \
+  guid.h \
   list.c \
   list.h \
   list16.c \

--- a/common/guid.c
+++ b/common/guid.c
@@ -1,0 +1,72 @@
+/**
+ * xrdp: A Remote Desktop Protocol server.
+ *
+ * Copyright (C) 2021 Matt Burt, all xrdp contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * @file common/guid.c
+ * @brief GUID manipulation definitions
+ */
+
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
+#include "guid.h"
+#include "os_calls.h"
+#include "string_calls.h"
+
+struct guid
+guid_new(void)
+{
+    struct guid guid = {0};
+    g_random(guid.g, sizeof(guid.g));
+    return guid;
+}
+
+void
+guid_clear(struct guid *guid)
+{
+    g_memset(&guid->g, '\x00', GUID_SIZE);
+}
+
+int
+guid_is_set(const struct guid *guid)
+{
+    unsigned int i;
+    int rv = 0;
+    if (guid != NULL)
+    {
+        for (i = 0 ; i < GUID_SIZE; ++i)
+        {
+            if (guid->g[i] != '\x00')
+            {
+                rv = 1;
+                break;
+            }
+        }
+    }
+
+    return rv;
+
+}
+
+const char *guid_to_str(const struct guid *guid, char *str)
+{
+    g_bytes_to_hexstr(guid->g, GUID_SIZE, str, GUID_STR_SIZE);
+    return str;
+}

--- a/common/guid.h
+++ b/common/guid.h
@@ -1,0 +1,75 @@
+/**
+ * xrdp: A Remote Desktop Protocol server.
+ *
+ * Copyright (C) Jay Sorg 2004-2021
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * @file common/guid.h
+ * @brief GUID manipulation declarations
+  */
+
+#ifndef GUID_H
+#define GUID_H
+
+#include "arch.h"
+
+#define GUID_SIZE 16  /* bytes */
+#define GUID_STR_SIZE (GUID_SIZE * 2 + 1)   /* Size for string representation */
+
+/**
+ * Use a struct for the guid so we can easily copy by assignment
+ */
+struct guid
+{
+    char g[GUID_SIZE];
+};
+
+/**
+ * Get an initialised GUID
+ *
+ * @return new GUID
+ */
+struct guid guid_new(void);
+
+/**
+ * Clears an initialised GUID, so guid_is_set() returns true
+ *
+ * @param guid GUID to clear
+ */
+void
+guid_clear(struct guid *guid);
+
+/**
+ * Checks if a GUID is initialised
+ *
+ * @param guid GUID to check (can be NULL)
+ * @return non-zero if GUID is set
+ */
+int
+guid_is_set(const struct guid *guid);
+
+/**
+ * Converts a GUID to a string representation
+ *
+ * @param guid GUID to represent
+ * @param str pointer to at least GUID_STR_SIZE bytes to store the
+ *            representation
+ * @return str is returned for convenience
+ */
+const char *guid_to_str(const struct guid *guid, char *str);
+
+#endif

--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -257,7 +257,15 @@ lxrdp_connect(struct mod *mod)
             LOG(LOG_LEVEL_INFO, buf);
             mod->server_msg(mod, buf, 0);
         }
-
+#else
+        {
+            /* This version of freerdp returns no useful information at
+             * all */
+            mod->server_msg(mod, "Neutrinordp connect failed.", 0);
+            mod->server_msg(mod, "No more information is available", 0);
+            mod->server_msg(mod, "Check host is up"
+                            " and credentials are correct", 0);
+        }
 #endif
         LOG(LOG_LEVEL_ERROR, "NeutrinoRDP proxy connection: status [Failed],"
             " RDP client [%s:%s], RDP server [%s:%d], RDP server username [%s],"

--- a/neutrinordp/xrdp-neutrinordp.h
+++ b/neutrinordp/xrdp-neutrinordp.h
@@ -108,7 +108,7 @@ struct mod
                              char *data, int width, int height, int srcx, int srcy);
     int (*server_set_pointer)(struct mod *v, int x, int y, char *data, char *mask);
     int (*server_palette)(struct mod *v, int *palette);
-    int (*server_msg)(struct mod *v, char *msg, int code);
+    int (*server_msg)(struct mod *v, const char *msg, int code);
     int (*server_is_term)(struct mod *v);
     int (*server_set_clip)(struct mod *v, int x, int y, int cx, int cy);
     int (*server_reset_clip)(struct mod *v);

--- a/sesman/libscp/libscp_connection.c
+++ b/sesman/libscp/libscp_connection.c
@@ -29,8 +29,7 @@
 #endif
 
 #include "libscp_connection.h"
-
-//extern struct log_config* s_log;
+#include "string_calls.h"
 
 struct trans *
 scp_trans_create(int sck)
@@ -39,6 +38,63 @@ scp_trans_create(int sck)
     if (result != NULL)
     {
         result->sck = sck;
+    }
+
+    return result;
+}
+
+/*****************************************************************************/
+
+const char *
+scp_client_state_to_str(enum SCP_CLIENT_STATES_E e)
+{
+    const char *result = "SCP_CLIENT_STATE_????";
+
+    /* Some compilers will warn if this switch is missing states */
+    switch (e)
+    {
+        case SCP_CLIENT_STATE_OK:
+            result = "SCP_CLIENT_STATE_OK";
+            break;
+        case SCP_CLIENT_STATE_NETWORK_ERR:
+            result = "SCP_CLIENT_STATE_NETWORK_ERR";
+            break;
+        case SCP_CLIENT_STATE_VERSION_ERR:
+            result = "SCP_CLIENT_STATE_VERSION_ERR";
+            break;
+        case SCP_CLIENT_STATE_SEQUENCE_ERR:
+            result = "SCP_CLIENT_STATE_SEQUENCE_ERR";
+            break;
+        case SCP_CLIENT_STATE_SIZE_ERR:
+            result = "SCP_CLIENT_STATE_SIZE_ERR";
+            break;
+        case SCP_CLIENT_STATE_INTERNAL_ERR:
+            result = "SCP_CLIENT_STATE_INTERNAL_ERR";
+            break;
+        case SCP_CLIENT_STATE_SESSION_LIST:
+            result = "SCP_CLIENT_STATE_SESSION_LIST";
+            break;
+        case SCP_CLIENT_STATE_LIST_OK:
+            result = "SCP_CLIENT_STATE_LIST_OK";
+            break;
+        case SCP_CLIENT_STATE_RESEND_CREDENTIALS:
+            result = "SCP_CLIENT_STATE_RESEND_CREDENTIALS";
+            break;
+        case SCP_CLIENT_STATE_CONNECTION_DENIED:
+            result = "SCP_CLIENT_STATE_CONNECTION_DENIED";
+            break;
+        case SCP_CLIENT_STATE_PWD_CHANGE_REQ:
+            result = "SCP_CLIENT_STATE_PWD_CHANGE_REQ";
+            break;
+        case SCP_CLIENT_STATE_RECONNECT_SINGLE:
+            result = "SCP_CLIENT_STATE_RECONNECT_SINGLE";
+            break;
+        case SCP_CLIENT_STATE_SELECTION_CANCEL:
+            result = "SCP_CLIENT_STATE_SELECTION_CANCEL";
+            break;
+        case SCP_CLIENT_STATE_END:
+            result = "SCP_CLIENT_STATE_END";
+            break;
     }
 
     return result;

--- a/sesman/libscp/libscp_connection.h
+++ b/sesman/libscp/libscp_connection.h
@@ -31,11 +31,12 @@
 
 /**
  *
- * @brief creates a new SCP transport object
- * @param sck the connection socket
- *
- * This is a convenience function which calls trans_create() with the
- * correct parameters.
+ * @brief creates a new SCP connection
+ * @param host Hostname to connect to (NULL for default)
+ * @param port Port to connect to (NULL for default)
+ * @param term_func Transport termination function (or NULL)
+ * @param data_in_func Transport 'data in' function
+ * @param callback_data Closure data for data in function
  *
  * Returned object can be freed with trans_delete()
  *
@@ -43,7 +44,10 @@
  *
  */
 struct trans *
-scp_trans_create(int sck);
+scp_connect(const char *host, const  char *port,
+            tis_term term_func,
+            ttrans_data_in data_in_func,
+            void *callback_data);
 
 /**
  * @brief Maps SCP_CLIENT_TYPES_E to a string

--- a/sesman/libscp/libscp_connection.h
+++ b/sesman/libscp/libscp_connection.h
@@ -45,4 +45,13 @@
 struct trans *
 scp_trans_create(int sck);
 
+/**
+ * @brief Maps SCP_CLIENT_TYPES_E to a string
+ * @param e
+ *
+ * @return Pointer to a string
+ *
+ */
+const char *scp_client_state_to_str(enum SCP_CLIENT_STATES_E e);
+
 #endif

--- a/sesman/libscp/libscp_session.c
+++ b/sesman/libscp/libscp_session.c
@@ -414,7 +414,7 @@ scp_session_set_addr(struct SCP_SESSION *s, int type, const void *addr)
 
 /*******************************************************************/
 int
-scp_session_set_guid(struct SCP_SESSION *s, const tui8 *guid)
+scp_session_set_guid(struct SCP_SESSION *s, const struct guid *guid)
 {
     if (0 == guid)
     {
@@ -422,7 +422,7 @@ scp_session_set_guid(struct SCP_SESSION *s, const tui8 *guid)
         return 1;
     }
 
-    g_memcpy(s->guid, guid, 16);
+    s->guid = *guid;
 
     return 0;
 }

--- a/sesman/libscp/libscp_session.h
+++ b/sesman/libscp/libscp_session.h
@@ -100,7 +100,7 @@ int
 scp_session_set_errstr(struct SCP_SESSION *s, const char *str);
 
 int
-scp_session_set_guid(struct SCP_SESSION *s, const tui8 *guid);
+scp_session_set_guid(struct SCP_SESSION *s, const struct guid *guid);
 
 /**
  *

--- a/sesman/libscp/libscp_types.h
+++ b/sesman/libscp/libscp_types.h
@@ -30,6 +30,7 @@
 #include "os_calls.h"
 #include "parse.h"
 #include "arch.h"
+#include "guid.h"
 #include "log.h"
 #include "trans.h"
 
@@ -85,7 +86,7 @@ struct SCP_SESSION
     char *program;
     char *directory;
     char *connection_description;
-    tui8 guid[16];
+    struct guid guid;
     /* added for state */
     int current_cmd;
     int return_sid;

--- a/sesman/libscp/libscp_v0.c
+++ b/sesman/libscp/libscp_v0.c
@@ -410,10 +410,9 @@ scp_v0s_accept(struct trans *atrans, struct SCP_SESSION *session)
         in_uint16_be(in_s, height);
         scp_session_set_height(session, height);
         in_uint16_be(in_s, bpp);
-        if (session_type == SCP_SESSION_TYPE_XORG && bpp != 24)
+        if (session_type == SCP_SESSION_TYPE_XORG)
         {
-            LOG(LOG_LEVEL_WARNING,
-                "Setting bpp to 24 from %d for Xorg session", bpp);
+            /* Client value is ignored */
             bpp = 24;
         }
         if (0 != scp_session_set_bpp(session, (tui8)bpp))

--- a/sesman/libscp/libscp_v0.c
+++ b/sesman/libscp/libscp_v0.c
@@ -403,13 +403,14 @@ scp_v0s_accept(struct trans *atrans, struct SCP_SESSION *session)
 
 /******************************************************************************/
 enum SCP_SERVER_STATES_E
-scp_v0s_allow_connection(struct trans *atrans, SCP_DISPLAY d, const tui8 *guid)
+scp_v0s_allow_connection(struct trans *atrans, SCP_DISPLAY d,
+                         const struct guid *guid)
 {
     int msg_size;
     struct stream *out_s;
 
     out_s = trans_get_out_s(atrans, 0);
-    msg_size = guid == 0 ? 14 : 14 + 16;
+    msg_size = guid == 0 ? 14 : 14 + GUID_SIZE;
     out_uint32_be(out_s, 0);  /* version */
     out_uint32_be(out_s, msg_size); /* size */
     out_uint16_be(out_s, 3);  /* cmd */
@@ -417,7 +418,7 @@ scp_v0s_allow_connection(struct trans *atrans, SCP_DISPLAY d, const tui8 *guid)
     out_uint16_be(out_s, d);  /* data */
     if (msg_size > 14)
     {
-        out_uint8a(out_s, guid, 16);
+        out_uint8a(out_s, guid->g, GUID_SIZE);
     }
     s_mark_end(out_s);
     if (0 != trans_write_copy(atrans))

--- a/sesman/libscp/libscp_v0.c
+++ b/sesman/libscp/libscp_v0.c
@@ -47,177 +47,290 @@ extern struct log_config *s_log;
  * Buffer is null-terminated on success
  *
  * @param s Input stream
- * @param [out] Output buffer (must be >= (STRING16_MAX_LEN+1) chars)
- * @param param Parameter we're reading
+ * @param [out] str Output buffer (must be >= (STRING16_MAX_LEN+1) chars)
+ * @param prefix Logging prefix for errors
  * @return != 0 if string read OK
  */
 static
-int in_string16(struct stream *s, char str[], const char *param)
+int in_string16(struct stream *s, char str[], const char *prefix)
 {
     int result;
+    unsigned int sz;
 
-    if (!s_check_rem(s, 2))
+    if ((result = s_check_rem_and_log(s, 2, prefix)) != 0)
     {
-        LOG(LOG_LEVEL_WARNING, "connection aborted: %s len missing", param);
-        result = 0;
-    }
-    else
-    {
-        unsigned int sz;
-
         in_uint16_be(s, sz);
         if (sz > STRING16_MAX_LEN)
         {
-            LOG(LOG_LEVEL_WARNING,
-                "connection aborted: %s too long (%u chars)",  param, sz);
+            LOG(LOG_LEVEL_ERROR, "%s input string too long (%u chars)",
+                prefix, sz);
             result = 0;
         }
-        else
+        else if ((result = s_check_rem_and_log(s, sz, prefix)) != 0)
         {
-            result = s_check_rem(s, sz);
-            if (!result)
-            {
-                LOG(LOG_LEVEL_WARNING, "connection aborted: %s data missing", param);
-            }
-            else
-            {
-                in_uint8a(s, str, sz);
-                str[sz] = '\0';
-            }
+            in_uint8a(s, str, sz);
+            str[sz] = '\0';
         }
     }
     return result;
 }
-/* client API */
-#if 0
-/******************************************************************************/
-static enum SCP_CLIENT_STATES_E
-scp_v0c_connect(struct SCP_CONNECTION *c, struct SCP_SESSION *s)
+
+/**
+ * Writes a big-endian uint16 followed by a string into a buffer
+ *
+ * @param s Output stream
+ * @param[in] str output string (must be <= (STRING16_MAX_LEN+1) chars)
+ * @param param Parameter we're sending
+ * @return != 0 if string written OK
+ */
+static
+int out_string16(struct stream *out_s, const char *str, const char *prefix)
 {
-    tui32 version;
-    int size;
-    tui16 sz;
+    int result;
 
-    init_stream(c->in_s, c->in_s->size);
-    init_stream(c->out_s, c->in_s->size);
-
-    LOG_DEVEL(LOG_LEVEL_DEBUG, "starting connection");
-    g_tcp_set_non_blocking(c->in_sck);
-    g_tcp_set_no_delay(c->in_sck);
-    s_push_layer(c->out_s, channel_hdr, 8);
-
-    /* code */
-    if (s->type == SCP_SESSION_TYPE_XVNC)
+    unsigned int sz = g_strlen(str);
+    if (sz > STRING16_MAX_LEN)
     {
-        out_uint16_be(c->out_s, 0);
+        LOG(LOG_LEVEL_WARNING, "%s String too long (%u chars)", prefix, sz);
+        result = 0;
     }
-    else if (s->type == SCP_SESSION_TYPE_XRDP)
+    else if ((result = s_check_rem_out_and_log(out_s, 2 + sz, prefix)) != 0)
     {
-        out_uint16_be(c->out_s, 10);
+        out_uint16_be(out_s, sz);
+        out_uint8a(out_s, str, sz);
     }
-    else if (s->type == SCP_SESSION_TYPE_XORG)
+
+    return result;
+}
+
+/***
+ * Terminates a V0 request, adds the header and sends it.
+ *
+ * On entry, channel_hdr on the transport output stream is expected to
+ * contain the location for the SCP header
+ *
+ * @param atrans Transport for the message
+ * @return error code
+ */
+static enum SCP_CLIENT_STATES_E
+terminate_and_send_v0_request(struct trans *atrans)
+{
+    enum SCP_CLIENT_STATES_E e;
+
+    struct stream *s = atrans->out_s;
+    s_mark_end(s);
+    s_pop_layer(s, channel_hdr);
+
+    /* version */
+    out_uint32_be(s, 0);
+    /* size */
+    out_uint32_be(s, s->end - s->data);
+
+    if (trans_force_write_s(atrans, s) == 0)
     {
-        out_uint16_be(c->out_s, 20);
+        e = SCP_CLIENT_STATE_OK;
     }
     else
     {
-        LOG(LOG_LEVEL_WARNING, "connection aborted: network error");
-        return SCP_CLIENT_STATE_INTERNAL_ERR;
+        LOG(LOG_LEVEL_ERROR, "connection aborted: network error");
+        e = SCP_CLIENT_STATE_NETWORK_ERR;
     }
 
-    sz = g_strlen(s->username);
-    if (sz > STRING16_MAX_LEN)
-    {
-        LOG(LOG_LEVEL_WARNING, "connection aborted: username too long");
-        return SCP_CLIENT_STATE_SIZE_ERR;
-    }
-    out_uint16_be(c->out_s, sz);
-    out_uint8a(c->out_s, s->username, sz);
-
-    sz = g_strlen(s->password);
-    if (sz > STRING16_MAX_LEN)
-    {
-        LOG(LOG_LEVEL_WARNING, "connection aborted: password too long");
-        return SCP_CLIENT_STATE_SIZE_ERR;
-    }
-    out_uint16_be(c->out_s, sz);
-    out_uint8a(c->out_s, s->password, sz);
-    out_uint16_be(c->out_s, s->width);
-    out_uint16_be(c->out_s, s->height);
-    out_uint16_be(c->out_s, s->bpp);
-
-    s_mark_end(c->out_s);
-    s_pop_layer(c->out_s, channel_hdr);
-
-    /* version */
-    out_uint32_be(c->out_s, 0);
-    /* size */
-    out_uint32_be(c->out_s, c->out_s->end - c->out_s->data);
-
-    if (0 != scp_tcp_force_send(c->in_sck, c->out_s->data, c->out_s->end - c->out_s->data))
-    {
-        LOG(LOG_LEVEL_WARNING, "connection aborted: network error");
-        return SCP_CLIENT_STATE_NETWORK_ERR;
-    }
-
-    if (0 != scp_tcp_force_recv(c->in_sck, c->in_s->data, 8))
-    {
-        LOG(LOG_LEVEL_WARNING, "connection aborted: network error");
-        return SCP_CLIENT_STATE_NETWORK_ERR;
-    }
-
-    in_uint32_be(c->in_s, version);
-
-    if (0 != version)
-    {
-        LOG(LOG_LEVEL_WARNING, "connection aborted: version error");
-        return SCP_CLIENT_STATE_VERSION_ERR;
-    }
-
-    in_uint32_be(c->in_s, size);
-
-    if (size < (8 + 2 + 2 + 2) || size > SCP_MAX_MESSAGE_SIZE)
-    {
-        LOG(LOG_LEVEL_WARNING, "connection aborted: msg size = %d", size);
-        return SCP_CLIENT_STATE_SIZE_ERR;
-    }
-
-    /* getting payload */
-    init_stream(c->in_s, size - 8);
-
-    if (0 != scp_tcp_force_recv(c->in_sck, c->in_s->data, size - 8))
-    {
-        LOG(LOG_LEVEL_WARNING, "connection aborted: network error");
-        return SCP_CLIENT_STATE_NETWORK_ERR;
-    }
-
-    c->in_s->end = c->in_s->data + (size - 8);
-
-    /* check code */
-    in_uint16_be(c->in_s, sz);
-
-    if (3 != sz)
-    {
-        LOG(LOG_LEVEL_WARNING, "connection aborted: sequence error");
-        return SCP_CLIENT_STATE_SEQUENCE_ERR;
-    }
-
-    /* message payload */
-    in_uint16_be(c->in_s, sz);
-
-    if (1 != sz)
-    {
-        LOG(LOG_LEVEL_WARNING, "connection aborted: connection denied");
-        return SCP_CLIENT_STATE_CONNECTION_DENIED;
-    }
-
-    in_uint16_be(c->in_s, sz);
-    s->display = sz;
-
-    LOG_DEVEL(LOG_LEVEL_DEBUG, "connection terminated");
-    return SCP_CLIENT_STATE_END;
+    return e;
 }
-#endif
+
+/* client API */
+/******************************************************************************/
+enum SCP_CLIENT_STATES_E
+scp_v0c_create_session_request(struct trans *atrans,
+                               const char *username,
+                               const char *password,
+                               unsigned short code,
+                               unsigned short width,
+                               unsigned short height,
+                               unsigned short bpp,
+                               const char *domain,
+                               const char *shell,
+                               const char *directory,
+                               const char *client_ip)
+{
+    enum SCP_CLIENT_STATES_E e;
+
+    struct stream *s = trans_get_out_s(atrans, 8192);
+    s_push_layer(s, channel_hdr, 8);
+
+    out_uint16_be(s, code);
+    if (!out_string16(s, username, "Session username") ||
+            !out_string16(s, password, "Session passwd"))
+    {
+        e = SCP_CLIENT_STATE_SIZE_ERR;
+    }
+    else
+    {
+        out_uint16_be(s, width);
+        out_uint16_be(s, height);
+        out_uint16_be(s, bpp);
+        if (!out_string16(s, domain, "Session domain") ||
+                !out_string16(s, shell, "Session shell") ||
+                !out_string16(s, directory, "Session directory") ||
+                !out_string16(s, client_ip, "Session client IP"))
+        {
+            e = SCP_CLIENT_STATE_SIZE_ERR;
+        }
+        else
+        {
+            e = terminate_and_send_v0_request(atrans);
+        }
+    }
+
+    return e;
+}
+
+enum SCP_CLIENT_STATES_E
+scp_v0c_gateway_request(struct trans *atrans,
+                        const char *username,
+                        const char *password)
+{
+    enum SCP_CLIENT_STATES_E e;
+
+    struct stream *s = trans_get_out_s(atrans, 500);
+    s_push_layer(s, channel_hdr, 8);
+
+    out_uint16_be(s, SCP_GW_AUTHENTICATION);
+    if (!out_string16(s, username, "Gateway username") ||
+            !out_string16(s, password, "Gateway passwd"))
+    {
+        e = SCP_CLIENT_STATE_SIZE_ERR;
+    }
+    else
+    {
+        e = terminate_and_send_v0_request(atrans);
+    }
+
+    return e;
+}
+
+/**************************************************************************//**
+ * Is a reply available from the other end?
+ *
+ * Returns true if it is, or if an error has occurred which needs handling.
+ *
+ * @param trans Transport to be polled
+ * @return True if scp_v0c_get_reply() should be called
+ */
+int
+scp_v0c_reply_available(struct trans *trans)
+{
+    int result = 1;
+    if (trans != NULL && trans->status == TRANS_STATUS_UP)
+    {
+        /* Have we read enough data from the stream? */
+        if ((trans->in_s->end - trans->in_s->data) < trans->header_size)
+        {
+            result = 0;
+        }
+        else if (trans->extra_flags == 0)
+        {
+            int version;
+            int size;
+
+            /* We've read the header only */
+            in_uint32_be(trans->in_s, version);
+            in_uint32_be(trans->in_s, size);
+
+            if (version != 0)
+            {
+                LOG(LOG_LEVEL_ERROR, "Unexpected version number %d from SCP",
+                    version);
+                trans->status = TRANS_STATUS_DOWN;
+            }
+            else if (size <= 8 || size > trans->in_s->size)
+            {
+                LOG(LOG_LEVEL_ERROR,
+                    "Invalid V0 message length %d from SCP",
+                    size);
+                trans->status = TRANS_STATUS_DOWN;
+            }
+            else
+            {
+                /* Read the rest of the message */
+                trans->header_size = size;
+                trans->extra_flags = 1;
+                result = 0;
+            }
+        }
+    }
+
+
+    return result;
+}
+/**************************************************************************//**
+ * Get a reply from the V0 transport
+ *
+ * Only call this once scp_v0c_reply_available() has returned true
+ *
+ * After a successful call, the transport is ready to be used for the
+ * next incoming message
+ *
+ * @param trans Transport containing the reply
+ * @param[out] reply, provided result is SCP_CLIENT_STATE_OK
+ * @return SCP client state
+ */
+enum SCP_CLIENT_STATES_E
+scp_v0c_get_reply(struct trans *trans, struct scp_v0_reply_type *reply)
+{
+    enum SCP_CLIENT_STATES_E e;
+
+    if (trans == NULL || trans->status != TRANS_STATUS_UP)
+    {
+        e = SCP_CLIENT_STATE_NETWORK_ERR;
+    }
+    else if (!s_check_rem_and_log(trans->in_s, 6, "SCPV0 reply"))
+    {
+        trans->status = TRANS_STATUS_DOWN;
+        e = SCP_CLIENT_STATE_NETWORK_ERR;
+    }
+    else
+    {
+        int word1;
+        int word2;
+        int word3;
+        in_uint16_be(trans->in_s, word1);
+        in_uint16_be(trans->in_s, word2);
+        in_uint16_be(trans->in_s, word3);
+
+        if (word1 == SCP_GW_AUTHENTICATION)
+        {
+            reply->is_gw_auth_response = 1;
+            reply->auth_result = word2;
+            reply->display = 0;
+            guid_clear(&reply->guid);
+        }
+        else
+        {
+            reply->is_gw_auth_response = 0;
+            reply->auth_result = word2;
+            reply->display = word3;
+            if (s_check_rem(trans->in_s, GUID_SIZE))
+            {
+                in_uint8a(trans->in_s, reply->guid.g, GUID_SIZE);
+            }
+            else
+            {
+                guid_clear(&reply->guid);
+            }
+        }
+
+        e = SCP_CLIENT_STATE_OK;
+
+        /* Reset the input stream for the next message */
+        trans->header_size = 8;
+        trans->extra_flags = 0;
+        init_stream(trans->in_s, 0);
+    }
+
+    return e;
+}
 
 /* server API */
 
@@ -265,7 +378,7 @@ scp_v0s_accept(struct trans *atrans, struct SCP_SESSION *session)
         scp_session_set_type(session, session_type);
 
         /* reading username */
-        if (!in_string16(in_s, buf, "username"))
+        if (!in_string16(in_s, buf, "Session username"))
         {
             return SCP_SERVER_STATE_SIZE_ERR;
         }
@@ -276,7 +389,7 @@ scp_v0s_accept(struct trans *atrans, struct SCP_SESSION *session)
         }
 
         /* reading password */
-        if (!in_string16(in_s, buf, "passwd"))
+        if (!in_string16(in_s, buf, "Session passwd"))
         {
             return SCP_SERVER_STATE_SIZE_ERR;
         }
@@ -313,7 +426,7 @@ scp_v0s_accept(struct trans *atrans, struct SCP_SESSION *session)
         if (s_check_rem(in_s, 2))
         {
             /* reading domain */
-            if (!in_string16(in_s, buf, "domain"))
+            if (!in_string16(in_s, buf, "Session domain"))
             {
                 return SCP_SERVER_STATE_SIZE_ERR;
             }
@@ -327,7 +440,7 @@ scp_v0s_accept(struct trans *atrans, struct SCP_SESSION *session)
         if (s_check_rem(in_s, 2))
         {
             /* reading program */
-            if (!in_string16(in_s, buf, "program"))
+            if (!in_string16(in_s, buf, "Session program"))
             {
                 return SCP_SERVER_STATE_SIZE_ERR;
             }
@@ -341,7 +454,7 @@ scp_v0s_accept(struct trans *atrans, struct SCP_SESSION *session)
         if (s_check_rem(in_s, 2))
         {
             /* reading directory */
-            if (!in_string16(in_s, buf, "directory"))
+            if (!in_string16(in_s, buf, "Session directory"))
             {
                 return SCP_SERVER_STATE_SIZE_ERR;
             }
@@ -369,7 +482,7 @@ scp_v0s_accept(struct trans *atrans, struct SCP_SESSION *session)
     {
         scp_session_set_type(session, SCP_GW_AUTHENTICATION);
         /* reading username */
-        if (!in_string16(in_s, buf, "username"))
+        if (!in_string16(in_s, buf, "Session username"))
         {
             return SCP_SERVER_STATE_SIZE_ERR;
         }
@@ -381,7 +494,7 @@ scp_v0s_accept(struct trans *atrans, struct SCP_SESSION *session)
         }
 
         /* reading password */
-        if (!in_string16(in_s, buf, "passwd"))
+        if (!in_string16(in_s, buf, "Session passwd"))
         {
             return SCP_SERVER_STATE_SIZE_ERR;
         }
@@ -410,7 +523,7 @@ scp_v0s_allow_connection(struct trans *atrans, SCP_DISPLAY d,
     struct stream *out_s;
 
     out_s = trans_get_out_s(atrans, 0);
-    msg_size = guid == 0 ? 14 : 14 + GUID_SIZE;
+    msg_size = guid_is_set(guid) ? 14 + GUID_SIZE : 14;
     out_uint32_be(out_s, 0);  /* version */
     out_uint32_be(out_s, msg_size); /* size */
     out_uint16_be(out_s, 3);  /* cmd */

--- a/sesman/libscp/libscp_v0.h
+++ b/sesman/libscp/libscp_v0.h
@@ -63,7 +63,8 @@ scp_v0s_accept(struct trans *atrans, struct SCP_SESSION *s);
  *
  */
 enum SCP_SERVER_STATES_E
-scp_v0s_allow_connection(struct trans *atrans, SCP_DISPLAY d, const tui8 *guid);
+scp_v0s_allow_connection(struct trans *atrans, SCP_DISPLAY d,
+                         const struct guid *guid);
 
 /**
  *

--- a/sesman/libscp/libscp_v0.h
+++ b/sesman/libscp/libscp_v0.h
@@ -60,6 +60,9 @@ scp_v0c_gateway_request(struct trans *atrans,
                         const char *username,
                         const char *password);
 
+/*
+ * Note client bpp is ignored by the sesman for Xorg sessions
+ */
 enum SCP_CLIENT_STATES_E
 scp_v0c_create_session_request(struct trans *atrans,
                                const char *username,

--- a/sesman/libscp/libscp_v0.h
+++ b/sesman/libscp/libscp_v0.h
@@ -28,22 +28,56 @@
 #define LIBSCP_V0_H
 
 #include "libscp.h"
+#include "guid.h"
 
-/*TODO : Replace this (unused) function with something that can be used
- * by xrdp_mm.c and sesrun.c */
-#if 0
 /* client API */
-/**
- *
- * @brief connects to sesman using scp v0
- * @param c connection descriptor
- * @param s session descriptor
- * @param d display
- *
- */
+
+struct scp_v0_reply_type
+{
+    /**
+     * True if this is a reply to a gateway authentication request
+     */
+    int is_gw_auth_response;
+
+    /**
+     * Authentication result. PAM code for gateway request, boolean otherwise
+     */
+    int auth_result;
+
+    /**
+     * Display number for successful non-gateway requests
+     */
+    int display;
+
+    /**
+     * GUID for successful non-gateway requests
+     */
+    struct guid guid;
+};
+
 enum SCP_CLIENT_STATES_E
-scp_v0c_connect(struct SCP_CONNECTION *c, struct SCP_SESSION *s);
-#endif
+scp_v0c_gateway_request(struct trans *atrans,
+                        const char *username,
+                        const char *password);
+
+enum SCP_CLIENT_STATES_E
+scp_v0c_create_session_request(struct trans *atrans,
+                               const char *username,
+                               const char *password,
+                               unsigned short code,
+                               unsigned short width,
+                               unsigned short height,
+                               unsigned short bpp,
+                               const char *domain,
+                               const char *shell,
+                               const char *directory,
+                               const char *client_ip);
+
+int
+scp_v0c_reply_available(struct trans *atrans);
+
+enum SCP_CLIENT_STATES_E
+scp_v0c_get_reply(struct trans *atrans, struct scp_v0_reply_type *reply);
 
 /* server API */
 /**

--- a/sesman/scp_v0.c
+++ b/sesman/scp_v0.c
@@ -82,7 +82,7 @@ scp_v0_process(struct trans *t, struct SCP_SESSION *s)
         if (s_item != 0)
         {
             display = s_item->display;
-            g_memcpy(s->guid, s_item->guid, 16);
+            s->guid = s_item->guid;
             if (0 != s->connection_description)
             {
                 LOG( LOG_LEVEL_INFO, "++ reconnected session: username %s, "
@@ -105,10 +105,9 @@ scp_v0_process(struct trans *t, struct SCP_SESSION *s)
 
             if (1 == access_login_allowed(s->username))
             {
-                tui8 guid[16];
+                struct guid guid = guid_new();
 
-                g_random((char *)guid, 16);
-                scp_session_set_guid(s, guid);
+                scp_session_set_guid(s, &guid);
 
                 if (0 != s->connection_description)
                 {
@@ -153,7 +152,7 @@ scp_v0_process(struct trans *t, struct SCP_SESSION *s)
         }
         else
         {
-            scp_v0s_allow_connection(t, display, s->guid);
+            scp_v0s_allow_connection(t, display, &s->guid);
         }
     }
     else

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -779,8 +779,8 @@ session_start_fork(tbus data, tui8 type, struct SCP_SESSION *s)
                 }
                 else if (type == SESMAN_SESSION_TYPE_XVNC)
                 {
-                    char guid_str[64];
-                    g_bytes_to_hexstr(s->guid, 16, guid_str, 64);
+                    char guid_str[GUID_STR_SIZE];
+                    guid_to_str(&s->guid, guid_str);
                     env_check_password_file(passwd_file, guid_str);
                     xserver_params = list_create();
                     xserver_params->auto_free = 1;
@@ -957,7 +957,7 @@ session_start_fork(tbus data, tui8 type, struct SCP_SESSION *s)
         temp->item->data = data;
         g_strncpy(temp->item->connection_description, s->connection_description, 255);   /* store client ip data */
         g_strncpy(temp->item->name, s->username, 255);
-        g_memcpy(temp->item->guid, s->guid, 16);
+        temp->item->guid = s->guid;
 
         ltime = g_time1();
         localtime_r(&ltime, &stime);

--- a/sesman/session.h
+++ b/sesman/session.h
@@ -29,6 +29,7 @@
 #define SESSION_H
 
 #include "libscp_types.h"
+#include "guid.h"
 
 #define SESMAN_SESSION_TYPE_XRDP      1
 #define SESMAN_SESSION_TYPE_XVNC      2
@@ -76,7 +77,7 @@ struct session_item
     struct session_date disconnect_time;
     struct session_date idle_time;
     char connection_description[256];
-    tui8 guid[16];
+    struct guid guid;
 };
 
 struct session_chain

--- a/sesman/tools/Makefile.am
+++ b/sesman/tools/Makefile.am
@@ -41,7 +41,8 @@ xrdp_xcon_SOURCES = \
   xcon.c
 
 xrdp_sesrun_LDADD = \
-  $(top_builddir)/common/libcommon.la
+  $(top_builddir)/common/libcommon.la \
+  $(top_builddir)/sesman/libscp/libscp.la
 
 xrdp_sestest_LDADD = \
   $(top_builddir)/common/libcommon.la \

--- a/sesman/tools/sesadmin.c
+++ b/sesman/tools/sesadmin.c
@@ -53,7 +53,6 @@ int main(int argc, char **argv)
     //int end;
     int idx;
     //int sel;
-    int sock;
     char *pwd;
     struct log_config *logging;
 
@@ -128,21 +127,14 @@ int main(int argc, char **argv)
 
     scp_init();
 
-    sock = g_tcp_socket();
-    if (sock < 0)
-    {
-        LOG_DEVEL(LOG_LEVEL_DEBUG, "Socket open error, g_tcp_socket() failed");
-        return 1;
-    }
-
     s = scp_session_create();
-    t = scp_trans_create(sock);
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "Connecting to %s:%s)", serv, port);
+    t = scp_connect(serv, port, NULL, NULL, NULL);
 
-    LOG_DEVEL(LOG_LEVEL_DEBUG, "Connecting to %s:%s with user %s (%s)", serv, port, user, pass);
 
-    if (0 != trans_connect(t, serv, port, 3000))
+    if (t == NULL)
     {
-        LOG(LOG_LEVEL_ERROR, "trans_connect() error");
+        LOG(LOG_LEVEL_ERROR, "scp_connect() error");
         return 1;
     }
 

--- a/sesman/tools/sesrun.c
+++ b/sesman/tools/sesrun.c
@@ -38,6 +38,7 @@
 #include "log.h"
 #include "tcp.h"
 #include "string_calls.h"
+#include "guid.h"
 
 #if !defined(PACKAGE_VERSION)
 #define PACKAGE_VERSION "???"
@@ -528,12 +529,12 @@ handle_scpv0_auth_reply(int sck)
                     }
                     else
                     {
-                        char guid[16];
-                        char guid_str[64];
-                        if (s_check_rem(in_s, 16) != 0)
+                        struct guid guid;
+                        char guid_str[MAX(GUID_STR_SIZE, 16)];
+                        if (s_check_rem(in_s, GUID_SIZE) != 0)
                         {
-                            in_uint8a(in_s, guid, 16);
-                            g_bytes_to_hexstr(guid, 16, guid_str, 64);
+                            in_uint8a(in_s, guid.g, GUID_SIZE);
+                            guid_to_str(&guid, guid_str);
                         }
                         else
                         {

--- a/sesman/tools/sestest.c
+++ b/sesman/tools/sestest.c
@@ -46,7 +46,6 @@ int main(int argc, char **argv)
     int scnt;
     int idx;
     int sel;
-    int sock;
 
     logging = log_config_init_for_console(LOG_LEVEL_INFO, NULL);
     log_start_from_param(logging);
@@ -54,16 +53,9 @@ int main(int argc, char **argv)
 
     scp_init();
 
-    sock = g_tcp_socket();
-    if (sock < 0)
-    {
-        return 1;
-    }
-
     s = scp_session_create();
-    t = scp_trans_create(sock);
-
-    if (0 != trans_connect(t, "localhost", "3350", 3000))
+    t = scp_connect("localhost", "3350", NULL, NULL, NULL);
+    if (t == NULL)
     {
         g_printf("error connecting");
         return 1;

--- a/vnc/vnc.c
+++ b/vnc/vnc.c
@@ -1717,10 +1717,10 @@ lib_mod_connect(struct vnc *v)
                 if (error == 0)
                 {
                     init_stream(s, 8192);
-                    if (v->got_guid)
+                    if (guid_is_set(&v->guid))
                     {
-                        char guid_str[64];
-                        g_bytes_to_hexstr(v->guid, 16, guid_str, 64);
+                        char guid_str[GUID_STR_SIZE];
+                        guid_to_str(&v->guid, guid_str);
                         rfbHashEncryptBytes(s->data, guid_str);
                     }
                     else
@@ -2091,8 +2091,7 @@ lib_mod_set_param(struct vnc *v, const char *name, const char *value)
     }
     else if (g_strcasecmp(name, "guid") == 0)
     {
-        v->got_guid = 1;
-        g_memcpy(v->guid, value, 16);
+        v->guid = *(struct guid *)value;
     }
     else if (g_strcasecmp(name, "disabled_encodings_mask") == 0)
     {

--- a/vnc/vnc.h
+++ b/vnc/vnc.h
@@ -26,6 +26,7 @@
 #include "parse.h"
 #include "os_calls.h"
 #include "defines.h"
+#include "guid.h"
 
 #define CURRENT_MOD_VER 4
 
@@ -159,8 +160,7 @@ struct vnc
     struct vnc_clipboard_data *vc;
     int delay_ms;
     struct trans *trans;
-    int got_guid;
-    tui8 guid[16];
+    struct guid guid;
     int suppress_output;
     unsigned int enabled_encodings_mask;
     /* Resizeable support */

--- a/xrdp/Makefile.am
+++ b/xrdp/Makefile.am
@@ -12,6 +12,7 @@ AM_CPPFLAGS = \
   -DXRDP_SOCKET_PATH=\"${socketdir}\" \
   -I$(top_builddir) \
   -I$(top_srcdir)/common \
+  -I$(top_srcdir)/sesman/libscp \
   -I$(top_srcdir)/libxrdp \
   $(IMLIB2_CFLAGS)
 
@@ -61,6 +62,7 @@ xrdp_SOURCES = \
 
 xrdp_LDADD = \
   $(top_builddir)/common/libcommon.la \
+  $(top_builddir)/sesman/libscp/libscp.la \
   $(top_builddir)/libxrdp/libxrdp.la \
   $(IMLIB2_LIBS) \
   $(XRDP_EXTRA_LIBS)

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -422,7 +422,7 @@ struct xrdp_mm *
 xrdp_mm_create(struct xrdp_wm *owner);
 void
 xrdp_mm_delete(struct xrdp_mm *self);
-int
+void
 xrdp_mm_connect(struct xrdp_mm *self);
 int
 xrdp_mm_process_channel_data(struct xrdp_mm *self, tbus param1, tbus param2,

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -151,6 +151,8 @@ int
 xrdp_wm_check_wait_objs(struct xrdp_wm *self);
 int
 xrdp_wm_set_login_state(struct xrdp_wm *self, enum wm_login_state login_state);
+void
+xrdp_wm_mod_connect_done(struct xrdp_wm *self, int status);
 
 /* xrdp_process.c */
 struct xrdp_process *

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -475,7 +475,7 @@ server_set_pointer_ex(struct xrdp_mod *mod, int x, int y,
 int
 server_palette(struct xrdp_mod *mod, int *palette);
 int
-server_msg(struct xrdp_mod *mod, char *msg, int code);
+server_msg(struct xrdp_mod *mod, const char *msg, int code);
 int
 server_is_term(struct xrdp_mod *mod);
 int

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -2132,7 +2132,7 @@ cleanup_states(struct xrdp_mm *self)
         self-> chan_trans = NULL; /* connection to chansrv */
         self-> chan_trans_up = 0; /* true once connected to chansrv */
         self-> delete_chan_trans = 0; /* boolean set when done with channel connection */
-        self-> usechansrv = 0; /* true if chansrvport is set in xrdp.ini or using sesman */
+        self-> use_chansrv = 0; /* true if chansrvport is set in xrdp.ini or using sesman */
     }
 }
 
@@ -2465,7 +2465,7 @@ xrdp_mm_connect(struct xrdp_mm *self)
             if (g_strcasecmp(value, "-1") == 0)
             {
                 self->sesman_controlled = 1;
-                self->usechansrv = 1;
+                self->use_chansrv = 1;
             }
         }
 
@@ -2496,7 +2496,7 @@ xrdp_mm_connect(struct xrdp_mm *self)
         {
             if (parse_chansrvport(value, chansrvport, sizeof(chansrvport)) == 0)
             {
-                self->usechansrv = 1;
+                self->use_chansrv = 1;
             }
         }
     }
@@ -2627,7 +2627,7 @@ xrdp_mm_connect(struct xrdp_mm *self)
     }
 
     if ((self->wm->login_state == WMLS_CLEANUP) && (self->sesman_controlled == 0) &&
-            (self->usechansrv != 0))
+            (self->use_chansrv != 0))
     {
         /* if sesman controlled, this will connect later */
         xrdp_mm_connect_chansrv(self, "", chansrvport);
@@ -3021,7 +3021,7 @@ server_chansrv_in_use(struct xrdp_mod *mod)
     struct xrdp_wm *wm;
 
     wm = (struct xrdp_wm *)(mod->wm);
-    return wm->mm->usechansrv;
+    return wm->mm->use_chansrv;
 }
 
 
@@ -3591,7 +3591,7 @@ server_get_channel_count(struct xrdp_mod *mod)
 
     wm = (struct xrdp_wm *)(mod->wm);
 
-    if (wm->mm->usechansrv)
+    if (wm->mm->use_chansrv)
     {
         return -1;
     }
@@ -3610,7 +3610,7 @@ server_query_channel(struct xrdp_mod *mod, int index, char *channel_name,
 
     wm = (struct xrdp_wm *)(mod->wm);
 
-    if (wm->mm->usechansrv)
+    if (wm->mm->use_chansrv)
     {
         return 1;
     }
@@ -3628,7 +3628,7 @@ server_get_channel_id(struct xrdp_mod *mod, const char *name)
 
     wm = (struct xrdp_wm *)(mod->wm);
 
-    if (wm->mm->usechansrv)
+    if (wm->mm->use_chansrv)
     {
         return -1;
     }
@@ -3646,7 +3646,7 @@ server_send_to_channel(struct xrdp_mod *mod, int channel_id,
 
     wm = (struct xrdp_wm *)(mod->wm);
 
-    if (wm->mm->usechansrv)
+    if (wm->mm->use_chansrv)
     {
         /* Modules should not be calling this if chansrv is running -
          * they can use server_chansrv_in_use() to avoid doing this */

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -3319,7 +3319,7 @@ server_palette(struct xrdp_mod *mod, int *palette)
 
 /*****************************************************************************/
 int
-server_msg(struct xrdp_mod *mod, char *msg, int code)
+server_msg(struct xrdp_mod *mod, const char *msg, int code)
 {
     struct xrdp_wm *wm;
 

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -28,6 +28,8 @@
 #include "ms-rdpedisp.h"
 #include "ms-rdpbcgr.h"
 
+#include "libscp_connection.h"
+
 #ifdef USE_PAM
 #if defined(HAVE__PAM_TYPES_H)
 #define LINUXPAM 1
@@ -42,6 +44,16 @@
 #include "xrdp_encoder.h"
 #include "xrdp_sockets.h"
 
+
+/* Forward declarations */
+static const char *
+getPAMError(const int pamError, char *text, int text_bytes);
+static const char *
+getPAMAdditionalErrorInfo(const int pamError, struct xrdp_mm *self);
+static int
+xrdp_mm_chansrv_connect(struct xrdp_mm *self, const char *ip, const char *port);
+static void
+xrdp_mm_connect_sm(struct xrdp_mm *self);
 
 
 /*****************************************************************************/
@@ -116,7 +128,6 @@ xrdp_mm_module_cleanup(struct xrdp_mm *self)
 
     trans_delete(self->chan_trans);
     self->chan_trans = 0;
-    self->chan_trans_up = 0;
     self->mod_init = 0;
     self->mod_exit = 0;
     self->mod = 0;
@@ -148,146 +159,15 @@ xrdp_mm_delete(struct xrdp_mm *self)
 
     trans_delete(self->sesman_trans);
     self->sesman_trans = 0;
-    self->sesman_trans_up = 0;
+    trans_delete(self->pam_auth_trans);
+    self->pam_auth_trans = 0;
     list_delete(self->login_names);
     list_delete(self->login_values);
     g_free(self);
 }
 
-/*****************************************************************************/
-/* Send login information to sesman */
-/* FIXME : This code duplicates functionality in the sesman tools sesrun.c.
- * When SCP is reworked, a common library function should be used */
-
-static int
-xrdp_mm_send_login(struct xrdp_mm *self)
-{
-    struct stream *s;
-    int rv;
-    int index;
-    int count;
-    int xserverbpp;
-    char *username;
-    char *password;
-    char *name;
-    char *value;
-
-    xrdp_wm_log_msg(self->wm, LOG_LEVEL_DEBUG,
-                    "sending login info to session manager, please wait...");
-    username = 0;
-    password = 0;
-    self->code = 0;
-    xserverbpp = 0;
-    count = self->login_names->count;
-
-    for (index = 0; index < count; index++)
-    {
-        name = (char *)list_get_item(self->login_names, index);
-        value = (char *)list_get_item(self->login_values, index);
-
-        if (g_strcasecmp(name, "username") == 0)
-        {
-            username = value;
-        }
-        else if (g_strcasecmp(name, "password") == 0)
-        {
-            password = value;
-        }
-        else if (g_strcasecmp(name, "code") == 0)
-        {
-            /* this code is either 0 for Xvnc, 10 for X11rdp or 20 for Xorg */
-            self->code = g_atoi(value);
-        }
-        else if (g_strcasecmp(name, "xserverbpp") == 0)
-        {
-            xserverbpp = g_atoi(value);
-        }
-    }
-
-    if ((username == 0) || (password == 0))
-    {
-        xrdp_wm_log_msg(self->wm, LOG_LEVEL_ERROR,
-                        "Error finding username and password");
-        return 1;
-    }
-
-    s = trans_get_out_s(self->sesman_trans, 8192);
-    s_push_layer(s, channel_hdr, 8);
-    /* this code is either 0 for Xvnc, 10 for X11rdp or 20 for Xorg */
-    out_uint16_be(s, self->code);
-    index = g_strlen(username);
-    out_uint16_be(s, index);
-    out_uint8a(s, username, index);
-    index = g_strlen(password);
-
-    out_uint16_be(s, index);
-    out_uint8a(s, password, index);
-    out_uint16_be(s, self->wm->screen->width);
-    out_uint16_be(s, self->wm->screen->height);
-
-    /* select and send X server bpp */
-    if (xserverbpp == 0)
-    {
-        if (self->code == 20)
-        {
-            xserverbpp = 24; /* xorgxrdp is always at 24 bpp */
-        }
-        else
-        {
-            xserverbpp = self->wm->screen->bpp; /* use client's bpp */
-        }
-    }
-    out_uint16_be(s, xserverbpp);
-
-    /* send domain */
-    if (self->wm->client_info->domain[0] != '_')
-    {
-        index = g_strlen(self->wm->client_info->domain);
-        out_uint16_be(s, index);
-        out_uint8a(s, self->wm->client_info->domain, index);
-    }
-    else
-    {
-        out_uint16_be(s, 0);
-        /* out_uint8a(s, "", 0); */
-    }
-
-    /* send program / shell */
-    index = g_strlen(self->wm->client_info->program);
-    out_uint16_be(s, index);
-    out_uint8a(s, self->wm->client_info->program, index);
-
-    /* send directory */
-    index = g_strlen(self->wm->client_info->directory);
-    out_uint16_be(s, index);
-    out_uint8a(s, self->wm->client_info->directory, index);
-
-    /* send client connection description */
-    index = g_strlen(self->wm->client_info->connection_description);
-    out_uint16_be(s, index);
-    out_uint8a(s, self->wm->client_info->connection_description, index);
-
-    s_mark_end(s);
-
-    s_pop_layer(s, channel_hdr);
-    /* Version 0 of the protocol to sesman is currently used by XRDP */
-    out_uint32_be(s, 0); /* version */
-    index = (int)(s->end - s->data);
-    out_uint32_be(s, index); /* size */
-
-    rv = trans_force_write(self->sesman_trans);
-
-    if (rv != 0)
-    {
-        xrdp_wm_log_msg(self->wm, LOG_LEVEL_WARNING,
-                        "xrdp_mm_send_login: xrdp_mm_send_login failed");
-    }
-
-    return rv;
-}
-
 /**************************************************************************//**
- * Looks for a value in the login_names/login_values array
+ * Looks for a string value in the login_names/login_values array
  *
  * In the event of multiple matches, the LAST value matched is returned.
  * This currently allows for values to be replaced by writing a new value
@@ -319,6 +199,120 @@ xrdp_mm_get_value(struct xrdp_mm *self, const char *aname)
     }
 
     return value;
+}
+/**************************************************************************//**
+ * Looks for a numeric value in the login_names/login_values array
+ *
+ * Returned strings are valid until the module is destroyed.
+ *
+ * @param self This module
+ * @param aname Name to lookup (case-insensitive)
+ * @param def Default to return if value not found.
+ *
+ * @return value from name, or the specified default.
+ */
+static int
+xrdp_mm_get_value_int(struct xrdp_mm *self, const char *aname, int def)
+{
+    const char *value = xrdp_mm_get_value(self, aname);
+
+    return (value == NULL) ? def : g_atoi(value);
+}
+
+/*****************************************************************************/
+/* Send gateway login information to sesman */
+static int
+xrdp_mm_send_gateway_login(struct xrdp_mm *self, const char *username,
+                           const char *password)
+{
+    int rv = 0;
+    enum SCP_CLIENT_STATES_E e;
+
+    xrdp_wm_log_msg(self->wm, LOG_LEVEL_DEBUG,
+                    "sending login info to session manager, please wait...");
+
+    e = scp_v0c_gateway_request(self->pam_auth_trans, username, password);
+
+    if (e != SCP_CLIENT_STATE_OK)
+    {
+        xrdp_wm_log_msg(self->wm, LOG_LEVEL_WARNING,
+                        "Error sending gateway login request to sesman [%s]",
+                        scp_client_state_to_str(e));
+        rv = 1;
+    }
+
+    return rv;
+}
+
+/*****************************************************************************/
+/* Send login information to sesman */
+static int
+xrdp_mm_send_login(struct xrdp_mm *self)
+{
+    enum SCP_CLIENT_STATES_E e;
+    int rv = 0;
+    int xserverbpp;
+    const char *username;
+    const char *password;
+
+    username = xrdp_mm_get_value(self, "username");
+    password = xrdp_mm_get_value(self, "password");
+    if (username == NULL || username[0] == '\0')
+    {
+        xrdp_wm_log_msg(self->wm, LOG_LEVEL_ERROR, "No username is available");
+        rv = 1;
+    }
+    else if (password == NULL)
+    {
+        /* Can't find a password definition at all - even an empty one */
+        xrdp_wm_log_msg(self->wm, LOG_LEVEL_ERROR,
+                        "No password field is available");
+        rv = 1;
+    }
+    else
+    {
+        const char *domain;
+
+        /* this code is either 0 for Xvnc, 10 for X11rdp or 20 for Xorg */
+        self->code = xrdp_mm_get_value_int(self, "code", 0);
+
+        xserverbpp = xrdp_mm_get_value_int(self, "xserverbpp",
+                                           self->wm->screen->bpp);
+
+        domain = self->wm->client_info->domain;
+        /* Don't send domains starting with '_' - see
+         * xrdp_login_wnd.c:xrdp_wm_parse_domain_information()
+         */
+        if (domain[0] == '_')
+        {
+            domain = "";
+        }
+
+        xrdp_wm_log_msg(self->wm, LOG_LEVEL_DEBUG,
+                        "sending login info to session manager. "
+                        "Please wait...");
+        e = scp_v0c_create_session_request(self->sesman_trans,
+                                           username,
+                                           password,
+                                           self->code,
+                                           self->wm->screen->width,
+                                           self->wm->screen->height,
+                                           xserverbpp,
+                                           domain,
+                                           self->wm->client_info->program,
+                                           self->wm->client_info->directory,
+                                           self->wm->client_info->connection_description);
+
+        if (e != SCP_CLIENT_STATE_OK)
+        {
+            xrdp_wm_log_msg(self->wm, LOG_LEVEL_WARNING,
+                            "Error sending create session to sesman [%s]",
+                            scp_client_state_to_str(e));
+            rv = 1;
+        }
+    }
+
+    return rv;
 }
 
 /*****************************************************************************/
@@ -354,7 +348,7 @@ xrdp_mm_setup_mod1(struct xrdp_mm *self)
 
     if (self->mod_handle == 0)
     {
-        g_snprintf(text, 255, "%s/%s", XRDP_MODULE_PATH, lib);
+        g_snprintf(text, sizeof(text), "%s/%s", XRDP_MODULE_PATH, lib);
         /* Let the main thread load the lib,*/
         self->mod_handle = g_xrdp_sync(xrdp_mm_sync_load, (tintptr)text, 0);
 
@@ -480,7 +474,7 @@ xrdp_mm_setup_mod1(struct xrdp_mm *self)
 
 /*****************************************************************************/
 static int
-xrdp_mm_setup_mod2(struct xrdp_mm *self, const struct guid *pguid)
+xrdp_mm_setup_mod2(struct xrdp_mm *self)
 {
     char text[256];
     const char *name;
@@ -558,9 +552,9 @@ xrdp_mm_setup_mod2(struct xrdp_mm *self, const struct guid *pguid)
         self->mod->mod_set_param(self->mod, "hostname", name);
         g_snprintf(text, 255, "%d", self->wm->session->client_info->keylayout);
         self->mod->mod_set_param(self->mod, "keylayout", text);
-        if (pguid != NULL)
+        if (guid_is_set(&self->guid))
         {
-            self->mod->mod_set_param(self->mod, "guid", (char *) &pguid);
+            self->mod->mod_set_param(self->mod, "guid", (char *) &self->guid);
         }
 
         for (i = 0; i < self->login_names->count; i++)
@@ -1578,7 +1572,7 @@ xrdp_mm_chan_data_in(struct trans *trans)
     int size;
     int error;
 
-    if (trans == 0)
+    if (trans == NULL)
     {
         return 1;
     }
@@ -1614,85 +1608,13 @@ xrdp_mm_chan_data_in(struct trans *trans)
 }
 
 /*****************************************************************************/
-/* connect to chansrv */
-static int
-xrdp_mm_connect_chansrv(struct xrdp_mm *self, const char *ip, const char *port)
-{
-    int index;
-
-    if (self->wm->client_info->channels_allowed == 0)
-    {
-        LOG(LOG_LEVEL_DEBUG, "%s: "
-            "skip connecting to chansrv because all channels are disabled",
-            __func__);
-        return 0;
-    }
-
-    /* connect channel redir */
-    if ((g_strcmp(ip, "127.0.0.1") == 0) || (ip[0] == 0))
-    {
-        /* unix socket */
-        self->chan_trans = trans_create(TRANS_MODE_UNIX, 8192, 8192);
-    }
-    else
-    {
-        /* tcp */
-        self->chan_trans = trans_create(TRANS_MODE_TCP, 8192, 8192);
-    }
-
-    self->chan_trans->is_term = g_is_term;
-    self->chan_trans->si = &(self->wm->session->si);
-    self->chan_trans->my_source = XRDP_SOURCE_CHANSRV;
-    self->chan_trans->trans_data_in = xrdp_mm_chan_data_in;
-    self->chan_trans->header_size = 8;
-    self->chan_trans->callback_data = self;
-    self->chan_trans->no_stream_init_on_data_in = 1;
-    self->chan_trans->extra_flags = 0;
-
-    /* try to connect up to 4 times */
-    for (index = 0; index < 4; index++)
-    {
-        if (trans_connect(self->chan_trans, ip, port, 3000) == 0)
-        {
-            self->chan_trans_up = 1;
-            break;
-        }
-        if (g_is_term())
-        {
-            break;
-        }
-        g_sleep(1000);
-        LOG(LOG_LEVEL_WARNING, "xrdp_mm_connect_chansrv: connect failed "
-            "trying again...");
-    }
-
-    if (!(self->chan_trans_up))
-    {
-        LOG(LOG_LEVEL_ERROR, "xrdp_mm_connect_chansrv: error in "
-            "trans_connect chan");
-    }
-
-    if (self->chan_trans_up)
-    {
-        if (xrdp_mm_trans_send_channel_setup(self, self->chan_trans) != 0)
-        {
-            LOG(LOG_LEVEL_ERROR, "xrdp_mm_connect_chansrv: error in "
-                "xrdp_mm_trans_send_channel_setup");
-        }
-        else
-        {
-            LOG(LOG_LEVEL_DEBUG, "xrdp_mm_connect_chansrv: chansrv "
-                "connect successful");
-        }
-    }
-
-    return 0;
-}
 
 static void cleanup_sesman_connection(struct xrdp_mm *self)
 {
+    /* Don't delete these transports here - we may be in
+     * an auth callback from one of them */
     self->delete_sesman_trans = 1;
-    self->connected_state = 0;
+    self->delete_pam_auth_trans = 1;
 
     if (self->wm->login_state != WMLS_CLEANUP)
     {
@@ -1740,94 +1662,6 @@ xrdp_mm_update_allowed_channels(struct xrdp_mm *self)
         }
     }
     return 0;
-}
-
-/*****************************************************************************/
-/* FIXME : This code duplicates functionality in the sesman tools sesrun.c.
- * When SCP is reworked, a common library function should be used */
-static int
-xrdp_mm_process_login_response(struct xrdp_mm *self, struct stream *s)
-{
-    int ok;
-    int display;
-    int rv;
-    const char *ip;
-    char port[256];
-    const char *username;
-    struct guid guid;
-    const struct guid *pguid = NULL;
-
-    rv = 0;
-    in_uint16_be(s, ok);
-    in_uint16_be(s, display);
-    if (s_check_rem(s, GUID_SIZE))
-    {
-        in_uint8a(s, guid.g, GUID_SIZE);
-        pguid = &guid;
-    }
-
-    if ((username = xrdp_mm_get_value(self, "username")) == NULL)
-    {
-        username = "???";
-    }
-
-    if (ok)
-    {
-        self->display = display;
-        xrdp_wm_log_msg(self->wm, LOG_LEVEL_INFO,
-                        "login successful for user %s on display %d",
-                        username, display);
-
-        if (xrdp_mm_setup_mod1(self) == 0)
-        {
-            if (xrdp_mm_setup_mod2(self, pguid) == 0)
-            {
-                ip = xrdp_mm_get_value(self, "ip");
-                xrdp_wm_set_login_state(self->wm, WMLS_CLEANUP);
-                self->wm->dragging = 0;
-
-                /* connect channel redir */
-                if (ip == NULL || (ip[0] == '\0') ||
-                        (g_strcmp(ip, "127.0.0.1") == 0))
-                {
-                    g_snprintf(port, 255, XRDP_CHANSRV_STR, display);
-                }
-                else
-                {
-                    g_snprintf(port, 255, "%d", 7200 + display);
-                }
-                xrdp_mm_connect_chansrv(self, ip, port);
-            }
-        }
-    }
-    else
-    {
-        char displayinfo[64];
-
-        if (display == 0)
-        {
-            /* A returned display of zero doesn't mean anything useful, and
-             * can confuse the user. It's most likely authentication has
-             * failed and no display was allocated */
-            displayinfo[0] = '\0';
-        }
-        else
-        {
-            g_snprintf(displayinfo, sizeof(displayinfo),
-                       " on display %d", display);
-        }
-        xrdp_wm_log_msg(self->wm, LOG_LEVEL_INFO,
-                        "login failed for user %s%s",
-                        username, displayinfo);
-        xrdp_wm_show_log(self->wm);
-        if (self->wm->hide_log_window)
-        {
-            rv = 1;
-        }
-    }
-
-    cleanup_sesman_connection(self);
-    return rv;
 }
 
 /*****************************************************************************/
@@ -1905,7 +1739,7 @@ xrdp_mm_process_channel_data(struct xrdp_mm *self, tbus param1, tbus param2,
 
     rv = 0;
 
-    if ((self->chan_trans != 0) && self->chan_trans_up)
+    if ((self->chan_trans != 0) && self->chan_trans->status == TRANS_STATUS_UP)
     {
         s = trans_get_out_s(self->chan_trans, 8192);
 
@@ -1941,177 +1775,124 @@ xrdp_mm_process_channel_data(struct xrdp_mm *self, tbus param1, tbus param2,
 }
 
 /*****************************************************************************/
-/* This is the callback registered for sesman communication replies. */
-static int
-xrdp_mm_sesman_data_in(struct trans *trans)
+static void
+xrdp_mm_scp_process_msg(struct xrdp_mm *self,
+                        const struct scp_v0_reply_type *msg)
 {
-    struct xrdp_mm *self;
-    struct stream *s;
-    int version;
-    int size;
-    int error;
-    int code;
-
-    if (trans == 0)
+    if (msg->is_gw_auth_response)
     {
-        return 1;
-    }
+        const char *additionalError;
+        char pam_error[128];
 
-    self = (struct xrdp_mm *)(trans->callback_data);
-    s = trans_get_in_s(trans);
+        /* We no longer need the pam_auth transport - it's only used
+         * for the one message */
+        self->delete_pam_auth_trans = 1;
 
-    if (s == 0)
-    {
-        return 1;
-    }
+        xrdp_wm_log_msg(self->wm, LOG_LEVEL_INFO,
+                        "Reply from access control: %s",
+                        getPAMError(msg->auth_result,
+                                    pam_error, sizeof(pam_error)));
 
-    in_uint32_be(s, version);
-    in_uint32_be(s, size);
-    error = trans_force_read(trans, size - 8);
-
-    if (error == 0)
-    {
-        in_uint16_be(s, code);
-
-        switch (code)
+        if (msg->auth_result != 0)
         {
-            /* even when the request is denied the reply will hold 3 as the command. */
-            case 3:
-                error = xrdp_mm_process_login_response(self, s);
-                break;
-            default:
-                xrdp_wm_log_msg(self->wm, LOG_LEVEL_ERROR,
-                                "Undefined reply code %d received from sesman",
-                                code);
-                cleanup_sesman_connection(self);
-                break;
-        }
-    }
-
-    return error;
-}
-
-#ifdef USE_PAM
-/*********************************************************************/
-/* return 0 on success */
-static int
-access_control(char *username, char *password, char *srv)
-{
-    int reply;
-    int rec = 32 + 1; /* 32 is reserved for PAM failures this means connect failure */
-    struct stream *in_s;
-    struct stream *out_s;
-    unsigned long version;
-    unsigned short int dummy;
-    unsigned short int pAM_errorcode;
-    unsigned short int code;
-    unsigned long size;
-    int index;
-    int socket = g_tcp_socket();
-    char port[8];
-
-    if (socket != -1)
-    {
-        xrdp_mm_get_sesman_port(port, sizeof(port));
-        /* we use a blocking socket here */
-        reply = g_tcp_connect(socket, srv, port);
-
-        if (reply == 0)
-        {
-            make_stream(in_s);
-            init_stream(in_s, 500);
-            make_stream(out_s);
-            init_stream(out_s, 500);
-            s_push_layer(out_s, channel_hdr, 8);
-            out_uint16_be(out_s, 4); /*0x04 means SCP_GW_AUTHENTICATION*/
-            index = g_strlen(username);
-            out_uint16_be(out_s, index);
-            out_uint8a(out_s, username, index);
-
-            index = g_strlen(password);
-            out_uint16_be(out_s, index);
-            out_uint8a(out_s, password, index);
-            s_mark_end(out_s);
-            s_pop_layer(out_s, channel_hdr);
-            out_uint32_be(out_s, 0); /* version */
-            index = (int)(out_s->end - out_s->data);
-            out_uint32_be(out_s, index); /* size */
-            LOG(LOG_LEVEL_DEBUG, "Number of data to send : %d", index);
-            reply = g_tcp_send(socket, out_s->data, index, 0);
-            free_stream(out_s);
-
-            if (reply > 0)
+            additionalError = getPAMAdditionalErrorInfo(msg->auth_result, self);
+            if (additionalError && additionalError[0])
             {
-                /* We wait in 5 sec for a reply from sesman*/
-                if (g_sck_can_recv(socket, 5000))
-                {
-                    reply = g_tcp_recv(socket, in_s->end, 500, 0);
-
-                    if (reply > 0)
-                    {
-                        in_s->end =  in_s->end + reply;
-                        in_uint32_be(in_s, version);
-                        LOG(LOG_LEVEL_INFO, "Version number in reply from sesman: %lu", version);
-                        in_uint32_be(in_s, size);
-
-                        if ((size == 14) && (version == 0))
-                        {
-                            in_uint16_be(in_s, code);
-                            in_uint16_be(in_s, pAM_errorcode); /* this variable holds the PAM error code if the variable is >32 it is a "invented" code */
-                            in_uint16_be(in_s, dummy);
-
-                            if (code != 4) /*0x04 means SCP_GW_AUTHENTICATION*/
-                            {
-                                LOG(LOG_LEVEL_ERROR, "Returned cmd code from "
-                                    "sesman is corrupt");
-                            }
-                            else
-                            {
-                                rec = pAM_errorcode; /* here we read the reply from the access control */
-                            }
-                        }
-                        else
-                        {
-                            LOG(LOG_LEVEL_ERROR, "Corrupt reply size or "
-                                "version from sesman: %ld", size);
-                        }
-                    }
-                    else
-                    {
-                        LOG(LOG_LEVEL_ERROR, "No data received from sesman");
-                    }
-                }
-                else
-                {
-                    LOG(LOG_LEVEL_ERROR, "Timeout when waiting for sesman");
-                }
-            }
-            else
-            {
-                LOG(LOG_LEVEL_ERROR, "No success sending to sesman");
+                xrdp_wm_log_msg(self->wm, LOG_LEVEL_INFO, "%s",
+                                additionalError);
             }
 
-            free_stream(in_s);
-            g_tcp_close(socket);
+            /* TODO : Check this is displayed */
+            cleanup_sesman_connection(self);
+            xrdp_wm_mod_connect_done(self->wm, 1);
         }
         else
         {
-            LOG(LOG_LEVEL_ERROR, "Failure connecting to socket sesman");
+            /* Authentication successful */
+            xrdp_mm_connect_sm(self);
         }
     }
     else
     {
-        LOG(LOG_LEVEL_ERROR, "Failure creating socket - for access control");
-    }
+        const char *username;
+        char displayinfo[64];
+        int auth_successful = (msg->auth_result != 0);
 
-    if (socket != -1)
-    {
-        g_tcp_close(socket);
-    }
+        /* Sort out some logging information */
+        if ((username = xrdp_mm_get_value(self, "username")) == NULL)
+        {
+            username = "???";
+        }
 
-    return rec;
+        if (msg->display == 0)
+        {
+            /* A returned display of zero doesn't mean anything useful, and
+             * can confuse the user. It's most likely authentication has
+             * failed and no display was allocated */
+            displayinfo[0] = '\0';
+        }
+        else
+        {
+            g_snprintf(displayinfo, sizeof(displayinfo),
+                       " on display %d", msg->display);
+        }
+
+        xrdp_wm_log_msg(self->wm, LOG_LEVEL_INFO,
+                        "login %s for user %s%s",
+                        (auth_successful ? "successful" : "failed"),
+                        username, displayinfo);
+
+        if (!auth_successful)
+        {
+            /* Authentication failure */
+            cleanup_sesman_connection(self);
+            xrdp_wm_mod_connect_done(self->wm, 1);
+        }
+        else
+        {
+            /* Authentication successful - carry on with the connect
+             * state machine */
+            self->display = msg->display;
+            self->guid = msg->guid;
+            xrdp_mm_connect_sm(self);
+        }
+    }
 }
-#endif
+
+/*****************************************************************************/
+/* This is the callback registered for sesman communication replies. */
+static int
+xrdp_mm_scp_data_in(struct trans *trans)
+{
+    int rv = 0;
+
+    if (trans == NULL)
+    {
+        rv = 1;
+    }
+    else if (scp_v0c_reply_available(trans))
+    {
+        struct scp_v0_reply_type reply;
+        struct xrdp_mm *self = (struct xrdp_mm *)(trans->callback_data);
+        enum SCP_CLIENT_STATES_E e = scp_v0c_get_reply(trans, &reply);
+        if (e != SCP_CLIENT_STATE_OK)
+        {
+            const char *src = (trans == self->pam_auth_trans)
+                              ? "PAM authenticator"
+                              : "sesman";
+            xrdp_wm_log_msg(self->wm, LOG_LEVEL_ERROR,
+                            "Error reading response from %s [%s]",
+                            src, scp_client_state_to_str(e));
+            rv = 1;
+        }
+        else
+        {
+            xrdp_mm_scp_process_msg(self, &reply);
+        }
+    }
+
+    return rv;
+}
 
 /*****************************************************************************/
 /* This routine clears all states to make sure that our next login will be
@@ -2122,21 +1903,21 @@ cleanup_states(struct xrdp_mm *self)
 {
     if (self != NULL)
     {
-        self-> connected_state = 0; /* true if connected to sesman else false */
-        self-> sesman_trans = NULL; /* connection to sesman */
-        self-> sesman_trans_up = 0; /* true once connected to sesman */
-        self-> delete_sesman_trans = 0; /* boolean set when done with sesman connection */
-        self-> display = 0; /* 10 for :10.0, 11 for :11.0, etc */
-        self-> code = 0; /* 0 Xvnc session, 10 X11rdp session, 20 Xorg session */
-        self-> sesman_controlled = 0; /* true if this is a sesman session */
-        self-> chan_trans = NULL; /* connection to chansrv */
-        self-> chan_trans_up = 0; /* true once connected to chansrv */
-        self-> delete_chan_trans = 0; /* boolean set when done with channel connection */
-        self-> use_chansrv = 0; /* true if chansrvport is set in xrdp.ini or using sesman */
+        self->connect_state = MMCS_CONNECT_TO_SESMAN;
+        self->use_sesman = 0; /* true if this is a sesman session */
+        self->use_chansrv = 0; /* true if chansrvport is set in xrdp.ini or using sesman */
+        self->use_pam_auth = 0; /* true if we're to use the PAM authentication facility */
+        self->sesman_trans = NULL; /* connection to sesman */
+        self->pam_auth_trans = NULL; /* connection to PAM authenticator */
+        self->chan_trans = NULL; /* connection to chansrv */
+        self->delete_sesman_trans = 0;
+        self->delete_pam_auth_trans = 0;
+        self->display = 0; /* 10 for :10.0, 11 for :11.0, etc */
+        guid_clear(&self->guid);
+        self->code = 0; /* 0 Xvnc session, 10 X11rdp session, 20 Xorg session */
     }
 }
 
-#ifdef USE_PAM
 static const char *
 getPAMError(const int pamError, char *text, int text_bytes)
 {
@@ -2365,7 +2146,6 @@ getPAMAdditionalErrorInfo(const int pamError, struct xrdp_mm *self)
             return "No expected error";
     }
 }
-#endif
 
 /*************************************************************************//**
  * Parses a chansrvport string
@@ -2416,227 +2196,363 @@ parse_chansrvport(const char *value, char *dest, int dest_size)
 }
 
 /*****************************************************************************/
-int
-xrdp_mm_connect(struct xrdp_mm *self)
+static struct trans *
+xrdp_mm_scp_connect(struct xrdp_mm *self, const char *target, const char *ip)
 {
-    struct list *names;
-    struct list *values;
+    char port[128];
+    struct trans *t;
+
+    xrdp_mm_get_sesman_port(port, sizeof(port));
+    xrdp_wm_log_msg(self->wm, LOG_LEVEL_DEBUG,
+                    "connecting to %s on %s:%s", target, ip, port);
+    t = scp_connect(ip, port, g_is_term,
+                    xrdp_mm_scp_data_in, self);
+    if (t != NULL)
+    {
+        /* fully connect */
+        xrdp_wm_log_msg(self->wm, LOG_LEVEL_INFO, "%s connect ok", target);
+    }
+    else
+    {
+        xrdp_wm_log_msg(self->wm, LOG_LEVEL_ERROR,
+                        "Error connecting to %s on %s:%s",
+                        target, ip, port);
+        trans_delete(t);
+        t = NULL;
+    }
+    return t;
+}
+
+/*****************************************************************************/
+static int
+xrdp_mm_pam_auth_connect(struct xrdp_mm *self, const char *ip)
+{
+    trans_delete(self->pam_auth_trans);
+    self->pam_auth_trans = xrdp_mm_scp_connect(self, "PAM authenticator", ip);
+
+    return (self->pam_auth_trans == NULL); /* 0 for success */
+}
+
+/*****************************************************************************/
+static int
+xrdp_mm_sesman_connect(struct xrdp_mm *self, const char *ip)
+{
+    trans_delete(self->sesman_trans);
+    self->sesman_trans = xrdp_mm_scp_connect(self, "sesman", ip);
+
+    return (self->sesman_trans == NULL); /* 0 for success */
+}
+
+/*****************************************************************************/
+static int
+xrdp_mm_chansrv_connect(struct xrdp_mm *self, const char *ip, const char *port)
+{
     int index;
-    int count;
-    int ok;
-    int rv;
-    char *name;
-    char *value;
-    char ip[256];
-    char port[8];
-    char chansrvport[256];
-#ifdef USE_PAM
-    int use_pam_auth = 0;
-    char pam_auth_sessionIP[256];
-    char pam_auth_password[256];
-    char pam_auth_username[256];
-#endif
-    char username[256];
-    char password[256];
-    username[0] = 0;
-    password[0] = 0;
 
-    /* make sure we start in correct state */
-    cleanup_states(self);
-    g_memset(ip, 0, sizeof(ip));
-    g_memset(port, 0, sizeof(port));
-    g_memset(chansrvport, 0, sizeof(chansrvport));
-    rv = 0; /* success */
-    names = self->login_names;
-    values = self->login_values;
-    count = names->count;
-
-    for (index = 0; index < count; index++)
+    if (self->wm->client_info->channels_allowed == 0)
     {
-        name = (char *)list_get_item(names, index);
-        value = (char *)list_get_item(values, index);
-
-        if (g_strcasecmp(name, "ip") == 0)
-        {
-            g_strncpy(ip, value, 255);
-        }
-        else if (g_strcasecmp(name, "port") == 0)
-        {
-            if (g_strcasecmp(value, "-1") == 0)
-            {
-                self->sesman_controlled = 1;
-                self->use_chansrv = 1;
-            }
-        }
-
-#ifdef USE_PAM
-        else if (g_strcasecmp(name, "pamusername") == 0)
-        {
-            use_pam_auth = 1;
-            g_strncpy(pam_auth_username, value, 255);
-        }
-        else if (g_strcasecmp(name, "pamsessionmng") == 0)
-        {
-            g_strncpy(pam_auth_sessionIP, value, 255);
-        }
-        else if (g_strcasecmp(name, "pampassword") == 0)
-        {
-            g_strncpy(pam_auth_password, value, 255);
-        }
-#endif
-        else if (g_strcasecmp(name, "password") == 0)
-        {
-            g_strncpy(password, value, 255);
-        }
-        else if (g_strcasecmp(name, "username") == 0)
-        {
-            g_strncpy(username, value, 255);
-        }
-        else if (g_strcasecmp(name, "chansrvport") == 0)
-        {
-            if (parse_chansrvport(value, chansrvport, sizeof(chansrvport)) == 0)
-            {
-                self->use_chansrv = 1;
-            }
-        }
+        LOG(LOG_LEVEL_DEBUG, "%s: "
+            "skip connecting to chansrv because all channels are disabled",
+            __func__);
+        return 0;
     }
 
-    xrdp_mm_update_allowed_channels(self);
-
-#ifdef USE_PAM
-    if (use_pam_auth)
+    /* connect channel redir */
+    if ((g_strcmp(ip, "127.0.0.1") == 0) || (ip[0] == 0))
     {
-        int reply;
-        char pam_error[128];
-        const char *additionalError;
-        xrdp_wm_log_msg(self->wm, LOG_LEVEL_DEBUG,
-                        "Please wait, we now perform access control...");
-
-        LOG(LOG_LEVEL_DEBUG, "we use pam modules to check if we can approve this user");
-        if (!g_strncmp(pam_auth_username, "same", 255))
-        {
-            LOG(LOG_LEVEL_DEBUG, "pamusername copied from username - same: %s", username);
-            g_strncpy(pam_auth_username, username, 255);
-        }
-
-        if (!g_strncmp(pam_auth_password, "same", 255))
-        {
-            LOG(LOG_LEVEL_DEBUG, "pam_auth_password copied from username - same: %s", password);
-            g_strncpy(pam_auth_password, password, 255);
-        }
-
-        /* access_control return 0 on success */
-        reply = access_control(pam_auth_username, pam_auth_password, pam_auth_sessionIP);
-
-        xrdp_wm_log_msg(self->wm, LOG_LEVEL_INFO,
-                        "Reply from access control: %s",
-                        getPAMError(reply, pam_error, 127));
-
-        additionalError = getPAMAdditionalErrorInfo(reply, self);
-        if (additionalError && additionalError[0])
-        {
-            xrdp_wm_log_msg(self->wm, LOG_LEVEL_INFO, "%s", additionalError);
-        }
-
-        if (reply != 0)
-        {
-            rv = 1;
-            return rv;
-        }
+        /* unix socket */
+        self->chan_trans = trans_create(TRANS_MODE_UNIX, 8192, 8192);
     }
-#endif
-
-    if (self->sesman_controlled)
+    else
     {
-        ok = 0;
-        trans_delete(self->sesman_trans);
-        self->sesman_trans = trans_create(TRANS_MODE_TCP, 8192, 8192);
-        self->sesman_trans->is_term = g_is_term;
-        xrdp_mm_get_sesman_port(port, sizeof(port));
-        xrdp_wm_log_msg(self->wm, LOG_LEVEL_DEBUG,
-                        "connecting to sesman ip %s port %s", ip, port);
-        /* xrdp_mm_sesman_data_in is the callback that is called when data arrives */
-        self->sesman_trans->trans_data_in = xrdp_mm_sesman_data_in;
-        self->sesman_trans->header_size = 8;
-        self->sesman_trans->callback_data = self;
-
-        /* try to connect up to 4 times */
-        for (index = 0; index < 4; index++)
-        {
-            if (trans_connect(self->sesman_trans, ip, port, 3000) == 0)
-            {
-                self->sesman_trans_up = 1;
-                ok = 1;
-                break;
-            }
-            if (g_is_term())
-            {
-                break;
-            }
-            g_sleep(1000);
-            LOG(LOG_LEVEL_INFO, "xrdp_mm_connect: connect failed "
-                "trying again...");
-        }
-
-        if (ok)
-        {
-            /* fully connect */
-            xrdp_wm_log_msg(self->wm, LOG_LEVEL_INFO, "sesman connect ok");
-            self->connected_state = 1;
-            rv = xrdp_mm_send_login(self);
-        }
-        else
-        {
-            xrdp_wm_log_msg(self->wm, LOG_LEVEL_ERROR,
-                            "Error connecting to sesman: %s port: %s",
-                            ip, port);
-            trans_delete(self->sesman_trans);
-            self->sesman_trans = 0;
-            self->sesman_trans_up = 0;
-            rv = 1;
-        }
-    }
-    else /* no sesman */
-    {
-        if (xrdp_mm_setup_mod1(self) == 0)
-        {
-            if (xrdp_mm_setup_mod2(self, 0) == 0)
-            {
-                xrdp_wm_set_login_state(self->wm, WMLS_CLEANUP);
-                rv = 0; /*success*/
-            }
-            else
-            {
-                /* connect error */
-                xrdp_wm_log_msg(self->wm, LOG_LEVEL_ERROR,
-                                "Error connecting to: %s", ip);
-                rv = 1; /* failure */
-            }
-        }
-        else
-        {
-            LOG(LOG_LEVEL_ERROR, "Failure setting up module");
-        }
-
-        if (self->wm->login_state != WMLS_CLEANUP)
-        {
-            xrdp_wm_set_login_state(self->wm, WMLS_INACTIVE);
-            xrdp_mm_module_cleanup(self);
-            rv = 1; /* failure */
-        }
+        /* tcp */
+        self->chan_trans = trans_create(TRANS_MODE_TCP, 8192, 8192);
     }
 
-    if ((self->wm->login_state == WMLS_CLEANUP) && (self->sesman_controlled == 0) &&
-            (self->use_chansrv != 0))
+    self->chan_trans->is_term = g_is_term;
+    self->chan_trans->si = &(self->wm->session->si);
+    self->chan_trans->my_source = XRDP_SOURCE_CHANSRV;
+    self->chan_trans->trans_data_in = xrdp_mm_chan_data_in;
+    self->chan_trans->header_size = 8;
+    self->chan_trans->callback_data = self;
+    self->chan_trans->no_stream_init_on_data_in = 1;
+    self->chan_trans->extra_flags = 0;
+
+    /* try to connect up to 4 times */
+    for (index = 0; index < 4; index++)
     {
-        /* if sesman controlled, this will connect later */
-        xrdp_mm_connect_chansrv(self, "", chansrvport);
+        if (trans_connect(self->chan_trans, ip, port, 3000) == 0)
+        {
+            break;
+        }
+        if (g_is_term())
+        {
+            break;
+        }
+        g_sleep(1000);
+        LOG(LOG_LEVEL_WARNING, "xrdp_mm_chansrv_connect: connect failed "
+            "trying again...");
     }
 
-    LOG(LOG_LEVEL_DEBUG, "return value from xrdp_mm_connect %d", rv);
+    if (self->chan_trans->status != TRANS_STATUS_UP)
+    {
+        LOG(LOG_LEVEL_ERROR, "xrdp_mm_chansrv_connect: error in "
+            "trans_connect chan");
+    }
+    else if (xrdp_mm_trans_send_channel_setup(self, self->chan_trans) != 0)
+    {
+        LOG(LOG_LEVEL_ERROR, "xrdp_mm_chansrv_connect: error in "
+            "xrdp_mm_trans_send_channel_setup");
+        trans_delete(self->chan_trans);
+        self->chan_trans = NULL;
+    }
+    else
+    {
+        LOG(LOG_LEVEL_DEBUG, "xrdp_mm_chansrv_connect: chansrv "
+            "connect successful");
+    }
+
+    return 0;
+}
+
+/*****************************************************************************/
+static int
+xrdp_mm_user_session_connect(struct xrdp_mm *self)
+{
+    int rv = 0;
+
+    if (xrdp_mm_setup_mod1(self) != 0)
+    {
+        LOG(LOG_LEVEL_ERROR, "Failure setting up module");
+        xrdp_mm_module_cleanup(self);
+        rv = 1;
+    }
+    else if (xrdp_mm_setup_mod2(self) != 0)
+    {
+        /* connect error */
+        xrdp_wm_log_msg(self->wm, LOG_LEVEL_ERROR,
+                        "Error connecting to user session");
+        xrdp_mm_module_cleanup(self);
+        rv = 1; /* failure */
+    }
+
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "return value from %s %d", __func__, rv);
 
     return rv;
 }
+
+/**************************************************************************//**
+ * Initialise and start the connect sequence
+ *
+ * @param self This object
+ */
+void
+xrdp_mm_connect(struct xrdp_mm *self)
+{
+    const char *port = xrdp_mm_get_value(self, "port");
+    const char *gateway_username = xrdp_mm_get_value(self, "pamusername");
+
+    /* make sure we start in correct state */
+    cleanup_states(self);
+
+    /* Look at our module parameters to decide if we need to connect
+     * to sesman or not */
+
+    if (port != NULL && g_strcmp(port, "-1") == 0)
+    {
+        self->use_sesman = 1;
+    }
+
+    if (gateway_username != NULL)
+    {
+#ifdef USE_PAM
+        self->use_pam_auth = 1;
+#else
+        xrdp_wm_log_msg(self->wm, LOG_LEVEL_WARNING,
+                        "pamusername parameter ignored - "
+                        "xrdp is compiled without PAM support");
+#endif
+    }
+
+    /* Will we need chansrv ? We use it unconditionally for a
+     * sesman session, but the user can also request it separately */
+    if (self->use_sesman)
+    {
+        self->use_chansrv = 1;
+    }
+    else
+    {
+        const char *csp = xrdp_mm_get_value(self, "chansrvport");
+        /* It's defined, but is it a valid string? */
+        if (csp != NULL && parse_chansrvport(csp, NULL, 0) == 0)
+        {
+            self->use_chansrv = 1;
+        }
+    }
+
+    xrdp_mm_connect_sm(self);
+}
+
+/*****************************************************************************/
+static void
+xrdp_mm_connect_sm(struct xrdp_mm *self)
+{
+    int status = 0;
+    int waiting_for_msg = 0; /* Set this to leave the sm to wait for a reply */
+
+    while (status == 0 && !waiting_for_msg && self->connect_state != MMCS_DONE)
+    {
+        switch (self->connect_state)
+        {
+            case MMCS_CONNECT_TO_SESMAN:
+            {
+                if (self->use_sesman)
+                {
+                    /* Synchronous call */
+                    const char *ip = xrdp_mm_get_value(self, "ip");
+                    status = xrdp_mm_sesman_connect(self, ip);
+                }
+
+                if (status == 0 && self->use_pam_auth)
+                {
+                    /* Synchronous call */
+                    const char *ip = xrdp_mm_get_value(self, "pamsessionmng");
+                    if (ip == NULL)
+                    {
+                        ip = xrdp_mm_get_value(self, "ip");
+                    }
+                    status = xrdp_mm_pam_auth_connect(self, ip);
+                }
+            }
+            break;
+
+            case MMCS_PAM_AUTH:
+            {
+                if (self->use_pam_auth)
+                {
+                    const char *gateway_username;
+                    const char *gateway_password;
+
+                    gateway_username = xrdp_mm_get_value(self, "pamusername");
+                    gateway_password = xrdp_mm_get_value(self, "pampassword");
+                    if (!g_strcmp(gateway_username, "same"))
+                    {
+                        gateway_username = xrdp_mm_get_value(self, "username");
+                    }
+
+                    if (gateway_password == NULL ||
+                            !g_strcmp(gateway_password, "same"))
+                    {
+                        gateway_password = xrdp_mm_get_value(self, "password");
+                    }
+
+                    if (gateway_username == NULL || gateway_password == NULL)
+                    {
+                        xrdp_wm_log_msg(self->wm, LOG_LEVEL_ERROR,
+                                        "Can't determine username and/or "
+                                        "password for gateway authorization");
+                        status = 1;
+                    }
+                    else
+                    {
+                        xrdp_wm_log_msg(self->wm, LOG_LEVEL_INFO,
+                                        "Performing access control for %s",
+                                        gateway_username);
+
+                        status = xrdp_mm_send_gateway_login(self,
+                                                            gateway_username,
+                                                            gateway_password);
+                        if (status == 0)
+                        {
+                            /* Now waiting for a reply from sesman */
+                            waiting_for_msg = 1;
+                        }
+                    }
+                }
+            }
+            break;
+
+            case MMCS_SESSION_AUTH:
+            {
+                if (self->use_sesman)
+                {
+                    if ((status = xrdp_mm_send_login(self)) == 0)
+                    {
+                        /* Now waiting for a reply from sesman */
+                        waiting_for_msg = 1;
+                    }
+                }
+            }
+            break;
+
+            case MMCS_CONNECT_TO_SESSION:
+            {
+                /* This is synchronous - no reply message expected */
+                status = xrdp_mm_user_session_connect(self);
+            }
+            break;
+
+            case MMCS_CONNECT_TO_CHANSRV:
+            {
+                if (self->use_chansrv)
+                {
+                    const char *ip = "";
+                    char portbuff[256];
+
+                    if (self->use_sesman)
+                    {
+                        ip = xrdp_mm_get_value(self, "ip");
+
+                        /* connect channel redir */
+                        if (ip == NULL || (ip[0] == '\0') ||
+                                (g_strcmp(ip, "127.0.0.1") == 0))
+                        {
+                            g_snprintf(portbuff, sizeof(portbuff),
+                                       XRDP_CHANSRV_STR, self->display);
+                        }
+                        else
+                        {
+                            g_snprintf(portbuff, sizeof(portbuff),
+                                       "%d", 7200 + self->display);
+                        }
+                    }
+                    else
+                    {
+                        const char *cp = xrdp_mm_get_value(self, "chansrvport");
+                        portbuff[0] = '\0';
+                        parse_chansrvport(cp, portbuff, sizeof(portbuff));
+
+                    }
+                    xrdp_mm_update_allowed_channels(self);
+                    xrdp_mm_chansrv_connect(self, ip, portbuff);
+                }
+            }
+            break;
+
+            case MMCS_DONE:
+            {
+                /* Shouldn't get here */
+                LOG(LOG_LEVEL_ERROR, "xrdp_mm_connect_sm: state machine error");
+                status = 1;
+            }
+            break;
+        }
+
+        /* Move to the next state */
+        if (self->connect_state < MMCS_DONE)
+        {
+            self->connect_state = (enum mm_connect_state)
+                                  (self->connect_state + 1);
+        }
+    }
+
+    if (!waiting_for_msg)
+    {
+        xrdp_wm_mod_connect_done(self->wm, status);
+        cleanup_sesman_connection(self);
+    }
+}
+
 
 /*****************************************************************************/
 int
@@ -2653,12 +2569,19 @@ xrdp_mm_get_wait_objs(struct xrdp_mm *self,
 
     rv = 0;
 
-    if ((self->sesman_trans != 0) && self->sesman_trans_up)
+    if (self->sesman_trans != 0 &&
+            self->sesman_trans->status == TRANS_STATUS_UP)
     {
         trans_get_wait_objs(self->sesman_trans, read_objs, rcount);
     }
 
-    if ((self->chan_trans != 0) && self->chan_trans_up)
+    if (self->pam_auth_trans != 0 &&
+            self->pam_auth_trans->status == TRANS_STATUS_UP)
+    {
+        trans_get_wait_objs(self->pam_auth_trans, read_objs, rcount);
+    }
+
+    if ((self->chan_trans != 0) && self->chan_trans->status == TRANS_STATUS_UP)
     {
         trans_get_wait_objs_rw(self->chan_trans, read_objs, rcount,
                                write_objs, wcount, timeout);
@@ -2741,20 +2664,17 @@ int
 xrdp_mm_check_chan(struct xrdp_mm *self)
 {
     LOG(LOG_LEVEL_TRACE, "xrdp_mm_check_chan:");
-    if ((self->chan_trans != 0) && self->chan_trans_up)
+    if ((self->chan_trans != 0) && self->chan_trans->status == TRANS_STATUS_UP)
     {
         if (trans_check_wait_objs(self->chan_trans) != 0)
         {
-            self->delete_chan_trans = 1;
+            /* This is safe to do here, as we're not in a chansrv
+             * transport callback */
+            trans_delete(self->chan_trans);
+            self->chan_trans = 0;
         }
     }
-    if (self->delete_chan_trans)
-    {
-        trans_delete(self->chan_trans);
-        self->chan_trans = 0;
-        self->chan_trans_up = 0;
-        self->delete_chan_trans = 0;
-    }
+
     return 0;
 }
 
@@ -2859,7 +2779,9 @@ xrdp_mm_check_wait_objs(struct xrdp_mm *self)
 
     rv = 0;
 
-    if ((self->sesman_trans != NULL) && self->sesman_trans_up)
+    if (self->sesman_trans != NULL &&
+            !self->delete_sesman_trans &&
+            self->sesman_trans->status == TRANS_STATUS_UP)
     {
         if (trans_check_wait_objs(self->sesman_trans) != 0)
         {
@@ -2871,12 +2793,37 @@ xrdp_mm_check_wait_objs(struct xrdp_mm *self)
             }
         }
     }
+    if (self->delete_sesman_trans)
+    {
+        trans_delete(self->sesman_trans);
+        self->sesman_trans = NULL;
+    }
 
-    if ((self->chan_trans != NULL) && self->chan_trans_up)
+    if (self->pam_auth_trans != NULL &&
+            !self->delete_pam_auth_trans &&
+            self->pam_auth_trans->status == TRANS_STATUS_UP)
+    {
+        if (trans_check_wait_objs(self->pam_auth_trans) != 0)
+        {
+            self->delete_pam_auth_trans = 1;
+        }
+    }
+    if (self->delete_pam_auth_trans)
+    {
+        trans_delete(self->pam_auth_trans);
+        self->pam_auth_trans = NULL;
+    }
+
+
+    if (self->chan_trans != NULL &&
+            self->chan_trans->status == TRANS_STATUS_UP)
     {
         if (trans_check_wait_objs(self->chan_trans) != 0)
         {
-            self->delete_chan_trans = 1;
+            /* This is safe to do here, as we're not in a chansrv
+             * transport callback */
+            trans_delete(self->chan_trans);
+            self->chan_trans = NULL;
         }
     }
 
@@ -2886,22 +2833,6 @@ xrdp_mm_check_wait_objs(struct xrdp_mm *self)
         {
             rv = self->mod->mod_check_wait_objs(self->mod);
         }
-    }
-
-    if (self->delete_sesman_trans)
-    {
-        trans_delete(self->sesman_trans);
-        self->sesman_trans = NULL;
-        self->sesman_trans_up = 0;
-        self->delete_sesman_trans = 0;
-    }
-
-    if (self->delete_chan_trans)
-    {
-        trans_delete(self->chan_trans);
-        self->chan_trans = NULL;
-        self->chan_trans_up = 0;
-        self->delete_chan_trans = 0;
     }
 
     if (self->encoder != NULL)

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -315,7 +315,7 @@ struct xrdp_mm
     struct trans *chan_trans; /* connection to chansrv */
     int chan_trans_up; /* true once connected to chansrv */
     int delete_chan_trans; /* boolean set when done with channel connection */
-    int usechansrv; /* true if chansrvport is set in xrdp.ini or using sesman */
+    int use_chansrv; /* true if chansrvport is set in xrdp.ini or using sesman */
     struct xrdp_encoder *encoder;
     int cs2xr_cid_map[256];
     int xr2cr_cid_map[256];

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -72,7 +72,7 @@ struct xrdp_mod
     int (*server_set_pointer)(struct xrdp_mod *v, int x, int y,
                               char *data, char *mask);
     int (*server_palette)(struct xrdp_mod *v, int *palette);
-    int (*server_msg)(struct xrdp_mod *v, char *msg, int code);
+    int (*server_msg)(struct xrdp_mod *v, const char *msg, int code);
     int (*server_is_term)(struct xrdp_mod *v);
     int (*server_set_clip)(struct xrdp_mod *v, int x, int y, int cx, int cy);
     int (*server_reset_clip)(struct xrdp_mod *v);

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -27,6 +27,7 @@
 #include "xrdp_rail.h"
 #include "xrdp_constants.h"
 #include "fifo.h"
+#include "guid.h"
 
 #define MAX_NR_CHANNELS 16
 #define MAX_CHANNEL_NAME 16
@@ -295,13 +296,40 @@ struct xrdp_cache
 /* defined later */
 struct xrdp_enc_data;
 
+/**
+ * Stages we go through connecting to the session
+ */
+enum mm_connect_state
+{
+    MMCS_CONNECT_TO_SESMAN,
+    MMCS_PAM_AUTH,
+    MMCS_SESSION_AUTH,
+    MMCS_CONNECT_TO_SESSION,
+    MMCS_CONNECT_TO_CHANSRV,
+    MMCS_DONE
+};
+
 struct xrdp_mm
 {
     struct xrdp_wm *wm; /* owner */
-    int connected_state; /* true if connected to sesman else false */
+    enum mm_connect_state connect_state; /* State of connection */
+    /* Other processes we connect to */
+    /* NB : When we move to UDS, the sesman and pam_auth
+     * connection be merged */
+    int use_sesman; /* true if this is a sesman session */
+    int use_pam_auth; /* True if we're to authenticate using PAM */
+    int use_chansrv; /* true if chansrvport is set in xrdp.ini or using sesman */
     struct trans *sesman_trans; /* connection to sesman */
-    int sesman_trans_up; /* true once connected to sesman */
-    int delete_sesman_trans; /* boolean set when done with sesman connection */
+    struct trans *pam_auth_trans; /* connection to pam authenticator */
+    struct trans *chan_trans; /* connection to chansrv */
+
+    /* We can't delete transports while we're in a callback for that
+     * transport, as this causes trans.c to reference undefined memory.
+     * These flags mark transports as needing to be deleted when
+     * we are definitely not in a transport callback */
+    int delete_sesman_trans;
+    int delete_pam_auth_trans;
+
     struct list *login_names;
     struct list *login_values;
     /* mod vars */
@@ -310,12 +338,8 @@ struct xrdp_mm
     int (*mod_exit)(struct xrdp_mod *);
     struct xrdp_mod *mod; /* module interface */
     int display; /* 10 for :10.0, 11 for :11.0, etc */
+    struct guid guid; /* GUID for the session, or all zeros  */
     int code; /* 0=Xvnc session, 10=X11rdp session, 20=xorg driver mode */
-    int sesman_controlled; /* true if this is a sesman session */
-    struct trans *chan_trans; /* connection to chansrv */
-    int chan_trans_up; /* true once connected to chansrv */
-    int delete_chan_trans; /* boolean set when done with channel connection */
-    int use_chansrv; /* true if chansrvport is set in xrdp.ini or using sesman */
     struct xrdp_encoder *encoder;
     int cs2xr_cid_map[256];
     int xr2cr_cid_map[256];

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -1845,7 +1845,7 @@ xrdp_wm_process_channel_data(struct xrdp_wm *self,
 
     if (self->mm->mod != 0)
     {
-        if (self->mm->usechansrv)
+        if (self->mm->use_chansrv)
         {
             rv = xrdp_mm_process_channel_data(self->mm, param1, param2,
                                               param3, param4);

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -1956,16 +1956,13 @@ xrdp_wm_login_state_changed(struct xrdp_wm *self)
     }
     else if (self->login_state == WMLS_START_CONNECT)
     {
-        if (xrdp_mm_connect(self->mm) == 0)
-        {
-            xrdp_wm_set_login_state(self, WMLS_CONNECT_IN_PROGRESS);
-            xrdp_wm_delete_all_children(self);
-            self->dragging = 0;
-        }
-        else
-        {
-            /* we do nothing on connect error so far */
-        }
+        xrdp_wm_delete_all_children(self);
+        self->dragging = 0;
+        xrdp_wm_set_login_state(self, WMLS_CONNECT_IN_PROGRESS);
+
+        /* This calls back to xrdp_wm_mod_connect_done() when the
+         * connect is finished*/
+        xrdp_mm_connect(self->mm);
     }
     else if (self->login_state == WMLS_CLEANUP)
     {

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -1977,6 +1977,26 @@ xrdp_wm_login_state_changed(struct xrdp_wm *self)
     return 0;
 }
 
+/******************************************************************************/
+/* this gets called when the module manager finishes a connect
+ * which was initiated by xrdp_mm_connect()
+ */
+void
+xrdp_wm_mod_connect_done(struct xrdp_wm *self, int status)
+{
+    LOG(LOG_LEVEL_DEBUG, "status from xrdp_mm_connect() : %d", status);
+    if (status == 0)
+    {
+        xrdp_wm_set_login_state(self, WMLS_CLEANUP);
+        self->dragging = 0;
+    }
+    else
+    {
+        xrdp_wm_set_login_state(self, WMLS_INACTIVE);
+        xrdp_wm_show_log(self);
+    }
+}
+
 /*****************************************************************************/
 /* this is the log windows notify function */
 static int


### PR DESCRIPTION
**Update 2021-11-04** This PR is now ready for review, following my own testing.

The point of the PR is to get xrdp and sesrun to use libscp to communicate with sesman. Once this is done, it becomes a lot easier to replace SCP V0/V1 with an SCP V2 to support #1961 

Most of it is relatively straightforward. The complication is within xrdp, and centres around two issues:-
1 The interface between `xrdp_mm.c` and `xrdp_wm.c`
2  Replacing the synchronous `access_control()` function in `xrdp_mm.c` with asynchronous calls to libscp.

For the first of these, I've added a function `xrdp_wm_mod_connect_done()` to xrdp_wm.c. The idea is that xrdp_mm.c uses this to notify the window manager of all connection results. As well as simplifying the interface, this should result in uniform behaviour when a connection attempt fails. At the moment, strange things happen when (for example) a neutrinordp proxy connection does not authenticate properly with `pamusername`. This is fixed by this PR.

The second of these is complicated by not moving to UDS yet. I've approached it by using a second connection to sesman to fire off the PAM authentication request. This makes the eventual move to UDS a lot easier, as the second connection can simply be removed.

There's a state machine `xrdp_mm_connect_sm()` in xrdp_mm.c to manage the connection request. I'm hoping this makes the steps which go into a connection easier to follow.

I haven't spent a lot of time unifying SCP V0 and SCP V1 further. At the moment I can't see the point, but I'm open to being convinced otherwise if necessary.
