### PR TITLE
Implement uds authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ NEWS
 README
 sesman/chansrv/xrdp-chansrv
 sesman/sessvc/xrdp-sessvc
+sesman/tools/xrdp-authtest
 sesman/tools/xrdp-dis
 sesman/tools/xrdp-sesadmin
 sesman/tools/xrdp-sesrun

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -671,7 +671,7 @@ g_sck_get_peer_cred(int sck, int *pid, int *uid, int *gid)
     unsigned int xucred_length;
     xucred_length = sizeof(xucred);
 
-    if (getsockopt(sck, SOL_SOCKET, LOCAL_PEERCRED, &xucred, &xucred_length))
+    if (getsockopt(sck, SOL_LOCAL, LOCAL_PEERCRED, &xucred, &xucred_length))
     {
         return 1;
     }

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -193,8 +193,10 @@ int      g_exit(int exit_code);
 int      g_getpid(void);
 int      g_sigterm(int pid);
 int      g_sighup(int pid);
-int      g_getuser_info(const char *username, int *gid, int *uid, char **shell,
-                        char **dir, char **gecos);
+int      g_getuser_info_by_name(const char *username, int *uid, int *gid,
+                                char **shell, char **dir, char **gecos);
+int      g_getuser_info_by_uid(int uid, char **username, int *gid,
+                               char **shell, char **dir, char **gecos);
 int      g_getgroup_info(const char *groupname, int *gid);
 int      g_check_user_in_group(const char *username, int gid, int *ok);
 int      g_time1(void);

--- a/configure.ac
+++ b/configure.ac
@@ -424,11 +424,6 @@ then
   AC_DEFINE([XRDP_ENABLE_IPV6],1,[Enable IPv6])
 fi
 
-if test "x$enable_pam" = "xyes"
-then
-  AC_DEFINE([USE_PAM],1,[Enable PAM])
-fi
-
 AS_IF( [test "x$enable_neutrinordp" = "xyes"] , [PKG_CHECK_MODULES(FREERDP, freerdp >= 1.0.0)] )
 
 # checking for libjpeg

--- a/docs/man/xrdp-sesadmin.8.in
+++ b/docs/man/xrdp-sesadmin.8.in
@@ -18,13 +18,11 @@ command.
 A summary of options is included below.
 .TP
 .BI \-u= username
-\fIUsername\fP for authentication on the server.
-Defaults to \fBroot\fP.
+Retained for compatibility, but ignored.
 
 .TP
 .BI \-p= password
-The \fIpassword\fP to authenticate with.
-The default is to ask for the password interactively.
+Retained for compatibility, but ignored.
 
 .TP
 .BI \-i= port
@@ -39,7 +37,7 @@ Valid commands are:
 .RS 4
 .TP
 .B list
-List currently active sessions.
+List active sessions for the current user.
 .TP
 .BI kill: sid
 Kills the session specified the given \fIsession id\fP.

--- a/docs/man/xrdp-sesrun.8.in
+++ b/docs/man/xrdp-sesrun.8.in
@@ -4,18 +4,28 @@
 
 .SH "SYNTAX"
 .B xrdp\-sesrun
-.I [ options ] username
+.I --help
+.br
+
+.B xrdp\-sesrun
+.I [ options ] [ username ]
 
 .SH "DESCRIPTION"
 \fBxrdp\-sesrun\fR starts a session using \fBxrdp\-sesman\fR(8).
 .br
-This is a tool useful for testing, it simply behaves like xrdp when some
+This is a tool useful for testing. It simply behaves like xrdp when some
 user logs in a new session and authenticates, thus starting a new session.
 
-Default values for the options are set at compile-time. Run the utility without
-a username to see what the defaults are for your installation.
+Default values for the options are set at compile-time. Run the utility with
+the '--help' option to see what the defaults are for your installation.
 
-The utility prompts for a password if neither \fB-p\fR or \fB-F\fR is used.
+If no username is used, the current username is used, and no password
+needs to be provided. In this instance, it is important that any necessary
+authentication tokens for a GUI session (e.g. a Kerberos ticket) have
+already been acquired.
+
+If a username is provided, a password must also be provided. In this instance
+the utility prompts for a password if neither \fB-p\fR or \fB-F\fR is used.
 
 .SH "OPTIONS"
 .TP
@@ -58,6 +68,10 @@ Override the default logging level. One of "error", "warn", "info",
 "debug", "trace" or a number 1-5.
 
 .SH "EXAMPLES"
+.TP
+.B
+xrdp-sesrun
+Create a default session for the current user.
 .TP
 .B
 xrdp-sesrun -F 0 user1 <passwd.txt

--- a/docs/man/xrdp.ini.5.in
+++ b/docs/man/xrdp.ini.5.in
@@ -107,7 +107,9 @@ If not specified or set to \fB0\fP, unlimited.
 
 .TP
 \fBpamerrortxt\fP=\fIerror_text\fP
-Specify text passed to PAM when authentication failed. The maximum length is \fB256\fP.
+Specify additional text displayed to user if authentication fails. The maximum length is \fB256\fP.
+
+The use of 'pam' in the name of this option is historic
 
 .TP
 \fBport\fP=\fIport\fP

--- a/libipm/Makefile.am
+++ b/libipm/Makefile.am
@@ -15,7 +15,8 @@ libipm_la_SOURCES = \
   libipm_private.h \
   scp.h \
   scp.c \
-  scp_application_types.h
+  scp_application_types.h \
+  scp_application_types.c
 
 libipm_la_LIBADD = \
   $(top_builddir)/common/libcommon.la

--- a/libipm/scp.h
+++ b/libipm/scp.h
@@ -43,12 +43,24 @@ struct trans;
 /* Message codes */
 enum scp_msg_code
 {
-    E_SCP_GATEWAY_REQUEST = 1,
-    E_SCP_GATEWAY_RESPONSE,
+    E_SCP_SET_PEERNAME_REQUEST = 1,
+    // No E_SCP_SET_PEERNAME_RESPONSE
+
+    E_SCP_SYS_LOGIN_REQUEST,
+    E_SCP_UDS_LOGIN_REQUEST,
+    E_SCP_LOGIN_RESPONSE, /* Shared between login request types */
+
+    E_SCP_LOGOUT_REQUEST,
+    // No S_SCP_LOGOUT_RESPONSE
+
     E_SCP_CREATE_SESSION_REQUEST,
     E_SCP_CREATE_SESSION_RESPONSE,
+
     E_SCP_LIST_SESSIONS_REQUEST,
-    E_SCP_LIST_SESSIONS_RESPONSE
+    E_SCP_LIST_SESSIONS_RESPONSE,
+
+    E_SCP_CLOSE_CONNECTION_REQUEST
+    // No E_SCP_CLOSE_CONNECTION_RESPONSE
 };
 
 /* Common facilities */
@@ -97,6 +109,7 @@ scp_port_to_display_string(const char *port, char *buff, unsigned int bufflen);
  * Connect to an SCP server
  *
  * @param port Port definition (e.g. from sesman.ini)
+ * @param peername Name of this program or object (e.g. "xrdp-sesadmin")
  * @param term_func Function to poll during connection for program
  *         termination, or NULL for none.
  * @return Initialised SCP transport
@@ -104,16 +117,19 @@ scp_port_to_display_string(const char *port, char *buff, unsigned int bufflen);
  * The returned transport has the is_term member set to term_func.
  */
 struct trans *
