### PR TITLE
Fix buffer size check

### DIFF
--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -816,6 +816,9 @@ xrdp_rdp_send_fastpath(struct xrdp_rdp *self, struct stream *s,
         updateHeader = (updateCode & 15) |
                        ((fragmentation & 3) << 4) |
                        ((compression & 3) << 6);
+
+        send_s.end = send_s.p + send_len;
+        send_s.size = send_s.end - send_s.data;
         out_uint8(&send_s, updateHeader);
         if (compression != 0)
         {
@@ -824,7 +827,6 @@ xrdp_rdp_send_fastpath(struct xrdp_rdp *self, struct stream *s,
         }
         send_len -= header_bytes;
         out_uint16_le(&send_s, send_len);
-        send_s.end = send_s.p + send_len;
         LOG_DEVEL(LOG_LEVEL_TRACE, "Adding header [MS-RDPBCGR] TS_FP_UPDATE "
                   "updateCode %d, fragmentation %d, compression %d, compressionFlags %s, size %d",
                   updateCode, fragmentation, compression,


### PR DESCRIPTION
Another uninitialised stream buffer fix, similar to #2066 

Found when investigating #2068 

The `send_s.size` variable needs to be set to a sane value before `out_uint8(&send_s, updateHeader);` is called.

This one is quite tricky to follow, as the line `send_s.end = send_s.p + send_len;` is moved to a place where both `send_s.p` and `send_len` have different values. Since in the new place `send_s.p` is `header_byes` less and `send_len` is `header_bytes` more, the net effect is the same.