### PR TITLE
Fix regression use-after-free

### DIFF
--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -574,8 +574,11 @@ xrdp_wm_init(struct xrdp_wm *self)
     load_xrdp_config(self->xrdp_config, self->session->xrdp_ini,
                      self->screen->bpp);
 
-    /* Load the font */
+    /* Remove a font loaded on the previous config */
     xrdp_font_delete(self->default_font);
+    self->painter->font = NULL; /* May be set to the default_font */
+
+    /* Load the font */
     dpi = xrdp_login_wnd_get_monitor_dpi(self);
     self->default_font = xrdp_font_create(self, dpi);
 


### PR DESCRIPTION
93d97dcb introduced a use-after-free error. The default_font for the window manager may be used as the font for the main window manager painter, and so deleting the default_font may cause the painter to access deallocated memory.

At the point xrdp_wm_init() is called, the only active painter should be the window manager one.