### PR TITLE
Refactoring resizing into state machine.

### DIFF
--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -147,8 +147,12 @@ xrdp_wm_get_wait_objs(struct xrdp_wm *self, tbus *robjs, int *rc,
                       tbus *wobjs, int *wc, int *timeout);
 int
 xrdp_wm_check_wait_objs(struct xrdp_wm *self);
+const char *
+xrdp_wm_login_state_to_str(enum wm_login_state login_state);
 int
 xrdp_wm_set_login_state(struct xrdp_wm *self, enum wm_login_state login_state);
+int
+xrdp_wm_can_resize(struct xrdp_wm *self);
 void
 xrdp_wm_mod_connect_done(struct xrdp_wm *self, int status);
 
@@ -397,18 +401,12 @@ xrdp_bitmap_compress(char *in_data, int width, int height,
 
 /* xrdp_mm.c */
 
-struct dynamic_monitor_layout
+struct display_control_monitor_layout_data
 {
-    int flags;
-    int left;
-    int top;
-    int width;
-    int height;
-    int physical_width;
-    int physical_height;
-    int orientation;
-    int desktop_scale_factor;
-    int device_scale_factor;
+    struct display_size_description description;
+    enum display_resize_state state;
+    int last_state_update_timestamp;
+    int start_time;
 };
 
 int

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -311,6 +311,30 @@ enum mm_connect_state
     MMCS_DONE
 };
 
+enum display_resize_state
+{
+    WMRZ_ENCODER_DELETE = 0,
+    WMRZ_SERVER_MONITOR_RESIZE,
+    WMRZ_SERVER_VERSION_MESSAGE,
+    WMRZ_XRDP_CORE_RESIZE,
+    WMRZ_ENCODER_CREATE,
+    WMRZ_SERVER_INVALIDATE,
+    WMRZ_COMPLETE,
+    WMRZ_ERROR
+};
+
+#define XRDP_DISPLAY_RESIZE_STATE_TO_STR(status) \
+    ((status) == WMRZ_ENCODER_DELETE ? "WMRZ_ENCODER_DELETE" : \
+     (status) == WMRZ_SERVER_MONITOR_RESIZE ? "WMRZ_SERVER_MONITOR_RESIZE" : \
+     (status) == WMRZ_SERVER_VERSION_MESSAGE ? "WMRZ_SERVER_VERSION_MESSAGE" : \
+     (status) == WMRZ_XRDP_CORE_RESIZE ? "WMRZ_XRDP_CORE_RESIZE" : \
+     (status) == WMRZ_ENCODER_CREATE ? "WMRZ_ENCODER_CREATE" : \
+     (status) == WMRZ_SERVER_INVALIDATE ? "WMRZ_SERVER_INVALIDATE" : \
+     (status) == WMRZ_COMPLETE ? "WMRZ_COMPLETE" : \
+     (status) == WMRZ_ERROR ? "WMRZ_ERROR" : \
+     "unknown" \
+    )
+
 struct xrdp_mm
 {
     struct xrdp_wm *wm; /* owner */
@@ -344,6 +368,11 @@ struct xrdp_mm
     int cs2xr_cid_map[256];
     int xr2cr_cid_map[256];
     int dynamic_monitor_chanid;
+
+    /* Resize on-the-fly control */
+    struct display_control_monitor_layout_data *resize_data;
+    struct list *resize_queue;
+    tbus resize_ready;
 };
 
 struct xrdp_key_info

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -2230,9 +2230,8 @@ xrdp_wm_check_wait_objs(struct xrdp_wm *self)
 }
 
 /*****************************************************************************/
