### PR TITLE
Make username and password case insensitive in more places

### DIFF
--- a/xrdp/xrdp_login_wnd.c
+++ b/xrdp/xrdp_login_wnd.c
@@ -438,7 +438,7 @@ xrdp_wm_show_edits(struct xrdp_wm *self, struct xrdp_bitmap *combo)
 
                 /* Use the domain name as the destination IP/DNS
                    This is useful in a gateway setup. */
-                if (g_strncmp(name, "ip", 255) == 0)
+                if (g_strncasecmp(name, "ip", 255) == 0)
                 {
                     /* If the first char in the domain name is '_' we use the
                        domain name as IP */
@@ -453,7 +453,7 @@ xrdp_wm_show_edits(struct xrdp_wm *self, struct xrdp_bitmap *combo)
 
                 }
 
-                if (g_strncmp(name, "username", 255) == 0 &&
+                if (g_strncasecmp(name, "username", 255) == 0 &&
                         self->session->client_info->username[0])
                 {
                     g_strncpy(b->caption1, self->session->client_info->username, 255);
@@ -465,7 +465,8 @@ xrdp_wm_show_edits(struct xrdp_wm *self, struct xrdp_bitmap *combo)
                     }
                 }
 
-                if ((g_strncmp(name, "password", 255) == 0) || (g_strncmp(name, "pampassword", 255) == 0))
+                if ((g_strncasecmp(name, "password", 255) == 0) ||
+                        (g_strncasecmp(name, "pampassword", 255) == 0))
                 {
                     b->password_char = '*';
 

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -704,7 +704,7 @@ xrdp_wm_init(struct xrdp_wm *self)
                     q = (char *)list_get_item(names, index);
                     r = (char *)list_get_item(values, index);
 
-                    if (g_strncmp("password", q, 255) == 0)
+                    if (g_strncasecmp("password", q, 255) == 0)
                     {
                         /* if the password has been asked for by the module, use what the
                            client says.
@@ -715,7 +715,7 @@ xrdp_wm_init(struct xrdp_wm *self)
                             r = self->session->client_info->password;
                         }
                     }
-                    else if (g_strncmp("username", q, 255) == 0)
+                    else if (g_strncasecmp("username", q, 255) == 0)
                     {
                         /* if the username has been asked for by the module, use what the
                            client says.
@@ -726,7 +726,7 @@ xrdp_wm_init(struct xrdp_wm *self)
                             r = self->session->client_info->username;
                         }
                     }
-                    else if (g_strncmp("ip", q, 255) == 0)
+                    else if (g_strncasecmp("ip", q, 255) == 0)
                     {
                         /* if the ip has been asked for by the module, use what the
                          client says (target ip should be in 'domain' field, when starting with "_")
@@ -742,7 +742,7 @@ xrdp_wm_init(struct xrdp_wm *self)
 
                         }
                     }
-                    else if (g_strncmp("port", q, 255) == 0)
+                    else if (g_strncasecmp("port", q, 255) == 0)
                     {
                         if (g_strncmp("ask3389", r, 7) == 0)
                         {


### PR DESCRIPTION
Partial solution to #2059 

With this, users can edit the xrdp.ini file to make Password and Username compatible with the Session string.

Without this patch, the password field is not masked, and the username won't be auto-filled in from the client.