### PR TITLE
Minor memory leaks found with valgrind

### DIFF
--- a/vnc/vnc_clip.c
+++ b/vnc/vnc_clip.c
@@ -1107,6 +1107,7 @@ vnc_clip_open_clip_channel(struct vnc *v)
         s_mark_end(s);
         send_stream_to_clip_channel(v, s);
 
+        free_stream(s);
         /* Need to complete the startup handshake before we send formats */
         v->vc->startup_complete = 1;
     }

--- a/xrdp/xrdp_cache.c
+++ b/xrdp/xrdp_cache.c
@@ -120,8 +120,8 @@ xrdp_cache_create(struct xrdp_wm *owner,
 }
 
 /*****************************************************************************/
-void
-xrdp_cache_delete(struct xrdp_cache *self)
+static void
+clear_all_cached_items(struct xrdp_cache *self)
 {
     int i;
     int j;
@@ -165,7 +165,13 @@ xrdp_cache_delete(struct xrdp_cache *self)
             list16_deinit(&(self->crc16[i][j]));
         }
     }
+}
 
+/*****************************************************************************/
+void
+xrdp_cache_delete(struct xrdp_cache *self)
+{
+    clear_all_cached_items(self);
     g_free(self);
 }
 
@@ -176,30 +182,12 @@ xrdp_cache_reset(struct xrdp_cache *self,
 {
     struct xrdp_wm *wm;
     struct xrdp_session *session;
-    int i;
-    int j;
-
-    /* free all the cached bitmaps */
-    for (i = 0; i < XRDP_MAX_BITMAP_CACHE_ID; i++)
-    {
-        for (j = 0; j < XRDP_MAX_BITMAP_CACHE_IDX; j++)
-        {
-            xrdp_bitmap_delete(self->bitmap_items[i][j].bitmap);
-        }
-    }
-
-    /* free all the cached font items */
-    for (i = 0; i < 12; i++)
-    {
-        for (j = 0; j < 256; j++)
-        {
-            g_free(self->char_items[i][j].font_item.data);
-        }
-    }
 
     /* save these */
     wm = self->wm;
     session = self->session;
+    /* De-allocate any allocated memory */
+    clear_all_cached_items(self);
     /* set whole struct to zero */
     g_memset(self, 0, sizeof(struct xrdp_cache));
     /* set some stuff back */


### PR DESCRIPTION
Two minor memory leaks found with:-

```
sudo valgrind --leak-check=full --keep-debuginfo=yes xrdp -n
```

The first of these is simply an unfree'd stream in the VNC module.

The second one relates to the `xrdp_cache` struct. When `xrdp_cache_reset()` is called, any memory currently allocated to offscreen bitmaps is lost permanently.

The fix is to add a common call to `xrdp_cache_delete()` and `xrdp_cache_reset()` to de-allocate all allocated memory within the structure before freeing it (in `xrdp_cache_delete()`) or re-initialising it (in `xrdp_cache_reset()`)
