### PR TITLE
Refactor ip address handling

### DIFF
--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -84,9 +84,7 @@ int      g_sck_vsock_bind(int sck, const char *port);
 int      g_sck_vsock_bind_address(int sck, const char *port, const char *address);
 int      g_tcp_bind_address(int sck, const char *port, const char *address);
 int      g_sck_listen(int sck);
-int      g_tcp_accept(int sck);
-int      g_sck_accept(int sck, char *addr, int addr_bytes,
-                      char *port, int port_bytes);
+int      g_sck_accept(int sck);
 int      g_sck_recv(int sck, void *ptr, int len, int flags);
 int      g_sck_send(int sck, const void *ptr, int len, int flags);
 int      g_sck_last_error_would_block(int sck);
@@ -94,18 +92,35 @@ int      g_sck_socket_ok(int sck);
 int      g_sck_can_send(int sck, int millis);
 int      g_sck_can_recv(int sck, int millis);
 int      g_sck_select(int sck1, int sck2);
-void     g_write_connection_description(int rcv_sck,
-                                        char *description, int bytes);
 /**
- * Extracts the IP address from the connection description
- * @param description Connection description (from
- *                    g_write_connection_description())
+ * Gets the IP address of a connected peer, if it has one
+ * @param sck File descriptor for peer
  * @param ip buffer to write IP address to
- * @param bytes Size of ip buffer
+ * @param bytes Size of ip buffer. Should be at least MAX_IP_ADDRSTRLEN
+ * @param[out] portptr Optional variable to receive the port number
  * @return Pointer to IP for convenience
+ *
+ * If the peer has no IP address (for example, it is a Unix Domain Socket),
+ * or the specified buffer is too small, the returned string is ""
  */
-const char *g_get_ip_from_description(const char *description,
-                                      char *ip, int bytes);
+const char *
+g_sck_get_peer_ip_address(int sck,
+                          char *ip, unsigned int bytes,
+                          unsigned short *port);
+/**
+ * Gets a description for a connected peer
+ * @param sck File descriptor for peer
+ * @param desc buffer to write description to
+ * @param bytes Size of description buffer. Should be at least
+ *              MAX_PEER_DESCSTRLEN
+ * @return Pointer to desc for convenience
+ *
+ * Unlike g_sck_get_peer_ip_address(), this will return a
+ * description of some sort for any socket type.
+ */
+const char *
+g_sck_get_peer_description(int sck,
+                           char *desc, unsigned int bytes);
 void     g_sleep(int msecs);
 tintptr  g_create_wait_obj(const char *name);
 tintptr  g_create_wait_obj_from_socket(tintptr socket, int write);

--- a/common/string_calls.c
+++ b/common/string_calls.c
@@ -1057,3 +1057,88 @@ g_str_to_bitmask(const char *str, const struct bitmask_string bitdefs[],
     return mask;
 }
 
+/*****************************************************************************/
+int
+g_bitmask_to_charstr(int bitmask, const struct bitmask_char bitdefs[],
+                     char *buff, int bufflen, int *rest)
+{
+    int rlen = 0; /* Returned length */
+
+    if (bufflen <= 0) /* Caller error */
+    {
+        rlen = -1;
+    }
+    else
+    {
+        char *p = buff;
+        /* Find the last writeable character in the buffer */
+        const char *last = buff + (bufflen - 1);
+
+        const struct bitmask_char *b;
+
+        for (b = &bitdefs[0] ; b->c != '\0'; ++b)
+        {
+            if ((bitmask & b->mask) != 0)
+            {
+                if (p < last)
+                {
+                    *p++ = b->c;
+                }
+                ++rlen;
+
+                /* Remove the bit so we don't report it back */
+                bitmask &= ~b->mask;
+            }
+        }
+        *p = '\0';
+
+        if (rest != NULL)
+        {
+            *rest = bitmask;
+        }
+    }
+
+    return rlen;
+}
+
+/*****************************************************************************/
+int
+g_charstr_to_bitmask(const char *str, const struct bitmask_char bitdefs[],
+                     char *unrecognised, int unrecognised_len)
+{
+    int bitmask = 0;
+    const char *cp;
+    int j = 0;
+
+    if (str != NULL && bitdefs != NULL)
+    {
+        for (cp = str ; *cp != '\0' ; ++cp)
+        {
+            const struct bitmask_char *b;
+            char c = toupper(*cp);
+
+            for (b = &bitdefs[0] ; b->c != '\0'; ++b)
+            {
+                if (toupper(b->c) == c)
+                {
+                    bitmask |= b->mask;
+                    break;
+                }
+            }
+            if (b->c == '\0')
+            {
+                if (unrecognised != NULL && j < (unrecognised_len - 1))
+                {
+                    unrecognised[j++] = *cp;
+                }
+            }
+        }
+    }
+
+    if (unrecognised != NULL && j < unrecognised_len)
+    {
+        unrecognised[j] = '\0';
+    }
+
+    return bitmask;
+}

--- a/common/string_calls.c
+++ b/common/string_calls.c
@@ -921,6 +921,7 @@ g_strnjoin(char *dest, int dest_len, const char *joiner, const char *src[], int 
     return dest;
 }
 
+/*****************************************************************************/
 int
 g_bitmask_to_str(int bitmask, const struct bitmask_string bitdefs[],
                  char delim, char *buff, int bufflen)
@@ -987,6 +988,7 @@ g_bitmask_to_str(int bitmask, const struct bitmask_string bitdefs[],
     return rlen;
 }
 
+/*****************************************************************************/
 int
 g_str_to_bitmask(const char *str, const struct bitmask_string bitdefs[],
                  const char *delim, char *unrecognised, int unrecognised_len)

--- a/common/string_calls.h
+++ b/common/string_calls.h
@@ -171,7 +171,7 @@ g_get_display_num_from_display(const char *display_text);
  *       a hexadecimal constant.
  */
 int
