### PR TITLE
[v0.9] Update github actions to address warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,19 +63,19 @@ jobs:
           - CC: gcc
             feature_set: max
             arch: i386
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             name_extra: for 32-bit arch (legacy OS)
 
           - CC: g++
             feature_set: max
             arch: i386
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             name_extra: for 32-bit arch (legacy OS)
 
           - CC: clang
             feature_set: max
             arch: i386
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             name_extra: for 32-bit arch (legacy OS)
 
     name: ${{ matrix.feature_set }} features with ${{ matrix.CC }} ${{ matrix.name_extra }}
@@ -95,8 +95,8 @@ jobs:
       CONF_FLAGS_amd64_max: "--enable-ipv6 --enable-jpeg --enable-fuse --enable-mp3lame
                   --enable-fdkaac --enable-opus --enable-rfxcodec --enable-painter
                   --enable-pixman --with-imlib2"
-      CONF_FLAGS_i386_max: "--enable-ipv6 --enable-jpeg --enable-fuse --enable-mp3lame
-                  --enable-fdkaac --enable-opus --enable-rfxcodec --enable-painter
+      CONF_FLAGS_i386_max: "--enable-ipv6 --enable-jpeg --enable-mp3lame
+                  --enable-opus --enable-rfxcodec --enable-painter
                   --disable-pixman --with-imlib2 --host=i686-linux"
 
       PKG_CONFIG_PATH_i386: "/usr/lib/i386-linux-gnu/pkgconfig"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,10 +130,11 @@ jobs:
       CPPCHECK_VER: 2.9
       CPPCHECK_REPO: https://github.com/danmar/cppcheck.git
     steps:
-      # This is currently the only way to get a version into
-      # the cache tag name - see https://github.com/actions/cache/issues/543
-      - run: |
-          echo "OS_VERSION=`lsb_release -sr`" >> $GITHUB_ENV
+      # Set steps.os.outputs.image to the specific OS (e.g. 'ubuntu20')
+      - name: Get operating system name and version.
+        id: os
+        run: echo "image=$ImageOS" >>$GITHUB_OUTPUT
+        shell: bash
       - uses: actions/checkout@v3
       - name: Cache cppcheck
         uses: actions/cache@v3
@@ -141,7 +142,7 @@ jobs:
           cache-name: cache-cppcheck
         with:
           path: ~/cppcheck.local
-          key: ${{ runner.os }}-${{ env.OS_VERSION }}-build-${{ env.cache-name }}-${{ env.CPPCHECK_VER }}
+          key: ${{ steps.os.outputs.image }}-build-${{ env.cache-name }}-${{ env.CPPCHECK_VER }}
       - run: sudo scripts/install_cppcheck_dependencies_with_apt.sh
       - run: ./bootstrap
       - run: scripts/install_cppcheck.sh $CPPCHECK_REPO $CPPCHECK_VER
@@ -157,10 +158,11 @@ jobs:
       ASTYLE_VER: 3.1
       ASTYLE_REPO: https://svn.code.sf.net/p/astyle/code/tags
     steps:
-      # This is currently the only way to get a version into
-      # the cache tag name - see https://github.com/actions/cache/issues/543
-      - run: |
-          echo "OS_VERSION=`lsb_release -sr`" >> $GITHUB_ENV
+      # Set steps.os.outputs.image to the specific OS (e.g. 'ubuntu20')
+      - name: Get operating system name and version.
+        id: os
+        run: echo "image=$ImageOS" >>$GITHUB_OUTPUT
+        shell: bash
       - uses: actions/checkout@v3
       - name: Cache astyle
         uses: actions/cache@v3
@@ -168,7 +170,7 @@ jobs:
           cache-name: cache-astyle
         with:
           path: ~/astyle.local
-          key: ${{ runner.os }}-${{ env.OS_VERSION }}-build-${{ env.cache-name }}-${{ env.ASTYLE_VER }}
+          key: ${{ steps.os.outputs.image }}-build-${{ env.cache-name }}-${{ env.ASTYLE_VER }}
       - run: sudo scripts/install_astyle_dependencies_with_apt.sh
       - run: scripts/install_astyle.sh $ASTYLE_REPO $ASTYLE_VER
       - name: Format code with astyle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
           echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH_${{ matrix.arch }}" >> $GITHUB_ENV
           echo "CFLAGS=$CFLAGS_${{ matrix.arch }}" >> $GITHUB_ENV
           echo "LDFLAGS=$LDFLAGS_${{ matrix.arch }}" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: sudo scripts/install_xrdp_build_dependencies_with_apt.sh ${{ matrix.feature_set }} ${{ matrix.arch }} --allow-downgrades --allow-remove-essential --allow-change-held-packages
       - run: ./bootstrap
       - run: ./configure $CONF_FLAGS
@@ -134,9 +134,9 @@ jobs:
       # the cache tag name - see https://github.com/actions/cache/issues/543
       - run: |
           echo "OS_VERSION=`lsb_release -sr`" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Cache cppcheck
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-cppcheck
         with:
@@ -161,9 +161,9 @@ jobs:
       # the cache tag name - see https://github.com/actions/cache/issues/543
       - run: |
           echo "OS_VERSION=`lsb_release -sr`" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Cache astyle
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-astyle
         with:

--- a/common/ssl_calls.c
+++ b/common/ssl_calls.c
@@ -337,7 +337,7 @@ ssl_sha1_clear(void *sha1_info)
 #else
     if (sha1_info != NULL)
     {
-        EVP_DigestInit_ex(sha1_info, g_md_sha1, NULL);
+        EVP_DigestInit_ex((EVP_MD_CTX *)sha1_info, g_md_sha1, NULL);
     }
 #endif
 }
@@ -417,7 +417,7 @@ ssl_md5_clear(void *md5_info)
 #else
     if (md5_info != NULL)
     {
-        EVP_DigestInit_ex(md5_info, g_md_md5, NULL);
+        EVP_DigestInit_ex((EVP_MD_CTX *)md5_info, g_md_md5, NULL);
     }
 #endif
 }

--- a/scripts/install_xrdp_build_dependencies_with_apt.sh
+++ b/scripts/install_xrdp_build_dependencies_with_apt.sh
@@ -94,6 +94,11 @@ in
         esac
         ;;
     i386)
+        # This list is not as complete as the amd64 list. It currently
+        # supports 32-bit CI building only, rather than being a generic
+        # build support tool.
+        # - Ubuntu 18.04 -> 20.04
+        #       Removed fdk-aac-dev:i386 and libfuse-dev:i386
         PACKAGES="$PACKAGES \
             g++-multilib \
             gcc-multilib \
@@ -102,7 +107,6 @@ in
             libjpeg-dev:i386 \
             libimlib2-dev:i386 \
             libmp3lame-dev:i386 \
-            libfdk-aac-dev:i386 \
             libopus-dev:i386 \
             libpam0g-dev:i386 \
             libssl-dev:i386 \
@@ -110,8 +114,7 @@ in
             libxext-dev:i386 \
             libxfixes-dev:i386 \
             libxrandr-dev:i386 \
-            libxrender-dev:i386 \
-            libfuse-dev:i386"
+            libxrender-dev:i386"
 
         dpkg --add-architecture i386
         dpkg --print-architecture


### PR DESCRIPTION
This PR removes CI warnings from the v0.9 branch. See #2394 for details.

@metalefty - I thought it was worth preparing this while I was still aware of the issues. Feel free to merge it, or I will if you're short of time.