### PR TITLE
LogFile=<stdout> redirects log to stdout, which is useful for debugging

### DIFF
--- a/common/log.c
+++ b/common/log.c
@@ -28,6 +28,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <time.h>
+#include <unistd.h>
 #include "list.h"
 #include "file.h"
 #include "os_calls.h"
@@ -61,8 +62,15 @@ internal_log_file_open(const char *fname)
 
     if (fname != NULL)
     {
-        ret = open(fname, O_WRONLY | O_CREAT | O_APPEND | O_SYNC,
-                   S_IRUSR | S_IWUSR);
+	if (g_strcmp(fname, "-") != 0)
+	{
+	    ret = open(fname, O_WRONLY | O_CREAT | O_APPEND | O_SYNC,
+		       S_IRUSR | S_IWUSR);
+	}
+	else
+	{
+	    ret = dup(1);
+	}
     }
 
 #ifdef FD_CLOEXEC
@@ -321,7 +329,7 @@ internal_config_read_logging(int file,
 
             if (lc->log_file != NULL)
             {
-                if (lc->log_file[0] != '/')
+                if (lc->log_file[0] != '/' && g_strcmp(lc->log_file, "-") != 0)
                 {
                     temp_buf = (char *)g_malloc(512, 0);
                     g_snprintf(temp_buf, 511, "%s/%s", XRDP_LOG_PATH, lc->log_file);

--- a/common/log.c
+++ b/common/log.c
@@ -62,15 +62,15 @@ internal_log_file_open(const char *fname)
 
     if (fname != NULL)
     {
-	if (g_strcmp(fname, "<stdout>") != 0)
-	{
-	    ret = open(fname, O_WRONLY | O_CREAT | O_APPEND | O_SYNC,
-		       S_IRUSR | S_IWUSR);
-	}
-	else
-	{
-	    ret = dup(1);
-	}
+        if (g_strcmp(fname, "<stdout>") != 0)
+        {
+            ret = open(fname, O_WRONLY | O_CREAT | O_APPEND | O_SYNC,
+                       S_IRUSR | S_IWUSR);
+        }
+        else
+        {
+            ret = dup(1);
+        }
     }
 
 #ifdef FD_CLOEXEC

--- a/common/log.c
+++ b/common/log.c
@@ -62,7 +62,7 @@ internal_log_file_open(const char *fname)
 
     if (fname != NULL)
     {
-	if (g_strcmp(fname, "-") != 0)
+	if (g_strcmp(fname, "<stdout>") != 0)
 	{
 	    ret = open(fname, O_WRONLY | O_CREAT | O_APPEND | O_SYNC,
 		       S_IRUSR | S_IWUSR);
@@ -329,7 +329,7 @@ internal_config_read_logging(int file,
 
             if (lc->log_file != NULL)
             {
-                if (lc->log_file[0] != '/' && g_strcmp(lc->log_file, "-") != 0)
+                if (lc->log_file[0] != '/' && g_strcmp(lc->log_file, "<stdout>") != 0)
                 {
                     temp_buf = (char *)g_malloc(512, 0);
                     g_snprintf(temp_buf, 511, "%s/%s", XRDP_LOG_PATH, lc->log_file);

--- a/docs/man/sesman.ini.5.in
+++ b/docs/man/sesman.ini.5.in
@@ -97,7 +97,10 @@ sections.
 .TP
 \fBLogFile\fR=\fIfilename\fR
 Log file path. It can be either absolute or relative. If not specified,
-defaults to \fI./sesman.log\fR It is ignored in the [ChansrvLogging] section
+defaults to \fI./sesman.log\fR. If set to \fB<stdout>\fR, log will go to
+stdout, which is useful for debugging\fR
+
+It is ignored in the [ChansrvLogging] section
 since the channel server creates one log file per display and instead uses the
 following log file naming convention \fIxrdp-chansrv.${DISPLAY}.log\fR
 

--- a/docs/man/sesman.ini.5.in
+++ b/docs/man/sesman.ini.5.in
@@ -98,7 +98,7 @@ sections.
 \fBLogFile\fR=\fIfilename\fR
 Log file path. It can be either absolute or relative. If not specified,
 defaults to \fI./sesman.log\fR. If set to \fB<stdout>\fR, log will go to
-stdout, which is useful for debugging\fR
+stdout. Use for debugging only\fR
 
 It is ignored in the [ChansrvLogging] section
 since the channel server creates one log file per display and instead uses the

--- a/docs/man/xrdp.ini.5.in
+++ b/docs/man/xrdp.ini.5.in
@@ -230,7 +230,7 @@ The following parameters can be used in the \fB[Logging]\fR section:
 
 .TP
 \fBLogFile\fR=\fI@localstatedir@/log/xrdp.log\fR
-This options contains the path to logfile. It can be either absolute or relative. If set to "-", log will go to stdout, which is useful for debugging\fR
+This options contains the path to logfile. It can be either absolute or relative. If set to \fB<stdout>\fR, log will go to stdout, which is useful for debugging\fR
 
 .TP
 \fBLogLevel\fR=\fIlevel\fR

--- a/docs/man/xrdp.ini.5.in
+++ b/docs/man/xrdp.ini.5.in
@@ -230,7 +230,7 @@ The following parameters can be used in the \fB[Logging]\fR section:
 
 .TP
 \fBLogFile\fR=\fI@localstatedir@/log/xrdp.log\fR
-This options contains the path to logfile. It can be either absolute or relative.\fR
+This options contains the path to logfile. It can be either absolute or relative. If set to "-", log will go to stdout, which is useful for debugging\fR
 
 .TP
 \fBLogLevel\fR=\fIlevel\fR

--- a/docs/man/xrdp.ini.5.in
+++ b/docs/man/xrdp.ini.5.in
@@ -230,7 +230,7 @@ The following parameters can be used in the \fB[Logging]\fR section:
 
 .TP
 \fBLogFile\fR=\fI@localstatedir@/log/xrdp.log\fR
-This options contains the path to logfile. It can be either absolute or relative. If set to \fB<stdout>\fR, log will go to stdout, which is useful for debugging\fR
+This options contains the path to logfile. It can be either absolute or relative. If set to \fB<stdout>\fR, log will go to stdout. Use for debugging only\fR
 
 .TP
 \fBLogLevel\fR=\fIlevel\fR


### PR DESCRIPTION
Hi!

This small pull requests adds possibility to redirect logging to the **stdout** instead of the log file, using the following simple syntax in the **xrdp.ini** file:
```
LogFile=-
```
This is useful for xrdp debugging and doesn't affect normal operations