-g_bitmask_to_str(int bitmask, const struct bitmask_string[],
+g_bitmask_to_str(int bitmask, const struct bitmask_string bitdefs[],
                  char delim, char *buff, int bufflen);
 
 /***
@@ -184,7 +184,7 @@ g_bitmask_to_str(int bitmask, const struct bitmask_string[],
  * @return bitmask value for recognised tokens
  */
 int
-g_str_to_bitmask(const char *str, const struct bitmask_string[],
+g_str_to_bitmask(const char *str, const struct bitmask_string bitdefs[],
                  const char *delim, char *unrecognised,
                  int unrecognised_len);
 

--- a/common/string_calls.h
+++ b/common/string_calls.h
@@ -53,6 +53,21 @@ struct bitmask_string
 #define BITMASK_STRING_END_OF_LIST { 0, NULL }
 
 /**
+ * Map a bitmask to a char value
+ *
+ *
+ * This structure is used by g_bitmask_to_charstr() to specify the
+ * char for each bit in the bitmask
+ */
+struct bitmask_char
+{
+    int mask;
+    char c;
+};
+
+#define BITMASK_CHAR_END_OF_LIST { 0, '\0' }
+
+/**
  * Processes a format string for general info
  *
  * @param[out] dest Destination buffer
@@ -158,6 +173,9 @@ g_get_display_num_from_display(const char *display_text);
 /**
  * Converts a bitmask into a string for output purposes
  *
+ * Similar to g_bitmask_to_charstr(), but tokens are strings, separated
+ * by delimiters.
+ *
  * @param bitmask Bitmask to convert
  * @param bitdefs Definitions for strings for bits
  * @param delim Delimiter to use between strings
@@ -176,8 +194,12 @@ g_bitmask_to_str(int bitmask, const struct bitmask_string bitdefs[],
 
 /***
  * Converts a string containing a series of tokens to a bitmask.
+ *
+ * Similar to g_charstr_to_bitmask(), but tokens are strings, separated
+ * by delimiters.
+ *
  * @param str Input string
- * @param bitmask_string Array mapping tokens to bitmask values
+ * @param bitdefs Array mapping tokens to bitmask values
  * @param delim Delimiter for tokens in str
  * @param[out] unrecognised Buffer for any unrecognised tokens
  * @param unrecognised_len Length of unrecognised including '\0';
@@ -187,6 +209,46 @@ int
 g_str_to_bitmask(const char *str, const struct bitmask_string bitdefs[],
                  const char *delim, char *unrecognised,
                  int unrecognised_len);
+
+/**
+ * Converts a bitmask into a string for output purposes
+ *
+ * Similar to g_bitmask_to_str(), but tokens are individual characters, and
+ * there are no delimiters.
+ *
+ * @param bitmask Bitmask to convert
+ * @param bitdefs Definitions for strings for bits
+ * @param buff Output buff
+ * @param bufflen Length of buff, including terminator '`\0'
+ * @param[out] rest Any unused bits which weren't covered by bitdefs.
+ *                  May be NULL.
+ *
+ * @return Total length excluding terminator which would be written, as
+ *         in snprintf(). Can be used to check for overflow
+ *
+ * @note Any undefined bits in the bitmask are appended to the output as
+ *       a hexadecimal constant.
+ */
+int
+g_bitmask_to_charstr(int bitmask, const struct bitmask_char bitdefs[],
+                     char *buff, int bufflen, int *rest);
+
+/***
+ * Converts a string containing a series of characters to a bitmask.
+ *
+ * Similar to g_str_to_bitmask(), but tokens are individual characters, and
+ * there are no delimiters.
+ *
+ * @param str Input string
+ * @param bitdefs Array mapping tokens to bitmask values
+ * @param delim Delimiter for tokens in str
+ * @param[out] unrecognised Buffer for any unrecognised tokens
+ * @param unrecognised_len Length of unrecognised including '\0';
+ * @return bitmask value for recognised tokens
+ */
+int
+g_charstr_to_bitmask(const char *str, const struct bitmask_char bitdefs[],
+                     char *unrecognised, int unrecognised_len);
 
 int      g_strlen(const char *text);
 char    *g_strchr(const char *text, int c);

--- a/common/trans.c
+++ b/common/trans.c
@@ -330,9 +330,7 @@ trans_check_wait_objs(struct trans *self)
     {
         if (g_sck_can_recv(self->sck, 0))
         {
-            in_sck = g_sck_accept(self->sck, self->addr, sizeof(self->addr),
-                                  self->port, sizeof(self->port));
-
+            in_sck = g_sck_accept(self->sck);
             if (in_sck == -1)
             {
                 if (g_tcp_last_error_would_block(self->sck))
@@ -357,10 +355,6 @@ trans_check_wait_objs(struct trans *self)
                     in_trans->type1 = TRANS_TYPE_SERVER;
                     in_trans->status = TRANS_STATUS_UP;
                     in_trans->is_term = self->is_term;
-                    g_strncpy(in_trans->addr, self->addr,
-                              sizeof(self->addr) - 1);
-                    g_strncpy(in_trans->port, self->port,
-                              sizeof(self->port) - 1);
                     g_sck_set_non_blocking(in_sck);
                     if (self->trans_conn_in(self, in_trans) != 0)
                     {

--- a/common/trans.h
+++ b/common/trans.h
@@ -104,8 +104,6 @@ struct trans
     char *listen_filename;
     tis_term is_term; /* used to test for exit */
     struct stream *wait_s;
-    char addr[256];
-    char port[256];
     int no_stream_init_on_data_in;
     int extra_flags; /* user defined */
     void *extra_data; /* user defined */

--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -114,7 +114,7 @@ struct xrdp_client_info
     int rdp5_performanceflags;
     int brush_cache_code; /* 0 = no cache 1 = 8x8 standard cache
                            2 = arbitrary dimensions */
-    char connection_description[256];
+
     int max_bpp;
     int jpeg; /* non standard bitmap cache v2 cap */
     int offscreen_support_level;
@@ -146,8 +146,6 @@ struct xrdp_client_info
     int pointer_flags; /* 0 color, 1 new, 2 no new */
     int use_fast_path;
     int require_credentials; /* when true, credentials *must* be passed on cmd line */
-    char client_addr[256];
-    char client_port[256];
 
     int security_layer; /* 0 = rdp, 1 = tls , 2 = hybrid */
     int multimon; /* 0 = deny , 1 = allow */
@@ -191,6 +189,9 @@ struct xrdp_client_info
     long ssl_protocols;
     char *tls_ciphers;
 
+    char client_ip[MAX_PEER_ADDRSTRLEN];
+    char client_description[MAX_PEER_DESCSTRLEN];
+
     int client_os_major;
     int client_os_minor;
 
@@ -207,6 +208,6 @@ struct xrdp_client_info
 };
 
 /* yyyymmdd of last incompatible change to xrdp_client_info */
-#define CLIENT_INFO_CURRENT_VERSION 20220320
+#define CLIENT_INFO_CURRENT_VERSION 20220428
 
 #endif

--- a/common/xrdp_constants.h
+++ b/common/xrdp_constants.h
@@ -37,7 +37,22 @@
  * ms-erref.h
  ******************************************************************************/
 
+/**
+ * Size of buffer including terminator for an IP address as returned
+ * by g_sck_get_peer_ip_address(). See POSIX INET6_ADDRSTRLEN
+ */
+#define MAX_PEER_ADDRSTRLEN 46
+
+/**
+ * Size of buffer including terminator for a socket description, as
+ * returned by g_sck_get_peer_description()
+ * Currently the largest is an IPv6 address (INET6_ADDRSTRLEN), plus
+ * []:<port> characters
+ */
+#define MAX_PEER_DESCSTRLEN (46 + 2 + 1 + 5)
+
 #define INFO_CLIENT_NAME_BYTES  32
+
 /**
  * Maximum length of a string including the mandatory null terminator
  * [MS-RDPBCGR] TS_INFO_PACKET(2.2.1.11.1.1)

--- a/docs/man/sesman.ini.5.in
+++ b/docs/man/sesman.ini.5.in
@@ -176,30 +176,34 @@ If set to \fI0\fR, idle sessions will never be disconnected by timeout.
 This works only with xorgxrdp sessions. Moreover, xorgxrdp must be v0.2.9 or later.
 
 .TP
-\fBPolicy\fR=\fI[Default|UBD|UBI|UBC|UBDI|UBDC]\fR
+\fBPolicy\fR=\fI[Default|Separate|{UBDI}]\fR
 Session allocation policy. Used to decide when to allocate a
 new session. Set to one of the following values:
 .br
 
-.br
-\fBDefault\fR - session per <User,BitPerPixel>
-.br
-\fBUBD\fR - session per <User,BitPerPixel,DisplaySize>
-.br
-\fBUBI\fR - session per <User,BitPerPixel,IPAddr>
-.br
-\fBUBC\fR - session per <User,BitPerPixel,Connection>
-.br
-\fBUBDI\fR - session per <User,BitPerPixel,DisplaySize,IPAddr>
-.br
-\fBUBDC\fR - session per <User,BitPerPixel,DisplaySize,Connection>
-.br
+.RS
+.HP 12
+\fBDefault\fR -   Currently the same as "UB" for all session types
+.HP 12
+\fBSeparate\fR -  All sessions are separate. Sessions can never be rejoined,
+and will need to be cleaned up manually, or automatically by setting other
+sesman options.
+.P
+Alternatively combine one-or-more of the following options
+.HP 4
+\fBU\fR - Sessions are separated per user
+.HP 4
+\fBB\fR - Sessions are separated by bits-per-pixel
+.HP 4
+\fBD\fR - Sessions are separated by initial display size
+.HP 4
+\fBI\fR - Sessions are separated by IP address
+.RE
 
-.br
-Note that the \fBUser\fR and \fBBitPerPixel\fR criteria cannot be turned
+.IP
+Note that the \fBU\fR and \fBB\fR criteria cannot be turned
 off. \fBDisplaySize\fR refers to the initial geometry of a connection,
 as actual display sizes can change dynamically.
-.br
 
 .SH "SECURITY"
 Following parameters can be used in the \fB[Security]\fR section.

--- a/libipm/scp.h
+++ b/libipm/scp.h
@@ -177,7 +177,7 @@ scp_msg_in_reset(struct trans *trans);
  * @param trans SCP transport
  * @param username Username
  * @param password Password
- * @param connection_description Description of the connection
+ * @param ip_addr IP address for the client (or "" if not known)
  * @return != 0 for error
  *
  * Server replies with E_SCP_GATEWAY_RESPONSE
@@ -186,7 +186,7 @@ int
 scp_send_gateway_request(struct trans *trans,
                          const char *username,
                          const char *password,
-                         const char *connection_description);
+                         const char *ip_addr);
 
 /**
  * Parse an incoming E_SCP_GATEWAY_REQUEST message (SCP server)
@@ -194,14 +194,14 @@ scp_send_gateway_request(struct trans *trans,
  * @param trans SCP transport
  * @param[out] username Username
  * @param[out] password Password
- * @param[out] connection_description Description of the connection
+ * @param[out] ip_addr IP address for the client. May be ""
  * @return != 0 for error
  */
 int
 scp_get_gateway_request(struct trans *trans,
                         const char **username,
                         const char **password,
-                        const char **connection_description);
+                        const char **ip_addr);
 
 /**
  * Send an E_SCP_GATEWAY_RESPONSE (SCP server)
@@ -239,7 +239,7 @@ scp_get_gateway_response(struct trans *trans,
  * @param bpp Session bits-per-pixel (ignored for Xorg sessions)
  * @param shell User program to run. May be ""
  * @param directory Directory to run the program in. May be ""
- * @param connection_description Description of the connection
+ * @param ip_addr IP address for the client (or "" if not known)
  * @return != 0 for error
  *
  * Server replies with E_SCP_CREATE_SESSION_RESPONSE
@@ -254,7 +254,7 @@ scp_send_create_session_request(struct trans *trans,
                                 unsigned char bpp,
                                 const char *shell,
                                 const char *directory,
-                                const char *connection_description);
+                                const char *ip_addr);
 
 
 /**
@@ -269,7 +269,7 @@ scp_send_create_session_request(struct trans *trans,
  * @param[out] bpp Session bits-per-pixel (ignored for Xorg sessions)
  * @param[out] shell User program to run. May be ""
  * @param[out] directory Directory to run the program in. May be ""
- * @param[out] connection_description Description of the connection
+ * @param[out] ip_addr IP address for the client. May be ""
  * @return != 0 for error
  *
  * Returned string pointers are valid until scp_msg_in_reset() is
@@ -285,7 +285,7 @@ scp_get_create_session_request(struct trans *trans,
                                unsigned char *bpp,
                                const char **shell,
                                const char **directory,
-                               const char **connection_description);
+                               const char **ip_addr);
 
 /**
  * Send an E_SCP_CREATE_SESSION_RESPONSE (SCP server)

--- a/libipm/scp_application_types.h
+++ b/libipm/scp_application_types.h
@@ -58,7 +58,7 @@ struct scp_session_info
     unsigned char bpp;  ///< Session bits-per-pixel
     time_t start_time;  ///< When sesion was created
     char *username;     ///< Username for session
-    char *connection_description; ///< Initial connection to session
+    char *start_ip_addr; ///< IP address of starting client
 };
 
 

--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -268,10 +268,9 @@ lxrdp_connect(struct mod *mod)
         }
 #endif
         LOG(LOG_LEVEL_ERROR, "NeutrinoRDP proxy connection: status [Failed],"
-            " RDP client [%s:%s], RDP server [%s:%d], RDP server username [%s],"
+            " RDP client [%s], RDP server [%s:%d], RDP server username [%s],"
             " xrdp pamusername [%s], xrdp process id [%d]",
-            mod->client_info.client_addr,
-            mod->client_info.client_port,
+            mod->client_info.client_description,
             mod->inst->settings->hostname,
             mod->inst->settings->port,
             mod->inst->settings->username,
@@ -282,10 +281,9 @@ lxrdp_connect(struct mod *mod)
     else
     {
         LOG(LOG_LEVEL_INFO, "NeutrinoRDP proxy connection: status [Success],"
-            " RDP client [%s:%s], RDP server [%s:%d], RDP server username [%s],"
+            " RDP client [%s], RDP server [%s:%d], RDP server username [%s],"
             " xrdp pamusername [%s], xrdp process id [%d]",
-            mod->client_info.client_addr,
-            mod->client_info.client_port,
+            mod->client_info.client_description,
             mod->inst->settings->hostname,
             mod->inst->settings->port,
             mod->inst->settings->username,
@@ -531,10 +529,9 @@ lxrdp_end(struct mod *mod)
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "lxrdp_end:");
     LOG(LOG_LEVEL_INFO, "NeutrinoRDP proxy connection: status [Disconnect],"
-        " RDP client [%s:%s], RDP server [%s:%d], RDP server username [%s],"
+        " RDP client [%s], RDP server [%s:%d], RDP server username [%s],"
         " xrdp pamusername [%s], xrdp process id [%d]",
-        mod->client_info.client_addr,
-        mod->client_info.client_port,
+        mod->client_info.client_description,
         mod->inst->settings->hostname,
         mod->inst->settings->port,
         mod->inst->settings->username,

--- a/sesman/auth.h
+++ b/sesman/auth.h
@@ -32,11 +32,13 @@
  * @brief Validates user's password
  * @param user user's login name
  * @param pass user's password
+ * @param client_ip IP address of connecting client (or ""/NULL if not known)
  * @return non-zero handle on success, 0 on failure
  *
  */
 long
-auth_userpass(const char *user, const char *pass, int *errorcode);
+auth_userpass(const char *user, const char *pass,
+              const char *client_ip, int *errorcode);
 
 /**
  *

--- a/sesman/config.h
+++ b/sesman/config.h
@@ -72,27 +72,18 @@
 
 #define SESMAN_CFG_SESS_POLICY_S "Policy"
 #define SESMAN_CFG_SESS_POLICY_DFLT_S "Default"
-#define SESMAN_CFG_SESS_POLICY_UBD_S "UBD"
-#define SESMAN_CFG_SESS_POLICY_UBI_S "UBI"
-#define SESMAN_CFG_SESS_POLICY_UBC_S "UBC"
-#define SESMAN_CFG_SESS_POLICY_UBDI_S "UBDI"
-#define SESMAN_CFG_SESS_POLICY_UBDC_S "UBDC"
+#define SESMAN_CFG_SESS_POLICY_SEP_S "Separate"
 
 enum SESMAN_CFG_SESS_POLICY_BITS
 {
-    SESMAN_CFG_SESS_POLICY_D = 0x01,
-    SESMAN_CFG_SESS_POLICY_I = 0x02,
-    SESMAN_CFG_SESS_POLICY_C = 0x04
-};
-
-enum SESMAN_CFG_SESS_POLICY
-{
-    SESMAN_CFG_SESS_POLICY_DFLT = 0,
-    SESMAN_CFG_SESS_POLICY_UBD = SESMAN_CFG_SESS_POLICY_D,
-    SESMAN_CFG_SESS_POLICY_UBI = SESMAN_CFG_SESS_POLICY_I,
-    SESMAN_CFG_SESS_POLICY_UBC = SESMAN_CFG_SESS_POLICY_C,
-    SESMAN_CFG_SESS_POLICY_UBDI = SESMAN_CFG_SESS_POLICY_D | SESMAN_CFG_SESS_POLICY_I,
-    SESMAN_CFG_SESS_POLICY_UBDC = SESMAN_CFG_SESS_POLICY_D | SESMAN_CFG_SESS_POLICY_C
+    /* If these two are set, they override everything else */
+    SESMAN_CFG_SESS_POLICY_DEFAULT = (1 << 0),
+    SESMAN_CFG_SESS_POLICY_SEPARATE = (1 << 1),
+    /* Configuration bits */
+    SESMAN_CFG_SESS_POLICY_U = (1 << 2),
+    SESMAN_CFG_SESS_POLICY_B = (1 << 3),
+    SESMAN_CFG_SESS_POLICY_D = (1 << 4),
+    SESMAN_CFG_SESS_POLICY_I = (1 << 5)
 };
 
 /**
@@ -180,7 +171,7 @@ struct config_sessions
      * @var policy
      * @brief session allocation policy
      */
-    enum SESMAN_CFG_SESS_POLICY policy;
+    unsigned int policy;
 };
 
 /**
@@ -303,5 +294,17 @@ config_dump(struct config_sesman *config);
  */
 void
 config_free(struct config_sesman *cs);
+
+/**
+ * Converts a session allocation Policy value to a strin
+ * @param value - Session allocation policy value
+ * @param buff - Buffer for result
+ * @param bufflen - Length of buffer
+ * @return Length of string that would be required without a terminator
+ *         to write the whole output (like snprintf())
+ */
+int
+config_output_policy_string(unsigned int value,
+                            char *buff, unsigned int bufflen);
 
 #endif

--- a/sesman/scp_process.c
+++ b/sesman/scp_process.c
@@ -75,7 +75,7 @@ process_gateway_request(struct trans *trans)
         LOG(LOG_LEVEL_INFO, "Received authentication request for user: %s",
             username);
 
-        data = auth_userpass(username, password, &errorcode);
+        data = auth_userpass(username, password, ip_addr, &errorcode);
         if (data)
         {
             if (1 == access_login_allowed(username))
@@ -133,7 +133,7 @@ process_create_session_request(struct trans *trans)
             SCP_SESSION_TYPE_TO_STR(sp.type),
             sp.username);
 
-        data = auth_userpass(sp.username, password, &errorcode);
+        data = auth_userpass(sp.username, password, sp.ip_addr, &errorcode);
         if (data)
         {
             s_item = session_get_bydata(&sp);
@@ -219,7 +219,7 @@ process_list_sessions_request(struct trans *trans)
         LOG(LOG_LEVEL_INFO,
             "Received request to list sessions for user %s", username);
 
-        data = auth_userpass(username, password, &errorcode);
+        data = auth_userpass(username, password, NULL, &errorcode);
         if (data)
         {
             struct scp_session_info *info = NULL;

--- a/sesman/scp_process.c
+++ b/sesman/scp_process.c
@@ -41,27 +41,19 @@
  * Logs an authentication failure message
  *
  * @param username Username
- * @param connection_description Connection details
+ * @param ip_addr IP address, if known
  *
  * The message is intended for use by fail2ban. Make changes with care.
  */
 static void
-log_authfail_message(const char *username, const char *connection_description)
+log_authfail_message(const char *username, const char *ip_addr)
 {
-    char ip[64];
-    const char *ipp;
-    if (connection_description != NULL &&
-            connection_description[0] != '\0')
+    if (ip_addr == NULL || ip_addr[0] == '\0')
     {
-        g_get_ip_from_description(connection_description, ip, sizeof(ip));
-        ipp = ip;
-    }
-    else
-    {
-        ipp = "unknown";
+        ip_addr = "unknown";
     }
     LOG(LOG_LEVEL_INFO, "AUTHFAIL: user=%s ip=%s time=%d",
-        username, ipp, g_time1());
+        username, ip_addr, g_time1());
 }
 
 /******************************************************************************/
@@ -72,10 +64,9 @@ process_gateway_request(struct trans *trans)
     int rv;
     const char *username;
     const char *password;
-    const char *connection_description;
+    const char *ip_addr;
 
-    rv = scp_get_gateway_request(trans, &username, &password,
-                                 &connection_description);
+    rv = scp_get_gateway_request(trans, &username, &password, &ip_addr);
     if (rv == 0)
     {
         int errorcode = 0;
@@ -103,7 +94,7 @@ process_gateway_request(struct trans *trans)
         }
         else
         {
-            log_authfail_message(username, connection_description);
+            log_authfail_message(username, ip_addr);
         }
         rv = scp_send_gateway_response(trans, errorcode);
         auth_end(data);
@@ -128,7 +119,7 @@ process_create_session_request(struct trans *trans)
              trans,
              &sp.username, &password,
              &sp.type, &sp.width, &sp.height, &sp.bpp,
-             &sp.shell, &sp.directory, &sp.connection_description);
+             &sp.shell, &sp.directory, &sp.ip_addr);
 
     if (rv == 0)
     {
@@ -150,12 +141,11 @@ process_create_session_request(struct trans *trans)
             {
                 display = s_item->display;
                 guid = s_item->guid;
-                if (sp.connection_description[0] != '\0')
+                if (sp.ip_addr[0] != '\0')
                 {
                     LOG( LOG_LEVEL_INFO, "++ reconnected session: username %s, "
                          "display :%d.0, session_pid %d, ip %s",
-                         sp.username, display, s_item->pid,
-                         sp.connection_description);
+                         sp.username, display, s_item->pid, sp.ip_addr);
                 }
                 else
                 {
@@ -172,12 +162,11 @@ process_create_session_request(struct trans *trans)
 
                 if (1 == access_login_allowed(sp.username))
                 {
-                    if (sp.connection_description[0] != '\0')
+                    if (sp.ip_addr[0] != '\0')
                     {
                         LOG(LOG_LEVEL_INFO,
                             "++ created session (access granted): "
-                            "username %s, ip %s", sp.username,
-                            sp.connection_description);
+                            "username %s, ip %s", sp.username, sp.ip_addr);
                     }
                     else
                     {
@@ -196,7 +185,7 @@ process_create_session_request(struct trans *trans)
         }
         else
         {
-            log_authfail_message(sp.username, sp.connection_description);
+            log_authfail_message(sp.username, sp.ip_addr);
         }
 
         if (do_auth_end)

--- a/sesman/sesman.ini.in
+++ b/sesman/sesman.ini.in
@@ -69,13 +69,20 @@ DisconnectedTimeLimit=0
 IdleTimeLimit=0
 
 ;; Policy - session allocation policy
-; Type: enum [ "Default" | "UBD" | "UBI" | "UBC" | "UBDI" | "UBDC" ]
-; "Default" session per <User,BitPerPixel>
-; "UBD" session per <User,BitPerPixel,DisplaySize>
-; "UBI" session per <User,BitPerPixel,IPAddr>
-; "UBC" session per <User,BitPerPixel,Connection>
-; "UBDI" session per <User,BitPerPixel,DisplaySize,IPAddr>
-; "UBDC" session per <User,BitPerPixel,DisplaySize,Connection>
+;
+;  Type: enum [ "Default" | "Separate" | Combination from {UBDI} ]
+;  "Default"    Currently same as "UB"
+;  "Separate"   All sessions are separate. Sessions can never be rejoined,
+;               and will need to be cleaned up manually, or automatically
+;               by setting other sesman options.
+;
+;   Combination options:-
+;      U        Sessions are separated per user
+;      B        Sessions are separated by bits-per-pixel
+;      D        Sessions are separated by initial display size
+;      I        Sessions are separated by IP address
+;
+;   The options U and B are always active, and cannot be de-selected.
 Policy=Default
 
 [Logging]

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -90,46 +90,33 @@ session_get_bydata(const struct session_parameters *sp)
 {
     struct session_chain *tmp;
     enum SESMAN_CFG_SESS_POLICY policy = g_cfg->sess.policy;
-    char ip[64];
-    char tmp_ip[64];
-
-    if ((policy & SESMAN_CFG_SESS_POLICY_I) != 0)
-    {
-        /* We'll need to compare on IP addresses */
-        g_get_ip_from_description(sp->connection_description,
-                                  ip, sizeof(ip));
-    }
-    else
-    {
-        ip[0] = '\0';
-        tmp_ip[0] = '\0';
-    }
 
     LOG(LOG_LEVEL_DEBUG,
         "session_get_bydata: search policy %d U %s W %d H %d bpp %d T %d IP %s",
         policy, sp->username, sp->width, sp->height, sp->bpp,
-        sp->type, sp->connection_description);
+        sp->type, sp->ip_addr);
+
+    if ((policy & SESMAN_CFG_SESS_POLICY_C) != 0)
+    {
+        /* Never matches */
+        return NULL;
+    }
 
     for (tmp = g_sessions ; tmp != 0 ; tmp = tmp->next)
     {
-
-        if ((policy & SESMAN_CFG_SESS_POLICY_I) != 0)
-        {
-            g_get_ip_from_description(tmp->item->connection_description,
-                                      tmp_ip, sizeof (tmp_ip));
-        }
+        struct session_item *item = tmp->item;
 
         LOG(LOG_LEVEL_DEBUG,
             "session_get_bydata: try %p U %s W %d H %d bpp %d T %d IP %s",
-            tmp->item,
-            tmp->item->name,
-            tmp->item->width, tmp->item->height,
-            tmp->item->bpp, tmp->item->type,
-            tmp->item->connection_description);
+            item,
+            item->name,
+            item->width, item->height,
+            item->bpp, item->type,
+            item->start_ip_addr);
 
-        if (g_strncmp(sp->username, tmp->item->name, 255) != 0 ||
-                tmp->item->bpp != sp->bpp ||
-                tmp->item->type != sp->type)
+        if (g_strncmp(sp->username, item->name, 255) != 0 ||
+                item->bpp != sp->bpp ||
+                item->type != sp->type)
         {
             LOG(LOG_LEVEL_DEBUG,
                 "session_get_bydata: Basic parameters don't match");
@@ -137,29 +124,23 @@ session_get_bydata(const struct session_parameters *sp)
         }
 
         if ((policy & SESMAN_CFG_SESS_POLICY_D) &&
-                (tmp->item->width != sp->width || tmp->item->height != sp->height))
+                (item->width != sp->width || item->height != sp->height))
         {
             LOG(LOG_LEVEL_DEBUG,
                 "session_get_bydata: Dimensions don't match for 'D' policy");
             continue;
         }
 
-        if ((policy & SESMAN_CFG_SESS_POLICY_I) && g_strcmp(ip, tmp_ip) != 0)
+        if ((policy & SESMAN_CFG_SESS_POLICY_I) &&
+                g_strcmp(item->start_ip_addr, sp->ip_addr) != 0)
         {
             LOG(LOG_LEVEL_DEBUG,
                 "session_get_bydata: IPs don't match for 'I' policy");
             continue;
         }
 
-        if ((policy & SESMAN_CFG_SESS_POLICY_C) &&
-                g_strncmp(sp->connection_description, tmp->item->connection_description, 255) != 0)
-        {
-            LOG(LOG_LEVEL_DEBUG,
-                "session_get_bydata: connections don't match for 'C' policy");
-        }
-
         LOG(LOG_LEVEL_DEBUG, "session_get_bydata: Got match");
-        return tmp->item;
+        return item;
     }
 
     return 0;
@@ -959,14 +940,15 @@ session_start(long data,
         LOG(LOG_LEVEL_INFO, "Starting session: session_pid %d, "
             "display :%d.0, width %d, height %d, bpp %d, client ip %s, "
             "user name %s",
-            pid, display, s->width, s->height, s->bpp, s->connection_description, s->username);
+            pid, display, s->width, s->height, s->bpp, s->ip_addr, s->username);
         temp->item->pid = pid;
         temp->item->display = display;
         temp->item->width = s->width;
         temp->item->height = s->height;
         temp->item->bpp = s->bpp;
         temp->item->data = data;
-        g_strncpy(temp->item->connection_description, s->connection_description, 255);   /* store client ip data */
+        g_strncpy(temp->item->start_ip_addr, s->ip_addr,
+                  sizeof(temp->item->start_ip_addr) - 1);
         g_strncpy(temp->item->name, s->username, 255);
         temp->item->guid = *guid;
 
@@ -1071,7 +1053,7 @@ session_kill(int pid)
             /* deleting the session */
             LOG(LOG_LEVEL_INFO,
                 "++ terminated session:  username %s, display :%d.0, session_pid %d, ip %s",
-                tmp->item->name, tmp->item->display, tmp->item->pid, tmp->item->connection_description);
+                tmp->item->name, tmp->item->display, tmp->item->pid, tmp->item->start_ip_addr);
             g_free(tmp->item);
 
             if (prev == 0)
