### PR TITLE
Explicitly link libxrdpapi with libcommon

### DIFF
--- a/xrdpapi/Makefile.am
+++ b/xrdpapi/Makefile.am
@@ -13,3 +13,6 @@ module_LTLIBRARIES = \
 libxrdpapi_la_SOURCES = \
   xrdpapi.c \
   xrdpapi.h
+
+libxrdpapi_la_LIBADD = \
+  $(top_builddir)/common/libcommon.la


### PR DESCRIPTION
Fixes #2167 

The rarely used libxrdpapi uses `g_get_display_num_from_display()` and `log_message()` from libcommon, and so should be explicitly linked against this library. PLD Linux picks this up in its extended consistency checks following the build.