### PR TITLE
Improve RDS compatibility

### DIFF
--- a/libxrdp/libxrdp.h
+++ b/libxrdp/libxrdp.h
@@ -67,6 +67,9 @@ struct xrdp_mcs
     struct stream *client_mcs_data;
     struct stream *server_mcs_data;
     struct list *channel_list;
+    /* This boolean is set to indicate we're expecing channel join
+     * requests as part of the connect sequence */
+    int expecting_channel_join_requests;
 };
 
 /* fastpath */

--- a/libxrdp/xrdp_mcs.c
+++ b/libxrdp/xrdp_mcs.c
@@ -718,6 +718,8 @@ xrdp_mcs_recv_cjrq(struct xrdp_mcs *self)
 {
     int opcode;
     struct stream *s;
+    int initiator;
+    int channel_id;
 
     s = libxrdp_force_read(self->iso_layer->trans);
     if (s == 0)
@@ -753,8 +755,8 @@ xrdp_mcs_recv_cjrq(struct xrdp_mcs *self)
         return 1;
     }
 
-    in_uint8s(s, 4); /* initiator (2 bytes)
-                        channelId (2 bytes) */
+    in_uint16_be(s, initiator);
+    in_uint16_be(s, channel_id);
 
     /*
      * [MS-RDPBCGR] 2.2.1.8 says that the mcsAUrq field is 5 bytes (which have
@@ -772,8 +774,9 @@ xrdp_mcs_recv_cjrq(struct xrdp_mcs *self)
     }
 
     LOG_DEVEL(LOG_LEVEL_TRACE, "Received [ITU-T T.125] ChannelJoinRequest "
-              "initiator (ignored), channelId (ignored), "
+              "initiator %d, channelId %d, "
               "nonStandard (%s)",
+              initiator, channel_id,
               (opcode & 2) ? "present" : "not present");
 
     if (!s_check_end_and_log(s, "MCS protocol error [ITU-T T.125] ChannelJoinRequest"))

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -1944,6 +1944,7 @@ xrdp_sec_send_fastpath(struct xrdp_sec *self, struct stream *s)
 static int
 xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec *self, struct stream *s)
 {
+    int version;
     int colorDepth;
     int postBeta2ColorDepth;
     int highColorDepth;
@@ -1951,8 +1952,10 @@ xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec *self, struct stream *s)
     int earlyCapabilityFlags;
     char clientName[INFO_CLIENT_NAME_BYTES / 2] = { '\0' };
 
+    UNUSED_VAR(version);
+
     /* TS_UD_CS_CORE requiered fields */
-    in_uint8s(s, 4); /* version */
+    in_uint32_le(s, version);
     in_uint16_le(s, self->rdp_layer->client_info.display_sizes.session_width);
     in_uint16_le(s, self->rdp_layer->client_info.display_sizes.session_height);
     in_uint16_le(s, colorDepth);
@@ -1975,12 +1978,13 @@ xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec *self, struct stream *s)
     in_uint8s(s, 4); /* keyboardFunctionKey */
     in_uint8s(s, 64); /* imeFileName */
     LOG_DEVEL(LOG_LEVEL_TRACE, "Received [MS-RDPBCGR] TS_UD_CS_CORE "
-              "<Requiered fields> version (ignored), desktopWidth %d, "
+              "<Required fields> version %08x, desktopWidth %d, "
               "desktopHeight %d, colorDepth %s, SASSequence (ingored), "
               "keyboardLayout (ignored), clientBuild (ignored), "
               "clientName %s, keyboardType (ignored), "
               "keyboardSubType (ignored), keyboardFunctionKey (ignored), "
-              "imeFileName (ignroed)",
+              "imeFileName (ignored)",
+              version,
               self->rdp_layer->client_info.display_sizes.session_width,
               self->rdp_layer->client_info.display_sizes.session_height,
               (colorDepth == 0xca00 ? "RNS_UD_COLOR_4BPP" :


### PR DESCRIPTION
Fixes #2166

This PR improves compatibility with RDS in two ways:-
1) Windows 10 (and FreeRDP) set the user channel ID (see [MS-RDPBCGR] [3.3.1.2](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/950cd069-252e-4c33-9988-cd5a6d3b5842)) to be one more than the last static channel ID. xrdp v0.9.19 and earlier use 1002 for the user channel ID. This is supposed to be the server channel ID ([MS-RDPBCGR] 3.3.1.5). This PR emulates Windows behaviour.
2) The use of MCS channel join PDUs is documented in [MS-RDPBCGR] [3.3.5.3.8](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/2cd07374-76de-4df9-b999-c796c84b6723) and [3.3.5.3.9](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/c604522b-33cb-4416-9826-71992e51c1d6). These sections do not mention what to do if too few channel join PDUs are received.
- xrdp versions which support TLS (i.e. xrdp v0.9.1 and later) insist on receiving exactly the right number of channel join PDUs. This is because immediately after these, a TLS client hello' is received and the code is much simpler if this can be started cleanly.
- xrdp versions which do not support TLS (i.e. previous to xrdp v0.9.1) simply accept the join requests they are given and acknowledge them. If any are missing, that's fine.
- Experiments with FreeRDP and Windows 10 (see [here](/neutrinolabs/xrdp/issues/2166#issuecomment-1124830344)) show that Windows RDS is fine with too few join requests in both TLS and non-TLS mode.

   The move to xrdp v0.9.x broke compatibility with some older clients (see #874, #2166) as these clients do not send a channel join request for the user channel.

We can't easily make xrdp emulate Windows behaviour fully, as this would really complicate the TLS handshake. What this PR does however, is to re-instate the pre v0.9.1 behaviour for non-TLS clients only. Older clients either can't use TLS, or can only use insecure versions of it, so this at least gives users of those devices a way to keep using them.