### PR TITLE
Replace various types used for auth_info

### DIFF
--- a/sesman/auth.h
+++ b/sesman/auth.h
@@ -27,59 +27,71 @@
 #ifndef AUTH_H
 #define AUTH_H
 
+
+/**
+ * Opaque type used to represent an authentication handle
+ */
+struct auth_info;
+
 /**
  *
  * @brief Validates user's password
  * @param user user's login name
  * @param pass user's password
  * @param client_ip IP address of connecting client (or ""/NULL if not known)
- * @return non-zero handle on success, 0 on failure
+ * @param[out] errorcode from result
+ * @return auth handle on success, NULL on failure
  *
  */
-long
+struct auth_info *
 auth_userpass(const char *user, const char *pass,
               const char *client_ip, int *errorcode);
 
 /**
  *
- * @brief FIXME
- * @param in_val
- * @param in_display
+ * @brief Starts a session
+ * @param auth_info. Auth handle created by auth_userpass
+ * @param display_num Display number
  * @return 0 on success, 1 on failure
  *
  */
 int
-auth_start_session(long in_val, int in_display);
+auth_start_session(struct auth_info *auth_info, int display_num);
 
 /**
  *
- * @brief FIXME
- * @param in_val
+ * @brief Stops a session previously started with auth_start_session()
+ * @param auth_info. Auth handle created by auth_userpass
  * @return 0 on success, 1 on failure
  *
  */
 int
-auth_stop_session(long in_val);
+auth_stop_session(struct auth_info *auth_info);
 
 /**
  *
- * @brief FIXME
- * @param in_val
+ * @brief Deallocates an auth handle and releases all resources
+ * @param auth_info. Auth handle created by auth_userpass
  * @return 0 on success, 1 on failure
  *
  */
 int
-auth_end(long in_val);
+auth_end(struct auth_info *auth_info);
 
 /**
  *
- * @brief FIXME
- * @param in_val
+ * @brief Sets up the environment for a session started
+ *        with auth_start_session()
+ *
+ * This call is only effective for PAM-based environments. It must be made
+ * after the context has been switched to the logged-in user.
+ *
+ * @param auth_info. Auth handle created by auth_userpass
  * @return 0 on success, 1 on failure
  *
  */
 int
-auth_set_env(long in_val);
+auth_set_env(struct auth_info *auth_info);
 
 
 #define AUTH_PWD_CHG_OK                0
@@ -90,8 +102,9 @@ auth_set_env(long in_val);
 
 /**
  *
- * @brief FIXME
- * @param in_val
+ * @brief WIP - Checks to see if the password for a user needs changing
+ *
+ * @param user - Username to check
  * @return 0 on success, 1 on failure
  *
  */
@@ -100,8 +113,10 @@ auth_check_pwd_chg(const char *user);
 
 /**
  *
- * @brief FIXME
- * @param in_val
+ * @brief WIP - Changes the password for a user
+ *
+ * @param user Username to check
+ * @param newpwd New password for user
  * @return 0 on success, 1 on failure
  *
  */

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -438,7 +438,7 @@ session_start_chansrv(const char *username, int display)
 /******************************************************************************/
 
 int
