### PR TITLE
Move to cppcheck 2.7 and bump default threads to 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
       CC: gcc
       # This is required to use a version of cppcheck other than that
       # supplied with the operating system
-      CPPCHECK_VER: 2.6
+      CPPCHECK_VER: 2.7
       CPPCHECK_REPO: https://github.com/danmar/cppcheck.git
     steps:
       # This is currently the only way to get a version into

--- a/scripts/run_cppcheck.sh
+++ b/scripts/run_cppcheck.sh
@@ -48,7 +48,7 @@ fi
 
 # Any options/directories specified?
 if [ $# -eq 0 ]; then
-    set -- .
+    set -- -j 2 .
 fi
 
 # Display the cppcheck version and command for debugging


### PR DESCRIPTION
New version of cppcheck

I've bumped the number of execution threads to 2, as this is the default number of cores for a Github runner. See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners