### PR TITLE
Fix sesman signal processing

### DIFF
--- a/common/log.h
+++ b/common/log.h
@@ -162,6 +162,22 @@ enum logReturns
 
 #endif
 
+/* Flags values for log_start() */
+
+/**
+ * Dump the log config on startup
+ */
+#define LOG_START_DUMP_CONFIG (1<<0)
+
+/**
+ * Restart the logging system.
+ *
+ * On a restart, existing files are not closed. This is because the
+ * files may be shared by sub-processes, and the result will not be what the
+ * user expects
+ */
+#define LOG_START_RESTART (1<<1)
+
 #ifdef LOG_PER_LOGGER_LEVEL
 enum log_logger_type
 {
@@ -179,8 +195,8 @@ struct log_logger_level
 
 struct log_config
 {
-    const char *program_name;
-    char *log_file;
+    const char *program_name; /* Pointer to static storage */
+    char *log_file; /* Dynamically allocated */
     int fd;
     enum logLevels log_level;
     int enable_console;
@@ -300,13 +316,12 @@ internal_log_location_overrides_level(const char *function_name,
  * @param iniFile
  * @param applicationName the name that is used in the log for the running
  *                        application
- * @param dump_on_start Whether to dump the config on stdout before
- *                      logging is started
+ * @param flags Flags to affect the operation of the call
  * @return LOG_STARTUP_OK on success
  */
 enum logReturns
 log_start(const char *iniFile, const char *applicationName,
-          bool_t dump_on_start);
+          unsigned int flags);
 
 /**
  * An alternative log_start where the caller gives the params directly.

--- a/common/log.h
+++ b/common/log.h
@@ -162,6 +162,7 @@ enum logReturns
 
 #endif
 
+#ifdef LOG_PER_LOGGER_LEVEL
 enum log_logger_type
 {
     LOG_TYPE_FILE = 0,
@@ -174,6 +175,7 @@ struct log_logger_level
     enum log_logger_type logger_type;
     char logger_name[LOGGER_NAME_SIZE + 1];
 };
+#endif
 
 struct log_config
 {
@@ -185,11 +187,15 @@ struct log_config
     enum logLevels console_level;
     int enable_syslog;
     enum logLevels syslog_level;
+#ifdef LOG_PER_LOGGER_LEVEL
     struct list *per_logger_level;
+#endif
     int dump_on_start;
     int enable_pid;
+#ifdef LOG_ENABLE_THREAD
     pthread_mutex_t log_lock;
     pthread_mutexattr_t log_lock_attr;
+#endif
 };
 
 /* internal functions, only used in log.c if this ifdef is defined.*/

--- a/sesman/access.c
+++ b/sesman/access.c
@@ -31,8 +31,6 @@
 #include "sesman.h"
 #include "string_calls.h"
 
-extern struct config_sesman *g_cfg; /* in sesman.c */
-
 /******************************************************************************/
 int
 access_login_allowed(const char *user)

--- a/sesman/env.c
+++ b/sesman/env.c
@@ -36,9 +36,6 @@
 #include "ssl_calls.h"
 #include "string_calls.h"
 
-extern unsigned char g_fixedkey[8]; /* in sesman.c */
-extern struct config_sesman *g_cfg;  /* in sesman.c */
-
 /******************************************************************************/
 int
 env_check_password_file(const char *filename, const char *passwd)

--- a/sesman/scp.c
+++ b/sesman/scp.c
@@ -33,8 +33,6 @@
 
 #include "sesman.h"
 
-extern struct config_sesman *g_cfg; /* in sesman.c */
-
 /******************************************************************************/
 enum SCP_SERVER_STATES_E
 scp_process(struct trans *t, struct SCP_SESSION *sdata)

--- a/sesman/scp_v0.c
+++ b/sesman/scp_v0.c
@@ -30,8 +30,6 @@
 
 #include "sesman.h"
 
-extern struct config_sesman *g_cfg; /* in sesman.c */
-
 /******************************************************************************/
 enum SCP_SERVER_STATES_E
 scp_v0_process(struct trans *t, struct SCP_SESSION *s)

--- a/sesman/scp_v1.c
+++ b/sesman/scp_v1.c
@@ -33,8 +33,6 @@
 //#include "libscp_types.h"
 #include "libscp.h"
 
-extern struct config_sesman *g_cfg; /* in sesman.c */
-
 static void
 parseCommonStates(enum SCP_SERVER_STATES_E e, const char *f);
 

--- a/sesman/scp_v1_mng.c
+++ b/sesman/scp_v1_mng.c
@@ -32,8 +32,6 @@
 
 #include "libscp.h"
 
-extern struct config_sesman *g_cfg; /* in sesman.c */
-
 static void parseCommonStates(enum SCP_SERVER_STATES_E e, const char *f);
 
 /******************************************************************************/

--- a/sesman/sesman.c
+++ b/sesman/sesman.c
@@ -627,8 +627,9 @@ main(int argc, char **argv)
     }
 
     /* starting logging subsystem */
-    log_error = log_start(startup_params.sesman_ini, "xrdp-sesman",
-                          startup_params.dump_config);
+    log_error = log_start(
+                    startup_params.sesman_ini, "xrdp-sesman",
+                    (startup_params.dump_config) ? LOG_START_DUMP_CONFIG : 0);
 
     if (log_error != LOG_STARTUP_OK)
     {

--- a/sesman/sesman.c
+++ b/sesman/sesman.c
@@ -52,11 +52,11 @@ struct sesman_startup_params
     int dump_config;
 };
 
-int g_pid;
+struct config_sesman *g_cfg;
 unsigned char g_fixedkey[8] = { 23, 82, 107, 6, 35, 78, 88, 7 };
-struct config_sesman *g_cfg; /* defined in config.h */
-
 tintptr g_term_event = 0;
+tintptr g_sigchld_event = 0;
+tintptr g_reload_event = 0;
 
 /**
  * Items stored on the g_con_list
@@ -67,8 +67,9 @@ struct sesman_con
     struct SCP_SESSION *s;
 };
 
-static struct trans *g_list_trans = NULL;
+static struct trans *g_list_trans;
 static struct list *g_con_list = NULL;
+static int g_pid;
 
 /*****************************************************************************/
 /**
@@ -263,7 +264,7 @@ sesman_close_all(void)
     struct sesman_con *sc;
 
     LOG_DEVEL(LOG_LEVEL_TRACE, "sesman_close_all:");
-    trans_delete(g_list_trans);
+    sesman_delete_listening_transport();
     for (index = 0; index < g_con_list->count; index++)
     {
         sc = (struct sesman_con *) list_get_item(g_con_list, index);
@@ -342,6 +343,86 @@ sesman_listen_conn_in(struct trans *self, struct trans *new_self)
 
 /******************************************************************************/
 /**
+ * Informs the main loop a termination signal has been received
+ */
+static void
+set_term_event(int sig)
+{
+    /* Don't try to use a wait obj in a child process */
+    if (g_getpid() == g_pid)
+    {
+        g_set_wait_obj(g_term_event);
+    }
+}
+
+/******************************************************************************/
+/**
+ * Informs the main loop a SIGCHLD has been received
+ */
+static void
+set_sigchld_event(int sig)
+{
+    /* Don't try to use a wait obj in a child process */
+    if (g_getpid() == g_pid)
+    {
+        g_set_wait_obj(g_sigchld_event);
+    }
+}
+
+/******************************************************************************/
+/**
+ * Informs the main loop a SIGHUP has been received
+ */
+static void
+set_reload_event(int sig)
+{
+    /* Don't try to use a wait obj in a child process */
+    if (g_getpid() == g_pid)
+    {
+        g_set_wait_obj(g_reload_event);
+    }
+}
+
+/******************************************************************************/
+void
+sesman_delete_listening_transport(void)
+{
+    trans_delete(g_list_trans);
+    g_list_trans = NULL;
+}
+
+/******************************************************************************/
+int
+sesman_create_listening_transport(const struct config_sesman *cfg)
+{
+    int rv = 1;
+    g_list_trans = trans_create(TRANS_MODE_TCP, 8192, 8192);
+    if (g_list_trans == NULL)
+    {
+        LOG(LOG_LEVEL_ERROR, "%s: trans_create failed", __func__);
+    }
+    else
+    {
+        LOG(LOG_LEVEL_DEBUG, "%s: address %s port %s",
+            __func__, cfg->listen_address, cfg->listen_port);
+        rv = trans_listen_address(g_list_trans, cfg->listen_port,
+                                  cfg->listen_address);
+        if (rv != 0)
+        {
+            LOG(LOG_LEVEL_ERROR, "%s: trans_listen_address failed", __func__);
+            sesman_delete_listening_transport();
+        }
+        else
+        {
+            g_list_trans->trans_conn_in = sesman_listen_conn_in;
+        }
+    }
+
+    return rv;
+}
+
+/******************************************************************************/
+/**
  *
  * @brief Starts sesman main loop
  *
@@ -352,7 +433,6 @@ sesman_main_loop(void)
     int error;
     int robjs_count;
     int wobjs_count;
-    int cont;
     int timeout;
     int index;
     intptr_t robjs[32];
@@ -365,33 +445,22 @@ sesman_main_loop(void)
         LOG(LOG_LEVEL_ERROR, "sesman_main_loop: list_create failed");
         return 1;
     }
-    g_list_trans = trans_create(TRANS_MODE_TCP, 8192, 8192);
-    if (g_list_trans == NULL)
+    if (sesman_create_listening_transport(g_cfg) != 0)
     {
-        LOG(LOG_LEVEL_ERROR, "sesman_main_loop: trans_create failed");
+        LOG(LOG_LEVEL_ERROR,
+            "sesman_main_loop: sesman_create_listening_transport failed");
         list_delete(g_con_list);
         return 1;
     }
 
-    LOG(LOG_LEVEL_DEBUG, "sesman_main_loop: address %s port %s",
-        g_cfg->listen_address, g_cfg->listen_port);
-    error = trans_listen_address(g_list_trans, g_cfg->listen_port,
-                                 g_cfg->listen_address);
-    if (error != 0)
-    {
-        LOG(LOG_LEVEL_ERROR, "sesman_main_loop: trans_listen_address "
-            "failed");
-        trans_delete(g_list_trans);
-        list_delete(g_con_list);
-        return 1;
-    }
-    g_list_trans->trans_conn_in = sesman_listen_conn_in;
-    cont = 1;
-    while (cont)
+    error = 0;
+    while (!error)
     {
         timeout = -1;
         robjs_count = 0;
         robjs[robjs_count++] = g_term_event;
+        robjs[robjs_count++] = g_sigchld_event;
+        robjs[robjs_count++] = g_reload_event;
         wobjs_count = 0;
         for (index = 0; index < g_con_list->count; index++)
         {
@@ -413,25 +482,45 @@ sesman_main_loop(void)
         {
             break;
         }
-        error = trans_get_wait_objs_rw(g_list_trans, robjs, &robjs_count,
-                                       wobjs, &wobjs_count, &timeout);
-        if (error != 0)
+        if (g_list_trans != NULL)
         {
-            LOG(LOG_LEVEL_ERROR, "sesman_main_loop: "
-                "trans_get_wait_objs_rw failed");
-            break;
+            /* g_list_trans might be NULL on a reconfigure if sesman
+             * is unable to listen again */
+            error = trans_get_wait_objs_rw(g_list_trans, robjs, &robjs_count,
+                                           wobjs, &wobjs_count, &timeout);
+            if (error != 0)
+            {
+                LOG(LOG_LEVEL_ERROR, "sesman_main_loop: "
+                    "trans_get_wait_objs_rw failed");
+                break;
+            }
         }
 
-        error = g_obj_wait(robjs, robjs_count, wobjs, wobjs_count, timeout);
-        if (error != 0)
+        if (g_obj_wait(robjs, robjs_count, wobjs, wobjs_count, timeout) != 0)
         {
-            /* error, should not get here */
+            /* should not get here */
+            LOG(LOG_LEVEL_WARNING, "sesman_main_loop: "
+                "Unexpected error from g_obj_wait()");
             g_sleep(100);
         }
 
         if (g_is_wait_obj_set(g_term_event)) /* term */
         {
+            LOG(LOG_LEVEL_INFO, "sesman_main_loop: "
+                "sesman asked to terminate");
             break;
+        }
+
+        if (g_is_wait_obj_set(g_sigchld_event)) /* A child has exited */
+        {
+            g_reset_wait_obj(g_sigchld_event);
+            sig_sesman_session_end();
+        }
+
+        if (g_is_wait_obj_set(g_reload_event)) /* We're asked to reload */
+        {
+            g_reset_wait_obj(g_reload_event);
+            sig_sesman_reload_cfg();
         }
 
         for (index = 0; index < g_con_list->count; index++)
@@ -439,8 +528,7 @@ sesman_main_loop(void)
             scon = (struct sesman_con *)list_get_item(g_con_list, index);
             if (scon != NULL)
             {
-                error = trans_check_wait_objs(scon->t);
-                if (error != 0)
+                if (trans_check_wait_objs(scon->t) != 0)
                 {
                     LOG(LOG_LEVEL_ERROR, "sesman_main_loop: "
                         "trans_check_wait_objs failed, removing trans");
@@ -451,12 +539,16 @@ sesman_main_loop(void)
                 }
             }
         }
-        error = trans_check_wait_objs(g_list_trans);
-        if (error != 0)
+
+        if (g_list_trans != NULL)
         {
-            LOG(LOG_LEVEL_ERROR, "sesman_main_loop: "
-                "trans_check_wait_objs failed");
-            break;
+            error = trans_check_wait_objs(g_list_trans);
+            if (error != 0)
+            {
+                LOG(LOG_LEVEL_ERROR, "sesman_main_loop: "
+                    "trans_check_wait_objs failed");
+                break;
+            }
         }
     }
     for (index = 0; index < g_con_list->count; index++)
@@ -465,7 +557,7 @@ sesman_main_loop(void)
         delete_connection(scon);
     }
     list_delete(g_con_list);
-    trans_delete(g_list_trans);
+    sesman_delete_listening_transport();
     return 0;
 }
 
@@ -710,20 +802,17 @@ main(int argc, char **argv)
 
     /* signal handling */
     g_pid = g_getpid();
-    /* old style signal handling is now managed synchronously by a
-     * separate thread. uncomment this block if you need old style
-     * signal handling and comment out thread_sighandler_start()
-     * going back to old style for the time being
-     * problem with the sigaddset functions in sig.c - jts */
-#if 1
-    g_signal_hang_up(sig_sesman_reload_cfg); /* SIGHUP  */
-    g_signal_user_interrupt(sig_sesman_shutdown); /* SIGINT  */
-    g_signal_terminate(sig_sesman_shutdown); /* SIGTERM */
-    g_signal_child_stop(sig_sesman_session_end); /* SIGCHLD */
-#endif
-#if 0
-    thread_sighandler_start();
-#endif
+    g_snprintf(text, 255, "xrdp_sesman_%8.8x_main_term", g_pid);
+    g_term_event = g_create_wait_obj(text);
+    g_snprintf(text, 255, "xrdp_sesman_%8.8x_sigchld", g_pid);
+    g_sigchld_event = g_create_wait_obj(text);
+    g_snprintf(text, 255, "xrdp_sesman_%8.8x_reload", g_pid);
+    g_reload_event = g_create_wait_obj(text);
+
+    g_signal_hang_up(set_reload_event); /* SIGHUP  */
+    g_signal_user_interrupt(set_term_event); /* SIGINT  */
+    g_signal_terminate(set_term_event); /* SIGTERM */
+    g_signal_child_stop(set_sigchld_event); /* SIGCHLD */
 
     if (daemon)
     {
@@ -765,9 +854,6 @@ main(int argc, char **argv)
         g_chmod_hex("/tmp/.X11-unix", 0x1777);
     }
 
