### PR TITLE
Add freetype2 to CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,11 +6,11 @@ FreeBSD_task:
     freebsd_instance:
       image_family: freebsd-12-3
   prepare_script:
-    - pkg install -y $SSL git autoconf automake libtool pkgconf opus jpeg-turbo fdk-aac pixman libX11 libXfixes libXrandr nasm fusefs-libs check imlib2
+    - pkg install -y $SSL git autoconf automake libtool pkgconf opus jpeg-turbo fdk-aac pixman libX11 libXfixes libXrandr nasm fusefs-libs check imlib2 freetype2
     - git submodule update --init --recursive
   configure_script:
     - ./bootstrap
-    - env CPPFLAGS=-I/usr/local/include LDFLAGS=-L/usr/local/lib ./configure --localstatedir=/var --enable-strict-locations --with-pkgconfigdir=/usr/local/libdata/pkgconfig --enable-strict-locations --enable-ipv6 --enable-opus --enable-jpeg --enable-fdkaac --enable-painter --enable-pixman --enable-fuse --with-imlib2
+    - env CPPFLAGS=-I/usr/local/include LDFLAGS=-L/usr/local/lib ./configure --localstatedir=/var --enable-strict-locations --with-pkgconfigdir=/usr/local/libdata/pkgconfig --enable-strict-locations --enable-ipv6 --enable-opus --enable-jpeg --enable-fdkaac --enable-painter --enable-pixman --enable-fuse --with-imlib2 --with-freetype2
   build_script:
     - make -j $(sysctl -n hw.ncpu || echo 4)
   install_script:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,10 +96,11 @@ jobs:
                   --disable-pixman"
       CONF_FLAGS_amd64_max: "--enable-ipv6 --enable-jpeg --enable-fuse --enable-mp3lame
                   --enable-fdkaac --enable-opus --enable-rfxcodec --enable-painter
-                  --enable-pixman --with-imlib2"
+                  --enable-pixman --with-imlib2 --with-freetype2"
       CONF_FLAGS_i386_max: "--enable-ipv6 --enable-jpeg --enable-fuse --enable-mp3lame
                   --enable-fdkaac --enable-opus --enable-rfxcodec --enable-painter
-                  --disable-pixman --with-imlib2 --host=i686-linux"
+                  --disable-pixman --with-imlib2 --with-freetype2
+                  --host=i686-linux"
 
       PKG_CONFIG_PATH_i386: "/usr/lib/i386-linux-gnu/pkgconfig"
       CFLAGS_i386: "-m32"

--- a/scripts/install_xrdp_build_dependencies_with_apt.sh
+++ b/scripts/install_xrdp_build_dependencies_with_apt.sh
@@ -61,6 +61,14 @@ PACKAGES=" \
     check \
     "
 
+# libfreetype-dev package was renamed from libfreetype6-dev in older
+# versions
+case `lsb_release -si`/`lsb_release -sr` in
+    Debian/10) LIBFREETYPE_DEV=libfreetype6-dev ;;
+    Ubuntu/18.*) LIBFREETYPE_DEV=libfreetype6-dev ;;
+    *) LIBFREETYPE_DEV=libfreetype-dev
+esac
+
 case "$ARCH"
 in
     amd64)
@@ -79,6 +87,7 @@ in
             max)
                 PACKAGES="$PACKAGES \
                     $PACKAGES_AMD64_MIN
+                    $LIBFREETYPE_DEV \
                     libfuse-dev \
                     libjpeg-dev \
                     libmp3lame-dev \
@@ -97,6 +106,7 @@ in
         PACKAGES="$PACKAGES \
             g++-multilib \
             gcc-multilib \
+            $LIBFREETYPE_DEV:i386 \
             libgl1-mesa-dev:i386 \
             libglu1-mesa-dev:i386 \
             libjpeg-dev:i386 \


### PR DESCRIPTION
The freetype2 library can now be used to create fv1 fonts. This library is added to the 'max features' CI builds to pick up any
regressions.

Should have been part of #2341