### PR TITLE
Update pamdir_suse to accommodate with TW pam.d move

### DIFF
--- a/instfiles/pam.d/mkpamrules
+++ b/instfiles/pam.d/mkpamrules
@@ -9,6 +9,10 @@ outfile="$3"
 service="xrdp-sesman"
 pamdir="/etc/pam.d"
 pamdir_suse="/usr/lib/pam.d"
+if [ ! -d $pamdir_suse ]; then
+   # Older SUSE distros uses /usr/etc/pam.d
+   pamdir_suse="/usr/etc/pam.d"
+fi
 
 # Modules needed by xrdp-sesman.unix, if we get to that
 unix_modules_needed="pam_unix.so pam_env.so pam_nologin.so"

--- a/instfiles/pam.d/mkpamrules
+++ b/instfiles/pam.d/mkpamrules
@@ -8,7 +8,7 @@ outfile="$3"
 
 service="xrdp-sesman"
 pamdir="/etc/pam.d"
-pamdir_suse="/usr/etc/pam.d"
+pamdir_suse="/usr/lib/pam.d"
 
 # Modules needed by xrdp-sesman.unix, if we get to that
 unix_modules_needed="pam_unix.so pam_env.so pam_nologin.so"


### PR DESCRIPTION
On newer builds of openSUSE tumbleweed the path of pam.d has moved from /usr/etc/pam.d to /usr/lib/pam.d, which prevents install script to correctly guess pam rules. Updating path in mkpamrules solves the problem.

The script should still work on older SUSE systems since there's still /etc/pam.d/common-account on those, which should allow for correct rule guess.