### PR TITLE
Fix regression introduced with UDS

### DIFF
--- a/xrdp/xrdp.ini.in
+++ b/xrdp/xrdp.ini.in
@@ -231,6 +231,7 @@ name=Xvnc
 lib=libvnc.@lib_extension@
 username=ask
 password=ask
+ip=127.0.0.1
 port=-1
 #xserverbpp=24
 #delay_ms=2000

--- a/xup/xup.c
+++ b/xup/xup.c
@@ -162,12 +162,6 @@ lib_mod_connect(struct mod *mod)
         return 1;
     }
 
-    if (g_strcmp(mod->ip, "") == 0)
-    {
-        mod->server_msg(mod, "error - no ip set", 0);
-        return 1;
-    }
-
     make_stream(s);
     g_sprintf(con_port, "%s", mod->port);
 
@@ -183,6 +177,12 @@ lib_mod_connect(struct mod *mod)
     {
         socket_mode = TRANS_MODE_TCP;
         LOG(LOG_LEVEL_INFO, "lib_mod_connect: connecting via TCP socket");
+        if (g_strcmp(mod->ip, "") == 0)
+        {
+            mod->server_msg(mod, "error - no ip set", 0);
+            free_stream(s);
+            return 1;
+        }
     }
 
     mod->trans = trans_create(socket_mode, 8 * 8192, 8192);


### PR DESCRIPTION
It seems when I tested UDS, I didn't think to check with the new config file - I just used my old ones and checked compatibility.

@jsorg71 has supplied the patch to xup. @Nexarian pointed out that I've broken VNC too.

The VNC fix is somewhat different in that at the moment VNC always uses a TCP socket, so the ip field which I'd removed is still required.