### PR TITLE
Disable touch events on XVNC session

### DIFF
--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -56,11 +56,6 @@ xrdp_mm_chansrv_connect(struct xrdp_mm *self, const char *port);
 static void
 xrdp_mm_connect_sm(struct xrdp_mm *self);
 
-/* Code values used in 'code=' settings */
-#define XVNC_SESSION_CODE 0
-#define XRDP_SESSION_CODE 10
-#define XORG_SESSION_CODE 20
-
 /*****************************************************************************/
 struct xrdp_mm *
 xrdp_mm_create(struct xrdp_wm *owner)

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -32,6 +32,14 @@
 #define MAX_NR_CHANNELS 16
 #define MAX_CHANNEL_NAME 16
 
+/* Code values used in 'xrdp_mm->code=' settings */
+#define XVNC_SESSION_CODE 0
+#define XRDP_SESSION_CODE 10
+#define XORG_SESSION_CODE 20
+
+/* To check whether touch events has been implemented on session type 'mm' */
+#define XRDP_MM_IMPLEMENTS_TOUCH(mm) ((mm)->code != XVNC_SESSION_CODE)
+
 struct source_info;
 
 /* lib */

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -29,11 +29,6 @@
 #include "log.h"
 #include "string_calls.h"
 
-/* Code values used in 'xrdp_mm->code=' settings */
-#define XVNC_SESSION_CODE 0
-#define XRDP_SESSION_CODE 10
-#define XORG_SESSION_CODE 20
-
 /*****************************************************************************/
 struct xrdp_wm *
 xrdp_wm_create(struct xrdp_process *owner,
@@ -1816,9 +1811,7 @@ xrdp_wm_process_input_mouse(struct xrdp_wm *self, int device_flags,
              * The negative number is represented by complement.
              */
             delta = (device_flags & WheelRotationMask) | ~WheelRotationMask;
-
-            // XVNC session has not implemented the touch event for now
-            if (delta != 0 && self->mm->code != XVNC_SESSION_CODE)
+            if (delta != 0 && XRDP_MM_IMPLEMENTS_TOUCH(self->mm))
             {
                 // Use nature scrolling, up direction is negative.
                 xrdp_wm_mouse_touch(self, TOUCH_TWO_FINGERS_UP, delta);
@@ -1831,9 +1824,7 @@ xrdp_wm_process_input_mouse(struct xrdp_wm *self, int device_flags,
         else
         {
             delta = device_flags & WheelRotationMask;
-
-            // XVNC session has not implemented the touch event for now
-            if (delta != 0 && self->mm->code != XVNC_SESSION_CODE)
+            if (delta != 0 && XRDP_MM_IMPLEMENTS_TOUCH(self->mm))
             {
                 xrdp_wm_mouse_touch(self, TOUCH_TWO_FINGERS_DOWN, delta);
             }
@@ -1866,9 +1857,7 @@ xrdp_wm_process_input_mouse(struct xrdp_wm *self, int device_flags,
              * The negative number is represented by complement.
              */
             delta = (device_flags & WheelRotationMask) | ~WheelRotationMask;
-
-            // XVNC session has not implemented the touch event for now
-            if (delta != 0 && self->mm->code != XVNC_SESSION_CODE)
+            if (delta != 0 && XRDP_MM_IMPLEMENTS_TOUCH(self->mm))
             {
                 // Use nature scrolling, right direction is negative.
                 xrdp_wm_mouse_touch(self, TOUCH_TWO_FINGERS_RIGHT, delta);
@@ -1881,9 +1870,7 @@ xrdp_wm_process_input_mouse(struct xrdp_wm *self, int device_flags,
         else
         {
             delta = device_flags & WheelRotationMask;
-
-            // XVNC session has not implemented the touch event for now
-            if (delta != 0 && self->mm->code != XVNC_SESSION_CODE)
+            if (delta != 0 && XRDP_MM_IMPLEMENTS_TOUCH(self->mm))
             {
                 xrdp_wm_mouse_touch(self, TOUCH_TWO_FINGERS_LEFT, delta);
             }

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -29,7 +29,7 @@
 #include "log.h"
 #include "string_calls.h"
 
-/* Code values used in 'code=' settings */
+/* Code values used in 'xrdp_mm->code=' settings */
 #define XVNC_SESSION_CODE 0
 #define XRDP_SESSION_CODE 10
 #define XORG_SESSION_CODE 20

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -29,7 +29,10 @@
 #include "log.h"
 #include "string_calls.h"
 
-
+/* Code values used in 'code=' settings */
+#define XVNC_SESSION_CODE 0
+#define XRDP_SESSION_CODE 10
+#define XORG_SESSION_CODE 20
 
 /*****************************************************************************/
 struct xrdp_wm *
@@ -1815,7 +1818,7 @@ xrdp_wm_process_input_mouse(struct xrdp_wm *self, int device_flags,
             delta = (device_flags & WheelRotationMask) | ~WheelRotationMask;
 
             // XVNC session has not implemented the touch event for now
-            if (delta != 0 && self->mm->code != 0)
+            if (delta != 0 && self->mm->code != XVNC_SESSION_CODE)
             {
                 // Use nature scrolling, up direction is negative.
                 xrdp_wm_mouse_touch(self, TOUCH_TWO_FINGERS_UP, delta);
@@ -1830,7 +1833,7 @@ xrdp_wm_process_input_mouse(struct xrdp_wm *self, int device_flags,
             delta = device_flags & WheelRotationMask;
 
             // XVNC session has not implemented the touch event for now
-            if (delta != 0 && self->mm->code != 0)
+            if (delta != 0 && self->mm->code != XVNC_SESSION_CODE)
             {
                 xrdp_wm_mouse_touch(self, TOUCH_TWO_FINGERS_DOWN, delta);
             }
@@ -1865,7 +1868,7 @@ xrdp_wm_process_input_mouse(struct xrdp_wm *self, int device_flags,
             delta = (device_flags & WheelRotationMask) | ~WheelRotationMask;
 
             // XVNC session has not implemented the touch event for now
-            if (delta != 0 && self->mm->code != 0)
+            if (delta != 0 && self->mm->code != XVNC_SESSION_CODE)
             {
                 // Use nature scrolling, right direction is negative.
                 xrdp_wm_mouse_touch(self, TOUCH_TWO_FINGERS_RIGHT, delta);
@@ -1880,7 +1883,7 @@ xrdp_wm_process_input_mouse(struct xrdp_wm *self, int device_flags,
             delta = device_flags & WheelRotationMask;
 
             // XVNC session has not implemented the touch event for now
-            if (delta != 0 && self->mm->code != 0)
+            if (delta != 0 && self->mm->code != XVNC_SESSION_CODE)
             {
                 xrdp_wm_mouse_touch(self, TOUCH_TWO_FINGERS_LEFT, delta);
             }

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -1813,7 +1813,9 @@ xrdp_wm_process_input_mouse(struct xrdp_wm *self, int device_flags,
              * The negative number is represented by complement.
              */
             delta = (device_flags & WheelRotationMask) | ~WheelRotationMask;
-            if (delta != 0)
+
+            // XVNC session has not implemented the touch event for now
+            if (delta != 0 && self->mm->code != 0)
             {
                 // Use nature scrolling, up direction is negative.
                 xrdp_wm_mouse_touch(self, TOUCH_TWO_FINGERS_UP, delta);
@@ -1826,7 +1828,9 @@ xrdp_wm_process_input_mouse(struct xrdp_wm *self, int device_flags,
         else
         {
             delta = device_flags & WheelRotationMask;
-            if (delta != 0)
+
+            // XVNC session has not implemented the touch event for now
+            if (delta != 0 && self->mm->code != 0)
             {
                 xrdp_wm_mouse_touch(self, TOUCH_TWO_FINGERS_DOWN, delta);
             }
@@ -1859,7 +1863,9 @@ xrdp_wm_process_input_mouse(struct xrdp_wm *self, int device_flags,
              * The negative number is represented by complement.
              */
             delta = (device_flags & WheelRotationMask) | ~WheelRotationMask;
-            if (delta != 0)
+
+            // XVNC session has not implemented the touch event for now
+            if (delta != 0 && self->mm->code != 0)
             {
                 // Use nature scrolling, right direction is negative.
                 xrdp_wm_mouse_touch(self, TOUCH_TWO_FINGERS_RIGHT, delta);
@@ -1872,7 +1878,9 @@ xrdp_wm_process_input_mouse(struct xrdp_wm *self, int device_flags,
         else
         {
             delta = device_flags & WheelRotationMask;
-            if (delta != 0)
+
+            // XVNC session has not implemented the touch event for now
+            if (delta != 0 && self->mm->code != 0)
             {
                 xrdp_wm_mouse_touch(self, TOUCH_TWO_FINGERS_LEFT, delta);
             }


### PR DESCRIPTION
According to #2424 , XVNC has no touch implemented yet. Here we temporarily disable them on XVNC session and force it the old way.