### PR TITLE
xrdp: don’t spit on the console when starting

### DIFF
--- a/xrdp/xrdp.c
+++ b/xrdp/xrdp.c
@@ -635,7 +635,6 @@ main(int argc, char **argv)
 
         if (0 != pid)
         {
-            g_writeln("daemon process %d started ok", pid);
             /* exit, this is the main process */
             log_end();
             g_deinit();


### PR DESCRIPTION
Picked from Debian's local patch [1].

We have worked on reducing Debian's local patches in #1762 #1765.
This is the last one left and helps to  remove shutup-daemon.diff
completely. I don't think this log to stdout is necessary.

[1] https://salsa.debian.org/debian-remote-team/xrdp/-/blob/debian/0.9.17-2/debian/patches/shutup-daemon.diff