### PR TITLE
Support imlib2 on RHEL 7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -224,7 +224,7 @@ case "$with_imlib2" in
         use_imlib2=no
         ;;
     yes)
-        PKG_CHECK_MODULES([IMLIB2], [imlib2 >= 1.4.10],
+        PKG_CHECK_MODULES([IMLIB2], [imlib2 >= 1.4.5],
             [use_imlib2=yes],
             [AC_MSG_ERROR([please install libimlib2-dev or imlib2-devel])])
         ;;


### PR DESCRIPTION
Slightly late here, but after [this comment](/neutrinolabs/xrdp/commit/8b9b22c773495b4d1f3ae98198a31ec905a8cd69#commitcomment-63453607) from @bensilea, I realised I hadn't considered the still active RHEL 7 for imlib2 support.

This PR fixes that. As an example, with these changes to `/etc/xrdp/xrdp.ini` on a stock CentOS 7 install:-

```
ls_background_image=/usr/share/backgrounds/default.jpg
ls_background_transform=zoom

ls_logo_filename=/usr/share/pixmaps/fedora-logo-sprite.png
ls_logo_transform=scale
ls_logo_width=140
ls_logo_height=140
```

I can get this login screen:-
![Capture](https://user-images.githubusercontent.com/30179339/149134501-36b8dffc-589c-4d1b-a1db-996984f2a2d3.PNG)

As I remarked to @bensilea, you'll need to compile with `CFLAGS="-Wno-error=missing-braces"` on RHEL 7 which is something I picked up from @bsmojver

Bojan - sorry this is late. Any good to you?