### PR TITLE
Move to Unix Domain Socket for SCP (sesman)

### DIFF
--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -128,6 +128,7 @@ int      g_file_write(int fd, const char *ptr, int len);
 int      g_file_seek(int fd, int offset);
 int      g_file_lock(int fd, int start, int len);
 int      g_chmod_hex(const char *filename, int flags);
+int      g_umask_hex(int flags);
 int      g_chown(const char *name, int uid, int gid);
 int      g_mkdir(const char *dirname);
 char    *g_get_current_dir(char *dirname, int maxlen);

--- a/common/xrdp_sockets.h
+++ b/common/xrdp_sockets.h
@@ -28,6 +28,7 @@
 #define CHANSRV_API_BASE_STR       "xrdpapi_%d"
 #define XRDP_X11RDP_BASE_STR       "xrdp_display_%d"
 #define XRDP_DISCONNECT_BASE_STR   "xrdp_disconnect_display_%d"
+#define SCP_LISTEN_PORT_BASE_STR   "sesman.socket"
 
 /* fullpath of sockets */
 #define XRDP_CHANSRV_STR      XRDP_SOCKET_PATH "/" XRDP_CHANSRV_BASE_STR

--- a/configure.ac
+++ b/configure.ac
@@ -52,9 +52,15 @@ AC_CHECK_SIZEOF([void *])
 
 AC_ARG_WITH([socketdir],
   [AS_HELP_STRING([--with-socketdir=DIR],
-                  [Use directory for UNIX sockets (default: /tmp/.xrdp)])],
-                  [], [with_socketdir="/tmp/.xrdp"])
+                  [Use directory for UNIX sockets for XRDP sessions (default: RUNSTATEDIR/xrdp)])],
+                  [], [with_socketdir="$runstatedir/xrdp"])
 AC_SUBST([socketdir], [$with_socketdir])
+
+AC_ARG_WITH([sesmanruntimedir],
+  [AS_HELP_STRING([--with-sesmanruntimedir=DIR],
+                  [Use directory for sesman runtime data (default: RUNSTATEDIR/xrdp-sesman))])],
+                  [], [with_sesmanruntimedir="$runstatedir/xrdp-sesman"])
+AC_SUBST([sesmanruntimedir], [$with_sesmanruntimedir])
 
 AC_ARG_WITH([systemdsystemunitdir],
         AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files, no to disable]),
@@ -547,6 +553,10 @@ echo "  exec_prefix             $exec_prefix"
 echo "  libdir                  $libdir"
 echo "  bindir                  $bindir"
 echo "  sysconfdir              $sysconfdir"
+echo "  localstatedir           $localstatedir"
+echo "  runstatedir             $runstatedir"
+echo "  socketdir               $socketdir"
+echo "  sesmanruntimedir        $sesmanruntimedir"
 echo ""
 echo "  unit tests performable  $perform_unit_tests"
 echo ""

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -19,6 +19,7 @@ SUBST_VARS = sed \
    -e 's|@localstatedir[@]|$(localstatedir)|g' \
    -e 's|@sysconfdir[@]|$(sysconfdir)|g' \
    -e 's|@socketdir[@]|$(socketdir)|g' \
+   -e 's|@sesmanruntimedir[@]|$(sesmanruntimedir)|g' \
    -e 's|@xrdpconfdir[@]|$(sysconfdir)/xrdp|g' \
    -e 's|@xrdphomeurl[@]|http://www.xrdp.org/|g'
 

--- a/docs/man/sesman.ini.5.in
+++ b/docs/man/sesman.ini.5.in
@@ -50,13 +50,19 @@ outside their proper section will be \fIignored\fR.
 Following parameters can be used in the \fB[Globals]\fR section.
 
 .TP
-\fBListenAddress\fR=\fIip address\fR
-xrdp-sesman listening address. If not specified, defaults to \fI0.0.0.0\fR
-(all interfaces).
-
-.TP
-\fBListenPort\fR=\fIport number\fR
-xrdp-sesman listening port. If not specified, defaults to \fI3350\fR.
+\fBListenPort\fR=\fIpath-to-socket\fR
+UNIX domain socket for xrdp-sesman(8) to listen on.
+.PP
+.RS
+The default value of this setting is 'sesman.socket'.
+.PP
+An absoute path can be specified by starting this parameter with a '/'.
+In this instance, the system administrator is responsible for ensuring
+the socket can only be created by a suitably privileged process.
+.PP
+If the parameter does not start with a '/', a name within
+@sesmanruntimedir@ is used.
+.RE
 
 .TP
 \fBEnableUserWindowManager\fR=\fI[true|false]\fR