-    g_snprintf(text, 255, "xrdp_sesman_%8.8x_main_term", g_pid);
-    g_term_event = g_create_wait_obj(text);
-
     error = sesman_main_loop();
 
     /* clean up PID file on exit */
@@ -776,6 +862,8 @@ main(int argc, char **argv)
         g_file_delete(pid_file);
     }
 
+    g_delete_wait_obj(g_reload_event);
+    g_delete_wait_obj(g_sigchld_event);
     g_delete_wait_obj(g_term_event);
 
     if (!daemon)

--- a/sesman/sesman.h
+++ b/sesman/sesman.h
@@ -41,6 +41,13 @@
 
 #include "libscp.h"
 
+/* Globals */
+extern struct config_sesman *g_cfg;
+extern unsigned char g_fixedkey[8];
+extern tintptr g_term_event;
+extern int g_pid;
+
+
 /*
  * Close all file descriptors used by sesman.
  *

--- a/sesman/sesman.h
+++ b/sesman/sesman.h
@@ -45,8 +45,8 @@
 extern struct config_sesman *g_cfg;
 extern unsigned char g_fixedkey[8];
 extern tintptr g_term_event;
-extern int g_pid;
-
+extern tintptr g_sigchld_event;
+extern tintptr g_reload_event;
 
 /*
  * Close all file descriptors used by sesman.
@@ -59,5 +59,21 @@ extern int g_pid;
  */
 int
 sesman_close_all(void);