-
-static const char *
-wm_login_state_to_str(enum wm_login_state login_state)
+const char *
+xrdp_wm_login_state_to_str(enum wm_login_state login_state)
 {
     const char *result = "unknown";
     /* Use a switch for this, as some compilers will warn about missing states
@@ -2266,10 +2265,24 @@ int
 xrdp_wm_set_login_state(struct xrdp_wm *self, enum wm_login_state login_state)
 {
     LOG(LOG_LEVEL_DEBUG, "Login state change request %s -> %s",
-        wm_login_state_to_str(self->login_state),
-        wm_login_state_to_str(login_state));
+        xrdp_wm_login_state_to_str(self->login_state),
+        xrdp_wm_login_state_to_str(login_state));
 
     self->login_state = login_state;
     g_set_wait_obj(self->login_state_event);
     return 0;
+}
+
+int
+xrdp_wm_can_resize(struct xrdp_wm *self)
+{
+    if (self->login_state != WMLS_CLEANUP
+            && self->login_state != WMLS_INACTIVE)
+    {
+        LOG(LOG_LEVEL_INFO, "Not allowing resize. Login in progress.");
+        LOG_DEVEL(LOG_LEVEL_INFO,
+                  "State is %s", xrdp_wm_login_state_to_str(self->login_state));
+        return 0;
+    }
+    return 1;
 }

--- a/xup/xup.c
+++ b/xup/xup.c
@@ -28,10 +28,12 @@
 #include "string_calls.h"
 
 static int
-send_server_monitor_resize(struct mod *mod, struct stream *s, int width, int height, int bpp);
+send_server_monitor_resize(
+    struct mod *mod, struct stream *s, int width, int height, int bpp);
 
 static int
-send_server_monitor_full_invalidate(struct mod *mod, struct stream *s, int width, int height);
+send_server_monitor_full_invalidate(
+    struct mod *mod, struct stream *s, int width, int height);
 
 static int
 send_server_version_message(struct mod *v, struct stream *s);
@@ -154,10 +156,15 @@ lib_mod_connect(struct mod *mod)
     mod->server_msg(mod, "started connecting", 0);
 
     /* only support 8, 15, 16, 24, and 32 bpp connections from rdp client */
-    if (mod->bpp != 8 && mod->bpp != 15 && mod->bpp != 16 && mod->bpp != 24 && mod->bpp != 32)
+    if (mod->bpp != 8
+            && mod->bpp != 15
+            && mod->bpp != 16
+            && mod->bpp != 24
+            && mod->bpp != 32)
     {
         mod->server_msg(mod,
-                        "error - only supporting 8, 15, 16, 24, and 32 bpp rdp connections", 0);
+                        "error - only supporting 8, 15, 16, 24, and 32"
+                        " bpp rdp connections", 0);
         return 1;
     }
 
@@ -220,12 +227,14 @@ lib_mod_connect(struct mod *mod)
     if (error == 0)
     {
         /* send screen size message */
-        error = send_server_monitor_resize(mod, s, mod->width, mod->height, mod->bpp);
+        error = send_server_monitor_resize(
+                    mod, s, mod->width, mod->height, mod->bpp);
     }
 
     if (error == 0)
     {
-        error = send_server_monitor_full_invalidate(mod, s, mod->width, mod->height);
+        error = send_server_monitor_full_invalidate(
+                    mod, s, mod->width, mod->height);
     }
 
     free_stream(s);
@@ -1261,7 +1270,8 @@ send_server_version_message(struct mod *mod, struct stream *s)
 /******************************************************************************/
 /* return error */
 static int
