### PR TITLE
Use LOG instead of LOG_DEVEL

### DIFF
--- a/sesman/chansrv/clipboard.c
+++ b/sesman/chansrv/clipboard.c
@@ -2533,7 +2533,7 @@ clipboard_xevent(void *xevent)
             }
             else
             {
-                LOG_DEVEL(LOG_LEVEL_DEBUG, "outbound clipboard is restricted because of config");
+                LOG(LOG_LEVEL_INFO, "outbound clipboard is restricted because of config");
                 return 1;
             }
             break;


### PR DESCRIPTION
According to https://github.com/neutrinolabs/xrdp/wiki/Logging,
it may be better to emit this log message because this log is
useful for system administrator to know whether RestrictOutboundClipboard
configuration works or not