### PR TITLE
Regain scrolling when using VNC backend

### DIFF
--- a/vnc/vnc.c
+++ b/vnc/vnc.c
@@ -680,7 +680,7 @@ process_touchpad_scroll(struct vnc *v, int axis, long param1, long param2,
      * Right -> Button7
      *
      */
-    switch(axis)
+    switch (axis)
     {
         case WM_TOUCH_VSCROLL:
             for (i = 0; i < abs_scaled_delta; i++)

--- a/vnc/vnc.c
+++ b/vnc/vnc.c
@@ -547,7 +547,12 @@ lib_mod_event(struct vnc *v, int msg, long param1, long param2,
             }
         }
     }
-    else if (msg >= 100 && msg <= 110) /* mouse events */
+    /* mouse events
+     *
+     * VNC supports up to 8 mouse buttons because mouse buttons are
+     * represented by 7 bits bitmask
+     */
+    else if (msg >= WM_MOUSEMOVE && msg <= WM_BUTTON8DOWN) /* 100 to 116 */
     {
         switch (msg)
         {
@@ -582,6 +587,24 @@ lib_mod_event(struct vnc *v, int msg, long param1, long param2,
                 break;
             case WM_BUTTON5DOWN:
                 v->mod_mouse_state |= 16;
+                break;
+            case WM_BUTTON6UP:
+                v->mod_mouse_state &= ~32;
+                break;
+            case WM_BUTTON6DOWN:
+                v->mod_mouse_state |= 32;
+                break;
+            case WM_BUTTON7UP:
+                v->mod_mouse_state &= ~64;
+                break;
+            case WM_BUTTON7DOWN:
+                v->mod_mouse_state |= 64;
+                break;
+            case WM_BUTTON8UP:
+                v->mod_mouse_state &= ~128;
+                break;
+            case WM_BUTTON8DOWN:
+                v->mod_mouse_state |= 128;
                 break;
         }
 

--- a/vnc/vnc.c
+++ b/vnc/vnc.c
@@ -551,36 +551,36 @@ lib_mod_event(struct vnc *v, int msg, long param1, long param2,
     {
         switch (msg)
         {
-            case 100:
-                break; /* WM_MOUSEMOVE */
-            case 101:
+            case WM_MOUSEMOVE:
+                break;
+            case WM_LBUTTONUP:
                 v->mod_mouse_state &= ~1;
-                break; /* WM_LBUTTONUP */
-            case 102:
+                break;
+            case WM_LBUTTONDOWN:
                 v->mod_mouse_state |= 1;
-                break; /* WM_LBUTTONDOWN */
-            case 103:
+                break;
+            case WM_RBUTTONUP:
                 v->mod_mouse_state &= ~4;
-                break; /* WM_RBUTTONUP */
-            case 104:
+                break;
+            case WM_RBUTTONDOWN:
                 v->mod_mouse_state |= 4;
-                break; /* WM_RBUTTONDOWN */
-            case 105:
+                break;
+            case WM_BUTTON3UP:
                 v->mod_mouse_state &= ~2;
                 break;
-            case 106:
+            case WM_BUTTON3DOWN:
                 v->mod_mouse_state |= 2;
                 break;
-            case 107:
+            case WM_BUTTON4UP:
                 v->mod_mouse_state &= ~8;
                 break;
-            case 108:
+            case WM_BUTTON4DOWN:
                 v->mod_mouse_state |= 8;
                 break;
-            case 109:
+            case WM_BUTTON5UP:
                 v->mod_mouse_state &= ~16;
                 break;
-            case 110:
+            case WM_BUTTON5DOWN:
                 v->mod_mouse_state |= 16;
                 break;
         }

--- a/vnc/vnc.h
+++ b/vnc/vnc.h
@@ -175,5 +175,8 @@ int
 lib_send_copy(struct vnc *v, struct stream *s);
 int
 skip_trans_bytes(struct trans *trans, unsigned int bytes);
+void
+process_touchpad_scroll(struct vnc *v, int axis, long param1, long param2,
+                        long param3, long param4);
 
 #endif /* VNC_H */


### PR DESCRIPTION
@seflerZ Fix for #2364.  Also added mouse buttons 6, 7, and 8 support.

This is a draft PR.  I haven't adjusted the scroll speed yet. I just bring back scroll. Comments and suggestions are welcome especially on implementation of `process_touchpad_scroll()`.