--- a/docs/man/xrdp-sesadmin.8.in
+++ b/docs/man/xrdp-sesadmin.8.in
@@ -27,14 +27,10 @@ The \fIpassword\fP to authenticate with.
 The default is to ask for the password interactively.
 
 .TP
-.BI \-s= server
-The host address of the \fIserver\fP to connect to.
-Defaults to \fBlocalhost\fP.
-
-.TP
 .BI \-i= port
-The TCP \fIport\fP number to connect to.
-Defaults to \fB3350\fP.
+The sesman \fIUNIX domain socket\fP to connect to.
+Defaults to \fBsesman.socket\fP.
+If no path is specified for the socket, a default of @sesmanruntimedir@ is used.
 
 .TP
 .BI \-c= command

--- a/docs/man/xrdp-sesman.8.in
+++ b/docs/man/xrdp-sesman.8.in
@@ -58,6 +58,8 @@ to read it.
 @localstatedir@/log/xrdp\-sesman.log
 .br
 @localstatedir@/run/xrdp\-sesman.pid
+.br
+@sesmanruntimedir@/sesman.socket
 
 .SH "AUTHORS"
 Jay Sorg <jsorg71@users.sourceforge.net>

--- a/docs/man/xrdp-sesrun.8.in
+++ b/docs/man/xrdp-sesrun.8.in
@@ -29,11 +29,6 @@ option may not do what you expect.
 Set session bits-per-pixel (colour depth). Some session types (i.e. Xorg)
 will ignore this setting.
 .TP
-.B -s <server>
-Server on which sesman is running (probably 'localhost').
-.br
-Use of this option is discouraged as it will be removed in the future.
-.TP
 .B -t <session-type>
 Session type - one of Xorg, Xvnc or X11rdp. Alternatively, for testing
 only, use the numeric session code.

--- a/libipm/Makefile.am
+++ b/libipm/Makefile.am
@@ -1,5 +1,6 @@
 
 AM_CPPFLAGS = \
+  -DSESMAN_RUNTIME_PATH=\"${sesmanruntimedir}\" \
   -I$(top_srcdir)/common
 
 module_LTLIBRARIES = \

--- a/libipm/scp.h
+++ b/libipm/scp.h
@@ -66,10 +66,37 @@ scp_msgno_to_str(enum scp_msg_code n, char *buff, unsigned int buff_size);
 /* Connection management facilities */
 
 /**
+ * Maps a port definition to a UNIX domain socket path
+ * @param port Port definition (e.g. from sesman.ini). Can be "" or NULL
+ * @param buff Buffer for result
+ * @param bufflen Length of buff
+ *
+ * @return Number of chars needed for result, excluding the '\0'
+ */
+int
+scp_port_to_unix_domain_path(const char *port, char *buff,
+                             unsigned int bufflen);
+
+/**
+ * Maps a port definition to a displayable string
+ * @param port Port definition (e.g. from sesman.ini). Can be "" or NULL
+ * @param buff Buffer for result
+ * @param bufflen Length of buff
+ *
+ * @return Number of chars needed for result, excluding the '\0'
+ *
+ * This differs from scp_port_to_unix_domain_path() in that the result is
+ * for displaying to the user (i.e. in a status message), rather than for
+ * connecting to. For log messages, use the result of
+ * scp_port_to_unix_domain_path()
+ */
+int
+scp_port_to_display_string(const char *port, char *buff, unsigned int bufflen);
+
+/**
  * Connect to an SCP server
  *
- * @param host Host providing SCP service
- * @param port TCP port for SCP service
+ * @param port Port definition (e.g. from sesman.ini)
  * @param term_func Function to poll during connection for program
  *         termination, or NULL for none.
  * @return Initialised SCP transport
@@ -77,7 +104,7 @@ scp_msgno_to_str(enum scp_msg_code n, char *buff, unsigned int buff_size);
  * The returned tranport has the is_term member set to term_func.
  */
 struct trans *