-scp_connect(const  char *port,
+scp_connect(const char *port,
+            const char *peername,
             int (*term_func)(void));
 
 /**
  * Converts a standard trans connected to an SCP endpoint to an SCP transport
  *
+ * If you are running on a client, you may wish to use
+ * scp_send_set_peername_request() after the commnect to inform the
+ * server who you are.
+ *
  * @param trans connected endpoint
  * @return != 0 for error
- *
- * The returned transport has the is_term member set to term_func.
  */
 int
 scp_init_trans(struct trans *trans);
@@ -170,9 +186,54 @@ scp_msg_in_start(struct trans *trans);
 void
 scp_msg_in_reset(struct trans *trans);
 
+/* -------------------- Setup messages--------------------  */
 
 /**
- * Send an E_SCP_GATEWAY_REQUEST (SCP client)
+ * Send an E_SCP_SET_PEERNAME_REQUEST (SCP client)
+ *
+ * @param trans SCP transport
+ * @param peername Peername
+ * @return != 0 for error
+ *
+ * Server does not send a response
+ *
+ * This message is sent automatically by scp_connect(), but it can
+ * be sent at any time.
+ */
+int
+scp_send_set_peername_request(struct trans *trans,
+                              const char *peername);
+
+/**
+ * Parse an incoming E_SCP_SET_PEERNAME_REQUEST message (SCP server)
+ *
+ * @param trans SCP transport
+ * @param[out] peername peername
+ * @return != 0 for error
+ */
+int
+scp_get_set_peername_request(struct trans *trans,
+                             const char **peername);
+
+/* -------------------- Login messages--------------------  */
+
+/**
+ * Send an E_SCP_UDS_LOGIN_REQUEST (SCP client)
+ *
+ * User is logged in using their socket details
+ *
+ * @param trans SCP transport
+ * @return != 0 for error
+ *
+ * Server replies with E_SCP_LOGIN_RESPONSE
+ */
+int
+scp_send_uds_login_request(struct trans *trans);
+
+/**
+ * Send an E_SCP_SYS_LOGIN_REQUEST (SCP client)
+ *
+ * User is logged in using explicit credentials
  *
  * @param trans SCP transport
  * @param username Username
@@ -180,16 +241,16 @@ scp_msg_in_reset(struct trans *trans);
  * @param ip_addr IP address for the client (or "" if not known)
  * @return != 0 for error
  *
- * Server replies with E_SCP_GATEWAY_RESPONSE
+ * Server replies with E_SCP_LOGIN_RESPONSE
  */
 int
-scp_send_gateway_request(struct trans *trans,
-                         const char *username,
-                         const char *password,
-                         const char *ip_addr);
+scp_send_sys_login_request(struct trans *trans,
+                           const char *username,
+                           const char *password,
+                           const char *ip_addr);
 
 /**
- * Parse an incoming E_SCP_GATEWAY_REQUEST message (SCP server)
+ * Parse an incoming E_SCP_SYS_LOGIN_REQUEST message (SCP server)
  *
  * @param trans SCP transport
  * @param[out] username Username
@@ -198,78 +259,89 @@ scp_send_gateway_request(struct trans *trans,
  * @return != 0 for error
  */
 int
-scp_get_gateway_request(struct trans *trans,
-                        const char **username,
-                        const char **password,
-                        const char **ip_addr);
+scp_get_sys_login_request(struct trans *trans,
+                          const char **username,
+                          const char **password,
+                          const char **ip_addr);
 
 /**
- * Send an E_SCP_GATEWAY_RESPONSE (SCP server)
+ * Send an E_SCP_LOGIN_RESPONSE (SCP server)
  *
  * @param trans SCP transport
- * @param auth_result 0 for success, PAM error code otherwise
+ * @param login_result What happened to the login
+ * @param server_closed. If login fails, whether server has closed connection.
+ *        If not, a retry can be made.
  * @return != 0 for error
  */
 int
-scp_send_gateway_response(struct trans *trans,
-                          int auth_result);
+scp_send_login_response(struct trans *trans,
+                        enum scp_login_status login_result,
+                        int server_closed);
 
 /**
- * Parses an incoming E_SCP_GATEWAY_RESPONSE (SCP client)
+ * Parses an incoming E_SCP_LOGIN_RESPONSE (SCP client)
  *
  * @param trans SCP transport
- * @param[out] auth_result 0 for success, PAM error code otherwise
+ * @param[out] login_result 0 for success, PAM error code otherwise
+ * @param[out] server_closed. If login fails, whether server has closed
+ *             connection. If not a retry can be made.
  * @return != 0 for error
  */
 int
-scp_get_gateway_response(struct trans *trans,
-                         int *auth_result);
+scp_get_login_response(struct trans *trans,
+                       enum scp_login_status *login_result,
+                       int *server_closed);
 
-/* Session messages */
+/**
+ * Send an E_SCP_LOGOUT_REQUEST (SCP client)
+ *
+ * @param trans SCP transport
+ * @return != 0 for error
+ *
+ * Logs the user out (if they are logged in), so that another
+ * login request can be sent, maybe with a different user.
+ *
+ * A reply is not sent
+ */
+int
+scp_send_logout_request(struct trans *trans);
+
+/* -------------------- Session messages--------------------  */
 
 /**
  * Send an E_SCP_CREATE_SESSION_REQUEST (SCP client)
  *
  * @param trans SCP transport
- * @param username Username of session to create or re-connect to
- * @param password Password for user
  * @param type Session type
  * @param width Initial session width
  * @param height Initial session height
  * @param bpp Session bits-per-pixel (ignored for Xorg sessions)
  * @param shell User program to run. May be ""
  * @param directory Directory to run the program in. May be ""
- * @param ip_addr IP address for the client (or "" if not known)
  * @return != 0 for error
  *
  * Server replies with E_SCP_CREATE_SESSION_RESPONSE
  */
 int
 scp_send_create_session_request(struct trans *trans,
-                                const char *username,
-                                const char *password,
                                 enum scp_session_type type,
                                 unsigned short width,
                                 unsigned short height,
                                 unsigned char bpp,
                                 const char *shell,
-                                const char *directory,
-                                const char *ip_addr);
+                                const char *directory);
 
 
 /**
  * Parse an incoming E_SCP_CREATE_SESSION_REQUEST (SCP server)
  *
  * @param trans SCP transport
- * @param[out] username Username of session to create or re-connect to
- * @param[out] password Password for user
  * @param[out] type Session type
  * @param[out] width Initial session width
  * @param[out] height Initial session height
  * @param[out] bpp Session bits-per-pixel (ignored for Xorg sessions)
  * @param[out] shell User program to run. May be ""
  * @param[out] directory Directory to run the program in. May be ""
- * @param[out] ip_addr IP address for the client. May be ""
  * @return != 0 for error
  *
  * Returned string pointers are valid until scp_msg_in_reset() is
@@ -277,29 +349,26 @@ scp_send_create_session_request(struct trans *trans,
  */
 int
 scp_get_create_session_request(struct trans *trans,
-                               const char **username,
-                               const char **password,
                                enum scp_session_type *type,
                                unsigned short *width,
                                unsigned short *height,
                                unsigned char *bpp,
                                const char **shell,
-                               const char **directory,
-                               const char **ip_addr);
+                               const char **directory);
 
 /**
  * Send an E_SCP_CREATE_SESSION_RESPONSE (SCP server)
  *
  * @param trans SCP transport
- * @param auth_result 0 for success, PAM error code otherwise
- * @param display Should be zero if authentication failed.
- * @param guid Guid for session. Should be all zeros if authentication failed
+ * @param status Status of creation request
+ * @param display Should be zero if create session failed.
+ * @param guid Guid for session. Should be all zeros if create session failed
  *
  * @return != 0 for error
  */
 int
 scp_send_create_session_response(struct trans *trans,
-                                 int auth_result,
+                                 enum scp_screate_status status,
                                  int display,
                                  const struct guid *guid);
 