@@ -1227,11 +1209,10 @@ session_get_byuser(const char *user, unsigned int *cnt, unsigned char flags)
                 (sess[index]).bpp = tmp->item->bpp;
                 (sess[index]).start_time = tmp->item->start_time;
                 (sess[index]).username = g_strdup(tmp->item->name);
-                (sess[index]).connection_description =
-                    g_strdup(tmp->item->connection_description);
+                (sess[index]).start_ip_addr = g_strdup(tmp->item->start_ip_addr);
 
                 if ((sess[index]).username == NULL ||
-                        (sess[index]).connection_description == NULL)
+                        (sess[index]).start_ip_addr == NULL)
                 {
                     free_session_info_list(sess, *cnt);
                     (*cnt) = 0;
@@ -1259,7 +1240,7 @@ free_session_info_list(struct scp_session_info *sesslist, unsigned int cnt)
         for (i = 0 ; i < cnt ; ++i)
         {
             g_free(sesslist[i].username);
-            g_free(sesslist[i].connection_description);
+            g_free(sesslist[i].start_ip_addr);
         }
     }
 
@@ -1374,7 +1355,7 @@ clone_session_params(const struct session_parameters *sp)
     len += g_strlen(sp->username) + 1;
     len += g_strlen(sp->shell) + 1;
     len += g_strlen(sp->directory) + 1;