+
+/*
+ * Remove the listening transport
+ *
+ * Needed if reloading the config and the listener has changed
+ */
+void
+sesman_delete_listening_transport(void);
+
+/*
+ * Create the listening socket transport
+ *
+ * @return 0 for success
+ */
+int
+sesman_create_listening_transport(const struct config_sesman *cfg);
 
 #endif

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -47,10 +47,8 @@
 #define PR_SET_NO_NEW_PRIVS 38
 #endif
 
-struct session_chain *g_sessions;
-int g_session_count;
-
-extern tbus g_term_event; /* in sesman.c */
+static struct session_chain *g_sessions;
+static int g_session_count;
 
 /**
  * Creates a string consisting of all parameters that is hosted in the param list
@@ -522,8 +520,13 @@ session_start_fork(tbus data, tui8 type, struct SCP_SESSION *s)
                 "Failed to clone the session data - out of memory");
             g_exit(1);
         }
-        auth_start_session(data, display);
+
+        /* Wait objects created in a parent are not valid in a child */
+        g_delete_wait_obj(g_reload_event);
+        g_delete_wait_obj(g_sigchld_event);
         g_delete_wait_obj(g_term_event);
+
+        auth_start_session(data, display);
         sesman_close_all();
         g_sprintf(geometry, "%dx%d", s->width, s->height);
         g_sprintf(depth, "%d", s->bpp);

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -47,8 +47,6 @@
 #define PR_SET_NO_NEW_PRIVS 38
 #endif
 
-extern unsigned char g_fixedkey[8];
-extern struct config_sesman *g_cfg; /* in sesman.c */
 struct session_chain *g_sessions;
 int g_session_count;
 

--- a/sesman/sig.c
+++ b/sesman/sig.c
@@ -32,10 +32,6 @@
 
 #include "sesman.h"
 
-extern int g_pid;
-extern struct config_sesman *g_cfg; /* in sesman.c */
-extern tbus g_term_event;
-
 /******************************************************************************/
 void
 sig_sesman_shutdown(int sig)