@@ -308,73 +377,29 @@ scp_send_create_session_response(struct trans *trans,
  * Parse an incoming E_SCP_CREATE_SESSION_RESPONSE (SCP client)
  *
  * @param trans SCP transport
- * @param[out] auth_result 0 for success, PAM error code otherwise
- * @param[out] display Should be zero if authentication failed.
- * @param[out] guid Guid for session. Should be all zeros if authentication
+ * @param[out] status Status of creation request
+ * @param[out] display Should be zero if create session failed.
+ * @param[out] guid Guid for session. Should be all zeros if create session
  *                  failed
  *
  * @return != 0 for error
  */
 int
 scp_get_create_session_response(struct trans *trans,
-                                int *auth_result,
+                                enum scp_screate_status *status,
                                 int *display,
                                 struct guid *guid);
-
-/**
- * Status of an E_SCP_LIST_SESSIONS_RESPONSE message
- */
-enum scp_list_sessions_status
-{
-    /**
-     * This message contains a valid session, and other messages
-     * will be sent
-     */
-    E_SCP_LS_SESSION_INFO = 0,
-
-    /**
-     * This message indicates the end of a list of sessions. No session
-     * is contained in the message */
-    E_SCP_LS_END_OF_LIST,
-
-    /**
-     * Authentication failed for the user
-     */
-    E_SCP_LS_AUTHENTICATION_FAIL = 100,
-
-    /**
-     * A client-side error occurred allocating memory for the session
-     */
-    E_SCP_LS_NO_MEMORY
-};
 
 /**
  * Send an E_LIST_SESSIONS_REQUEST (SCP client)
  *
  * @param trans SCP transport
- * @param username Username
- * @param password Password
  * @return != 0 for error
  *
  * Server replies with one or more E_SCP_LIST_SESSIONS_RESPONSE
  */
 int
-scp_send_list_sessions_request(struct trans *trans,
-                               const char *username,
-                               const char *password);
-
-/**
- * Parse an incoming E_LIST_SESSIONS_REQUEST (SCP server)
- *
- * @param trans SCP transport
- * @param[out] username Username
- * @param[out] password Password
- * @return != 0 for error
- */
-int
-scp_get_list_sessions_request(struct trans *trans,
-                              const char **username,
-                              const char **password);
+scp_send_list_sessions_request(struct trans *trans);
 
 /**
  * Send an E_LIST_SESSIONS_RESPONSE (SCP server)
@@ -410,6 +435,17 @@ scp_get_list_sessions_response(
     struct trans *trans,
     enum scp_list_sessions_status *status,
     struct scp_session_info **info);
+
+/**
+ * Send an E_CLOSE_CONNECTION_REQUEST (SCP client)
+ *
+ * @param trans SCP transport
+ * @return != 0 for error
+ *
+ * Server closes the connection quietly.
+ */
+int
+scp_send_close_connection_request(struct trans *trans);
 
 
 #endif /* SCP_H */

--- a/libipm/scp_application_types.c
+++ b/libipm/scp_application_types.c
@@ -1,0 +1,84 @@
+/**
+ * xrdp: A Remote Desktop Protocol server.
+ *
+ * Copyright (C) Jay Sorg 2004-2022, all xrdp contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *
+ * @file libipm/scp_application_types.c
+ * @brief Support routines for types in scp_application_types.h
+ * @author Matt Burt
+ */
+
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
+#include "scp_application_types.h"
+#include "os_calls.h"
+
+/*****************************************************************************/
+const char *
+scp_login_status_to_str(enum scp_login_status n,
+                        char *buff, unsigned int buff_size)
+{
+    const char *str =
+        (n == E_SCP_LOGIN_OK) ?  "OK" :
+        (n == E_SCP_LOGIN_ALREADY_LOGGED_IN) ? "A user is already logged in" :
+        (n == E_SCP_LOGIN_NO_MEMORY) ? "No memory for login" :
+        (n == E_SCP_LOGIN_NOT_AUTHENTICATED) ? "User does not exist, or could not be authenticated" :
+        (n == E_SCP_LOGIN_NOT_AUTHORIZED) ? "User is not authorized" :
+        (n == E_SCP_LOGIN_GENERAL_ERROR) ? "General login error" :
+        /* Default */ NULL;
+
+    if (str == NULL)
+    {
+        g_snprintf(buff, buff_size, "[login error code #%d]", (int)n);
+    }
+    else
+    {
+        g_snprintf(buff, buff_size, "%s", str);
+    }
+
+    return buff;
+}
+
+/*****************************************************************************/
+const char *
+scp_screate_status_to_str(enum scp_screate_status n,
+                          char *buff, unsigned int buff_size)
+{
+    const char *str =
+        (n == E_SCP_SCREATE_OK) ? "OK" :
+        (n == E_SCP_SCREATE_NO_MEMORY) ? "No memory for session" :
+        (n == E_SCP_SCREATE_NOT_LOGGED_IN) ? "Connection is not logged in" :
+        (n == E_SCP_SCREATE_MAX_REACHED) ? "Max session limit reached" :
+        (n == E_SCP_SCREATE_NO_DISPLAY) ? "No X displays are avaiable" :
+        (n == E_SCP_SCREATE_GENERAL_ERROR) ? "General session creation error" :
+        /* Default */ NULL;
+
+    if (str == NULL)
+    {
+        g_snprintf(buff, buff_size, "[session creation error code #%d]",
+                   (int)n);
+    }
+    else
+    {
+        g_snprintf(buff, buff_size, "%s", str);
+    }
+
+    return buff;
+}

--- a/libipm/scp_application_types.h
+++ b/libipm/scp_application_types.h
@@ -26,7 +26,7 @@
 #ifndef SCP_APPLICATION_TYPES_H
 #define SCP_APPLICATION_TYPES_H
 
-#include <time.h>
+#include <sys/types.h>
 
 /**
  * Select the desktop application session type
@@ -57,8 +57,84 @@ struct scp_session_info
     unsigned short height; ///< Initial session height
     unsigned char bpp;  ///< Session bits-per-pixel
     time_t start_time;  ///< When session was created
-    char *username;     ///< Username for session
+    uid_t uid;     ///< Username for session
     char *start_ip_addr; ///< IP address of starting client
+};
+
+/**
+ * Status of a login request
+ */
+enum scp_login_status
+{
+    E_SCP_LOGIN_OK = 0, ///< The connection is now loggned in
+    E_SCP_LOGIN_ALREADY_LOGGED_IN, //< A user is currently logged in
+    E_SCP_LOGIN_NO_MEMORY, ///< Memory allocation failure
+    /**
+     * User couldn't be authenticated, or user doesn't exist */
+    E_SCP_LOGIN_NOT_AUTHENTICATED,
+    E_SCP_LOGIN_NOT_AUTHORIZED, ///< User is authenticated, but not authorized
+    E_SCP_LOGIN_GENERAL_ERROR ///< An unspecific error has occurred
+};
+
+/**
+ * Convert an scp_login_status code to a readable string for output
+ * @param n Message code
+ * @param buff to contain string
+ * @param buff_size length of buff
+ * @return buff is returned for convenience.
+ */
+const char *
+scp_login_status_to_str(enum scp_login_status n,
+                        char *buff, unsigned int buff_size);
+
+/**
+ * Status of a session creation request
+ */
+enum scp_screate_status
+{
+    E_SCP_SCREATE_OK = 0, ///< Session created
+    E_SCP_SCREATE_NO_MEMORY, ///< Memory allocation failure
+    E_SCP_SCREATE_NOT_LOGGED_IN, ///< Connection is not logged in
+    E_SCP_SCREATE_MAX_REACHED, ///< Max number of sessions already reached
+    E_SCP_SCREATE_NO_DISPLAY, ///< No X server display number is available
+    E_SCP_SCREATE_GENERAL_ERROR ///< An unspecific error has occurred
+};
+
+/**
+ * Convert an scp_session creation code to a readable string for output
+ * @param n Message code
+ * @param buff to contain string
+ * @param buff_size length of buff
+ * @return buff is returned for convenience.
+ */
+const char *
+scp_screate_status_to_str(enum scp_screate_status n,
+                          char *buff, unsigned int buff_size);
+
+/**
+ * Status of an list sessions message
+ */
+enum scp_list_sessions_status
+{
+    /**
+     * This message contains a valid session, and other messages
+     * will be sent
+     */
+    E_SCP_LS_SESSION_INFO = 0,
+
+    /**
+     * This message indicates the end of a list of sessions. No session
+     * is contained in the message */
+    E_SCP_LS_END_OF_LIST,
+
+    /**
+     * Client hasn't logged in yet
+     */
+    E_SCP_LS_NOT_LOGGED_IN = 100,
+    /**
+     * A client-side error occurred allocating memory for the session
+     */
+    E_SCP_LS_NO_MEMORY
 };
 
 

--- a/sesman/access.c
+++ b/sesman/access.c
@@ -28,7 +28,13 @@
 #include <config_ac.h>
 #endif
 
+#include "arch.h"
+
+#include "access.h"
+#include "config.h"
+#include "log.h"
 #include "sesman.h"
+#include "os_calls.h"
 #include "string_calls.h"
 
 /******************************************************************************/

--- a/sesman/access.c
+++ b/sesman/access.c
@@ -51,7 +51,7 @@ access_login_allowed(const char *user)
         return 1;
     }
 
