### PR TITLE
Set stream size correctly for TS_SURFCMD_STREAM_SURF_BITS header

### DIFF
--- a/libxrdp/libxrdp.c
+++ b/libxrdp/libxrdp.c
@@ -1673,6 +1673,7 @@ libxrdp_fastpath_send_surface(struct xrdp_session *session,
     s->sec_hdr = s->data;
     s->rdp_hdr = s->sec_hdr + sec_bytes;
     s->end = data_pad + pad_bytes + data_bytes;
+    s->size = s->end - s->data;
     s->p = s->data + (rdp_bytes + sec_bytes);
     /* TS_SURFCMD_STREAM_SURF_BITS */
     out_uint16_le(s, CMDTYPE_STREAM_SURFACE_BITS);


### PR DESCRIPTION
Without this PR, the fastpath code aborts when xrdp is build with `--enable-devel-streamcheck` :-

```
[20211130-11:13:04] [CORE ] [parser_stream_overflow_check(parse.c:49)] libxrdp.c:1678 Stream output buffer overflow. Size=0, pos=7, requested=2
```