### PR TITLE
Set permissions on pcsc socket dir to owner only

### DIFF
--- a/sesman/chansrv/smartcard_pcsc.c
+++ b/sesman/chansrv/smartcard_pcsc.c
@@ -1874,7 +1874,9 @@ scard_pcsc_init(void)
                 }
             }
         }
-        g_chmod_hex(g_pcsclite_ipc_dir, 0x1777);
+        /* Only the current user should be able to access the remote
+         * smartcard */
+        g_chmod_hex(g_pcsclite_ipc_dir, 0x700);
         g_snprintf(g_pcsclite_ipc_file, 255, "%s/pcscd.comm", g_pcsclite_ipc_dir);
         g_lis->trans_conn_in = my_pcsc_trans_conn_in;
         error = trans_listen(g_lis, g_pcsclite_ipc_file);


### PR DESCRIPTION
Fixes #2454

There is no reason for any user other than the current one to be able to communicate with the remote smartcard.