-scp_connect(const char *host, const  char *port,
+scp_connect(const  char *port,
             int (*term_func)(void));
 
 /**

--- a/sesman/Makefile.am
+++ b/sesman/Makefile.am
@@ -8,6 +8,7 @@ AM_CPPFLAGS = \
   -DXRDP_SHARE_PATH=\"${datadir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \
   -DXRDP_SOCKET_PATH=\"${socketdir}\" \
+  -DSESMAN_RUNTIME_PATH=\"${sesmanruntimedir}\" \
   -I$(top_srcdir)/common \
   -I$(top_srcdir)/libipm
 

--- a/sesman/Makefile.am
+++ b/sesman/Makefile.am
@@ -45,6 +45,8 @@ xrdp_sesman_SOURCES = \
   config.h \
   env.c \
   env.h \
+  lock_uds.c \
+  lock_uds.h \
   scp_process.c \
   scp_process.h \
   sesman.c \

--- a/sesman/config.h
+++ b/sesman/config.h
@@ -202,15 +202,10 @@ struct config_sesman
     char *sesman_ini;
 
     /**
-     * @var listen_address
-     * @brief Listening address
-     */
-    char listen_address[32];
-    /**
      * @var listen_port
      * @brief Listening port
      */
-    char listen_port[16];
+    char listen_port[256];
     /**
      * @var enable_user_wm
      * @brief Flag that enables user specific wm

--- a/sesman/lock_uds.c
+++ b/sesman/lock_uds.c
@@ -1,0 +1,146 @@
+/**
+ * xrdp: A Remote Desktop Protocol server.
+ *
+ * Copyright (C) 2022 Matt Burt, all xrdp contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *
+ * @file lock_uds.c
+ * @brief Providing a locking facility for Unix Domain Sockets
+ * @author Matt Burt
+ *
+ * It is difficult for a server to determine whether a socket it wishes
+ * to listen on is already active or not. The purpose of this module is to
+ * provide a locking facility which can be used as a proxy for this.
+ */
+
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
+#include "arch.h"
+#include "os_calls.h"
+#include "string_calls.h"
+#include "log.h"
+#include "lock_uds.h"
+
+struct lock_uds
+{
+    char *filename; ///<< Name of the lock file
+    int fd; ///<< File decriptor for open file
+    int pid; ///<< PID of process originally taking out lock
+};
+
+/******************************************************************************/
+struct lock_uds *
+lock_uds(const char *sockname)
+{
+    struct lock_uds *lock = NULL;
+    char *filename = NULL;
+    int fd = -1;
+
+    if (sockname == NULL || sockname[0] != '/')
+    {
+        LOG_DEVEL(LOG_LEVEL_ERROR, "Invalid sockname '%s'",
+                  (sockname == NULL) ? "<null>" : sockname);
+    }
+    else
+    {
+        /* Allocate space for lock filename and result */
+        filename = (char *)g_malloc(g_strlen(sockname) + 1 + 5 + 1, 0);
+        lock = g_new0(struct lock_uds, 1);
+        if (lock == NULL || filename == NULL)
+        {
+            LOG(LOG_LEVEL_ERROR, "%s : Out of memory", __func__);
+        }
+        else
+        {
+            int saved_umask;
+            /* Construct the filename */
+            /* This call is guaranteed to succeed as we know that sockname
+             * contains at least one '/' */
+            char *p = filename;
+            const char *basename = g_strrchr(sockname, '/') + 1;
+            g_memcpy(p, sockname, basename - sockname);
+            p += basename - sockname;
+            *p++ = '.';
+            g_strcpy(p, basename);
+            p += g_strlen(p);
+            *p++ = '.';
+            *p++ = 'l';
+            *p++ = 'o';
+            *p++ = 'c';
+            *p++ = 'k';
+            *p++ = '\0';
+
+            saved_umask = g_umask_hex(0x77);
+            fd = g_file_open(filename);
+            g_umask_hex(saved_umask);
+            if (fd < 0)
+            {
+                LOG(LOG_LEVEL_ERROR, "Unable to create '%s' [%s]",
+                    filename, g_get_strerror());
+            }
+            else if (g_file_lock(fd, 0, 0) == 0)
+            {
+                LOG(LOG_LEVEL_ERROR, "Unable to get lock for '%s' - "
+                    "program already running?", sockname);
+                g_file_close(fd);
+                fd = -1;
+            }
+        }
+    }
+
+    if (fd >= 0)
+    {
+        /* Success - finish off */
+        lock->filename = filename;
+        lock->fd = fd;
+        lock->pid = g_getpid();
+    }
+    else
+    {
+        g_free(filename);
+        g_free(lock);
+        lock = NULL;
+    }
+
+    return lock;
+}
+
+/******************************************************************************/
+void
+unlock_uds(struct lock_uds *lock)
+{
+    if (lock != NULL)
+    {
+        if (lock->fd >= 0)
+        {
+            g_file_close(lock->fd);
+            lock->fd = -1; // In case of use-after-free
+        }
+
+        /* Only delete the lock file if we are the process which
+         * created it */
+        if (g_getpid() == lock->pid)
+        {
+            g_file_delete(lock->filename);
+        }
+        g_free(lock->filename);
+        lock->filename = NULL;
+        g_free(lock);
+    }
+}

--- a/sesman/lock_uds.h
+++ b/sesman/lock_uds.h
@@ -1,0 +1,59 @@
+/**
+ * xrdp: A Remote Desktop Protocol server.
+ *
+ * Copyright (C) 2022 Matt Burt, all xrdp contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *
+ * @file lock_uds.h
+ * @brief Providing a locking facility for Unix Domain Sockets
+ * @author Matt Burt
+ *
+ * It is difficult for a server to determine whether a socket it wishes
+ * to listen on is already active or not. The purpose of this module is to
+ * provide a locking facility which can be used as a proxy for this.
+ */
+
+#ifndef LOCK_UDS_H
+#define LOCK_UDS_H
+
+struct lock_uds;
+
+/**
+ * Take out a lock for the specified Unix Domain socket
+ * @param sockname Name of socket. Must start with a '/'
+ * @return A struct lock_uds instance if the lock was successfully acquired.
+ *
+ * A NULL return may indicate a lack of memory, or that another
+ * process has the lock.
+ *
+ * A file is created in the same directory as the socket. The name
+ * of the file is ".${basename}.lock", where basename is the base name
+ * of the socket. THE file is removed when the lock is relinquished. */
+struct lock_uds *
+lock_uds(const char *sockname);
+
+/**
+ * Relinquish a lock on the specified Unix Domain Socket.
+ * @param lock to relinquish
+ *
+ * If the process which has originally taken out the lock forks, this
+ * routine should be called from the child process to prevent the lock
+ * inadvertently being passed to the child. */
+void
+unlock_uds(struct lock_uds *lock);
+
+#endif // LOCK_UDS_H

--- a/sesman/sesman.ini.in
+++ b/sesman/sesman.ini.in
@@ -1,8 +1,8 @@
 ;; See `man 5 sesman.ini` for details
 
 [Globals]
-ListenAddress=127.0.0.1
-ListenPort=3350
+; listening port
+#ListenPort=sesman.socket
 EnableUserWindowManager=true
 ; Give in relative path to user's home directory
 UserWindowManager=startwm.sh

--- a/sesman/sig.c
+++ b/sesman/sig.c
@@ -47,16 +47,19 @@ sig_sesman_reload_cfg(void)
     }
 
     /* Deal with significant config changes */