-    if (0 != g_getuser_info(user, &gid, 0, 0, 0, 0))
+    if (0 != g_getuser_info_by_name(user, 0, &gid, 0, 0, 0))
     {
         LOG(LOG_LEVEL_ERROR, "Cannot read user info! - login denied");
         return 0;
@@ -100,7 +100,7 @@ access_login_mng_allowed(const char *user)
         return 1;
     }
 
-    if (0 != g_getuser_info(user, &gid, 0, 0, 0, 0))
+    if (0 != g_getuser_info_by_name(user, 0, &gid, 0, 0, 0))
     {
         LOG(LOG_LEVEL_ERROR, "[MNG] Cannot read user info! - login denied");
         return 0;

--- a/sesman/auth.h
+++ b/sesman/auth.h
@@ -27,11 +27,11 @@
 #ifndef AUTH_H
 #define AUTH_H
 
-
 /**
  * Opaque type used to represent an authentication handle
  */
 struct auth_info;
+#include "scp_application_types.h"
 
 /**
  *
@@ -39,13 +39,25 @@ struct auth_info;
  * @param user user's login name
  * @param pass user's password
  * @param client_ip IP address of connecting client (or ""/NULL if not known)
- * @param[out] errorcode from result
+ * @param[out] Error code for the operation. E_SCP_LOGIN_OK on success.
  * @return auth handle on success, NULL on failure
  *
  */
 struct auth_info *
 auth_userpass(const char *user, const char *pass,
-              const char *client_ip, int *errorcode);
+              const char *client_ip, enum scp_login_status *errorcode);
+
+/**
+ *
+ * @brief Gets an auth handle for a UDS login
+ *
+ * @param uid User ID
+ * @param[out] Error code for the operation. E_SCP_LOGIN_OK on success.
+ * @return auth handle on success, NULL on failure
+ *
+ */
+struct auth_info *
+auth_uds(const char *user, enum scp_login_status *errorcode);
 
 /**
  *

--- a/sesman/config.c
+++ b/sesman/config.c
@@ -29,9 +29,10 @@
 #endif
 
 #include "arch.h"
+#include "config.h"
+
 #include "list.h"
 #include "file.h"
-#include "sesman.h"
 #include "log.h"
 #include "string_calls.h"
 #include "chansrv/chansrv_common.h"

--- a/sesman/env.c
+++ b/sesman/env.c
@@ -107,7 +107,8 @@ env_set_user(const char *username, char **passwd_file, int display,
     pw_shell = 0;
     pw_dir = 0;
 
-    error = g_getuser_info(username, &pw_gid, &pw_uid, &pw_shell, &pw_dir, 0);
+    error = g_getuser_info_by_name(username, &pw_uid, &pw_gid, &pw_shell,
+                                   &pw_dir, 0);
 
     if (error == 0)
     {

--- a/sesman/env.c
+++ b/sesman/env.c
@@ -30,11 +30,15 @@
 
 #include <grp.h>
 
-#include "xrdp_sockets.h"
+#include "env.h"
+#include "config.h"
 #include "list.h"
+#include "log.h"
+#include "os_calls.h"
 #include "sesman.h"
 #include "ssl_calls.h"
 #include "string_calls.h"
+#include "xrdp_sockets.h"
 
 /******************************************************************************/
 int

--- a/sesman/env.h
+++ b/sesman/env.h
@@ -43,14 +43,14 @@ env_check_password_file(const char *filename, const char *password);
 /**
  *
  * @brief Sets user environment ($PATH, $HOME, $UID, and others)
- * @param username Username
+ * @param uid user ID
  * @param passwd_file VNC password file
  * @param display The session display
  * @return 0 on success, g_getuser_info() error codes on error
  *
  */
 int
