### PR TITLE
Bump cppcheck version to 2.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
       CC: gcc
       # This is required to use a version of cppcheck other than that
       # supplied with the operating system
-      CPPCHECK_VER: 2.7
+      CPPCHECK_VER: 2.8
       CPPCHECK_REPO: https://github.com/danmar/cppcheck.git
     steps:
       # This is currently the only way to get a version into

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,10 +132,12 @@ jobs:
       CPPCHECK_VER: 2.8
       CPPCHECK_REPO: https://github.com/danmar/cppcheck.git
     steps:
-      # This is currently the only way to get a version into
-      # the cache tag name - see https://github.com/actions/cache/issues/543
-      - run: |
-          echo "OS_VERSION=`lsb_release -sr`" >> $GITHUB_ENV
+      # Set steps.os.outputs.image to the specific OS (e.g. 'ubuntu20')
+      # see https://github.com/actions/cache/issues/543
+      - name: Get operating system name and version.
+        id: os
+        run: echo "::set-output name=image::$ImageOS"
+        shell: bash
       - uses: actions/checkout@v2
       - name: Cache cppcheck
         uses: actions/cache@v2
@@ -143,7 +145,7 @@ jobs:
           cache-name: cache-cppcheck
         with:
           path: ~/cppcheck.local
-          key: ${{ runner.os }}-${{ env.OS_VERSION }}-build-${{ env.cache-name }}-${{ env.CPPCHECK_VER }}
+          key: ${{ steps.os.outputs.image }}-build-${{ env.cache-name }}-${{ env.CPPCHECK_VER }}
       - run: sudo scripts/install_cppcheck_dependencies_with_apt.sh
       - run: ./bootstrap
       - run: scripts/install_cppcheck.sh $CPPCHECK_REPO $CPPCHECK_VER

--- a/fontdump/fontdump.c
+++ b/fontdump/fontdump.c
@@ -72,14 +72,18 @@ msg(char *msg1, ...)
 static int
 show_last_error(void)
 {
-    LPVOID lpMsgBuf;
-
-    FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
-                   NULL, GetLastError(),
-                   MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-                   (LPSTR)&lpMsgBuf, 0, NULL);
-    msg("GetLastError - %s", lpMsgBuf);
-    LocalFree(lpMsgBuf);
+    LPVOID lpMsgBuf = NULL;
+    DWORD len;
+    len = FormatMessageA(
+              FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
+              NULL, GetLastError(),
+              MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+              (LPSTR)&lpMsgBuf, 0, NULL);
+    if (len > 0)
+    {
+        msg("GetLastError - %s", lpMsgBuf);
+        LocalFree(lpMsgBuf);
+    }
     return 0;
 }
 


### PR DESCRIPTION
Minor change to the (Windows) `fontdump/fontdump.c` was needed to prevent this error:-

```
fontdump/fontdump.c:80:28: error: Uninitialized variable: lpMsgBuf [uninitvar]
                   (LPSTR)&lpMsgBuf, 0, NULL);
                           ^
```
Message is a false positive, possibly caused by the cast and the lack of a prototype.

However, there is an error here, which is if the call to [FormatMesasgeA](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-formatmessagea) fails, lpMsgBuf will be unititialised after the call.

Simplest fix is to initialise the variable to NULL which fixes the cppcheck error and check the call result before dereferencing the pointer.