### PR TITLE
Fix CI failure after 8484767

### DIFF
--- a/sesman/libscp/libscp_v0.c
+++ b/sesman/libscp/libscp_v0.c
@@ -225,7 +225,7 @@ scp_v0c_reply_available(struct trans *trans)
     if (trans != NULL && trans->status == TRANS_STATUS_UP)
     {
         /* Have we read enough data from the stream? */
-        if ((trans->in_s->end - trans->in_s->data) < trans->header_size)
+        if ((unsigned int)(trans->in_s->end - trans->in_s->data) < trans->header_size)
         {
             result = 0;
         }


### PR DESCRIPTION
```
libscp_v0.c:228:52: error: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Werror=sign-compare]
  228 |         if ((trans->in_s->end - trans->in_s->data) < trans->header_size)
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
```