### PR TITLE
xrdp.ini.5.in: Fix mixed up config options

### DIFF
--- a/docs/man/xrdp.ini.5.in
+++ b/docs/man/xrdp.ini.5.in
@@ -118,7 +118,7 @@ Multiple address:port instances must be separated by spaces or commas. Check the
 Specifying interfaces requires said interfaces to be UP before xrdp starts.
 
 .TP
-\fBrequire_credentials\fP=\fI[true|false]\fP
+\fBenable_token_login\fP=\fI[true|false]\fP
 If set to \fB1\fP, \fBtrue\fP or \fByes\fP, \fBxrdp\fP will scan the user name provided by the
 client for the ASCII field separator character (0x1F). It will then copy over what is after the
 separator as the password supplied by the user and treats it as autologon. If not specified,
@@ -130,7 +130,7 @@ If specified the domain name supplied by the client is appended to the username 
 by \fBseparator\fP.
 
 .TP
-\fBenable_token_login\fP=\fI[true|false]\fP
+\fBrequire_credentials\fP=\fI[true|false]\fP
 If set to \fB1\fP, \fBtrue\fP or \fByes\fP, \fBxrdp\fP requires clients to include username and
 password initial connection phase. In other words, xrdp doesn't allow clients to show login
 screen if set to true. If not specified, defaults to \fBfalse\fP.


### PR DESCRIPTION
It seems to me that descriptions for config options `require_credentials` and `enable_token_login` are mixed up.