-env_set_user(const char *username, char **passwd_file, int display,
+env_set_user(int uid, char **passwd_file, int display,
              const struct list *env_names, const struct list *env_values);
 
 #endif

--- a/sesman/scp_process.h
+++ b/sesman/scp_process.h
@@ -27,15 +27,15 @@
 #ifndef SCP_PROCESS_H
 #define SCP_PROCESS_H
 
-struct trans;
+struct sesman_con;
 
 /**
  *
  * @brief Processes an SCP message
- * @param t the connection trans
+ * @param sc the sesman connection
  *
  */
 int
-scp_process(struct trans *t);
+scp_process(struct sesman_con *sc);
 
 #endif

--- a/sesman/sesman.c
+++ b/sesman/sesman.c
@@ -33,6 +33,7 @@
 #include "arch.h"
 #include "sesman.h"
 
+#include "auth.h"
 #include "config.h"
 #include "lock_uds.h"
 #include "os_calls.h"
@@ -123,9 +124,11 @@ alloc_connection(struct trans *t)
 {
     struct sesman_con *result;
 
-    if ((result = g_new(struct sesman_con, 1)) != NULL)
+    if ((result = g_new0(struct sesman_con, 1)) != NULL)
     {
+        g_snprintf(result->peername, sizeof(result->peername), "%s", "unknown");
         result->t = t;
+        result->auth_retry_count = g_cfg->sec.login_retry;
     }
 
     return result;
@@ -137,15 +140,40 @@ alloc_connection(struct trans *t)
  * After this call, the passed-in pointer is invalid and must not be
  * referenced.
  *
+ * Any auth_info struct found in the sesman_con is also deallocated.
+ *
  * @param sc struct to de-allocate
  */
 static void
 delete_connection(struct sesman_con *sc)
 {
-    trans_delete(sc->t);
-    g_free(sc);
+    if (sc != NULL)
+    {
+        trans_delete(sc->t);
+        if (sc->auth_info != NULL)
+        {
+            auth_end(sc->auth_info);
+        }
+        g_free(sc->username);
+        g_free(sc->ip_addr);
+        g_free(sc);
+    }
 }
 
+/*****************************************************************************/
+int
+sesman_set_connection_peername(struct sesman_con *sc, const char *name)
+{
+    int rv = 1;
+
+    if (sc != NULL && name != NULL)
+    {
+        g_snprintf(sc->peername, sizeof(sc->peername), "%s", name);
+        rv = 0;
+    }
+
+    return rv;
+}
 
 /*****************************************************************************/
 /**
@@ -272,16 +300,23 @@ static int sesman_listen_test(struct config_sesman *cfg)
 
 /******************************************************************************/
 int
-sesman_close_all(void)
+sesman_close_all(unsigned int flags)
 {
     int index;
     struct sesman_con *sc;
 
     LOG_DEVEL(LOG_LEVEL_TRACE, "sesman_close_all:");
+
+
     sesman_delete_listening_transport();
     for (index = 0; index < g_con_list->count; index++)
     {
         sc = (struct sesman_con *) list_get_item(g_con_list, index);
+        if (sc != NULL && (flags & SCA_CLOSE_AUTH_INFO) == 0)
+        {
+            // Prevent delete_connection() closing the auth_info down
+            sc->auth_info = NULL;
+        }
         delete_connection(sc);
     }
     return 0;
@@ -298,7 +333,8 @@ sesman_data_in(struct trans *self)
 
     if (rv == 0 && available)
     {
-        if ((rv = scp_process(self)) != 0)
+        struct sesman_con *sc = (struct sesman_con *)self->callback_data;
+        if ((rv = scp_process(sc)) != 0)
         {
             LOG(LOG_LEVEL_ERROR, "sesman_data_in: scp_process_msg failed");
         }
@@ -324,7 +360,7 @@ sesman_listen_conn_in(struct trans *self, struct trans *new_self)
     {
         LOG(LOG_LEVEL_ERROR, "sesman_data_in: No memory to allocate "
             "new connection");
-        trans_delete(new_self);
+        delete_connection(sc);
     }
     else
     {
@@ -546,20 +582,30 @@ sesman_main_loop(void)
             sig_sesman_reload_cfg();
         }
 
-        for (index = 0; index < g_con_list->count; index++)
+        index = 0;
+        while (index < g_con_list->count)
         {
+            int remove_con = 0;
             scon = (struct sesman_con *)list_get_item(g_con_list, index);
-            if (scon != NULL)
+            if (trans_check_wait_objs(scon->t) != 0)
             {
-                if (trans_check_wait_objs(scon->t) != 0)
-                {
-                    LOG(LOG_LEVEL_ERROR, "sesman_main_loop: "
-                        "trans_check_wait_objs failed, removing trans");
-                    delete_connection(scon);
-                    list_remove_item(g_con_list, index);
-                    index--;
-                    continue;
-                }
+                LOG(LOG_LEVEL_ERROR, "sesman_main_loop: "
+                    "trans_check_wait_objs failed, removing trans");
+                remove_con = 1;
+            }
+            else if (scon->close_requested)
+            {
+                remove_con = 1;
+            }
+
+            if (remove_con)
+            {
+                delete_connection(scon);
+                list_remove_item(g_con_list, index);
+            }
+            else
+            {
+                ++index;
             }
         }
 
@@ -574,13 +620,9 @@ sesman_main_loop(void)
             }
         }
     }
-    for (index = 0; index < g_con_list->count; index++)
-    {
-        scon = (struct sesman_con *) list_get_item(g_con_list, index);
-        delete_connection(scon);
-    }
+
+    sesman_close_all(SCA_CLOSE_AUTH_INFO);
     list_delete(g_con_list);
-    sesman_delete_listening_transport();
     return 0;
 }
 

--- a/sesman/sesman.c
+++ b/sesman/sesman.c
@@ -30,13 +30,18 @@
 
 #include <stdarg.h>
 
+#include "arch.h"
 #include "sesman.h"
-#include "xrdp_configure_options.h"
+
+#include "config.h"
+#include "lock_uds.h"
+#include "os_calls.h"
+#include "scp.h"
+#include "scp_process.h"
+#include "sig.h"
 #include "string_calls.h"
 #include "trans.h"
-
-#include "scp_process.h"
-#include "lock_uds.h"
+#include "xrdp_configure_options.h"
 
 /**
  * Maximum number of short-lived connections to sesman
@@ -71,14 +76,6 @@ unsigned char g_fixedkey[8] = { 23, 82, 107, 6, 35, 78, 88, 7 };
 tintptr g_term_event = 0;
 tintptr g_sigchld_event = 0;
 tintptr g_reload_event = 0;
-
-/**
- * Items stored on the g_con_list
- */
-struct sesman_con
-{
-    struct trans *t;
-};
 
 static struct trans *g_list_trans;
 

--- a/sesman/sesman.h
+++ b/sesman/sesman.h
@@ -33,6 +33,13 @@
 struct sesman_con
 {
     struct trans *t;
+    char peername[15 + 1]; /* Name of peer, if known, for logging */
+    int    close_requested; /* Set to close the connection normally */
+    unsigned int auth_retry_count;
+    struct auth_info *auth_info; /* non-NULL for an authenticated connection */
+    int    uid; /* User */
+    char *username; /* Username from UID (at time of logon) */
+    char  *ip_addr; /* Connecting IP address */
 };
 
 /* Globals */
@@ -42,6 +49,15 @@ extern tintptr g_term_event;
 extern tintptr g_sigchld_event;
 extern tintptr g_reload_event;
 
+/**
+ * Set the peername of a connection
+ *
+ * @param name Name to set
+ * @result 0 for success
+ */
+int
+sesman_set_connection_peername(struct sesman_con *sc, const char *name);
+
 /*
  * Close all file descriptors used by sesman.
  *
@@ -50,9 +66,14 @@ extern tintptr g_reload_event;
  *
  * This call will also release all trans and SCP_SESSION objects
  * held by sesman
+ *
+ * @param flags Set SCA_CLOSE_AUTH_INFO to close any open auth_info
+ *              objects. By default these are not cleared, and should
+ *              only be done so when exiting sesman.
  */
+#define SCA_CLOSE_AUTH_INFO (1<<0)
 int
-sesman_close_all(void);
+sesman_close_all(unsigned int flags);
 
 /*
  * Remove the listening transport

--- a/sesman/sesman.h
+++ b/sesman/sesman.h
@@ -27,17 +27,13 @@
 #ifndef SESMAN_H
 #define SESMAN_H
 
-#include "arch.h"
-#include "parse.h"
-#include "os_calls.h"
-#include "log.h"
-#include "env.h"
-#include "auth.h"
-#include "config.h"
-#include "sig.h"
-#include "session.h"
-#include "access.h"
-#include "scp.h"
+/**
+ * Type for managing sesman connections from xrdp (etc)
+ */
+struct sesman_con
+{
+    struct trans *t;
+};
 
 /* Globals */
 extern struct config_sesman *g_cfg;

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -37,10 +37,19 @@
 #include <sys/prctl.h>
 #endif
 
+#include "arch.h"
+#include "session.h"
+
+#include "auth.h"
+#include "config.h"
+#include "env.h"
+#include "list.h"
+#include "log.h"
+#include "os_calls.h"
 #include "sesman.h"
