### PR TITLE
Remove TCP socket support from chansrv

### DIFF
--- a/sesman/chansrv/chansrv.c
+++ b/sesman/chansrv/chansrv.c
@@ -1241,18 +1241,9 @@ setup_listen(void)
         trans_delete(g_lis_trans);
     }
 
-    if (g_cfg->use_unix_socket)
-    {
-        g_lis_trans = trans_create(TRANS_MODE_UNIX, 8192, 8192);
-        g_lis_trans->is_term = g_is_term;
-        g_snprintf(port, 255, XRDP_CHANSRV_STR, g_display_num);
-    }
-    else
-    {
-        g_lis_trans = trans_create(TRANS_MODE_TCP, 8192, 8192);
-        g_lis_trans->is_term = g_is_term;
-        g_snprintf(port, 255, "%d", 7200 + g_display_num);
-    }
+    g_lis_trans = trans_create(TRANS_MODE_UNIX, 8192, 8192);
+    g_lis_trans->is_term = g_is_term;
+    g_snprintf(port, 255, XRDP_CHANSRV_STR, g_display_num);
 
     g_lis_trans->trans_conn_in = my_trans_conn_in;
     error = trans_listen(g_lis_trans, port);

--- a/sesman/chansrv/chansrv_config.h
+++ b/sesman/chansrv/chansrv_config.h
@@ -23,9 +23,6 @@
 
 struct config_chansrv
 {
-    /** Whether to use a UNIX socket for chansrv */
-    int use_unix_socket;
-
     /** Whether the FUSE mount is enabled or not */
     int enable_fuse_mount;
 


### PR DESCRIPTION
The code in xrdp_mm.c to connect to chansrv over a TCP socket has been removed, with the move to UDS (see 0db849fc5c3f02ee24f10acd9f54a91a96fa2eaa). This PR simply removes the chansrv TCP listening code. Without doing this, some configurations result in a failure of xrdp to connect to chansrv.