### PR TITLE
Fix definitely lost memory leaks

### DIFF
--- a/common/log.c
+++ b/common/log.c
@@ -667,6 +667,13 @@ log_config_free(struct log_config *config)
             list_delete(config->per_logger_level);
             config->per_logger_level = NULL;
         }
+
+        if (0 != config->log_file)
+        {
+            g_free(config->log_file);
+            config->log_file = 0;
+        }
+
         g_free(config);
     }
 

--- a/vnc/vnc.c
+++ b/vnc/vnc.c
@@ -1006,6 +1006,8 @@ find_matching_extended_rect(struct vnc *v,
         }
     }
 
+    free_stream(s);
+
     return error;
 }
 

--- a/xrdp/xrdp.c
+++ b/xrdp/xrdp.c
@@ -572,6 +572,7 @@ main(int argc, char **argv)
     {
         g_writeln("It looks like xrdp is already running.");
         g_writeln("If not, delete %s and try again.", pid_file);
+        log_end();
         g_deinit();
         g_exit(0);
     }
@@ -591,6 +592,7 @@ main(int argc, char **argv)
         if (fd == -1)
         {
             g_writeln("running in daemon mode with no access to pid files, quitting");
+            log_end();
             g_deinit();
             g_exit(0);
         }
@@ -598,6 +600,7 @@ main(int argc, char **argv)
         if (g_file_write(fd, "0", 1) == -1)
         {
             g_writeln("running in daemon mode with no access to pid files, quitting");
+            log_end();
             g_deinit();
             g_exit(0);
         }
@@ -613,6 +616,7 @@ main(int argc, char **argv)
         {
             LOG(LOG_LEVEL_ERROR, "Failed to start xrdp daemon, "
                 "possibly address already in use.");
+            log_end();
             g_deinit();
             /* must exit with failure status,
                or systemd cannot detect xrdp daemon couldn't start properly */
@@ -624,6 +628,7 @@ main(int argc, char **argv)
         if (pid == -1)
         {
             g_writeln("problem forking");
+            log_end();
             g_deinit();
             g_exit(1);
         }
@@ -632,6 +637,7 @@ main(int argc, char **argv)
         {
             g_writeln("daemon process %d started ok", pid);
             /* exit, this is the main process */
+            log_end();
             g_deinit();
             g_exit(0);
         }


### PR DESCRIPTION
Fixes #1562, although it seems a lot of this has been done already.

Remove some minor 'definitely lost' memory leaks which are generating noise while testing #2011 

The first of these is in `common/log.c`, and occurs when `log_config_free()` is called here as part of `log_start()`:-

https://github.com/neutrinolabs/xrdp/blob/c11d0e3d2efd0d2df3ee6cce03cca76508f2c29a/common/log.c#L735

Memory is allocated here:-
https://github.com/neutrinolabs/xrdp/blob/c11d0e3d2efd0d2df3ee6cce03cca76508f2c29a/common/log.c#L319-L330

The second change is to the VNC module where a stream is not freed after use.

The third change is simply to close the log properly in `xrdp/xrdp.c` if error conditions are detected during startup.

Leaks were tracked down by running xrdp as follows:-

```
sudo valgrind --leak-check=full --keep-debuginfo=yes xrdp -n
```