### PR TITLE
Fixed possible SIGCHILD signal lost

### DIFF
--- a/sesman/sig.c
+++ b/sesman/sig.c
@@ -122,12 +122,16 @@ sig_sesman_session_end(int sig)
         return;
     }
 
-    pid = g_waitchild();
-
-    if (pid > 0)
+    do
     {
-        session_kill(pid);
+        pid = g_waitchild();
+
+        if (pid > 0)
+        {
+            session_kill(pid);
+        }
     }
+    while (pid >= 0);
 }
 
 /******************************************************************************/

--- a/xrdp/xrdp.c
+++ b/xrdp/xrdp.c
@@ -163,9 +163,7 @@ xrdp_shutdown(int sig)
 static void
 xrdp_child(int sig)
 {
-    int safety;
-
-    for (safety = 0; (g_waitchild() >= 0) && (safety <= 10); safety++)
+    while (g_waitchild() >= 0)
     {
     }
 }


### PR DESCRIPTION
When multiple(eg. 20) xrdp connections are disconnected at the same time(eg.  close all rdp client at the same time), zombie process will be spawned. 
use xorgrdp session and set the parameter KillDisconnected to true.

I found similar code in file chansrv.c
```
void
child_signal_handler(int sig)
{
    int pid;

    LOG_DEVEL(LOG_LEVEL_INFO, "child_signal_handler:");
    do
    {
        pid = g_waitchild();
        LOG_DEVEL(LOG_LEVEL_INFO, "child_signal_handler: child pid %d", pid);
        if ((pid == g_exec_pid) && (pid > 0))
        {
            LOG_DEVEL(LOG_LEVEL_INFO, "child_signal_handler: found pid %d", pid);
            //shutdownx();
        }
    }
    while (pid >= 0);
}
```