### PR TITLE
Remove unnecessary error from neutrinordp log

### DIFF
--- a/mc/mc.h
+++ b/mc/mc.h
@@ -79,6 +79,7 @@ struct mod
                             int box_right, int box_bottom,
                             int x, int y, char *data, int data_len);
     int (*server_reset)(struct mod *v, int width, int height, int bpp);
+    int (*server_get_channel_count)(struct mod *v);
     int (*server_query_channel)(struct mod *v, int index,
                                 char *channel_name,
                                 int *channel_flags);
@@ -88,7 +89,7 @@ struct mod
                                   int total_data_len, int flags);
     int (*server_bell_trigger)(struct mod *v);
     int (*server_chansrv_in_use)(struct mod *v);
-    tintptr server_dumby[100 - 26]; /* align, 100 minus the number of server
+    tintptr server_dumby[100 - 27]; /* align, 100 minus the number of server
                                      functions above */
     /* common */
     tintptr handle; /* pointer to self as long */

--- a/neutrinordp/xrdp-neutrinordp.h
+++ b/neutrinordp/xrdp-neutrinordp.h
@@ -131,6 +131,7 @@ struct mod
                             int box_right, int box_bottom,
                             int x, int y, char *data, int data_len);
     int (*server_reset)(struct mod *v, int width, int height, int bpp);
+    int (*server_get_channel_count)(struct mod *v);
     int (*server_query_channel)(struct mod *v, int index,
                                 char *channel_name,
                                 int *channel_flags);
@@ -194,7 +195,7 @@ struct mod
                               int flags, int frame_id);
     int (*server_session_info)(struct mod *v, const char *data,
                                int data_bytes);
-    tintptr server_dumby[100 - 45]; /* align, 100 minus the number of server
+    tintptr server_dumby[100 - 46]; /* align, 100 minus the number of server
                                        functions above */
     /* common */
     tintptr handle; /* pointer to self as long */

--- a/vnc/vnc.h
+++ b/vnc/vnc.h
@@ -123,6 +123,7 @@ struct vnc
                             int box_right, int box_bottom,
                             int x, int y, char *data, int data_len);
     int (*server_reset)(struct vnc *v, int width, int height, int bpp);
+    int (*server_get_channel_count)(struct vnc *v);
     int (*server_query_channel)(struct vnc *v, int index,
                                 char *channel_name,
                                 int *channel_flags);
@@ -132,7 +133,7 @@ struct vnc
                                   int total_data_len, int flags);
     int (*server_bell_trigger)(struct vnc *v);
     int (*server_chansrv_in_use)(struct vnc *v);
-    tintptr server_dumby[100 - 26]; /* align, 100 minus the number of server
+    tintptr server_dumby[100 - 27]; /* align, 100 minus the number of server
                                      functions above */
     /* common */
     tintptr handle; /* pointer to self as long */

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -513,6 +513,8 @@ server_reset(struct xrdp_mod *mod, int width, int height, int bpp);
 int
 is_channel_allowed(struct xrdp_wm *wm, int channel_id);
 int
+server_get_channel_count(struct xrdp_mod *mod);
+int
 server_query_channel(struct xrdp_mod *mod, int index, char *channel_name,
                      int *channel_flags);
 int

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -448,6 +448,7 @@ xrdp_mm_setup_mod1(struct xrdp_mm *self)
             self->mod->server_add_char = server_add_char;
             self->mod->server_draw_text = server_draw_text;
             self->mod->server_reset = server_reset;
+            self->mod->server_get_channel_count = server_get_channel_count;
             self->mod->server_query_channel = server_query_channel;
             self->mod->server_get_channel_id = server_get_channel_id;
             self->mod->server_send_to_channel = server_send_to_channel;
@@ -3567,6 +3568,24 @@ server_reset(struct xrdp_mod *mod, int width, int height, int bpp)
     xrdp_wm_load_static_pointers(wm);
     return 0;
 }
+
+/*****************************************************************************/
+/*return -1 if channels are controlled by chansrv */
+int
+server_get_channel_count(struct xrdp_mod *mod)
+{
+    struct xrdp_wm *wm;
+
+    wm = (struct xrdp_wm *)(mod->wm);
+
+    if (wm->mm->usechansrv)
+    {
+        return -1;
+    }
+
+    return libxrdp_get_channel_count(wm->session);
+}
+
 
 /*****************************************************************************/
 /*return 0 if the index is not found*/

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -95,6 +95,7 @@ struct xrdp_mod
                             int box_right, int box_bottom,
                             int x, int y, char *data, int data_len);
     int (*server_reset)(struct xrdp_mod *v, int width, int height, int bpp);
+    int (*server_get_channel_count)(struct xrdp_mod *v);
     int (*server_query_channel)(struct xrdp_mod *v, int index,
                                 char *channel_name,
                                 int *channel_flags);
@@ -159,7 +160,7 @@ struct xrdp_mod
                               int flags, int frame_id);
     int (*server_session_info)(struct xrdp_mod *v, const char *data,
                                int data_bytes);
-    tintptr server_dumby[100 - 45]; /* align, 100 minus the number of server
+    tintptr server_dumby[100 - 46]; /* align, 100 minus the number of server
                                      functions above */
     /* common */
     tintptr handle; /* pointer to self as int */

--- a/xup/xup.h
+++ b/xup/xup.h
@@ -92,6 +92,7 @@ struct mod
                             int box_right, int box_bottom,
                             int x, int y, char *data, int data_len);
     int (*server_reset)(struct mod *v, int width, int height, int bpp);
+    int (*server_get_channel_count)(struct mod *v);
     int (*server_query_channel)(struct mod *v, int index,
                                 char *channel_name,
                                 int *channel_flags);
@@ -152,7 +153,7 @@ struct mod
                               char *data, int width, int height,
                               int flags, int frame_id);
 
-    tintptr server_dumby[100 - 44]; /* align, 100 minus the number of server
+    tintptr server_dumby[100 - 45]; /* align, 100 minus the number of server
                                      functions above */
     /* common */
     tintptr handle; /* pointer to self as long */


### PR DESCRIPTION
This PR removes the following error from the xrdp.log when the neutrinordp module is being used:-

```
[20211012-10:08:27] [ERROR] libxrdp_query_channel: Channel index out of range. max channel index 4, received channel index 4
```

This was highlighted recently in a Gitter conversation with @GG668.

See also #1775, where exactly the same error was being generated. The same logic was in use, which was to get the number of channels by calling `libxrdp_query_channel()` with increasing indexes until an error was returned.

The fix in that case was to query the channel count directly from libxrdp. This applies the same fix, but it is also necessary to add a call to get the channel count to the module interface so that neutrinordp can access it.