### PR TITLE
Chansrv hang fix

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -2511,6 +2511,50 @@ g_file_get_size(const char *filename)
 }
 
 /*****************************************************************************/
+/* returns device number, -1 on error */
+int
+g_file_get_device_number(const char *filename)
+{
+#if defined(_WIN32)
+    return -1;
+#else
+    struct stat st;
+
+    if (stat(filename, &st) == 0)
+    {
+        return (int)(st.st_dev);
+    }
+    else
+    {
+        return -1;
+    }
+
+#endif
+}
+
+/*****************************************************************************/
+/* returns inode number, -1 on error */
+int
+g_file_get_inode_num(const char *filename)
+{
+#if defined(_WIN32)
+    return -1;
+#else
+    struct stat st;
+
+    if (stat(filename, &st) == 0)
+    {
+        return (int)(st.st_ino);
+    }
+    else
+    {
+        return -1;
+    }
+
+#endif
+}
+
+/*****************************************************************************/
 long
 g_load_library(char *in)
 {

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -128,6 +128,8 @@ int      g_create_path(const char *path);
 int      g_remove_dir(const char *dirname);
 int      g_file_delete(const char *filename);
 int      g_file_get_size(const char *filename);
+int      g_file_get_device_number(const char *filename);
+int      g_file_get_inode_num(const char *filename);
 long     g_load_library(char *in);
 int      g_free_library(long lib);
 void    *g_get_proc_address(long lib, const char *name);

--- a/common/string_calls.c
+++ b/common/string_calls.c
@@ -188,7 +188,7 @@ g_strlen(const char *text)
 
 /*****************************************************************************/
 /* locates char in text */
-const char *
+char *
 g_strchr(const char *text, int c)
 {
     if (text == NULL)
@@ -196,12 +196,27 @@ g_strchr(const char *text, int c)
         return 0;
     }
 
-    return strchr(text, c);
+    /* Cast needed to compile with C++ */
+    return (char *)strchr(text, c);
+}
+
+/*****************************************************************************/
+/* locates char in text */
+char *
+g_strrchr(const char *text, int c)
+{
+    if (text == NULL)
+    {
+        return 0;
+    }
+
+    /* Cast needed to compile with C++ */
+    return (char *)strrchr(text, c);
 }
 
 /*****************************************************************************/
 /* locates char in text with length */
-const char *
+char *
 g_strnchr(const char *text, int c, int len)
 {
     if (text == NULL || len <= 0)
@@ -209,7 +224,7 @@ g_strnchr(const char *text, int c, int len)
         return NULL;
     }
 
-    return (const char *)memchr(text, c, len);
+    return (char *)memchr(text, c, len);
 }
 
 /*****************************************************************************/
@@ -678,6 +693,20 @@ g_pos(const char *str, const char *to_find)
     }
 
     return (pp - str);
+}
+
+/*****************************************************************************/
+
+char *
+g_strstr(const char *haystack, const char *needle)
+{
+    if (haystack == NULL || needle == NULL)
+    {
+        return NULL;
+    }
+
+    /* Cast needed to compile with C++ */
+    return (char *)strstr(haystack, needle);
 }
 
 /*****************************************************************************/

--- a/common/string_calls.h
+++ b/common/string_calls.h
@@ -175,8 +175,9 @@ g_bitmask_to_str(int bitmask, const struct bitmask_string[],
                  char delim, char *buff, int bufflen);
 
 int      g_strlen(const char *text);
-const char *g_strchr(const char *text, int c);
-const char *g_strnchr(const char *text, int c, int len);
+char    *g_strchr(const char *text, int c);
+char    *g_strrchr(const char *text, int c);
+char    *g_strnchr(const char *text, int c, int len);
 char    *g_strcpy(char *dest, const char *src);
 char    *g_strncpy(char *dest, const char *src, int len);
 char    *g_strcat(char *dest, const char *src);
@@ -202,6 +203,7 @@ int      g_htoi(char *str);
 int      g_bytes_to_hexstr(const void *bytes, int num_bytes, char *out_str,
                            int bytes_out_str);
 int      g_pos(const char *str, const char *to_find);
+char    *g_strstr(const char *haystack, const char *needle);
 int      g_mbstowcs(twchar *dest, const char *src, int n);
 int      g_wcstombs(char *dest, const twchar *src, int n);
 int      g_strtrim(char *str, int trim_flags);

--- a/sesman/chansrv/chansrv_fuse.h
+++ b/sesman/chansrv/chansrv_fuse.h
@@ -114,4 +114,13 @@ void xfuse_devredir_cb_rename_file(struct state_rename *fip,
 
 void xfuse_devredir_cb_file_close(struct state_close *fip);
 
+/*
+ * Returns true if a filesystem path lies in the FUSE filesystem
+ *
+ * Use to prevent deadlocks. For example, if chansrv tries to open
+ * a file in the FUSE filesystem it will fail, as it will call back
+ * into itself to handle the I/O
+ */
+int xfuse_path_in_xfuse_fs(const char *path);
+
 #endif


### PR DESCRIPTION
Fixes #2031 

Before chansrv adds a UN*X file system path to the Windows clipboard, it checks that the file is not already remote (i.e. on a Windows filesystem).

There is no point in adding these files to the Windows clipboard as they are already on the remote system. Note that the files are in any case still added to the UN*X clipboard, so cut-paste functionality within the remote session works as expected.

Without this fix, selecting file in the remote filesystem and hitting CTRL-C hangs chansrv hard.

With the fix, it is possible to use the Unix desktop copy-paste functionality to copy files from the remote filesystem.