### PR TITLE
Bump FreeBSD CI version to 12.3

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@ FreeBSD_task:
       SSL: libressl
   matrix:
     freebsd_instance:
-      image_family: freebsd-12-2
+      image_family: freebsd-12-3
   prepare_script:
     - pkg install -y $SSL git autoconf automake libtool pkgconf opus jpeg-turbo fdk-aac pixman libX11 libXfixes libXrandr nasm fusefs-libs check imlib2
     - git submodule update --init --recursive


### PR DESCRIPTION
Update to latest FreeBSD 12.x version for CI to prevent these kind of errors:-

```
./bootstrap
/usr/local/bin/autoconf
/usr/local/bin/automake
/usr/local/bin/libtool
/usr/local/bin/pkg-config
autoreconf-2.69: Entering directory `.'
autoreconf-2.69: configure.ac: not using Gettext
autoreconf-2.69: running: aclocal --force -I m4
ld-elf.so.1: /usr/local/lib/perl5/5.32/mach/CORE/libperl.so.5.32: Undefined symbol "strerror_l@FBSD_1.6"
aclocal: error: /usr/local/bin/autom4te-2.69 failed with exit status: 1
autoreconf-2.69: aclocal failed with exit status: 1
ld-elf.so.1: /usr/local/lib/perl5/5.32/mach/CORE/libperl.so.5.32: Undefined symbol "strerror_l@FBSD_1.6"
```

See also #1804