-send_server_monitor_resize(struct mod *mod, struct stream *s, int width, int height, int bpp)
+send_server_monitor_resize(
+    struct mod *mod, struct stream *s, int width, int height, int bpp)
 {
     /* send screen size message */
     init_stream(s, 8192);
@@ -1271,8 +1281,9 @@ send_server_monitor_resize(struct mod *mod, struct stream *s, int width, int hei
     out_uint32_le(s, width);
     out_uint32_le(s, height);
     /*
-        TODO: The bpp here is only necessary for initial creation. We should modify XUP to require this
-        only on server initialization, but not on resize. Microsoft's RDP protocol does not support changing
+        TODO: The bpp here is only necessary for initial creation. We should
+        modify XUP to require this only on server initialization, but not on
+        resize. Microsoft's RDP protocol does not support changing
         the bpp on resize.
     */
     out_uint32_le(s, bpp);
@@ -1282,14 +1293,16 @@ send_server_monitor_resize(struct mod *mod, struct stream *s, int width, int hei
     s_pop_layer(s, iso_hdr);
     out_uint32_le(s, len);
     int rv = lib_send_copy(mod, s);
-    LOG_DEVEL(LOG_LEVEL_DEBUG, "send_server_monitor_resize: sent resize message with following properties to xorgxrdp backend "
-              "width=%d, height=%d, bpp=%d, return value=%d",
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "send_server_monitor_resize:"
+              " sent resize message with following properties to"
+              " xorgxrdp backend width=%d, height=%d, bpp=%d, return value=%d",
               width, height, bpp, rv);
     return rv;
 }
 
 static int
-send_server_monitor_full_invalidate(struct mod *mod, struct stream *s, int width, int height)
+send_server_monitor_full_invalidate(
+    struct mod *mod, struct stream *s, int width, int height)
 {
     /* send invalidate message */
     init_stream(s, 8192);
@@ -1309,8 +1322,10 @@ send_server_monitor_full_invalidate(struct mod *mod, struct stream *s, int width
     s_pop_layer(s, iso_hdr);
     out_uint32_le(s, len);
     int rv = lib_send_copy(mod, s);
-    LOG_DEVEL(LOG_LEVEL_DEBUG, "send_server_monitor_full_invalidate: sent invalidate message with following properties to xorgxrdp backend "
-              "width=%d, height=%d, return value=%d",
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "send_server_monitor_full_invalidate:"
+              " sent invalidate message with following"
+              " properties to xorgxrdp backend"
+              " width=%d, height=%d, return value=%d",
               width, height, rv);
     return rv;
 }
@@ -1456,7 +1471,8 @@ lib_mod_process_orders(struct mod *mod, int type, struct stream *s)
             rv = process_server_paint_rect_shmem_ex(mod, s);
             break;
         default:
-            LOG_DEVEL(LOG_LEVEL_WARNING, "lib_mod_process_orders: unknown order type %d", type);
+            LOG_DEVEL(LOG_LEVEL_WARNING,
+                      "lib_mod_process_orders: unknown order type %d", type);
             rv = 0;
             break;
     }
@@ -1523,7 +1539,8 @@ lib_mod_process_message(struct mod *mod, struct stream *s)
         }
         else if (type == 2) /* caps */
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "lib_mod_process_message: type 2 len %d", len);
+            LOG_DEVEL(LOG_LEVEL_TRACE,
+                      "lib_mod_process_message: type 2 len %d", len);
             for (index = 0; index < num_orders; index++)
             {
                 phold = s->p;
@@ -1533,7 +1550,9 @@ lib_mod_process_message(struct mod *mod, struct stream *s)
                 switch (type)
                 {
                     default:
-                        LOG_DEVEL(LOG_LEVEL_TRACE, "lib_mod_process_message: unknown cap type %d len %d",
+                        LOG_DEVEL(LOG_LEVEL_TRACE,
+                                  "lib_mod_process_message: unknown"
+                                  " cap type %d len %d",
                                   type, len);
                         break;
                 }
@@ -1661,7 +1680,8 @@ lib_mod_check_wait_objs(struct mod *mod)
 int
 lib_mod_frame_ack(struct mod *amod, int flags, int frame_id)
 {
-    LOG_DEVEL(LOG_LEVEL_TRACE, "lib_mod_frame_ack: flags 0x%8.8x frame_id %d", flags, frame_id);
+    LOG_DEVEL(LOG_LEVEL_TRACE,
+              "lib_mod_frame_ack: flags 0x%8.8x frame_id %d", flags, frame_id);
     send_paint_rect_ex_ack(amod, flags, frame_id);
     return 0;
 }
@@ -1672,7 +1692,8 @@ int
 lib_mod_suppress_output(struct mod *amod, int suppress,
                         int left, int top, int right, int bottom)
 {
-    LOG_DEVEL(LOG_LEVEL_TRACE, "lib_mod_suppress_output: suppress 0x%8.8x left %d top %d "
+    LOG_DEVEL(LOG_LEVEL_TRACE,
+              "lib_mod_suppress_output: suppress 0x%8.8x left %d top %d "
               "right %d bottom %d", suppress, left, top, right, bottom);
     send_suppress_output(amod, suppress, left, top, right, bottom);
     return 0;
@@ -1699,7 +1720,8 @@ mod_init(void)
     mod->mod_frame_ack = lib_mod_frame_ack;
     mod->mod_suppress_output = lib_mod_suppress_output;
     mod->mod_server_monitor_resize = lib_send_server_monitor_resize;
-    mod->mod_server_monitor_full_invalidate = lib_send_server_monitor_full_invalidate;
+    mod->mod_server_monitor_full_invalidate
+        = lib_send_server_monitor_full_invalidate;
     mod->mod_server_version_message = lib_send_server_version_message;
     return (tintptr) mod;
 }


### PR DESCRIPTION
Switch to a state machine that is processed at its fastest once per XRDP main loop cycle. This allows for for more flexibility in how resizing is managed, and also allows for preparation for resizing to work with the EGFX changes that require this.

This also is a stability enhancement in that by queueing up the resize changes, they are processed one at a time, and if multiple resizes were to come in at once, or duplicates were to come in, this handles them elegantly. With the older version, XRDP was more likely to crash or cause a client disconnect, especially if there was a duplicate resize that came in as it sometimes does from MSTSC.

Fixes: https://github.com/neutrinolabs/xrdp/issues/1928

