### PR TITLE
Update github actions to address warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,10 +134,9 @@ jobs:
       CPPCHECK_REPO: https://github.com/danmar/cppcheck.git
     steps:
       # Set steps.os.outputs.image to the specific OS (e.g. 'ubuntu20')
-      # see https://github.com/actions/cache/issues/543
       - name: Get operating system name and version.
         id: os
-        run: echo "::set-output name=image::$ImageOS"
+        run: echo "image=$ImageOS" >>$GITHUB_OUTPUT
         shell: bash
       - uses: actions/checkout@v3
       - name: Cache cppcheck
@@ -163,10 +162,9 @@ jobs:
       ASTYLE_REPO: https://svn.code.sf.net/p/astyle/code/tags
     steps:
       # Set steps.os.outputs.image to the specific OS (e.g. 'ubuntu20')
-      # see https://github.com/actions/cache/issues/543
       - name: Get operating system name and version.
         id: os
-        run: echo "::set-output name=image::$ImageOS"
+        run: echo "image=$ImageOS" >>$GITHUB_OUTPUT
         shell: bash
       - uses: actions/checkout@v3
       - name: Cache astyle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
           echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH_${{ matrix.arch }}" >> $GITHUB_ENV
           echo "CFLAGS=$CFLAGS_${{ matrix.arch }}" >> $GITHUB_ENV
           echo "LDFLAGS=$LDFLAGS_${{ matrix.arch }}" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: sudo scripts/install_xrdp_build_dependencies_with_apt.sh ${{ matrix.feature_set }} ${{ matrix.arch }} --allow-downgrades --allow-remove-essential --allow-change-held-packages
       - run: ./bootstrap
       - run: ./configure $CONF_FLAGS
@@ -139,9 +139,9 @@ jobs:
         id: os
         run: echo "::set-output name=image::$ImageOS"
         shell: bash
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Cache cppcheck
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-cppcheck
         with:
@@ -168,9 +168,9 @@ jobs:
         id: os
         run: echo "::set-output name=image::$ImageOS"
         shell: bash
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Cache astyle
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-astyle
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,19 +65,19 @@ jobs:
           - CC: gcc
             feature_set: max
             arch: i386
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             name_extra: for 32-bit arch (legacy OS)
 
           - CC: g++
             feature_set: max
             arch: i386
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             name_extra: for 32-bit arch (legacy OS)
 
           - CC: clang
             feature_set: max
             arch: i386
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             name_extra: for 32-bit arch (legacy OS)
 
     name: ${{ matrix.feature_set }} features with ${{ matrix.CC }} ${{ matrix.name_extra }}
@@ -97,8 +97,8 @@ jobs:
       CONF_FLAGS_amd64_max: "--enable-ipv6 --enable-jpeg --enable-fuse --enable-mp3lame
                   --enable-fdkaac --enable-opus --enable-rfxcodec --enable-painter
                   --enable-pixman --with-imlib2 --with-freetype2"
-      CONF_FLAGS_i386_max: "--enable-ipv6 --enable-jpeg --enable-fuse --enable-mp3lame
-                  --enable-fdkaac --enable-opus --enable-rfxcodec --enable-painter
+      CONF_FLAGS_i386_max: "--enable-ipv6 --enable-jpeg --enable-mp3lame
+                  --enable-opus --enable-rfxcodec --enable-painter
                   --disable-pixman --with-imlib2 --with-freetype2
                   --host=i686-linux"
 

--- a/common/ssl_calls.c
+++ b/common/ssl_calls.c
@@ -337,7 +337,7 @@ ssl_sha1_clear(void *sha1_info)
 #else
     if (sha1_info != NULL)
     {
-        EVP_DigestInit_ex(sha1_info, g_md_sha1, NULL);
+        EVP_DigestInit_ex((EVP_MD_CTX *)sha1_info, g_md_sha1, NULL);
     }
 #endif
 }
@@ -417,7 +417,7 @@ ssl_md5_clear(void *md5_info)
 #else
     if (md5_info != NULL)
     {
-        EVP_DigestInit_ex(md5_info, g_md_md5, NULL);
+        EVP_DigestInit_ex((EVP_MD_CTX *)md5_info, g_md_md5, NULL);
     }
 #endif
 }

--- a/scripts/install_xrdp_build_dependencies_with_apt.sh
+++ b/scripts/install_xrdp_build_dependencies_with_apt.sh
@@ -103,6 +103,11 @@ in
         esac
         ;;
     i386)
+        # This list is not as complete as the amd64 list. It currently
+        # supports 32-bit CI building only, rather than being a generic
+        # build support tool.
+        # - Ubuntu 18.04 -> 20.04
+        #       Removed fdk-aac-dev:i386 and libfuse-dev:i386
         PACKAGES="$PACKAGES \
             g++-multilib \
             gcc-multilib \
@@ -112,7 +117,6 @@ in
             libjpeg-dev:i386 \
             libimlib2-dev:i386 \
             libmp3lame-dev:i386 \
-            libfdk-aac-dev:i386 \
             libopus-dev:i386 \
             libpam0g-dev:i386 \
             libssl-dev:i386 \
@@ -120,8 +124,7 @@ in
             libxext-dev:i386 \
             libxfixes-dev:i386 \
             libxrandr-dev:i386 \
-            libxrender-dev:i386 \
-            libfuse-dev:i386"
+            libxrender-dev:i386"
 
         dpkg --add-architecture i386
         dpkg --print-architecture


### PR DESCRIPTION
This PR fixes the following warnings issued by the CI system:-

- Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/cache
- The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/virtual-environments/issues/6002

For the last of these it is necessary to remove the `-enable-fuse` and `--enable-fdkaac` switches from the 32-bit compile, as the 32-bit packages to support these options are no longer available.
