### PR TITLE
Fix wrong debug level log message for g_file_atom2

### DIFF
--- a/sesman/chansrv/clipboard.c
+++ b/sesman/chansrv/clipboard.c
@@ -2061,7 +2061,7 @@ clipboard_event_selection_notify(XEvent *xevent)
             }
             else if (lxevent->target == g_file_atom2)
             {
-                LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_event_selection_notify: text/uri-list "
+                LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_event_selection_notify: x-special/gnome-copied-files "
                           "data_size %d", data_size);
                 if ((g_clip_s2c.incr_in_progress == 0) && (data_size > 0))
                 {


### PR DESCRIPTION
As g_file_atom2 is x-special/gnome-copied-files
(See g_file_atom2 definition in sesman/chansrv/clipboard.c),
it should be "x-special/gnome-copied-files" in this context.

https://github.com/neutrinolabs/xrdp/blob/b557de48885337357a709e630a83902bc251e663/sesman/chansrv/clipboard.c#L2062-L2066