### PR TITLE
Update handling of scale factor

### DIFF
--- a/libxrdp/libxrdp.c
+++ b/libxrdp/libxrdp.c
@@ -1959,30 +1959,33 @@ libxrdp_process_monitor_stream(struct stream *s,
             }
 
             in_uint32_le(s, monitor_layout->desktop_scale_factor);
-            if (monitor_layout->desktop_scale_factor < 100
-                    || monitor_layout->desktop_scale_factor > 500
-                    || (monitor_layout->desktop_scale_factor != 100
-                        && monitor_layout->desktop_scale_factor != 140
-                        && monitor_layout->desktop_scale_factor != 180))
+            int check_desktop_scale_factor
+                = monitor_layout->desktop_scale_factor < 100
+                  || monitor_layout->desktop_scale_factor > 500;
+            if (check_desktop_scale_factor)
             {
                 LOG(LOG_LEVEL_WARNING, "libxrdp_process_monitor_stream:"
-                    " desktop_scale_factor is not within valid range. Assuming 100."
-                    " Value was: %d",
+                    " desktop_scale_factor is not within valid range"
+                    " of [100, 500]. Assuming 100. Value was: %d",
                     monitor_layout->desktop_scale_factor);
-                monitor_layout->desktop_scale_factor = 100;
             }
 
             in_uint32_le(s, monitor_layout->device_scale_factor);
-            if (monitor_layout->device_scale_factor < 100
-                    || monitor_layout->device_scale_factor > 500
-                    || (monitor_layout->device_scale_factor != 100
-                        && monitor_layout->device_scale_factor != 140
-                        && monitor_layout->device_scale_factor != 180))
+            int check_device_scale_factor
+                = monitor_layout->device_scale_factor != 100
+                  && monitor_layout->device_scale_factor != 140
+                  && monitor_layout->device_scale_factor != 180;
+            if (check_device_scale_factor)
             {
                 LOG(LOG_LEVEL_WARNING, "libxrdp_process_monitor_stream:"
-                    " device_scale_factor is not within valid range. Assuming 100."
-                    " Value was: %d",
+                    " device_scale_factor a valid value (One of 100, 140, 180)."
+                    " Assuming 100. Value was: %d",
                     monitor_layout->device_scale_factor);
+            }
+
+            if (check_desktop_scale_factor || check_device_scale_factor)
+            {
+                monitor_layout->desktop_scale_factor = 100;
                 monitor_layout->device_scale_factor = 100;
             }
 

--- a/tests/libxrdp/test_libxrdp_process_monitor_stream.c
+++ b/tests/libxrdp/test_libxrdp_process_monitor_stream.c
@@ -273,7 +273,7 @@ START_TEST(test_libxrdp_process_monitor_stream__with_sextuple_monitor_happy_path
     ck_assert_int_eq(description->minfo[2].physical_height, 1000);
     ck_assert_int_eq(description->minfo[2].orientation, 0);
     ck_assert_int_eq(description->minfo[2].desktop_scale_factor, 100);
-    ck_assert_int_eq(description->minfo[2].device_scale_factor, 140);
+    ck_assert_int_eq(description->minfo[2].device_scale_factor, 100);
     ck_assert_int_eq(description->minfo[2].is_primary, 0);
 
     ck_assert_int_eq(description->minfo[3].left, 0);
@@ -342,7 +342,7 @@ START_TEST(test_libxrdp_process_monitor_stream__with_sextuple_monitor_happy_path
     ck_assert_int_eq(description->minfo_wm[2].physical_height, 1000);
     ck_assert_int_eq(description->minfo_wm[2].orientation, 0);
     ck_assert_int_eq(description->minfo_wm[2].desktop_scale_factor, 100);
-    ck_assert_int_eq(description->minfo_wm[2].device_scale_factor, 140);
+    ck_assert_int_eq(description->minfo_wm[2].device_scale_factor, 100);
     ck_assert_int_eq(description->minfo_wm[2].is_primary, 0);
 
     ck_assert_int_eq(description->minfo_wm[3].left, 0);


### PR DESCRIPTION
Looking at 2.2.2.2.1 DISPLAYCONTROL_MONITOR_LAYOUT (https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpedisp/ea2de591-9203-42cd-9908-be7a55237d1c),
the way we were handling it was slightly off. device_scale_factor and
desktop_scale_factor are interdependent. If either one is out of spec,
both are set to default. That wasn't how it was previously being
handled.