### PR TITLE
Remove unnecessary log message (regression)

### DIFF
--- a/sesman/chansrv/chansrv_config.c
+++ b/sesman/chansrv/chansrv_config.c
@@ -341,7 +341,7 @@ config_dump(struct config_chansrv *config)
                          clip_restrict_map, ',', buf, sizeof(buf));
         g_writeln("    RestrictOutboundClipboard: %s", buf);
     }
-    g_writeln("    RestrictInboundClipboard:  %s", buf);
+
     if (config->restrict_inbound_clipboard == CLIP_RESTRICT_NONE)
     {
         g_writeln("    RestrictInboundClipboard:  %s", "none");


### PR DESCRIPTION
Remove extra chansrv logging line introduced by bd820845057f41f135ac4406ab87732db9c868e0

On my machine I'm getting logging like the following:-

```
Global configuration:
    UseUnixSocket (derived):   true

Security configuration:
    RestrictOutboundClipboard: none
    RestrictInboundClipboard:  �YUUU
    RestrictInboundClipboard:  none

Chansrv configuration:
    EnableFuseMount            true
    FuseMountName:             thinclient_drives/////
    FileMask:                  077
    Nautilus 3 Flist Format:   false
```