-    len += g_strlen(sp->connection_description) + 1;
+    len += g_strlen(sp->ip_addr) + 1;
 
     if ((result = (struct session_parameters *)g_malloc(len, 0)) != NULL)
     {
@@ -1394,8 +1375,7 @@ clone_session_params(const struct session_parameters *sp)
         COPY_STRING_MEMBER(sp->username, result->username);
         COPY_STRING_MEMBER(sp->shell, result->shell);
         COPY_STRING_MEMBER(sp->directory, result->directory);
-        COPY_STRING_MEMBER(sp->connection_description,
-                           result->connection_description);
+        COPY_STRING_MEMBER(sp->ip_addr, result->ip_addr);
 
 #undef COPY_STRING_MEMBER
     }

--- a/sesman/session.h
+++ b/sesman/session.h
@@ -32,6 +32,7 @@
 
 #include "guid.h"
 #include "scp_application_types.h"
+#include "xrdp_constants.h"
 
 #define SESMAN_SESSION_STATUS_ACTIVE        0x01
 #define SESMAN_SESSION_STATUS_IDLE          0x02
@@ -68,7 +69,7 @@ struct session_item
     time_t start_time;
     // struct session_date disconnect_time; // Currently unused
     // struct session_date idle_time; // Currently unused
-    char connection_description[256];
+    char start_ip_addr[MAX_PEER_ADDRSTRLEN];
     struct guid guid;
 };
 
