### PR TITLE
Fix problems with check 0.15.2 (F36)

### DIFF
--- a/tests/common/test_os_calls.c
+++ b/tests/common/test_os_calls.c
@@ -4,8 +4,9 @@
 #endif
 
 #include <stdlib.h>
-#include "test_common.h"
 #include "os_calls.h"
+
+#include "test_common.h"
 
 #ifndef TOP_SRCDIR
 #define TOP_SRCDIR "."

--- a/tests/common/test_string_calls.c
+++ b/tests/common/test_string_calls.c
@@ -3,8 +3,9 @@
 #include "config_ac.h"
 #endif
 
-#include "test_common.h"
 #include "string_calls.h"
+
+#include "test_common.h"
 
 #define RESULT_LEN 1024
 

--- a/tests/libxrdp/test_monitor_processing.c
+++ b/tests/libxrdp/test_monitor_processing.c
@@ -2,9 +2,10 @@
 #include "config_ac.h"
 #endif
 
-#include "test_libxrdp.h"
 #include "libxrdp.h"
 #include "os_calls.h"
+
+#include "test_libxrdp.h"
 
 struct xrdp_sec *sec_layer;
 struct xrdp_rdp *rdp_layer;

--- a/tests/xrdp/test_bitmap_load.c
+++ b/tests/xrdp/test_bitmap_load.c
@@ -2,8 +2,9 @@
 #include "config_ac.h"
 #endif
 
-#include "test_xrdp.h"
 #include "xrdp.h"
+
+#include "test_xrdp.h"
 
 /* Where the image files are located */
 #ifndef IMAGEDIR

--- a/tests/xrdp/test_xrdp_main.c
+++ b/tests/xrdp/test_xrdp_main.c
@@ -33,8 +33,9 @@
 
 #include "log.h"
 #include "os_calls.h"
-#include "test_xrdp.h"
 #include <stdlib.h>
+
+#include "test_xrdp.h"
 
 int main (void)
 {


### PR DESCRIPTION
While investigating #2121, I found that `make check` did not work on Fedora 36

The problem seems to be caused by `/usr/include/check_stdint.h` (included by `/usr/include/check.h`). This contains the following code:-

```
/* Imported CMake variables created during build. */
#define HAVE_STDINT_H 1

#ifdef HAVE_STDINT_H
#define _STDINT_HAVE_STDINT_H 1
#include <stdint.h>
#undef HAVE_STDINT_H
#endif /* defined HAVE_STDINT_H */
```

If `check.h` is included before `common/arch.h` this then leads to problems, as the latter file is expecting `HAVE_STDINT_H` to be defined.

This PR works around the problem by making sure `check.h` is defined after `arch.h`