-    if (g_strcmp(g_cfg->listen_address, cfg->listen_address) != 0 ||
-            g_strcmp(g_cfg->listen_port, cfg->listen_port) != 0)
+    if (g_strcmp(g_cfg->listen_port, cfg->listen_port) != 0)
     {
-        LOG(LOG_LEVEL_INFO, "sesman listen address changed to %s:%s",
-            cfg->listen_address, cfg->listen_port);
+        LOG(LOG_LEVEL_INFO, "sesman listen port changed to %s",
+            cfg->listen_port);
 
         /* We have to delete the old port before listening to the new one
          * in case they overlap in scope */
         sesman_delete_listening_transport();
-        sesman_create_listening_transport(cfg);
+        if (sesman_create_listening_transport(cfg) == 0)
+        {
+            LOG(LOG_LEVEL_INFO, "Sesman now listening on %s",
+                g_cfg->listen_port);
+        }
     }
 
     /* free old config data */

--- a/sesman/tools/sesadmin.c
+++ b/sesman/tools/sesadmin.c
@@ -34,7 +34,6 @@
 char user[257];
 char pass[257];
 char cmnd[257];
-char serv[257];
 char port[257];
 
 static int cmndList(struct trans *t);
@@ -55,7 +54,6 @@ int main(int argc, char **argv)
     user[0] = '\0';
     pass[0] = '\0';
     cmnd[0] = '\0';