@@ -91,7 +92,7 @@ struct session_parameters
     const char *username;
     const char *shell;
     const char *directory;
-    const char *connection_description;
+    const char *ip_addr;
 };
 
 /**

--- a/sesman/tools/sesadmin.c
+++ b/sesman/tools/sesadmin.c
@@ -153,9 +153,9 @@ print_session(const struct scp_session_info *s)
     printf("\tScreen size: %dx%d, color depth %d\n",
            s->width, s->height, s->bpp);
     printf("\tStarted: %s", ctime(&s->start_time));
-    if (s->connection_description[0] != '\0')
+    if (s->start_ip_addr[0] != '\0')
     {
-        printf("\tConnection Description: %s\n", s->connection_description);
+        printf("\tStart IP address: %s\n", s->start_ip_addr);
     }
 }
 

--- a/sesman/verify_user.c
+++ b/sesman/verify_user.c
@@ -51,7 +51,8 @@ auth_account_disabled(struct spwd *stp);
 /******************************************************************************/
 /* returns boolean */
 long
-auth_userpass(const char *user, const char *pass, int *errorcode)
+auth_userpass(const char *user, const char *pass,
+              const char *client_ip, int *errorcode)
 {
     const char *encr;
     const char *epass;

--- a/sesman/verify_user_bsd.c
+++ b/sesman/verify_user_bsd.c
@@ -46,7 +46,8 @@
 /******************************************************************************/
 /* returns boolean */
 long
-auth_userpass(const char *user, const char *pass, int *errorcode)
+auth_userpass(const char *user, const char *pass,
+              const char *client_ip, int *errorcode)
 {
     int ret = auth_userokay(user, NULL, "auth-xrdp", pass);
     return ret;

--- a/sesman/verify_user_kerberos.c
+++ b/sesman/verify_user_kerberos.c
@@ -400,8 +400,9 @@ cleanup:
 
 /******************************************************************************/
 /* returns boolean */
-int
-auth_userpass(const char *user, const char *pass, int *errorcode)
+long
+auth_userpass(const char *user, const char *pass,
+              const char *client_ip, int *errorcode)
 {
     struct k_opts opts;
     struct k5_data k5;

--- a/sesman/verify_user_pam_userpass.c
+++ b/sesman/verify_user_pam_userpass.c
@@ -38,8 +38,9 @@
 
 /******************************************************************************/
 /* returns boolean */
-int
-auth_userpass(const char *user, const char *pass, int *errorcode)
+long
+auth_userpass(const char *user, const char *pass,
+              const char *client_ip, int *errorcode)
 {
     pam_handle_t *pamh;
     pam_userpass_t userpass;

--- a/tools/devel/tcp_proxy/main.c
+++ b/tools/devel/tcp_proxy/main.c
@@ -112,7 +112,7 @@ main_loop(char *local_port, char *remote_ip, char *remote_port, int hexdump)
     {
         while ((!g_terminated) && (error == 0))
         {
-            acc_sck = g_tcp_accept(lis_sck);
+            acc_sck = g_sck_accept(lis_sck);
 
             if ((acc_sck == -1) && g_tcp_last_error_would_block(lis_sck))
             {

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -232,7 +232,7 @@ xrdp_mm_send_gateway_login(struct xrdp_mm *self, const char *username,
 
     return scp_send_gateway_request(
                self->sesman_trans, username, password,
-               self->wm->client_info->connection_description);
+               self->wm->client_info->client_ip);
 }
 
 /*****************************************************************************/
@@ -301,7 +301,7 @@ xrdp_mm_send_login(struct xrdp_mm *self)
                      xserverbpp,
                      self->wm->client_info->program,
                      self->wm->client_info->directory,
-                     self->wm->client_info->connection_description);
+                     self->wm->client_info->client_ip);
         }
     }
 

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -683,12 +683,11 @@ xrdp_wm_init(struct xrdp_wm *self)
             if (file_read_section(fd, section_name, names, values) != 0)
             {
                 LOG(LOG_LEVEL_INFO,
-                    "Module \"%s\" specified by %s from %s port %s "
+                    "Module \"%s\" specified by %s from %s "
                     "is not configured. Using \"%s\" instead.",
                     section_name,
                     self->session->client_info->username,
-                    self->session->client_info->client_addr,
-                    self->session->client_info->client_port,
+                    self->session->client_info->client_description,
                     default_section_name);
                 list_clear(names);
                 list_clear(values);

--- a/xup/xup.c
+++ b/xup/xup.c
@@ -73,10 +73,9 @@ lib_mod_log_peer(struct mod *mod)
     {
         LOG(LOG_LEVEL_INFO, "lib_mod_log_peer: xrdp_pid=%d connected "
             "to X11rdp_pid=%d X11rdp_uid=%d X11rdp_gid=%d "
-            "client_ip=%s client_port=%s",
+            "client=%s",
             my_pid, pid, uid, gid,
-            mod->client_info.client_addr,
-            mod->client_info.client_port);
+            mod->client_info.client_description);
     }
     else
     {


### PR DESCRIPTION
Fixes #392 #2239

Replacement for the withdrawn #2223 

The main reason for withdrawing #2223 was I discovered there were two separate places in the xrdp_client_info structure which described the currently connected client:-

1) The `connection_description` field. This was originally (and confusingly) called `client_ip`, and introduced by commit d797b2cf497587355bbf25cd27d59edd1c3f2915 for xrdp v0.6.0

2) The `client_addr` and `client_port` fields introduced by commit 25369460a1b2f204d03a6bc4821251d7ef2d7adf for xrdp v0.8.0

In terms of maintainability and readability, it made sense to unify these two sets of fields into a single set of fields.

Another confusion is the presence of the 'C' argument to the session allocation policy in sesman.ini. The code for this in sesman uses the `connection_description` field. This is explored further in #2239 

This series of commits does the following:-
1) Replaces `connection_description`, `client_addr` and `client_port` with two unified fields in xrdp_client_info. These fields are 
`client_ip` and `client_description`. they are used as follows:-
   - for AF_INET/AF_INET6 connections only, `client_ip` contains the IP address of the client. For other connection types (e.g. AF_UNIX and AF_VSOCK) this field is empty.
   - for all connection types, `client_description` contains a string which describes the connected client.
2) PAM_RHOST support is added (#392) for PAM stacks that can make use of this information.
3) A couple of utility functions `g_bitmask_to_charstr()` and `g_charstr_to_bitmask()` are added to string_calls.c. These are intended for parsing the `Policy` string in sesman.ini in a more flexible way.
4) Unit tests are added for the above.
5) The session allocation policy code is updated as discussed in #2239. Not only does this make the policy more flexible (see, for example #2099), but it makes it possible to trace the action of session matching by enabling standard debug logging.

**This PR changes the public interface of the session allocation policy in sesman.ini**. Effectively, the old 'C' policy is achieved by setting the policy to 'Separate'. This is I believe a little clearer, and I also think it is unlikely there are many users of the 'Separate' policy anyway. A use of the old 'C' flag is not honoured, but a warning is currently generated if it is discovered.