### PR TITLE
Change development version to 0.9.80

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 # Process this file with autoconf to produce a configure script
 
 AC_PREREQ(2.65)
-AC_INIT([xrdp], [0.9.19], [xrdp-devel@googlegroups.com])
+AC_INIT([xrdp], [0.9.80], [xrdp-devel@googlegroups.com])
 AC_CONFIG_HEADERS(config_ac.h:config_ac-h.in)
 AM_INIT_AUTOMAKE([1.7.2 foreign])
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
This idea is inspired by TigerVNC.

----

If I build the current git head from source, `xrdp -v` shows like this:

```
xrdp 0.9.19
  A Remote Desktop Protocol Server.
  Copyright (C) 2004-2020 Jay Sorg, Neutrino Labs, and all contributors.
  See https://github.com/neutrinolabs/xrdp for more information.
```

This is a little bit confusing because there are lots of changes in devel branch since 0.9.19. So until we release next major version, I give git head a tentative version 0.9.80.

TigerVNC always does this thing. After 1.11.0 release, set develop version to 1.11.80 and will release 1.20.0. After 1.20.0 release set develop version to 1.20.80...
* https://github.com/TigerVNC/tigervnc/commit/56c50c01463c5cd15607d4efdacd03c090420d24

What do you think?