-    serv[0] = '\0';
     port[0] = '\0';
 
     logging = log_config_init_for_console(LOG_LEVEL_INFO, NULL);
@@ -72,10 +70,6 @@ int main(int argc, char **argv)
         {
             g_strncpy(pass, (argv[idx]) + 3, 256);
         }
-        else if (0 == g_strncmp(argv[idx], "-s=", 3))
-        {
-            g_strncpy(serv, (argv[idx]) + 3, 256);
-        }
         else if (0 == g_strncmp(argv[idx], "-i=", 3))
         {
             g_strncpy(port, (argv[idx]) + 3, 256);
@@ -84,11 +78,6 @@ int main(int argc, char **argv)
         {
             g_strncpy(cmnd, (argv[idx]) + 3, 256);
         }
-    }
-
-    if (0 == g_strncmp(serv, "", 1))
-    {
-        g_strncpy(serv, "localhost", 256);
     }
 
     if (0 == g_strncmp(port, "", 1))
@@ -115,7 +104,7 @@ int main(int argc, char **argv)
 
     }
 
-    t = scp_connect(serv, port, NULL);
+    t = scp_connect(port, NULL);
 
 
     if (t == NULL)

--- a/sesman/tools/sesrun.c
+++ b/sesman/tools/sesrun.c
@@ -63,10 +63,6 @@
 #   define DEFAULT_BPP 32
 #endif
 
-#ifndef DEFAULT_SERVER
-#   define DEFAULT_SERVER "localhost"
-#endif
-
 #ifndef DEFAULT_TYPE
 #   define DEFAULT_TYPE "Xorg"
 #endif
@@ -95,7 +91,6 @@ struct session_params
     int height;
     int bpp;
     enum scp_session_type session_type;
-    const char *server;
 
     const char *directory;
     const char *shell;
@@ -175,9 +170,6 @@ usage(void)
     g_printf("    -g <geometry>         Default:%dx%d\n",
              DEFAULT_WIDTH, DEFAULT_HEIGHT);
     g_printf("    -b <bits-per-pixel>   Default:%d\n", DEFAULT_BPP);