--- a/sesman/sig.h
+++ b/sesman/sig.h
@@ -29,37 +29,18 @@
 
 /**
  *
- * @brief Shutdown signal code
- * @param sig The received signal
- *
- */
-void
-sig_sesman_shutdown(int sig);
-
-/**
- *
  * @brief SIGHUP handling code
- * @param sig The received signal
  *
  */
 void
-sig_sesman_reload_cfg(int sig);
+sig_sesman_reload_cfg(void);
 
 /**
  *
  * @brief SIGCHLD handling code
- * @param sig The received signal
  *
  */
 void
-sig_sesman_session_end(int sig);
-
-/**
- *
- * @brief signal handling thread
- *
- */
-void *
-sig_handler_thread(void *arg);
+sig_sesman_session_end(void);
 
 #endif

--- a/sesman/verify_user.c
+++ b/sesman/verify_user.c
@@ -42,8 +42,6 @@
 #define SECS_PER_DAY (24L*3600L)
 #endif
 
-extern struct config_sesman *g_cfg; /* in sesman.c */
-
 static int
 auth_crypt_pwd(const char *pwd, const char *pln, char *crp);
 

--- a/sesman/verify_user_bsd.c
+++ b/sesman/verify_user_bsd.c
@@ -43,8 +43,6 @@
 #define SECS_PER_DAY (24L*3600L)
 #endif
 
-extern struct config_sesman *g_cfg; /* in sesman.c */
-
 /******************************************************************************/
 /* returns boolean */
 long

--- a/xrdp/xrdp.c
+++ b/xrdp/xrdp.c
@@ -538,7 +538,7 @@ main(int argc, char **argv)
 
     /* starting logging subsystem */
     error = log_start(startup_params.xrdp_ini, "xrdp",
-                      startup_params.dump_config);
+                      (startup_params.dump_config) ? LOG_START_DUMP_CONFIG : 0);
 
     if (error != LOG_STARTUP_OK)
     {


### PR DESCRIPTION
**edit 2022-03-04:** No longer draft.

This series of commits fixes #1729 and may also address reports of other session ending problems (e.g. #2021).

The "self-pipe trick" [Stevens 1992] is used to keep the processing performed in all signal handlers to a minimum. This is really simple to do in xrdp by using `g_set_wait_obj()` and related calls.

As a result, SIGPIPE and SIGHUP are now processed from the sesman main loop, like all other events.

Other problems with SIGHUP processing have been addressed:-

1) The log file was closed and re-opened. Since the log file is shared with the child processes, this will cause the parent and the children to have a different file table entries. Writes at the end of the file will not be synchronised.
2) The existing code does not allow for the listening port to be changed, which is a major reason why the user may have edited the config in the first place.

This series of 4 commits addresses these issues as follows:-
1) [tidy-up] Some of the global variables defined in sesman.c are declared in other c files as `extern`. This commit moves these declarations into `sesman.h`
2) [tidy-up] `struct log_config` contains a few members which are not always needed. For example, the `per_logger_level` member is only used for debug builds. This commit makes these members (and associated code) conditional.
3) The 3rd parameter of the `log_start()` call is change from a boolean `dump_on_start` to a more generic `flags` field. One of the new flags is `LOG_START_DUMP_CONFIG`, which provides the existing `dump_on_start` functionality. The other one, `LOG_START_RESTART` allows for logging to be restarted smoothly. Existing log files are left untouched by a restart, even if the name changes.
4) Finally, sesman is updated as follows:-
   - Signal handlers now just call `g_set_wait_obj()`. No significant processing is done in the signal handlers.
   - In the main loop, the wait objects are handled in the same way as file descriptors. All actions resulting from signals are synchronised with actions resulting from file activity.
   - The restart code now calls `log_start()` with `LOG_START_RESTART`, and allows the user to change the listening port dynamically.