### PR TITLE
Open log in sesman before reading config

### DIFF
--- a/sesman/sesman.c
+++ b/sesman/sesman.c
@@ -674,21 +674,13 @@ main(int argc, char **argv)
         g_exit(1);
     }
 
-    /* reading config */
-    if ((g_cfg = config_read(startup_params.sesman_ini)) == NULL)
+    /* starting logging subsystem */
+    if (!g_file_exist(startup_params.sesman_ini))
     {
-        g_printf("error reading config %s: %s\nquitting.\n",
-                 startup_params.sesman_ini, g_get_strerror());
+        g_printf("Config file %s does not exist\n", startup_params.sesman_ini);
         g_deinit();
         g_exit(1);
     }
-
-    if (startup_params.dump_config)
-    {
-        config_dump(g_cfg);
-    }
-
-    /* starting logging subsystem */
     log_error = log_start(
                     startup_params.sesman_ini, "xrdp-sesman",
                     (startup_params.dump_config) ? LOG_START_DUMP_CONFIG : 0);
@@ -705,13 +697,27 @@ main(int argc, char **argv)
                           getLogFile(text, 255));
                 break;
             default:
-                g_writeln("error");
+                // Assume sufficient messages have already been generated
                 break;
         }
 
-        config_free(g_cfg);
         g_deinit();
         g_exit(1);
+    }
+
+    /* reading config */
+    if ((g_cfg = config_read(startup_params.sesman_ini)) == NULL)
+    {
+        LOG(LOG_LEVEL_ALWAYS, "error reading config %s: %s",
+            startup_params.sesman_ini, g_get_strerror());
+        log_end();
+        g_deinit();
+        g_exit(1);
+    }
+
+    if (startup_params.dump_config)
+    {
+        config_dump(g_cfg);
     }
 
     LOG(LOG_LEVEL_TRACE, "config loaded in %s at %s:%d", __func__, __FILE__, __LINE__);


### PR DESCRIPTION
Fixes a problem introduced with bd820845057f41f135ac4406ab87732db9c868e0 as part of #2082.

Before this commit, the sesman config parser made no calls to the logging facility. Now it does.

sesman reads the config before starting the logging. As a consequence, if `sesman.ini` contains a line like this:-

```
RestrictOutboundClipboard=zzz
```

sesman outputs the following on stdout when it starts:-

```
The log reference is NULL - log not initialized properly when called from [config_read_security(config.c:263)]
```

also, the log message is lost.

It seems to me that there is no reason not to start the logging before reading the config. They both use the same file, but parse different sections. Also, logging warnings about unexpected parameters should definitely be supported.

After implementing this PR, the sesman log file contains the warning messages generated by a faulty config:-

```
[20220328-19:02:25] [WARN ] [config_read_security(config.c:263)] Unrecognised tokens parsing 'RestrictOutboundClipboard' zzz
```

@metalefty - although this is applicable to the devel branch, we may want to back-port it to V0.9.x as well, for a possible bug-fix release.