### PR TITLE
Fixes a stream overflow in the test suite

### DIFF
--- a/tests/libxrdp/test_libxrdp_main.c
+++ b/tests/libxrdp/test_libxrdp_main.c
@@ -4,6 +4,7 @@
 
 #include <stdlib.h>
 #include <check.h>
+#include "log.h"
 #include "test_libxrdp.h"
 
 int main (void)
@@ -15,8 +16,16 @@ int main (void)
     srunner_add_suite(sr, make_suite_test_monitor_processing());
 
     srunner_set_tap(sr, "-");
+
+    /*
+     * Set up console logging */
+    struct log_config *lc = log_config_init_for_console(LOG_LEVEL_INFO, NULL);
+    log_start_from_param(lc);
+    log_config_free(lc);
+
     srunner_run_all (sr, CK_ENV);
     number_failed = srunner_ntests_failed(sr);
     srunner_free(sr);
+    log_end();
     return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/tests/libxrdp/test_libxrdp_process_monitor_stream.c
+++ b/tests/libxrdp/test_libxrdp_process_monitor_stream.c
@@ -146,7 +146,7 @@ START_TEST(test_libxrdp_process_monitor_stream__with_sextuple_monitor_happy_path
 {
     struct stream *s = (struct stream *)NULL;
     make_stream(s);
-    init_stream(s, 233);
+    init_stream(s, 8192);
 
     out_uint32_le(s, 6); //monitorCount
 


### PR DESCRIPTION
An overflow has been found in `test_libxrdp_process_monitor_stream__with_sextuple_monitor_happy_path()`

This is triggered when xrdp is built with `--enable-devel-logging`

Also, the logging sub-system is initialised for libxrdp tests. With this change, the test program generates this line when `--enable-devel-logging` is used:-

```
[20220406-12:03:44] [CORE ] [parser_stream_overflow_check(parse.c:49)] test_libxrdp_process_monitor_stream.c:221 Stream output buffer overflow. Size=233, pos=232, requested=4
```