-session_start(long data,
+session_start(struct auth_info *auth_info,
               const struct session_parameters *s,
               struct guid *guid)
 {
@@ -546,7 +546,7 @@ session_start(long data,
             g_exit(1);
         }
 
-        auth_start_session(data, display);
+        auth_start_session(auth_info, display);
         sesman_close_all();
         g_sprintf(geometry, "%dx%d", s->width, s->height);
         g_sprintf(depth, "%d", s->bpp);
@@ -615,7 +615,7 @@ session_start(long data,
                          g_cfg->env_values);
             if (x_server_running(display))
             {
-                auth_set_env(data);
+                auth_set_env(auth_info);
                 if (s->directory != 0)
                 {
                     if (s->directory[0] != 0)
@@ -932,8 +932,8 @@ session_start(long data,
                 LOG(LOG_LEVEL_INFO,
                     "Calling auth_stop_session and auth_end from pid %d",
                     g_getpid());
-                auth_stop_session(data);
-                auth_end(data);
+                auth_stop_session(auth_info);
+                auth_end(auth_info);
 
                 LOG(LOG_LEVEL_INFO,
                     "Terminating X server (pid %d) on display %d",
@@ -976,7 +976,7 @@ session_start(long data,
         temp->item->width = s->width;
         temp->item->height = s->height;
         temp->item->bpp = s->bpp;
-        temp->item->data = data;
+        temp->item->auth_info = auth_info;
         g_strncpy(temp->item->start_ip_addr, s->ip_addr,
                   sizeof(temp->item->start_ip_addr) - 1);
         g_strncpy(temp->item->name, s->username, 255);
@@ -1001,7 +1001,8 @@ session_start(long data,
 
 /******************************************************************************/
 int
-session_reconnect(int display, const char *username, long data)
+session_reconnect(int display, const char *username,
+                  struct auth_info *auth_info)
 {
     int pid;
 
@@ -1018,7 +1019,7 @@ session_reconnect(int display, const char *username, long data)
                      display,
                      g_cfg->env_names,
                      g_cfg->env_values);
-        auth_set_env(data);
+        auth_set_env(auth_info);
 
         if (g_file_exist(g_cfg->reconnect_sh))
         {

--- a/sesman/session.h
+++ b/sesman/session.h
@@ -59,7 +59,7 @@ struct session_item
     int width;
     int height;
     int bpp;
-    long data;
+    struct auth_info *auth_info;
 
     /* status info */
     unsigned char status;
@@ -114,12 +114,13 @@ session_get_bydata(const struct session_parameters *params);
  *
  */
 int
-session_start(long authdata,
+session_start(struct auth_info *auth_info,
               const struct session_parameters *params,
               struct guid *guid);
 
 int
-session_reconnect(int display, const char *username, long data);
+session_reconnect(int display, const char *username,
+                  struct auth_info *auth_info);
 
 /**
  *

--- a/sesman/verify_user.c
+++ b/sesman/verify_user.c
@@ -28,7 +28,10 @@
 #include <config_ac.h>
 #endif
 
-#include "sesman.h"
+#include "arch.h"
+#include "auth.h"
+#include "log.h"
+#include "os_calls.h"
 #include "string_calls.h"
 
 #include <stdio.h>
@@ -48,9 +51,17 @@ auth_crypt_pwd(const char *pwd, const char *pln, char *crp);
 static int
 auth_account_disabled(struct spwd *stp);
 
+/*
+ * Need a complete type for struct auth_info, even though we're
+ * not really using it if this module (UNIX authentication) is selected */
+struct auth_info
+{
+    char dummy;
+};
+
 /******************************************************************************/
-/* returns boolean */
-long
+/* returns non-NULL for success */
+struct auth_info *
 auth_userpass(const char *user, const char *pass,
               const char *client_ip, int *errorcode)
 {
@@ -58,12 +69,14 @@ auth_userpass(const char *user, const char *pass,
     const char *epass;
     struct passwd *spw;
     struct spwd *stp;
+    /* Need a non-NULL pointer to return to indicate success */
+    static struct auth_info success = {0};
 
     spw = getpwnam(user);
 
     if (spw == 0)
     {
-        return 0;
+        return NULL;
     }
 
     if (g_strncmp(spw->pw_passwd, "x", 3) == 0)
@@ -73,13 +86,13 @@ auth_userpass(const char *user, const char *pass,
 
         if (stp == 0)
         {
-            return 0;
+            return NULL;
         }
 
         if (1 == auth_account_disabled(stp))
         {
             LOG(LOG_LEVEL_INFO, "account %s is disabled", user);
-            return 0;
+            return NULL;
         }
 
         encr = stp->sp_pwdp;
@@ -92,15 +105,15 @@ auth_userpass(const char *user, const char *pass,
     epass = crypt(pass, encr);
     if (epass == 0)
     {
-        return 0;
+        return NULL;
     }
-    return (strcmp(encr, epass) == 0);
+    return (strcmp(encr, epass) == 0) ? &success : NULL;
 }
 
 /******************************************************************************/
 /* returns error */
 int
-auth_start_session(long in_val, int in_display)
+auth_start_session(struct auth_info *auth_info, int display_num)
 {
     return 0;
 }
@@ -108,21 +121,21 @@ auth_start_session(long in_val, int in_display)
 /******************************************************************************/
 /* returns error */
 int
-auth_stop_session(long in_val)
+auth_stop_session(struct auth_info *auth_info)
 {
     return 0;
 }
 
 /******************************************************************************/
 int
-auth_end(long in_val)
+auth_end(struct auth_info *auth_info)
 {
     return 0;
 }
 
 /******************************************************************************/
 int
-auth_set_env(long in_val)
+auth_set_env(struct auth_info *auth_info)
 {
     return 0;
 }

--- a/sesman/verify_user_bsd.c
+++ b/sesman/verify_user_bsd.c
@@ -28,7 +28,8 @@
 #include <config_ac.h>
 #endif
 
-#include "sesman.h"
+#include "arch.h"
+#include "auth.h"
 
 #define _XOPEN_SOURCE
 #include <stdio.h>
@@ -43,34 +44,49 @@
 #define SECS_PER_DAY (24L*3600L)
 #endif
 
+/*
+ * Need a complete type for struct auth_info, even though we're
+ * not really using it if this module (BSD authentication) is selected */
+struct auth_info
+{
+    char dummy;
+};
+
 /******************************************************************************/
-/* returns boolean */
-long
+/* returns non-NULL for success */
+struct auth_info *
 auth_userpass(const char *user, const char *pass,
               const char *client_ip, int *errorcode)
 {
-    int ret = auth_userokay(user, NULL, "auth-xrdp", pass);
+    /* Need a non-NULL pointer to return to indicate success */
+    static struct auth_info success = {0};
+    struct auth_info *ret = NULL;
+
+    if (auth_userokay(user, NULL, "auth-xrdp", pass))
+    {
+        ret = &success;
+    }
     return ret;
 }
 
 /******************************************************************************/
 /* returns error */
 int
-auth_start_session(long in_val, int in_display)
+auth_start_session(struct auth_info *auth_info, int display_num)
 {
     return 0;
 }
 
 /******************************************************************************/
 int
-auth_end(long in_val)
+auth_end(struct auth_info *auth_info)
 {
     return 0;
 }
 
 /******************************************************************************/
 int
-auth_set_env(long in_val)
+auth_set_env(struct auth_info *auth_info)
 {
     return 0;
 }
@@ -89,33 +105,7 @@ auth_change_pwd(const char *user, const char *newpwd)
 }
 
 int
-auth_stop_session(long in_val)
-{
-    return 0;
-}
-
-/**
- *
- * @brief Password encryption
- * @param pwd Old password
- * @param pln Plaintext new password
- * @param crp Crypted new password
- *
- */
-
-static int
-auth_crypt_pwd(const char *pwd, const char *pln, char *crp)
-{
-    return 0;
-}
-
-/**
- *
- * @return 1 if the account is disabled, 0 otherwise
- *
- */
-static int
-auth_account_disabled(struct spwd *stp)
+auth_stop_session(struct auth_info *auth_info)
 {
     return 0;
 }

--- a/sesman/verify_user_pam_userpass.c
+++ b/sesman/verify_user_pam_userpass.c
@@ -29,6 +29,7 @@
 #endif
 
 #include "arch.h"
+#include "auth.h"
 #include "os_calls.h"
 #include "string_calls.h"
 
@@ -36,9 +37,17 @@
 
 #define SERVICE "xrdp"
 
+/*
+ * Need a complete type for struct auth_info, even though we're
+ * not really using it if this module (PAM userpass) is selected */
+struct auth_info
+{
+    char dummy;
+};
+
 /******************************************************************************/
-/* returns boolean */
-long
+/* returns non-NULL for success */
+struct auth_info *
 auth_userpass(const char *user, const char *pass,
               const char *client_ip, int *errorcode)
 {
@@ -47,13 +56,15 @@ auth_userpass(const char *user, const char *pass,
     struct pam_conv conv = {pam_userpass_conv, &userpass};
     const void *template1;
     int status;
+    /* Need a non-NULL pointer to return to indicate success */
+    static struct auth_info success = {0};
 
     userpass.user = user;
     userpass.pass = pass;
 
     if (pam_start(SERVICE, user, &conv, &pamh) != PAM_SUCCESS)
     {
-        return 0;
+        return NULL;
     }
 
     status = pam_authenticate(pamh, 0);
@@ -61,7 +72,7 @@ auth_userpass(const char *user, const char *pass,
     if (status != PAM_SUCCESS)
     {
         pam_end(pamh, status);
-        return 0;
+        return NULL;
     }
 
     status = pam_acct_mgmt(pamh, 0);
@@ -69,7 +80,7 @@ auth_userpass(const char *user, const char *pass,
     if (status != PAM_SUCCESS)
     {
         pam_end(pamh, status);
-        return 0;
+        return NULL;
     }
 
     status = pam_get_item(pamh, PAM_USER, &template1);
@@ -77,21 +88,21 @@ auth_userpass(const char *user, const char *pass,
     if (status != PAM_SUCCESS)
     {
         pam_end(pamh, status);
-        return 0;
+        return NULL;
     }
 
     if (pam_end(pamh, PAM_SUCCESS) != PAM_SUCCESS)
     {
-        return 0;
+        return NULL;
     }
 
-    return 1;
+    return &success;
 }
 
 /******************************************************************************/
 /* returns error */
 int
-auth_start_session(long in_val, int in_display)
+auth_start_session(struct auth_info *auth_info, int display_num)
 {
     return 0;
 }
@@ -99,21 +110,21 @@ auth_start_session(long in_val, int in_display)
 /******************************************************************************/
 /* returns error */
 int
-auth_stop_session(long in_val)
+auth_stop_session(struct auth_info *auth_info)
 {
     return 0;
 }
 
 /******************************************************************************/
 int
-auth_end(long in_val)
+auth_end(struct auth_info *auth_info)
 {
     return 0;
 }
 
 /******************************************************************************/
 int
-auth_set_env(long in_val)
+auth_set_env(struct auth_info *auth_info)
 {
     return 0;
 }


### PR DESCRIPTION
Code tidy-up.

The loadable sesman authentication modules use different types for the authentication handle returned from `auth_userpass()`. The PAM module uses a pointer, and the other modules use (effectively) a boolean. Within sesman itself, a `long` or `tbus` (`intptr_t`) is used.

This PR replaces all of these types with a pointer to an incomplete type.

Consequently:-
- A single better-labelled type is used it all places within sesman so it's more obvious what's being handled.
- There is no need to cast the authentication handle within the PAM module to a long and back again.
- The compiler can check function signatures between auth.h and the various verify modules.