### PR TITLE
github actions: use canonical way to get ImageOS for astyle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,10 +161,12 @@ jobs:
       ASTYLE_VER: 3.1
       ASTYLE_REPO: https://svn.code.sf.net/p/astyle/code/tags
     steps:
-      # This is currently the only way to get a version into
-      # the cache tag name - see https://github.com/actions/cache/issues/543
-      - run: |
-          echo "OS_VERSION=`lsb_release -sr`" >> $GITHUB_ENV
+      # Set steps.os.outputs.image to the specific OS (e.g. 'ubuntu20')
+      # see https://github.com/actions/cache/issues/543
+      - name: Get operating system name and version.
+        id: os
+        run: echo "::set-output name=image::$ImageOS"
+        shell: bash
       - uses: actions/checkout@v2
       - name: Cache astyle
         uses: actions/cache@v2
@@ -172,7 +174,7 @@ jobs:
           cache-name: cache-astyle
         with:
           path: ~/astyle.local
-          key: ${{ runner.os }}-${{ env.OS_VERSION }}-build-${{ env.cache-name }}-${{ env.ASTYLE_VER }}
+          key: ${{ steps.os.outputs.image }}-build-${{ env.cache-name }}-${{ env.ASTYLE_VER }}
       - run: sudo scripts/install_astyle_dependencies_with_apt.sh
       - run: scripts/install_astyle.sh $ASTYLE_REPO $ASTYLE_VER
       - name: Format code with astyle


### PR DESCRIPTION
Missed this out of #2278, as I didn't spot it.

It's another use of the same method to cache the astyle executable, and it's used further down in the same file