-    /* Don't encourage use of this one - we need to move to local sockets */
-    g_printf("    -s <server>           Default:%s (Deprecated)\n",
-             DEFAULT_SERVER);
     g_printf("    -t <type>             Default:%s\n", DEFAULT_TYPE);
     g_printf("    -D <directory>        Default: $HOME\n"
              "    -S <shell>            Default: Defined window manager\n"
@@ -291,7 +283,6 @@ parse_program_args(int argc, char *argv[], struct session_params *sp,
     sp->height = DEFAULT_HEIGHT;
     sp->bpp = DEFAULT_BPP;
     (void)string_to_session_type(DEFAULT_TYPE, &sp->session_type);
-    sp->server = DEFAULT_SERVER;
 
     sp->directory = "";
     sp->shell = "";
@@ -313,11 +304,6 @@ parse_program_args(int argc, char *argv[], struct session_params *sp,
 
             case 'b':
                 sp->bpp = atoi(optarg);
-                break;
-
-            case 's':
-                LOG(LOG_LEVEL_WARNING, "Using deprecated option '-s'");
-                sp->server = optarg;
                 break;
 
             case 't':
@@ -419,10 +405,10 @@ send_create_session_request(struct trans *t, const struct session_params *sp)
 {
     LOG(LOG_LEVEL_DEBUG,
         "width:%d  height:%d  bpp:%d  code:%d\n"
-        "server:\"%s\"   directory:\"%s\"\n"
+        "directory:\"%s\"\n"
         "shell:\"%s\"    connection_description:\"%s\"",
         sp->width, sp->height, sp->bpp, sp->session_type,
-        sp->server, sp->directory,
+        sp->directory,
         sp->shell, sp->connection_description);
     /* Only log the password in development builds */
     LOG_DEVEL(LOG_LEVEL_DEBUG, "password:\"%s\"", sp->password);
@@ -498,7 +484,7 @@ main(int argc, char **argv)
         LOG(LOG_LEVEL_ERROR, "error reading config file %s : %s",
             sesman_ini, g_get_strerror());
     }
-    else if (!(t = scp_connect(sp.server, cfg->listen_port, NULL)))
+    else if (!(t = scp_connect(cfg->listen_port, NULL)))
     {
         LOG(LOG_LEVEL_ERROR, "connect error - %s", g_get_strerror());
     }

--- a/xrdp/xrdp.ini.in
+++ b/xrdp/xrdp.ini.in
@@ -223,7 +223,6 @@ name=Xorg
 lib=libxup.@lib_extension@
 username=ask
 password=ask
-ip=127.0.0.1
 port=-1
 code=20
 
@@ -232,7 +231,6 @@ name=Xvnc
 lib=libvnc.@lib_extension@
 username=ask
 password=ask
-ip=127.0.0.1
 port=-1
 #xserverbpp=24
 #delay_ms=2000
@@ -256,7 +254,6 @@ username=na
 password=ask
 #pamusername=asksame
 #pampassword=asksame
-#pamsessionmng=127.0.0.1
 #delay_ms=2000
 
 ; Generic RDP proxy using NeutrinoRDP
@@ -275,7 +272,6 @@ password=ask
 ; connections.
 #pamusername=ask
 #pampassword=ask
-#pamsessionmng=127.0.0.1
 ; Currently NeutrinoRDP doesn't support dynamic resizing. Uncomment
 ; this line if you're using a client which does.
 #enable_dynamic_resizing=false

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -322,7 +322,6 @@ struct xrdp_mm
     int use_pam_auth; /* True if we're to authenticate using PAM */
     int use_chansrv; /* true if chansrvport is set in xrdp.ini or using sesman */
     struct trans *sesman_trans; /* connection to sesman */
-    struct trans *pam_auth_trans; /* connection to pam authenticator */
     struct trans *chan_trans; /* connection to chansrv */
 
     /* We can't delete transports while we're in a callback for that
@@ -330,7 +329,6 @@ struct xrdp_mm
      * These flags mark transports as needing to be deleted when
      * we are definitely not in a transport callback */
     int delete_sesman_trans;
-    int delete_pam_auth_trans;
 
     struct list *login_names;
     struct list *login_values;


### PR DESCRIPTION
Depends on #2204 

Fixes : #1596 #1805 #1855

This draft PR implements sesman listening on a UNIX domain socket rather than TCP port 3350

It's currently in draft, as more testing is required. I thought however it was worth having visibility of this while I work on it.

Noteworthy features:-
1) The existing sockets directory is unsuitable for the sesman socket, as the file permissions mean anyone could create `sesman.socket` which is essentially what  CVE-2020-4044 was all about. So I've added another configuration value `--with-sesmanruntimedir` which defaults to `/var/run/xrdp-sesman`
2) I've changed the default value of the socketdir location to `/var/run/xrdp` rather than `/tmp/.xrdp` which better fits in with existing filesystem guidelines and also means polyinstantiation of /tmp works out-of-the-box (see #1482)
3) The server parameter has been removed from xrdp-sesrun and xrdp-sesadmin
4) Compatibility with the existing sesman and xrdp configs is maintained for upgrades, but the older settings are warned about and ignored if found.
5) I've needed to create a lock file for the UNIX domain socket, as the listen test which can be used for TCP sockets to enforce a single listener doesn't work with UNIX domain sockets.

No additional features of UNIX domain sockets are yet implemented. That is for later.

I'm not expecting anyone to review the code yet, but comments/questions on the above would be welcome.
