### PR TITLE
Move DRDYNVC_STATUS_* to xrdp_channel.h

### DIFF
--- a/libxrdp/Makefile.am
+++ b/libxrdp/Makefile.am
@@ -45,6 +45,7 @@ libxrdp_la_SOURCES = \
   xrdp_bitmap_compress.c \
   xrdp_caps.c \
   xrdp_channel.c \
+  xrdp_channel.h \
   xrdp_fastpath.c \
   xrdp_iso.c \
   xrdp_jpeg_compress.c \

--- a/libxrdp/xrdp_channel.c
+++ b/libxrdp/xrdp_channel.c
@@ -24,25 +24,13 @@
 
 #include "libxrdp.h"
 #include "string_calls.h"
+#include "xrdp_channel.h"
 
 #define CMD_DVC_OPEN_CHANNEL    0x10
 #define CMD_DVC_DATA_FIRST      0x20
 #define CMD_DVC_DATA            0x30
 #define CMD_DVC_CLOSE_CHANNEL   0x40
 #define CMD_DVC_CAPABILITY      0x50
-
-#define XRDP_DRDYNVC_STATUS_CLOSED          0
-#define XRDP_DRDYNVC_STATUS_OPEN_SENT       1
-#define XRDP_DRDYNVC_STATUS_OPEN            2
-#define XRDP_DRDYNVC_STATUS_CLOSE_SENT      3
-
-#define XRDP_DRDYNVC_STATUS_TO_STR(status) \
-    ((status) == XRDP_DRDYNVC_STATUS_CLOSED ? "CLOSED" : \
-     (status) == XRDP_DRDYNVC_STATUS_OPEN_SENT ? "OPEN_SENT" : \
-     (status) == XRDP_DRDYNVC_STATUS_OPEN ? "OPEN" : \
-     (status) == XRDP_DRDYNVC_STATUS_CLOSE_SENT ? "CLOSE_SENT" : \
-     "unknown" \
-    )
 
 #define XRDP_DRDYNVC_CHANNEL_ID_TO_NAME(self, chan_id) \
     (xrdp_channel_get_item((self), (chan_id)) != NULL \

--- a/libxrdp/xrdp_channel.h
+++ b/libxrdp/xrdp_channel.h
@@ -1,0 +1,42 @@
+/**
+ * xrdp: A Remote Desktop Protocol server.
+ *
+ * MS-RDPEDYC : Definitions related to documentation in [MS-RDPEDYC]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * References to MS-RDPEDYC are currently correct for v20210406 of that
+ * document
+ */
+
+#if !defined(XRDP_CHANNEL_H)
+#define XRDP_CHANNEL_H
+
+/*
+   These are not directly defined in MS-RDPEDYC, but
+   they are derived statuses needed to implement it.
+*/
+#define XRDP_DRDYNVC_STATUS_CLOSED          0
+#define XRDP_DRDYNVC_STATUS_OPEN_SENT       1
+#define XRDP_DRDYNVC_STATUS_OPEN            2
+#define XRDP_DRDYNVC_STATUS_CLOSE_SENT      3
+
+#define XRDP_DRDYNVC_STATUS_TO_STR(status) \
+    ((status) == XRDP_DRDYNVC_STATUS_CLOSED ? "CLOSED" : \
+     (status) == XRDP_DRDYNVC_STATUS_OPEN_SENT ? "OPEN_SENT" : \
+     (status) == XRDP_DRDYNVC_STATUS_OPEN ? "OPEN" : \
+     (status) == XRDP_DRDYNVC_STATUS_CLOSE_SENT ? "CLOSE_SENT" : \
+     "unknown" \
+    )
+
+#endif /* XRDP_CHANNEL_H */


### PR DESCRIPTION
These statuses are necessary for egfx resizing, as visibility to channel status is a pre-req for closing and re-opening a channel.