### PR TITLE
mark count with unused attribute

### DIFF
--- a/sesman/chansrv/chansrv.c
+++ b/sesman/chansrv/chansrv.c
@@ -197,7 +197,7 @@ check_timeout(void)
     struct timeout_obj *temp_tobj;
     int count;
     tui32 now;
-
+    UNUSED_VAR(count);
     LOG_DEVEL(LOG_LEVEL_DEBUG, "check_timeout:");
     count = 0;
     tobj = g_timeout_head;


### PR DESCRIPTION
This may throw a warning when devel logs are disabled
Fixed
../../../xrdp-0.9.19/sesman/chansrv/chansrv.c:198:9: error: variable 'count' set but not used [-Werror,-Wunused-but-set-variable]                                                                                                                     int count;                                                                                                                   ^                                                                                                                1 error generated.

Upstream-Status: Pending
Signed-off-by: Khem Raj <raj.khem@gmail.com>