+#include "string_calls.h"
 #include "xauth.h"
 #include "xrdp_sockets.h"
-#include "string_calls.h"
 
 #ifndef PR_SET_NO_NEW_PRIVS
 #define PR_SET_NO_NEW_PRIVS 38

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -112,10 +112,10 @@ session_get_bydata(const struct session_parameters *sp)
     config_output_policy_string(policy, policy_str, sizeof(policy_str));
 
     LOG(LOG_LEVEL_DEBUG,
-        "%s: search policy=%s type=%s U=%s B=%d D=(%dx%d) I=%s",
+        "%s: search policy=%s type=%s U=%d B=%d D=(%dx%d) I=%s",
         __func__,
         policy_str, SCP_SESSION_TYPE_TO_STR(sp->type),
-        sp->username, sp->bpp, sp->width, sp->height,
+        sp->uid, sp->bpp, sp->width, sp->height,
         sp->ip_addr);
 
     /* 'Separate' policy never matches */
@@ -130,11 +130,11 @@ session_get_bydata(const struct session_parameters *sp)
         struct session_item *item = tmp->item;
 
         LOG(LOG_LEVEL_DEBUG,
-            "%s: try %p type=%s U=%s B=%d D=(%dx%d) I=%s",
+            "%s: try %p type=%s U=%d B=%d D=(%dx%d) I=%s",
             __func__,
             item,
             SCP_SESSION_TYPE_TO_STR(item->type),
-            item->name,
+            item->uid,
             item->bpp,
             item->width, item->height,
             item->start_ip_addr);
@@ -145,11 +145,10 @@ session_get_bydata(const struct session_parameters *sp)
             continue;
         }
 
-        if ((policy & SESMAN_CFG_SESS_POLICY_U) &&
-                g_strncmp(sp->username, item->name, sizeof(item->name) - 1) != 0)
+        if ((policy & SESMAN_CFG_SESS_POLICY_U) && sp->uid != item->uid)
         {
             LOG(LOG_LEVEL_DEBUG,
-                "%s: Username doesn't match for 'U' policy", __func__);
+                "%s: UID doesn't match for 'U' policy", __func__);
             continue;
         }
 
@@ -408,7 +407,7 @@ wait_for_xserver(int display)
 
 /******************************************************************************/
 static int
