### PR TITLE
sesman: fix spacing in log

### DIFF
--- a/sesman/session.c
+++ b/sesman/session.c
@@ -656,7 +656,7 @@ session_start(long data,
                     {
                         LOG(LOG_LEVEL_INFO,
                             "Starting window manager on display %d"
-                            "from user home directory: %s", display, text);
+                            " from user home directory: %s", display, text);
                         g_execlp3(text, g_cfg->user_wm, 0);
                     }
                     else


### PR DESCRIPTION
```
[20220301-18:25:01] [INFO ] Starting window manager on display 12from user home directory: /home/user/startwm.sh
                                                                ^^
```