### PR TITLE
Disable autologon for empty passwords

### DIFF
--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -951,6 +951,17 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
     }
     in_uint16_le(s, len_password);
 
+    /*
+     * Ignore autologin requests if the password is empty. System managers
+     * who really want to allow empty passwords can do this with a
+     * special session type */
+    if (len_password == 0 && self->rdp_layer->client_info.rdp_autologin)
+    {
+        LOG(LOG_LEVEL_DEBUG,
+            "Client supplied password is empty, disabling autologin");
+        self->rdp_layer->client_info.rdp_autologin = 0;
+    }
+
     if (len_password >= INFO_CLIENT_MAX_CB_LEN)
     {
         LOG(LOG_LEVEL_ERROR,


### PR DESCRIPTION
See #2474 

Thanks for raising this, @igh-gr

Although there is nothing in the specification to prevent automatic logons with empty passwords, this is not a secure default.

The autologon flag INFO_AUTOLOGON ([MS-RDPBCGR] 2.2.1.11.1.1) is now ignored for empty passwords.

Tested with Remmina 1.4.29 which sets INFO_AUTOLOGON if a username is specified without a password.