### PR TITLE
Fix freetype2 version checking

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -281,14 +281,21 @@ if test x$use_imlib2 = xyes; then
 fi
 
 # Find freetype2
+#
+# The modversion used by pkgcheck does not correspond to the
+# freetype2 release. See docs/VERSIONS.TXT in the freetype2
+# source for a table of correspondences. If you change one
+# of the below defines, change both.
+m4_define([FT2_REQUIRED_VERSION], [2_8_0])
+m4_define([FT2_REQUIRED_MODVERSION], [20.0.14])
 case "$with_freetype2" in
     '' | no) AC_MSG_NOTICE([freetype2 will not be supported])
         use_freetype2=no
         ;;
     yes)
-        PKG_CHECK_MODULES([FREETYPE2], [freetype2 >= 2.8],
+        PKG_CHECK_MODULES([FREETYPE2], [freetype2 >= FT2_REQUIRED_MODVERSION],
             [use_freetype2=yes],
-            [AC_MSG_ERROR([please install libfreetype6-dev or freetype-devel])])
+            [AC_MSG_ERROR([please install version FT2_REQUIRED_VERSION or later of libfreetype6-dev or freetype-devel])])
         ;;
     /*) AC_MSG_CHECKING([for freetype2 in $with_freetype2])
         if test -d $with_freetype2/lib; then


### PR DESCRIPTION
The version of freetype2 returned by `pkg-config --modversion` is not the same as the freetype2 release version - more information [here](/egorodet/FreeType2/blob/master/docs/VERSIONS.TXT).

Consequently, the existing autoconfigure check for version >= 2.8.0 does not work.

This version was chosen as 2.8.x was the easiest early one to test on - Ubuntu 18.04 uses 2.8.1 and CentOS 7 uses 2.8.14.

I've just discovered the check doesn't work for Ubuntu 16.04 which only has version 2.6.1 of libfreetype6. Without this PR, the configure step works fine but the compilation fails. The failure is due to a change made in version 2.6.3 relating to removing identifiers with double underscores '__'. 

With this PR, the following error is generated on Ubuntu 16.04 if `--with-freetype2` is used:-

```
configure: error: please install version 2_8_0 or later of libfreetype6-dev or freetype-devel
```

Omitting `--with-freetype2` from the configure simply means that the new font generation utility `xrdp-mkfv1` will not be available.