-session_start_chansrv(const char *username, int display)
+session_start_chansrv(int uid, int display)
 {
     struct list *chansrv_params;
     char exe_path[262];
@@ -430,7 +429,7 @@ session_start_chansrv(const char *username, int display)
         list_add_item(chansrv_params, (intptr_t) g_strdup(exe_path));
         list_add_item(chansrv_params, 0); /* mandatory */
 
-        env_set_user(username, 0, display,
+        env_set_user(uid, 0, display,
                      g_cfg->env_names,
                      g_cfg->env_values);
 
@@ -445,10 +444,38 @@ session_start_chansrv(const char *username, int display)
 }
 
 /******************************************************************************/
+/**
+ * Convert a UID to a username
+ *
+ * @param uid UID
+ * @param uname pointer to output buffer
+ * @param uname_len Length of output buffer
+ * @return 0 for success.
+ */
+static int
+username_from_uid(int uid, char *uname, int uname_len)
+{
+    char *ustr;
+    int rv = g_getuser_info_by_uid(uid, &ustr, NULL, NULL, NULL, NULL);
 
-int
+    if (rv == 0)
+    {
+        g_snprintf(uname, uname_len, "%s", ustr);
+        g_free(ustr);
+    }
+    else
+    {
+        g_snprintf(uname, uname_len, "<unknown>");
+    }
+    return rv;
+}
+
+/******************************************************************************/
+
+enum scp_screate_status
 session_start(struct auth_info *auth_info,
               const struct session_parameters *s,
+              int *returned_display,
               struct guid *guid)
 {
     int display = 0;
@@ -457,6 +484,7 @@ session_start(struct auth_info *auth_info,
     char depth[32];
     char screen[32]; /* display number */
     char text[256];
+    char username[256];
     char execvpparams[2048];
     char *xserver = NULL; /* absolute/relative path to Xorg/X11rdp/Xvnc */
     char *passwd_file;
@@ -476,12 +504,15 @@ session_start(struct auth_info *auth_info,
 
     passwd_file = 0;
 
+    /* Get the username for display purposes */
+    username_from_uid(s->uid, username, sizeof(username));
+
     /* check to limit concurrent sessions */
     if (g_session_count >= g_cfg->sess.max_sessions)
     {
         LOG(LOG_LEVEL_ERROR, "max concurrent session limit "
-            "exceeded. login for user %s denied", s->username);
-        return 0;
+            "exceeded. login for user %s denied", username);
+        return E_SCP_SCREATE_MAX_REACHED;
     }
 
     temp = (struct session_chain *)g_malloc(sizeof(struct session_chain), 0);
@@ -489,8 +520,8 @@ session_start(struct auth_info *auth_info,
     if (temp == 0)
     {
         LOG(LOG_LEVEL_ERROR, "Out of memory error: cannot create new session "
-            "chain element - user %s", s->username);
-        return 0;
+            "chain element - user %s", username);
+        return E_SCP_SCREATE_NO_MEMORY;
     }
 
     temp->item = (struct session_item *)g_malloc(sizeof(struct session_item), 0);
@@ -499,8 +530,8 @@ session_start(struct auth_info *auth_info,
     {
         g_free(temp);
         LOG(LOG_LEVEL_ERROR, "Out of memory error: cannot create new session "
-            "item - user %s", s->username);
-        return 0;
+            "item - user %s", username);
+        return E_SCP_SCREATE_NO_MEMORY;
     }
 
     display = session_get_avail_display_from_chain();
@@ -509,11 +540,12 @@ session_start(struct auth_info *auth_info,
     {
         g_free(temp->item);
         g_free(temp);
-        return 0;
+        return E_SCP_SCREATE_NO_DISPLAY;
     }
 
-    /* Create a GUID for the new session before we work */
+    /* Create a GUID for the new session before we fork */
     *guid = guid_new();
+    *returned_display = display;
 
     pid = g_fork(); /* parent is fork from tcp accept,
                        child forks X and wm, then becomes scp */
@@ -524,8 +556,12 @@ session_start(struct auth_info *auth_info,
             "[session start] (display %d): Failed to fork for scp with "
             "errno: %d, description: %s",
             display, g_get_errno(), g_get_strerror());
+        g_free(temp->item);
+        g_free(temp);
+        return E_SCP_SCREATE_GENERAL_ERROR;
     }
-    else if (pid == 0)
+
+    if (pid == 0)
     {
         LOG(LOG_LEVEL_INFO,
             "[session start] (display %d): calling auth_start_session from pid %d",
@@ -547,16 +583,16 @@ session_start(struct auth_info *auth_info,
 
         /* Set the secondary groups before starting the session to prevent
          * problems on PAM-based systems (see pam_setcred(3)) */
-        if (g_initgroups(s->username) != 0)
+        if (g_initgroups(username) != 0)
         {
             LOG(LOG_LEVEL_ERROR,
                 "Failed to initialise secondary groups for %s: %s",
-                s->username, g_get_strerror());
+                username, g_get_strerror());
             g_exit(1);
         }
 
+        sesman_close_all(0);
         auth_start_session(auth_info, display);
-        sesman_close_all();
         g_sprintf(geometry, "%dx%d", s->width, s->height);
         g_sprintf(depth, "%d", s->bpp);
         g_sprintf(screen, ":%d", display);
@@ -588,11 +624,11 @@ session_start(struct auth_info *auth_info,
                     display, g_getpid());
             }
 
-            if (g_setlogin(s->username) < 0)
+            if (g_setlogin(username) < 0)
             {
                 LOG(LOG_LEVEL_WARNING,
                     "[session start] (display %d): setlogin failed for user %s - pid %d",
-                    display, s->username, g_getpid());
+                    display, username, g_getpid());
             }
         }
 
@@ -617,7 +653,7 @@ session_start(struct auth_info *auth_info,
         else if (window_manager_pid == 0)
         {
             wait_for_xserver(display);
-            env_set_user(s->username,
+            env_set_user(s->uid,
                          0,
                          display,
                          g_cfg->env_names,
@@ -715,7 +751,7 @@ session_start(struct auth_info *auth_info,
             {
                 if (s->type == SCP_SESSION_TYPE_XVNC)
                 {
-                    env_set_user(s->username,
+                    env_set_user(s->uid,
                                  &passwd_file,
                                  display,
                                  g_cfg->env_names,
@@ -723,7 +759,7 @@ session_start(struct auth_info *auth_info,
                 }
                 else
                 {
-                    env_set_user(s->username,
+                    env_set_user(s->uid,
                                  0,
                                  display,
                                  g_cfg->env_names,
@@ -901,11 +937,11 @@ session_start(struct auth_info *auth_info,
                 struct exit_status chansrv_exit_status;
 
                 wait_for_xserver(display);
-                chansrv_pid = session_start_chansrv(s->username, display);
+                chansrv_pid = session_start_chansrv(s->uid, display);
 
                 LOG(LOG_LEVEL_INFO,
                     "Session started successfully for user %s on display %d",
-                    s->username, display);
+                    username, display);
 
                 /* Monitor the amount of time we wait for the
                  * window manager. This is approximately how long the window
@@ -939,10 +975,12 @@ session_start(struct auth_info *auth_info,
                         window_manager_pid, display, wm_wait_time);
                 }
                 LOG(LOG_LEVEL_INFO,
-                    "Calling auth_stop_session and auth_end from pid %d",
+                    "Calling auth_stop_session from pid %d",
                     g_getpid());
                 auth_stop_session(auth_info);
-                auth_end(auth_info);
+                // auth_end() is called from the main process currently,
+                // as this called auth_start()
+                //auth_end(auth_info);
 
                 LOG(LOG_LEVEL_INFO,
                     "Terminating X server (pid %d) on display %d",
@@ -978,8 +1016,8 @@ session_start(struct auth_info *auth_info,
     {
         LOG(LOG_LEVEL_INFO, "Starting session: session_pid %d, "
             "display :%d.0, width %d, height %d, bpp %d, client ip %s, "
-            "user name %s",
-            pid, display, s->width, s->height, s->bpp, s->ip_addr, s->username);
+            "UID %d",
+            pid, display, s->width, s->height, s->bpp, s->ip_addr, s->uid);
         temp->item->pid = pid;
         temp->item->display = display;
         temp->item->width = s->width;
@@ -988,7 +1026,7 @@ session_start(struct auth_info *auth_info,
         temp->item->auth_info = auth_info;
         g_strncpy(temp->item->start_ip_addr, s->ip_addr,
                   sizeof(temp->item->start_ip_addr) - 1);
-        g_strncpy(temp->item->name, s->username, 255);
+        temp->item->uid = s->uid;
         temp->item->guid = *guid;
 
         temp->item->start_time = g_time1();
@@ -1000,17 +1038,18 @@ session_start(struct auth_info *auth_info,
         g_sessions = temp;
         g_session_count++;
 
-        return display;
+        return E_SCP_SCREATE_OK;
     }
 
+    /* Shouldn't get here */
     g_free(temp->item);
     g_free(temp);
-    return display;
+    return E_SCP_SCREATE_GENERAL_ERROR;
 }
 
 /******************************************************************************/
 int
-session_reconnect(int display, const char *username,
+session_reconnect(int display, int uid,
                   struct auth_info *auth_info)
 {
     int pid;
@@ -1023,7 +1062,7 @@ session_reconnect(int display, const char *username,
     }
     else if (pid == 0)
     {
-        env_set_user(username,
+        env_set_user(uid,
                      0,
                      display,
                      g_cfg->env_names,
@@ -1090,10 +1129,23 @@ session_kill(int pid)
 
         if (tmp->item->pid == pid)
         {
+            char username[256];
+            username_from_uid(tmp->item->uid, username, sizeof(username));
+
             /* deleting the session */
+            if (tmp->item->auth_info != NULL)
+            {
+                LOG(LOG_LEVEL_INFO,
+                    "Calling auth_end for pid %d from pid %d",
+                    pid, g_getpid());
+                auth_end(tmp->item->auth_info);
+                tmp->item->auth_info = NULL;
+            }
             LOG(LOG_LEVEL_INFO,
-                "++ terminated session:  username %s, display :%d.0, session_pid %d, ip %s",
-                tmp->item->name, tmp->item->display, tmp->item->pid, tmp->item->start_ip_addr);
+                "++ terminated session: UID %d (%s), display :%d.0, "
+                "session_pid %d, ip %s",
+                tmp->item->uid, username, tmp->item->display,
+                tmp->item->pid, tmp->item->start_ip_addr);
             g_free(tmp->item);
 
             if (prev == 0)
@@ -1186,7 +1238,7 @@ session_get_bypid(int pid)
 
 /******************************************************************************/
 struct scp_session_info *
-session_get_byuser(const char *user, unsigned int *cnt, unsigned char flags)
+session_get_byuid(int uid, unsigned int *cnt, unsigned char flags)
 {
     struct session_chain *tmp;
     struct scp_session_info *sess;
@@ -1197,10 +1249,10 @@ session_get_byuser(const char *user, unsigned int *cnt, unsigned char flags)
 
     tmp = g_sessions;
 
-    LOG(LOG_LEVEL_DEBUG, "searching for session by user: %s", user);
+    LOG(LOG_LEVEL_DEBUG, "searching for session by UID: %d", uid);
     while (tmp != 0)
     {
-        if ((NULL == user) || (!g_strncasecmp(user, tmp->item->name, 256)))
+        if (uid == tmp->item->uid)
         {
             LOG(LOG_LEVEL_DEBUG, "session_get_byuser: status=%d, flags=%d, "
                 "result=%d", (tmp->item->status), flags,
@@ -1236,8 +1288,7 @@ session_get_byuser(const char *user, unsigned int *cnt, unsigned char flags)
 
     while (tmp != 0 && index < count)
     {
-        /* #warning FIXME: we should get only disconnected sessions! */
-        if ((NULL == user) || (!g_strncasecmp(user, tmp->item->name, 256)))
+        if (uid == tmp->item->uid)
         {
             if ((tmp->item->status) & flags)
             {
@@ -1248,11 +1299,11 @@ session_get_byuser(const char *user, unsigned int *cnt, unsigned char flags)
                 (sess[index]).width = tmp->item->width;
                 (sess[index]).bpp = tmp->item->bpp;
                 (sess[index]).start_time = tmp->item->start_time;
-                (sess[index]).username = g_strdup(tmp->item->name);
+                (sess[index]).uid = tmp->item->uid;
                 (sess[index]).start_ip_addr = g_strdup(tmp->item->start_ip_addr);
 
-                if ((sess[index]).username == NULL ||
-                        (sess[index]).start_ip_addr == NULL)
+                /* Check for string allocation failures */
+                if ((sess[index]).start_ip_addr == NULL)
                 {
                     free_session_info_list(sess, *cnt);
                     (*cnt) = 0;
@@ -1279,7 +1330,6 @@ free_session_info_list(struct scp_session_info *sesslist, unsigned int cnt)
         unsigned int i;
         for (i = 0 ; i < cnt ; ++i)
         {
-            g_free(sesslist[i].username);
             g_free(sesslist[i].start_ip_addr);
         }
     }
@@ -1392,7 +1442,6 @@ clone_session_params(const struct session_parameters *sp)
     /* Allocate a single block of memory big enough for the structure and
      * all the strings it points to */
     unsigned int len = sizeof(*result);
-    len += g_strlen(sp->username) + 1;
     len += g_strlen(sp->shell) + 1;
     len += g_strlen(sp->directory) + 1;
     len += g_strlen(sp->ip_addr) + 1;
@@ -1412,7 +1461,6 @@ clone_session_params(const struct session_parameters *sp)
         strptr += len;\
     }
 
-        COPY_STRING_MEMBER(sp->username, result->username);
         COPY_STRING_MEMBER(sp->shell, result->shell);
         COPY_STRING_MEMBER(sp->directory, result->directory);
         COPY_STRING_MEMBER(sp->ip_addr, result->ip_addr);

--- a/sesman/session.h
+++ b/sesman/session.h
@@ -53,7 +53,7 @@ struct scp_session_info;
 
 struct session_item
 {
-    char name[256];
+    int uid; /* UID of session */
     int pid; /* pid of sesman waiting for wm to end */
     int display;
     int width;
@@ -85,11 +85,11 @@ struct session_chain
  */
 struct session_parameters
 {
+    int uid;
     enum scp_session_type type;
     unsigned short height;
     unsigned short width;
     unsigned char  bpp;
-    const char *username;
     const char *shell;
     const char *directory;
     const char *ip_addr;
@@ -110,16 +110,17 @@ session_get_bydata(const struct session_parameters *params);
 /**
  *
  * @brief starts a session
- * @return 0 on error, display number if success
  *
+ * @return Connection status.
  */
-int
+enum scp_screate_status
 session_start(struct auth_info *auth_info,
               const struct session_parameters *params,
+              int *display,
               struct guid *guid);
 
 int
-session_reconnect(int display, const char *username,
+session_reconnect(int display, int uid,
                   struct auth_info *auth_info);
 
 /**
@@ -154,14 +155,14 @@ session_get_bypid(int pid);
 /**
  *
  * @brief retrieves session descriptions
- * @param user the user for the sessions
+ * @param UID the UID for the descriptions
  * @return A block of session descriptions
  *
  * Pass the return result to free_session_info_list() after use
  *
  */
 struct scp_session_info *
-session_get_byuser(const char *user, unsigned int *cnt, unsigned char flags);
+session_get_byuid(int uid, unsigned int *cnt, unsigned char flags);
 
 /**
  *

--- a/sesman/sig.c
+++ b/sesman/sig.c
@@ -28,8 +28,15 @@
 #include <config_ac.h>
 #endif
 
-#include "string_calls.h"
+#include "arch.h"
+#include "sig.h"
+
+#include "config.h"
+#include "log.h"
+#include "os_calls.h"
 #include "sesman.h"
+#include "session.h"
+#include "string_calls.h"
 
 /******************************************************************************/
 void

--- a/sesman/tools/Makefile.am
+++ b/sesman/tools/Makefile.am
@@ -61,4 +61,5 @@ xrdp_xcon_LDADD = \
 
 xrdp_authtest_LDADD = \
   $(top_builddir)/common/libcommon.la \
+  $(top_builddir)/libipm/libipm.la \
   $(AUTHMOD_LIB)

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -312,8 +312,9 @@ struct xrdp_enc_data;
 enum mm_connect_state
 {
     MMCS_CONNECT_TO_SESMAN,
-    MMCS_PAM_AUTH,
-    MMCS_SESSION_AUTH,
+    MMCS_GATEWAY_LOGIN,
+    MMCS_SESSION_LOGIN,
+    MMCS_CREATE_SESSION,
     MMCS_CONNECT_TO_SESSION,
     MMCS_CONNECT_TO_CHANSRV,
     MMCS_DONE
@@ -348,10 +349,8 @@ struct xrdp_mm
     struct xrdp_wm *wm; /* owner */
     enum mm_connect_state connect_state; /* State of connection */
     /* Other processes we connect to */
-    /* NB : When we move to UDS, the sesman and pam_auth
-     * connection be merged */
     int use_sesman; /* true if this is a sesman session */
-    int use_pam_auth; /* True if we're to authenticate using PAM */
+    int use_gw_login; /* True if we're to login using  a gateway */
     int use_chansrv; /* true if chansrvport is set in xrdp.ini or using sesman */
     struct trans *sesman_trans; /* connection to sesman */
     struct trans *chan_trans; /* connection to chansrv */
@@ -495,6 +494,7 @@ struct xrdp_wm
     struct xrdp_font *default_font;
     struct xrdp_keymap keymap;
     int hide_log_window;
+    int fatal_error_in_log_window;
     struct xrdp_bitmap *target_surface; /* either screen or os surface */
     int current_surface_index;
     int hints;

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -2034,12 +2034,22 @@ xrdp_wm_login_state_changed(struct xrdp_wm *self)
     LOG(LOG_LEVEL_DEBUG, "xrdp_wm_login_mode_changed: login_mode is %d", self->login_state);
     if (self->login_state == WMLS_RESET)
     {
-        /* this is the initial state of the login window */
-        xrdp_wm_set_login_state(self, WMLS_USER_PROMPT);
         list_clear(self->log);
         xrdp_wm_delete_all_children(self);
         self->dragging = 0;
-        xrdp_wm_init(self);
+
+        if (self->fatal_error_in_log_window)
+        {
+            /* We've got here after OK is pressed in the log
+             * window, so the user has read the message(s) in it */
+            g_set_wait_obj(self->pro_layer->self_term_event);
+        }
+        else
+        {
+            /* this is the initial state of the login window */
+            xrdp_wm_set_login_state(self, WMLS_USER_PROMPT);
+            xrdp_wm_init(self);
+        }
     }
     else if (self->login_state == WMLS_START_CONNECT)
     {
@@ -2160,7 +2170,6 @@ add_string_to_logwindow(const char *msg, struct list *log)
     do
     {
         new_part_message = g_strndup(current_pointer, LOG_WINDOW_CHAR_PER_LINE);
-        LOG(LOG_LEVEL_INFO, "%s", new_part_message);
         list_add_item(log, (tintptr) new_part_message);
         len_done += g_strlen(new_part_message);
         current_pointer += g_strlen(new_part_message);


### PR DESCRIPTION
**Update : ready for review**
Fixes #642
Fixes #909
Fixes #1739
Fixes #1823 

See also #1921
This is moving some way towards the architectural changes in #1961.

This series of commits separates authentication+authorization (AA) from commands in the sesman interface. AA can be either via username/password, or via Unix Domain Socket (UDS) ownership.

Here are some notes for the commits:-
- More information is now provided to the user in the event of a session not being created.
-  sesrun can use either password or UDS logins. With some limitations, this can allow for automatic creation of sessions for local users without a password being needed.
- sesadmin now operates using UDS logins only and so a username and password are not required. To use sesadmin for another user, use `su`/`sudo`/`doas` to authenticate as the other user.
- `MaxLoginRetry` now has an effect.
- Configurations using federated naming services (e.g. AD) no longer have trouble with sessions where the same user can be referred to in more than one way.

The most significant of these is that the sesman tools are starting to become more useful.