### PR TITLE
Parse more physical monitor size information

### DIFF
--- a/common/ms-rdpbcgr.h
+++ b/common/ms-rdpbcgr.h
@@ -57,6 +57,7 @@
 #define SEC_TAG_CLI_CHANNELS           0xc003 /* CS_CHANNELS? */
 #define SEC_TAG_CLI_4                  0xc004 /* CS_CLUSTER? */
 #define SEC_TAG_CLI_MONITOR            0xc005 /* CS_MONITOR */
+#define SEC_TAG_CLI_MONITOR_EX         0xc008 /* CS_MONITOR_EX */
 
 /* Client Core Data: colorDepth, postBeta2ColorDepth (2.2.1.3.2) */
 #define RNS_UD_COLOR_4BPP              0xCA00

--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -38,7 +38,8 @@ struct monitor_info
     int bottom;
     int flags;
 
-    /* From 2.2.2.2.1 DISPLAYCONTROL_MONITOR_LAYOUT */
+    /* From [MS-RDPEDISP] 2.2.2.2.1 DISPLAYCONTROL_MONITOR_LAYOUT, or
+     * [MS-RDPBCGR] 2.2.1.3.9.1 (TS_MONITOR_ATTRIBUTES) */
     unsigned int physical_width;
     unsigned int physical_height;
     unsigned int orientation;
@@ -205,6 +206,13 @@ struct xrdp_client_info
 
     /* xrdp.override_* values */
     struct xrdp_keyboard_overrides xrdp_keyboard_overrides;
+
+    /* These values are optionally send over as part of TS_UD_CS_CORE.
+     * They can be used as a fallback for a single monitor session
+     * if physical sizes are not available in the monitor-specific
+     * data */
+    unsigned int session_physical_width; /* in mm */
+    unsigned int session_physical_height; /* in mm */
 };
 
 /* yyyymmdd of last incompatible change to xrdp_client_info */

--- a/libxrdp/libxrdp.h
+++ b/libxrdp/libxrdp.h
@@ -364,9 +364,10 @@ xrdp_mcs_disconnect(struct xrdp_mcs *self);
 /* xrdp_sec.c */
 
 /*
-    These are error return codes for both:
+    These are error return codes for:-
         1. xrdp_sec_process_mcs_data_monitors
         2. libxrdp_process_monitor_stream
+        3. libxrdp_process_monitor_ex_stream
     To clarify any reason for a non-zero response code.
 */
 #define SEC_PROCESS_MONITORS_ERR 1

--- a/libxrdp/libxrdpinc.h
+++ b/libxrdp/libxrdpinc.h
@@ -324,4 +324,19 @@ int EXPORT_CC
 libxrdp_process_monitor_stream(struct stream *s, struct display_size_description *description,
                                int full_parameters);
 
+/**
+ * Processes a stream that is based on [MS-RDPBCGR] 2.2.1.3.9 Client
+ * Monitor Extended Data (TS_UD_CS_MONITOR_EX)
+ *
+ * Data is stored in a struct which has already been read by
+ * libxrdp_process_monitor_stream() withj full_parameters set to 0.
+ *
+ * @param s Stream to read data from. Stream is read up to monitorAttributeSize
+ * @param description Result of reading TS_UD_CS_MONITOR PDU
+ * @return 0 if the data is processed, non-zero if there is an error.
+ */
+int EXPORT_CC
+libxrdp_process_monitor_ex_stream(struct stream *s,
+                                  struct display_size_description *description);
+
 #endif


### PR DESCRIPTION
Draft PR to parse more physical monitor information.

This is a precursor to a scalable login screen - we need to be able to calculate the DPI for the login screen monitor, and to do this, we need access to the physical monitor size.

I need to do more testing of this before it's ready for release, but I'm going to be a bit stuck for time for a couple of weeks.

@Nexarian - can you take a look and give me any informal comments you have?