### PR TITLE
Fix memory leak in font handler

### DIFF
--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -577,6 +577,7 @@ xrdp_wm_init(struct xrdp_wm *self)
                      self->screen->bpp);
 
     /* Load the font */
+    xrdp_font_delete(self->default_font);
     dpi = xrdp_login_wnd_get_monitor_dpi(self);
     self->default_font = xrdp_font_create(self, dpi);
 


### PR DESCRIPTION
The following sequence of events results in a memory leak as a font is loaded twice
1) Invoke login screen
2) Try to log in to session, which fails
3) Back to login screen

Fix is to make sure font is deleted before being reloaded.