### PR TITLE
log: change date format to ISO8601-like

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -71,7 +71,6 @@ libcommon_la_SOURCES = \
   $(PIXMAN_SOURCES)
 
 libcommon_la_LIBADD = \
-  -lm \
   -lpthread \
   $(OPENSSL_LIBS) \
   $(DLOPEN_LIBS)

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -71,6 +71,7 @@ libcommon_la_SOURCES = \
   $(PIXMAN_SOURCES)
 
 libcommon_la_LIBADD = \
+  -lm \
   -lpthread \
   $(OPENSSL_LIBS) \
   $(DLOPEN_LIBS)

--- a/common/log.c
+++ b/common/log.c
@@ -1146,9 +1146,9 @@ getLogFile(char *replybuf, int bufsize)
 char *
 getFormattedDateTime(char *replybuf, int bufsize)
 {
-    char buf_datetime[21];
-    char buf_millisec[4];
-    char buf_timezone[6];
+    char buf_datetime[21]; /* 2022-10-07T16:36:04 + . */
+    char buf_millisec[4];  /* 357 */
+    char buf_timezone[6];  /* +0900 */
 
     struct tm *now;
     struct timeval tv;

--- a/common/log.c
+++ b/common/log.c
@@ -24,7 +24,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <math.h>
 #include <syslog.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -1158,7 +1157,7 @@ getFormattedDateTime(char *replybuf, int bufsize)
     gettimeofday(&tv, NULL);
     now = localtime(&tv.tv_sec);
 
-    millisec = lrint(tv.tv_usec / 1000.0);
+    millisec = (tv.tv_usec + 500 / 1000);
     g_snprintf(buf_millisec, sizeof(buf_millisec), "%03d", millisec);
 
     strftime(buf_datetime, sizeof(buf_datetime), "%FT%T.", now);

--- a/common/log.h
+++ b/common/log.h
@@ -434,4 +434,10 @@ log_hexdump_with_location(const char *function_name,
  * @return
  */
 char *getLogFile(char *replybuf, int bufsize);
+
+/**
+ * Returns formatted datetime for log
+ * @return
+ */
+char *getFormattedDateTime(char *replybuf, int bufsize);
 #endif


### PR DESCRIPTION
Former format:  "[20221007-16:36:02] "
New format:     "[2022-10-07T16:36:04.357+0900] "

Two reasons for this change:
- msec is required 
- timezone info is required 

While I was debugging, I want to add msec for more precision. However, this will break backward compatibility. I think logs are mostly read by human so compatibility is not a serious problem. Any opinions?

The difference between the true ISO 8601 and this format is msec.  The true ISO 8601 doesn't include msec.
```
[20221007-16:13:33] [DEBUG] item bitmap_compression, value true
[20221007-16:13:33] [DEBUG] item bulk_compression, value true
[20221007-16:13:33] [DEBUG] item max_bpp, value 32
[20221007-16:13:33] [DEBUG] item new_cursors, value true
[20221007-16:13:33] [DEBUG] item use_fastpath, value none
[20221007-16:13:33] [DEBUG] item grey, value e1e1e1
[20221007-16:13:33] [DEBUG] item dark_grey, value b4b4b4
[20221007-16:13:33] [DEBUG] item blue, value 0078d7
[20221007-16:13:33] [DEBUG] item dark_blue, value 0078d7
[20221007-16:13:33] [DEBUG] item ls_top_window_bg_color, value 003057
[20221007-16:13:33] [DEBUG] item ls_width, value 350
[20221007-16:13:33] [DEBUG] item ls_height, value 360
[20221007-16:13:33] [DEBUG] item ls_bg_color, value f0f0f0
[20221007-16:13:33] [DEBUG] item ls_logo_filename, value
[20221007-16:13:33] [DEBUG] item ls_logo_transform, value scale
[20221007-16:13:33] [DEBUG] item ls_logo_width, value 250
[20221007-16:13:33] [DEBUG] item ls_logo_height, value 110
[20221007-16:13:33] [DEBUG] item ls_logo_x_pos, value 55
[20221007-16:13:33] [DEBUG] item ls_logo_y_pos, value 35
[20221007-16:13:33] [DEBUG] item ls_label_x_pos, value 30
[20221007-16:13:33] [DEBUG] item ls_label_width, value 68
[20221007-16:13:33] [DEBUG] item ls_input_x_pos, value 110
[20221007-16:13:33] [DEBUG] item ls_input_width, value 210
[20221007-16:13:33] [DEBUG] item ls_input_y_pos, value 158
[20221007-16:13:33] [DEBUG] item ls_btn_ok_x_pos, value 142
[20221007-16:13:33] [DEBUG] item ls_btn_ok_y_pos, value 308
[20221007-16:13:33] [DEBUG] item ls_btn_ok_width, value 85
[20221007-16:13:33] [DEBUG] item ls_btn_ok_height, value 30
[20221007-16:13:33] [DEBUG] item ls_btn_cancel_x_pos, value 237
[20221007-16:13:33] [DEBUG] item ls_btn_cancel_y_pos, value 308
[20221007-16:13:33] [DEBUG] item ls_btn_cancel_width, value 85
[20221007-16:13:33] [DEBUG] item ls_btn_cancel_height, value 30
[20221007-16:13:33] [INFO ] Security protocol: configured [SSL], requested [SSL|HYBRID|RDP], selected [SSL]
```


Finally, I get the following log.

#### xrdp-sesman.log
```
[2022-10-07T21:48:24.826+0900] [INFO ] [session start] (display 10): calling auth_start_session from pid 75249
[2022-10-07T21:48:24.848+0900] [INFO ] PAM: Last login: Fri Oct  7 21:19:04 from tmux(1745).%12
[2022-10-07T21:48:24.877+0900] [INFO ] Starting X server on display 10: /usr/local/libexec/Xorg :10 -auth .Xauthority -config xrdp/xorg.conf -noreset -nolisten tcp -logfile .xorgxrdp.%s.log
[2022-10-07T21:48:25.126+0900] [INFO ] Found X server running at /tmp/.X11-unix/X10
[2022-10-07T21:48:25.170+0900] [INFO ] Session started successfully for user meta on display 10
[2022-10-07T21:48:25.127+0900] [INFO ] Found X server running at /tmp/.X11-unix/X10
[2022-10-07T21:48:25.171+0900] [INFO ] Starting the xrdp channel server for display 10
[2022-10-07T21:48:25.237+0900] [INFO ] Found X server running at /tmp/.X11-unix/X10
[2022-10-07T21:48:25.302+0900] [INFO ] Starting the default window manager on display 10: /usr/local/etc/xrdp/startwm.sh
[2022-10-07T21:48:25.226+0900] [INFO ] Session in progress on display 10, waiting until the window manager (pid 75251) exits to end the session
[2022-10-07T21:48:26.909+0900] [ERROR] sesman_main_loop: trans_check_wait_objs failed, removing trans
```

### xrdp.log
```
[2022-10-07T21:54:53.888+0900] [DEBUG] item ssl_protocols, value TLSv1.2, TLSv1.3
[2022-10-07T21:54:53.890+0900] [DEBUG] TLSv1.3 enabled
[2022-10-07T21:54:53.891+0900] [DEBUG] TLSv1.2 enabled
[2022-10-07T21:54:53.893+0900] [DEBUG] item autorun, value
[2022-10-07T21:54:53.894+0900] [DEBUG] item allow_channels, value true
[2022-10-07T21:54:53.896+0900] [DEBUG] item allow_multimon, value true
[2022-10-07T21:54:53.898+0900] [DEBUG] item bitmap_cache, value true
[2022-10-07T21:54:53.899+0900] [DEBUG] item bitmap_compression, value true
[2022-10-07T21:54:53.901+0900] [DEBUG] item bulk_compression, value true
[2022-10-07T21:54:53.902+0900] [DEBUG] item max_bpp, value 32
[2022-10-07T21:54:53.904+0900] [DEBUG] item new_cursors, value true
[2022-10-07T21:54:53.906+0900] [DEBUG] item use_fastpath, value none
```