### PR TITLE
Hardening xrdp with AppArmor

### DIFF
--- a/common/file.c
+++ b/common/file.c
@@ -349,7 +349,7 @@ file_by_name_read_sections(const char *file_name, struct list *names)
         return 1;
     }
 
-    fd = g_file_open_ex(file_name, 1, 0, 0, 0);
+    fd = g_file_open_ro(file_name);
 
     if (fd < 0)
     {
@@ -390,7 +390,7 @@ file_by_name_read_section(const char *file_name, const char *section,
         return 1;
     }
 
-    fd = g_file_open_ex(file_name, 1, 0, 0, 0);
+    fd = g_file_open_ro(file_name);
 
     if (fd < 0)
     {

--- a/common/log.c
+++ b/common/log.c
@@ -689,7 +689,7 @@ log_config_init_from_config(const char *iniFilename,
         return NULL;
     }
 
-    fd = g_file_open_ex(iniFilename, 1, 0, 0, 0);
+    fd = g_file_open_ro(iniFilename);
 
     if (-1 == fd)
     {

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -53,6 +53,9 @@
 #include <sys/stat.h>
 #include <sys/ipc.h>
 #include <sys/shm.h>
+#if defined(HAVE_SYS_PRCTL_H)
+#include <sys/prctl.h>
+#endif
 #include <dlfcn.h>
 #include <arpa/inet.h>
 #include <netdb.h>
@@ -3952,5 +3955,21 @@ g_tcp6_bind_address(int sck, const char *port, const char *address)
     return rv;
 #else
     return -1;
+#endif
+}
+
+/*****************************************************************************/
+/* returns error, zero is success, non zero is error */
+/* only works in linux */
+int
+g_no_new_privs(void)
+{
+#if defined(HAVE_SYS_PRCTL_H) && defined(PR_SET_NO_NEW_PRIVS)
+    /*
+     * PR_SET_NO_NEW_PRIVS requires Linux kernel 3.5 and newer.
+     */
+    return prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+#else
+    return 0;
 #endif
 }

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -2086,24 +2086,14 @@ g_memcmp(const void *s1, const void *s2, int len)
 /*****************************************************************************/
 /* returns -1 on error, else return handle or file descriptor */
 int
-g_file_open(const char *file_name)
+g_file_open_rw(const char *file_name)
 {
 #if defined(_WIN32)
     return (int)CreateFileA(file_name, GENERIC_READ | GENERIC_WRITE,
                             FILE_SHARE_READ | FILE_SHARE_WRITE,
                             0, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, 0);
 #else
-    int rv;
-
-    rv =  open(file_name, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
-
-    if (rv == -1)
-    {
-        /* can't open read / write, try to open read only */
-        rv =  open(file_name, O_RDONLY);
-    }
-
-    return rv;
+    return open(file_name, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
 #endif
 }
 
@@ -2143,6 +2133,14 @@ g_file_open_ex(const char *file_name, int aread, int awrite,
     rv =  open(file_name, flags, S_IRUSR | S_IWUSR);
     return rv;
 #endif
+}
+
+/*****************************************************************************/
+/* returns -1 on error, else return handle or file descriptor */
+int
+g_file_open_ro(const char *file_name)
+{
+    return g_file_open_ex(file_name, 1, 0, 0, 0);
 }
 
 /*****************************************************************************/

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -206,9 +206,10 @@ int      g_obj_wait(tintptr *read_objs, int rcount, tintptr *write_objs,
 void     g_random(char *data, int len);
 int      g_abs(int i);
 int      g_memcmp(const void *s1, const void *s2, int len);
-int      g_file_open(const char *file_name);
+int      g_file_open_rw(const char *file_name);
 int      g_file_open_ex(const char *file_name, int aread, int awrite,
                         int acreate, int atrunc);
+int      g_file_open_ro(const char *file_name);
 int      g_file_close(int fd);
 /**
  * Returns 1 if a file is open (i.e. the file descriptor is valid)

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -333,6 +333,7 @@ int      g_tcp4_socket(void);
 int      g_tcp4_bind_address(int sck, const char *port, const char *address);
 int      g_tcp6_socket(void);
 int      g_tcp6_bind_address(int sck, const char *port, const char *address);
+int      g_no_new_privs(void);
 
 /* glib-style wrappers */
 #define g_new(struct_type, n_structs) \

--- a/docs/man/sesman.ini.5.in
+++ b/docs/man/sesman.ini.5.in
@@ -303,6 +303,15 @@ if the group specified in \fBTerminalServerUsers\fR doesn't exist.
 \fBAllowAlternateShell\fR=\fI[true|false]\fR
 If set to \fB0\fR, \fBfalse\fR or \fBno\fR, prevent usage of alternate shells by users.
 
+.TP
+\fBXorgNoNewPrivileges\fR=\fI[true|false]\fR
+Only applicable on Linux. If set to \fB0\fR, \fBfalse\fR or \fBno\fR, do
+not use the kernel's \fIno_new_privs\fR restriction when invoking the Xorg
+X11 server. The use of \fIno_new_privs\fR is intended to prevent issues due
+to a setuid Xorg executable. However, if a kernel security module (such as
+AppArmor) is used to confine xrdp, \fIno_new_privs\fR may interfere with
+transitions between confinement domains.
+
 .SH "X11 SERVER"
 Following parameters can be used in the \fB[Xvnc]\fR and
 \fB[Xorg]\fR sections.

--- a/fontutils/fv1.c
+++ b/fontutils/fv1.c
@@ -170,7 +170,7 @@ fv1_file_load(const char *filename)
             int fd;
             make_stream(s);
             init_stream(s, file_size + 1024);
-            fd = g_file_open(filename);
+            fd = g_file_open_ro(filename);
 
             if (fd < 0)
             {

--- a/fontutils/windows/fontdump.c
+++ b/fontutils/windows/fontdump.c
@@ -155,7 +155,7 @@ font_dump(void)
     g_snprintf(filename, 255, "%s-%d.fv1", g_font_name, g_font_size);
     msg("creating file %s", filename);
     g_file_delete(filename);
-    fd = g_file_open(filename);
+    fd = g_file_open_rw(filename);
     g_file_write(fd, "FNT1", 4);
     strlen1 = g_strlen(g_font_name);
     g_file_write(fd, g_font_name, strlen1);

--- a/keygen/keygen.c
+++ b/keygen/keygen.c
@@ -367,7 +367,7 @@ save_all(const char *e_data, int e_len, const char *n_data, int n_len,
         }
     }
 
-    fd = g_file_open(filename);
+    fd = g_file_open_rw(filename);
 
     if (fd != -1)
     {

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -420,7 +420,7 @@ xrdp_load_keyboard_layout(struct xrdp_client_info *client_info)
     g_snprintf(keyboard_cfg_file, 255, "%s/xrdp_keyboard.ini", XRDP_CFG_PATH);
     LOG(LOG_LEVEL_DEBUG, "keyboard_cfg_file %s", keyboard_cfg_file);
 
-    fd = g_file_open(keyboard_cfg_file);
+    fd = g_file_open_ro(keyboard_cfg_file);
 
     if (fd >= 0)
     {

--- a/sesman/chansrv/chansrv_config.c
+++ b/sesman/chansrv/chansrv_config.c
@@ -231,7 +231,7 @@ config_read(int use_logger, const char *sesman_ini)
     log_func_t logmsg = (use_logger) ? log_message : log_to_stdout;
     int fd;
 
-    fd = g_file_open_ex(sesman_ini, 1, 0, 0, 0);
+    fd = g_file_open_ro(sesman_ini);
     if (fd < 0)
     {
         logmsg(LOG_LEVEL_ERROR, "Can't open config file %s", sesman_ini);

--- a/sesman/chansrv/clipboard_file.c
+++ b/sesman/chansrv/clipboard_file.c
@@ -462,7 +462,7 @@ clipboard_send_file_data(int streamId, int lindex,
               "nPositionLow %d cbRequested %d", streamId, lindex,
               nPositionLow, cbRequested);
     g_snprintf(full_fn, 255, "%s/%s", cfi->pathname, cfi->filename);
-    fd = g_file_open_ex(full_fn, 1, 0, 0, 0);
+    fd = g_file_open_ro(full_fn);
     if (fd == -1)
     {
         LOG(LOG_LEVEL_ERROR, "clipboard_send_file_data: file open [%s] failed: %s",

--- a/sesman/libsesman/sesman_config.c
+++ b/sesman/libsesman/sesman_config.c
@@ -70,6 +70,7 @@
 #define SESMAN_CFG_SEC_RESTRICT_OUTBOUND_CLIPBOARD "RestrictOutboundClipboard"
 #define SESMAN_CFG_SEC_RESTRICT_INBOUND_CLIPBOARD  "RestrictInboundClipboard"
 #define SESMAN_CFG_SEC_ALLOW_ALTERNATE_SHELL       "AllowAlternateShell"
+#define SESMAN_CFG_SEC_XORG_NO_NEW_PRIVILEGES      "XorgNoNewPrivileges"
 
 #define SESMAN_CFG_SESSIONS          "Sessions"
 #define SESMAN_CFG_SESS_MAX          "MaxSessions"
@@ -310,6 +311,7 @@ config_read_security(int file, struct config_security *sc,
     sc->restrict_outbound_clipboard = 0;
     sc->restrict_inbound_clipboard = 0;
     sc->allow_alternate_shell = 1;
+    sc->xorg_no_new_privileges = 1;
 
     file_read_section(file, SESMAN_CFG_SECURITY, param_n, param_v);
 
@@ -383,6 +385,11 @@ config_read_security(int file, struct config_security *sc,
                 g_text2bool((char *)list_get_item(param_v, i));
         }
 
+        if (0 == g_strcasecmp(buf, SESMAN_CFG_SEC_XORG_NO_NEW_PRIVILEGES))
+        {
+            sc->xorg_no_new_privileges =
+                g_text2bool((char *)list_get_item(param_v, i));
+        }
     }
 
     return 0;
@@ -670,6 +677,9 @@ config_dump(struct config_sesman *config)
     g_writeln("    MaxLoginRetry:             %d", sc->login_retry);
     g_writeln("    AlwaysGroupCheck:          %d", sc->ts_always_group_check);
     g_writeln("    AllowAlternateShell:       %d", sc->allow_alternate_shell);
+#ifdef HAVE_SYS_PRCTL_H
+    g_writeln("    XorgNoNewPrivileges:       %d", sc->xorg_no_new_privileges);
+#endif
     sesman_clip_restrict_mask_to_string(sc->restrict_outbound_clipboard,
                                         restrict_s, sizeof(restrict_s));
     g_writeln("    RestrictOutboundClipboard: %s", restrict_s);

--- a/sesman/libsesman/sesman_config.c
+++ b/sesman/libsesman/sesman_config.c
@@ -583,7 +583,7 @@ config_read(const char *sesman_ini)
         if ((cfg->sesman_ini = g_strdup(sesman_ini)) != NULL)
         {
             int fd;
-            if ((fd = g_file_open_ex(cfg->sesman_ini, 1, 0, 0, 0)) != -1)
+            if ((fd = g_file_open_ro(cfg->sesman_ini)) != -1)
             {
                 struct list *sec;
                 struct list *param_n;

--- a/sesman/libsesman/sesman_config.h
+++ b/sesman/libsesman/sesman_config.h
@@ -103,6 +103,12 @@ struct config_security
      *          If not specified, 'YES' is assumed.
      */
     int allow_alternate_shell;
+
+    /*
+     * @var xorg_no_new_privileges
+     * @brief if the Xorg X11 server should be started with no_new_privs (Linux only)
+     */
+    int xorg_no_new_privileges;
 };
 
 /**

--- a/sesman/lock_uds.c
+++ b/sesman/lock_uds.c
@@ -87,7 +87,7 @@ lock_uds(const char *sockname)
             *p++ = '\0';
 
             saved_umask = g_umask_hex(0x77);
-            fd = g_file_open(filename);
+            fd = g_file_open_rw(filename);
             g_umask_hex(saved_umask);
             if (fd < 0)
             {

--- a/sesman/sesexec/session.c
+++ b/sesman/sesexec/session.c
@@ -33,10 +33,6 @@
 #include "config_ac.h"
 #endif
 
-#ifdef HAVE_SYS_PRCTL_H
-#include <sys/prctl.h>
-#endif
-
 #include <errno.h>
 
 #include "arch.h"
@@ -55,10 +51,6 @@
 #include "xauth.h"
 #include "xwait.h"
 #include "xrdp_sockets.h"
-
-#ifndef PR_SET_NO_NEW_PRIVS
-#define PR_SET_NO_NEW_PRIVS 38
-#endif
 
 struct session_data
 {
@@ -347,21 +339,18 @@ prepare_xorg_xserver_params(const struct session_parameters *s,
     {
         params->auto_free = 1;
 
-#ifdef HAVE_SYS_PRCTL_H
         /*
          * Make sure Xorg doesn't run setuid root. Root access is not
          * needed. Xorg can fail when run as root and the user has no
          * console permissions.
-         * PR_SET_NO_NEW_PRIVS requires Linux kernel 3.5 and newer.
          */
-        if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) < 0)
+        if (g_no_new_privs() != 0)
         {
             LOG(LOG_LEVEL_WARNING,
                 "[session start] (display %u): Failed to disable "
                 "setuid on X server: %s",
                 s->display, g_get_strerror());
         }
-#endif
 
         g_snprintf(screen, sizeof(screen), ":%u", s->display);
 

--- a/sesman/sesexec/session.c
+++ b/sesman/sesexec/session.c
@@ -344,7 +344,7 @@ prepare_xorg_xserver_params(const struct session_parameters *s,
          * needed. Xorg can fail when run as root and the user has no
          * console permissions.
          */
-        if (g_no_new_privs() != 0)
+        if (g_cfg->sec.xorg_no_new_privileges && g_no_new_privs() != 0)
         {
             LOG(LOG_LEVEL_WARNING,
                 "[session start] (display %u): Failed to disable "

--- a/sesman/sesman.c
+++ b/sesman/sesman.c
@@ -658,7 +658,7 @@ read_pid_file(const char *pid_file, int *pid)
     {
         g_printf("sesman is not running (pid file not found - %s)\n", pid_file);
     }
-    else if ((fd = g_file_open(pid_file)) < 0)
+    else if ((fd = g_file_open_ro(pid_file)) < 0)
     {
         g_printf("error opening pid file[%s]: %s\n", pid_file, g_get_strerror());
     }
@@ -838,15 +838,15 @@ main(int argc, char **argv)
         g_file_close(1);
         g_file_close(2);
 
-        if (g_file_open("/dev/null") < 0)
+        if (g_file_open_rw("/dev/null") < 0)
         {
         }
 
-        if (g_file_open("/dev/null") < 0)
+        if (g_file_open_rw("/dev/null") < 0)
         {
         }
 
-        if (g_file_open("/dev/null") < 0)
+        if (g_file_open_rw("/dev/null") < 0)
         {
         }
     }
@@ -905,7 +905,7 @@ main(int argc, char **argv)
     {
         /* writing pid file */
         char pid_s[32];
-        int fd = g_file_open(pid_file);
+        int fd = g_file_open_rw(pid_file);
 
         if (-1 == fd)
         {

--- a/sesman/sesman.ini.in
+++ b/sesman/sesman.ini.in
@@ -39,6 +39,11 @@ RestrictOutboundClipboard=none
 RestrictInboundClipboard=none
 ; Set to 'no' to prevent users from logging in with alternate shells
 #AllowAlternateShell=true
+; On Linux systems, the Xorg X11 server is normally invoked using
+; no_new_privs to avoid problems if the executable is suid. This may,
+; however, interfere with the use of security modules such as AppArmor.
+; Leave this unset unless you need to disable it.
+#XorgNoNewPrivileges=true
 
 [Sessions]
 ;; X11DisplayOffset - x11 display number offset

--- a/sesman/session_list.c
+++ b/sesman/session_list.c
@@ -33,10 +33,6 @@
 #include "config_ac.h"
 #endif
 
-#ifdef HAVE_SYS_PRCTL_H
-#include <sys/prctl.h>
-#endif
-
 #include "arch.h"
 #include "session_list.h"
 #include "trans.h"

--- a/tests/libipm/test_libipm_main.c
+++ b/tests/libipm/test_libipm_main.c
@@ -58,7 +58,7 @@ suite_test_libipm_calls_start(void)
         const char *errstr = g_get_strerror();
         LOG(LOG_LEVEL_ERROR, "Can't create test transport 3 [%s]", errstr);
     }
-    else if ((fd = g_file_open("/dev/zero")) < 0)
+    else if ((fd = g_file_open_rw("/dev/zero")) < 0)
     {
         const char *errstr = g_get_strerror();
         LOG(LOG_LEVEL_ERROR, "Can't open /dev/zero [%s]", errstr);

--- a/xrdp/lang.c
+++ b/xrdp/lang.c
@@ -288,7 +288,7 @@ int km_load_file(const char *filename, struct xrdp_keymap *keymap)
     int fd;
 
     LOG(LOG_LEVEL_INFO, "Loading keymap file %s", filename);
-    fd = g_file_open(filename);
+    fd = g_file_open_ro(filename);
 
     if (fd != -1)
     {

--- a/xrdp/xrdp.c
+++ b/xrdp/xrdp.c
@@ -375,7 +375,7 @@ main(int argc, char **argv)
 
         if (g_file_exist(pid_file)) /* xrdp.pid */
         {
-            fd = g_file_open(pid_file); /* xrdp.pid */
+            fd = g_file_open_ro(pid_file); /* xrdp.pid */
         }
 
         if (fd == -1)
@@ -450,7 +450,7 @@ main(int argc, char **argv)
         g_create_path(pid_file);
 
         /* make sure we can write to pid file */
-        fd = g_file_open(pid_file); /* xrdp.pid */
+        fd = g_file_open_rw(pid_file); /* xrdp.pid */
 
         if (fd == -1)
         {
@@ -509,7 +509,7 @@ main(int argc, char **argv)
         g_sleep(1000);
         /* write the pid to file */
         pid = g_getpid();
-        fd = g_file_open(pid_file); /* xrdp.pid */
+        fd = g_file_open_rw(pid_file); /* xrdp.pid */
 
         if (fd == -1)
         {
@@ -528,15 +528,15 @@ main(int argc, char **argv)
         g_file_close(1);
         g_file_close(2);
 
-        if (g_file_open("/dev/null") < 0)
+        if (g_file_open_rw("/dev/null") < 0)
         {
         }
 
-        if (g_file_open("/dev/null") < 0)
+        if (g_file_open_rw("/dev/null") < 0)
         {
         }
 
-        if (g_file_open("/dev/null") < 0)
+        if (g_file_open_rw("/dev/null") < 0)
         {
         }
 

--- a/xrdp/xrdp_bitmap_load.c
+++ b/xrdp/xrdp_bitmap_load.c
@@ -542,7 +542,7 @@ xrdp_bitmap_load_bmp(struct xrdp_bitmap *self, const char *filename,
         return 1;
     }
 
-    fd = g_file_open(filename);
+    fd = g_file_open_ro(filename);
 
     if (fd == -1)
     {

--- a/xrdp/xrdp_font.c
+++ b/xrdp/xrdp_font.c
@@ -210,7 +210,7 @@ xrdp_font_create(struct xrdp_wm *wm, unsigned int dpi)
     self->wm = wm;
     make_stream(s);
     init_stream(s, file_size + 1024);
-    fd = g_file_open(file_path);
+    fd = g_file_open_ro(file_path);
 
     if (fd != -1)
     {

--- a/xrdp/xrdp_listen.c
+++ b/xrdp/xrdp_listen.c
@@ -170,7 +170,7 @@ xrdp_listen_get_startup_params(struct xrdp_listen *self)
     startup_params = self->startup_params;
     port_override = startup_params->port[0] != 0;
     fork_override = startup_params->fork;
-    fd = g_file_open(startup_params->xrdp_ini);
+    fd = g_file_open_ro(startup_params->xrdp_ini);
     if (fd != -1)
     {
         names = list_create();

--- a/xrdp/xrdp_login_wnd.c
+++ b/xrdp/xrdp_login_wnd.c
@@ -607,7 +607,7 @@ xrdp_wm_login_fill_in_combo(struct xrdp_wm *self, struct xrdp_bitmap *b)
     section_names->auto_free = 1;
     section_values = list_create();
     section_values->auto_free = 1;
-    fd = g_file_open(xrdp_ini);
+    fd = g_file_open_ro(xrdp_ini);
 
     if (fd < 0)
     {
@@ -1107,7 +1107,7 @@ load_xrdp_config(struct xrdp_config *config, const char *xrdp_ini, int bpp)
     globals->ls_unscaled.help_wnd_height = DEFAULT_WND_HELP_H;
 
     /* open xrdp.ini file */
-    if ((fd = g_file_open(xrdp_ini)) < 0)
+    if ((fd = g_file_open_ro(xrdp_ini)) < 0)
     {
         LOG(LOG_LEVEL_ERROR, "load_config: Could not read "
             "xrdp.ini file %s", xrdp_ini);

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -2073,7 +2073,7 @@ xrdp_mm_get_sesman_port(char *port, int port_bytes)
     g_strncpy(port, "3350", port_bytes - 1);
     /* see if port is in sesman.ini file */
     g_snprintf(cfg_file, 255, "%s/sesman.ini", XRDP_CFG_PATH);
-    fd = g_file_open(cfg_file);
+    fd = g_file_open_ro(cfg_file);
 
     if (fd >= 0)
     {
@@ -2861,7 +2861,7 @@ xrdp_mm_dump_jpeg(struct xrdp_mm *self, XRDP_ENC_DATA_DONE *enc_done)
     header.bytes_follow = enc_done->comp_bytes - (2 + pheader_bytes[0]);
     if (ii == 0)
     {
-        ii = g_file_open("/tmp/jpeg.beef.bin");
+        ii = g_file_open_rw("/tmp/jpeg.beef.bin");
         if (ii == -1)
         {
             ii = 0;

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -245,7 +245,7 @@ xrdp_wm_load_pointer(struct xrdp_wm *self, char *file_name, char *data,
 
     make_stream(fs);
     init_stream(fs, 8192);
-    fd = g_file_open(file_name);
+    fd = g_file_open_ro(file_name);
 
     if (fd < 0)
     {
@@ -414,7 +414,7 @@ xrdp_wm_load_static_colors_plus(struct xrdp_wm *self, char *autorun_name)
     self->background = HCOLOR(self->screen->bpp, 0x000000);
 
     /* now load them from the globals in xrdp.ini if defined */
-    fd = g_file_open(self->session->xrdp_ini);
+    fd = g_file_open_ro(self->session->xrdp_ini);
 
     if (fd >= 0)
     {
@@ -638,7 +638,7 @@ xrdp_wm_init(struct xrdp_wm *self)
          * NOTE: this should eventually be accessed from self->xrdp_config
          */
 
-        fd = g_file_open(self->session->xrdp_ini);
+        fd = g_file_open_ro(self->session->xrdp_ini);
         if (fd != -1)
         {
             names = list_create();

--- a/xrdp/xrdpwin.c
+++ b/xrdp/xrdpwin.c
@@ -214,7 +214,7 @@ MyServiceMain(DWORD dwArgc, LPTSTR *lpszArgv)
     //  int fd;
     //  char text[256];
 
-    //  fd = g_file_open("c:\\temp\\xrdp\\log.txt");
+    //  fd = g_file_open_rw("c:\\temp\\xrdp\\log.txt");
     //  g_file_write(fd, "hi\r\n", 4);
     //event_han = RegisterEventSource(0, "xrdp");
     //log_event(event_han, "hi xrdp log");
@@ -452,7 +452,7 @@ main(int argc, char **argv)
 
             if (g_file_exist(pid_file)) /* xrdp.pid */
             {
-                fd = g_file_open(pid_file); /* xrdp.pid */
+                fd = g_file_open_ro(pid_file); /* xrdp.pid */
             }
 
             if (fd == -1)
@@ -539,7 +539,7 @@ main(int argc, char **argv)
     if (!no_daemon)
     {
         /* make sure we can write to pid file */
-        fd = g_file_open(pid_file); /* xrdp.pid */
+        fd = g_file_open_rw(pid_file); /* xrdp.pid */
 
         if (fd == -1)
         {
@@ -579,9 +579,9 @@ main(int argc, char **argv)
         g_file_close(0);
         g_file_close(1);
         g_file_close(2);
-        g_file_open("/dev/null");
-        g_file_open("/dev/null");
-        g_file_open("/dev/null");
+        g_file_open_rw("/dev/null");
+        g_file_open_rw("/dev/null");
+        g_file_open_rw("/dev/null");
         /* end of daemonizing code */
     }
 
@@ -589,7 +589,7 @@ main(int argc, char **argv)
     {
         /* write the pid to file */
         pid = g_getpid();
-        fd = g_file_open(pid_file); /* xrdp.pid */
+        fd = g_file_open_rw(pid_file); /* xrdp.pid */
 
         if (fd == -1)
         {


### PR DESCRIPTION
For some time now, I've been wanting to develop AppArmor profiles to confine xrdp and its components while running. Given that the `xrdp` process is open to the network, and `xrdp-sesman` runs as root, these are good candidates for security hardening.

### Code changes

I found that some modifications to the code are necessary, however, to make this feasible. These changes are in my first commit, and they are relatively minor:

* The function `g_file_open()` is used in numerous places to read things like configuration files. However, it is also used for writing files (e.g. PID files). The meat of the function, on the POSIX side, is as follows:
  ```
      rv =  open(file_name, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);

      if (rv == -1)
      {
          /* can't open read / write, try to open read only */
          rv =  open(file_name, O_RDONLY);
      }
  ```
  This "try at first to open the file read/write" approach does not look good in a confinement framework. With AppArmor enabled, I see messages like this in the system log:
  ```
  Mar 29 17:13:05 darkstar kernel: [  494.847515] audit: type=1400 audit(1648588385.232:73): apparmor="DENIED" operation="mknod" profile="/usr/sbin/xrdp" name="/etc/xrdp/xrdp_keyboard.ini" pid=1922 comm="xrdp" requested_mask="c" denied_mask="c" fsuid=123 ouid=123
  ```
  At first, this left me scratching my head thinking, "Why is xrdp trying to write to the keyboard config file?" This didn't prevent xrdp from running correctly (as can happen with AppArmor if you're not careful), but security-minded admins would look askance at this.

  There is a different call in the xrdp code that is used in a few places, that gives proper read-only access:
  ```
      fd = g_file_open_ex(file_name, 1, 0, 0, 0);
  ```
  The parameters are four flags, requesting any combination of read access, write access, file creation, and file truncation. Most of the time, however, the above combination is used.

  The first change I made was to turn all the `g_file_open()` calls that appear to need only read access, to use a proper read-only call. At first, I replaced them with calls like the above `g_file_open_ex()` example. But I realized that this function call is not very clear as to what it's doing unless you have the function signature in front of you, and it's used in exactly this form numerous times throughout the code. So I added a new function `g_file_open_ro()` that wraps this specific combination, and made my edits use *that* instead.

  (Philosophically speaking, it would probably be better to have `g_file_open()` return a read-only descriptor, and add a new function like `g_file_open_rw()` or `g_file_open_write()` to return a writable one, so that the request for write access is explicit. But that's beyond the scope of this change.)

* When the X server is executed, xrdp uses (when available) the Linux kernel's "no new privileges" feature to avoid potential fallout from invoking a setuid-root X server binary. This is a good thing to do, from a security perspective---but paradoxically, it gets in the way of further security hardening via AppArmor.

  As it happens, the `NoNewPrivs` flag on a process prevents AppArmor from changing its confinement profile *at all*, even if the destination profile is more restrictive than the source one. What this means for xrdp is that the X server cannot be confined using a different, narrower profile than its parent (xrdp-sesman). If I attempt to do so, I get an error like this in the system log:
  ```
  Apr  1 01:26:53 darkstar kernel: [ 4711.096244] audit: type=1400 audit(1648790813.552:691): apparmor="DENIED" operation="exec" info="no new privs" error=-1 profile="xrdp-sesman" name="/usr/lib/xorg/Xorg" pid=32353 comm="xrdp-sesman" requested_mask="x" denied_mask="x" fsuid=1000 ouid=0 target="xrdp-sesman//xorg"
  ```
  This is not ideal, because the X server needs access to a lot fewer things than xrdp-sesman---and, in turn, the X server needs a few things that xrdp-sesman can do without. The two processes should not run with the same set of permissions.

  I didn't want to get rid of the `PR_SET_NO_NEW_PRIVS` functionality, and I wanted to avoid adding a new configuration option, so what I did was add a check: If AppArmor is loaded, *and* the process is already confined in some way, then don't set `NoNewPrivs`. This is done by examining the content of `/proc/self/attr/apparmor/current`. The check is performed in a fail-safe way, so if anything goes wrong, the `NoNewPrivs` transition remains in effect.

### Apparmor profiles

My second commit adds the new profiles. Some notes on these:

* These profiles have been developed and tested on Ubuntu.

* I tested only with Xorg and Xvnc (specifically Xtigervnc). I don't have the setup to test vnc-any or neutrinordp-any.

* My changes are to the latest Git `devel` branch, but I tested by applying them to the Debian 0.9.19 package and compiling it on Ubuntu. (Ubuntu does not have 0.9.19 yet, as of this writing.)

* I accommodated the FUSE stuff so that users can login/logout without issue, but I have no idea how to test that functionality.

* The profile filenames follow the standard AppArmor convention of reflecting the absolute path of the installed binary. That said, the filenames are arbitrary, and are not parsed in any way.

* The profiles themselves do contain absolute paths to various binaries, as AppArmor requires. These can be handled by parameterization (see e.g. `@{Xorg}` in the `usr.sbin.xrdp-sesman` profile), alternation (AppArmor supports `{a,b,c}` syntax in paths), and of course build-time substitutions `@like_this@`.

* The profiles can be enabled by copying them into `/etc/apparmor.d/`, running `/etc/init.d/apparmor force-reload` (or rebooting), and restarting xrdp. Any prohibited actions will appear in the system log with `apparmor="DENIED"`.

* The profiles, as written, are in "enforce" mode. If you would like to experiment, you may want to enable them in "complain" mode. This will cause AppArmor to allow the application to do whatever it wants, but still log anything that it would have prohibited in "enforce" mode. All that is needed is to symlink the profiles into the `/etc/apparmor.d/force-complain/` directory, and run `/etc/init.d/apparmor force-reload` (or reboot). Then, watch your system log for `apparmor="ALLOWED"` messages.

  (Additionally, any `deny` AppArmor directives should be preceded with `audit` [if not already present] so that violations of same are logged. Normally, `deny` directives request "silent deny" behavior.)

### Further work

* Careful testing of the more advanced xrdp functionality will be needed, to ensure that the AppArmor profiles allow the necessary access. I've covered the basic use cases, but of course there are going to be more exotic setups that need to be supported.

* Some adaptation to other Linux distributions will likely be needed. My experience is only with Debian/Ubuntu, however, so I'm not in a good position to address this.

* There is one major hole in these AppArmor profiles, which will require additional work to address. It is this line in `usr.sbin.xrdp-sesman`:
  ```
    /etc/xrdp/startwm.sh Uxr,
  ```
  This allows `startwm.sh` to be executed without confinement. The user session cannot run within the tightly-defined profile for xrdp-sesman; in fact, it probably can't run (or at least normally doesn't run) in any AppArmor profile at all. So this line allows that script an "escape hatch" out of the restrictions imposed on xrdp-sesman.

  Because this is a shell script, however, there is a risk that could allow an attacker to take advantage of the "escape hatch." Rather than explain the issue here, I will link [this excellent article](https://web.archive.org/web/20120907231819/http://blog.azimuthsecurity.com/2012/09/poking-holes-in-apparmor-profiles.html) that describes it in detail. (This is an old article, hence the Wayback link, but its analysis still reflects the situation today.)

  The current versions of the `startwm.sh` script rely on xrdp-sesman setting up `PATH` and `LANG` variables (using `pam_env`) prior to its invocation. However, in an environment where this script represents a loosening of process confinement, at least `PATH` has to be treated as "tainted" data potentially originating from an attacker.

  The simplest thing to do would be to put e.g. `PATH=/bin:/usr/bin` at the top of the script, and then set up `PATH`/`LANG` properly in shell space. A more complex solution would be to have a separate helper program for this: this helper would be executed unconfined, and then it does the `pam_env` stuff, reads `DefaultWindowManager` or whatever from `sesman.ini`, and finally exec()s the program. (Importantly, this helper cannot take arguments, as they may come from an attacker and AppArmor rules cannot match against those.)

I'll be happy to answer any questions, and revise these changes as needed.