### PR TITLE
Remove support for x11rdp

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,5 +150,5 @@ xrdp
 ├── xrdp ········ main server code
 ├── xrdpapi ····· virtual channel API
 ├── xrdpvr ······ API for playing media over RDP
-└── xup ········· X11rdp and xorgxrdp client module
+└── xup ········· xorgxrdp client module
 ```

--- a/docs/man/sesman.ini.5.in
+++ b/docs/man/sesman.ini.5.in
@@ -25,10 +25,6 @@ Session management
 Access control
 
 .TP
-\fB[X11rdp]\fR, \fB[Xvnc]\fR, \fB[Xorg]\fR
-X11 server settings for supported servers
-
-.TP
 \fB[Chansrv]\fR
 Settings for xrdp-chansrv(8)
 
@@ -297,7 +293,7 @@ If set to \fB1\fR, \fBtrue\fR or \fByes\fR, require group membership even
 if the group specified in \fBTerminalServerUsers\fR doesn't exist.
 
 .SH "X11 SERVER"
-Following parameters can be used in the \fB[X11rdp]\fR, \fB[Xvnc]\fR and
+Following parameters can be used in the \fB[Xvnc]\fR and
 \fB[Xorg]\fR sections.
 
 .TP

--- a/docs/man/xrdp-sesrun.8.in
+++ b/docs/man/xrdp-sesrun.8.in
@@ -40,7 +40,7 @@ Set session bits-per-pixel (colour depth). Some session types (i.e. Xorg)
 will ignore this setting.
 .TP
 .B -t <session-type>
-Session type - one of Xorg, Xvnc or X11rdp. Alternatively, for testing
+Session type - one of Xorg or Xvnc. Alternatively, for testing
 only, use the numeric session code.
 .TP
 .B -D <directory>

--- a/docs/man/xrdp.ini.5.in
+++ b/docs/man/xrdp.ini.5.in
@@ -336,7 +336,7 @@ Specifies the port number to connect to. If set to \fI\-1\fR, the default port f
 .TP
 \fBxserverbpp\fR=\fI<number>\fR
 Specifies color depth of the backend X server. The default is the color
-depth of the client. Only Xvnc and X11rdp use that setting. Xorg runs at
+depth of the client. Only Xvnc uses that setting. Xorg runs at
 \fI24\fR bpp.
 
 .TP
@@ -349,8 +349,8 @@ values supported for a particular release of \fBxrdp\fR(8) are documented in
 
 .TP
 \fBcode\fR=\fI<number>\fR|\fI0\fR
-Specifies the session type. The default, \fI0\fR, is Xvnc, \fI10\fR is
-X11rdp, and \fI20\fR is Xorg with xorgxrdp modules.
+Specifies the session type. The default, \fI0\fR, is Xvnc,
+and \fI20\fR is Xorg with xorgxrdp modules.
 
 .TP
 \fBchansrvport\fR=\fBDISPLAY(\fR\fIn\fR\fB)\fR|\fI/path/to/domain-socket\fR

--- a/libipm/scp_application_types.h
+++ b/libipm/scp_application_types.h
@@ -34,13 +34,11 @@
 enum scp_session_type
 {
     SCP_SESSION_TYPE_XVNC = 0,  ///< Session used Xvnc
-    SCP_SESSION_TYPE_XRDP, ///< Session uses X11rdp
     SCP_SESSION_TYPE_XORG  ///< Session used Xorg + xorgxrdp
 };
 
 #define SCP_SESSION_TYPE_TO_STR(t) \
     ((t) == SCP_SESSION_TYPE_XVNC ? "Xvnc" : \
-     (t) == SCP_SESSION_TYPE_XRDP ? "Xrdp" : \
      (t) == SCP_SESSION_TYPE_XORG ? "Xorg" : \
      "unknown" \
     )

--- a/sesman/config.c
+++ b/sesman/config.c
@@ -428,38 +428,6 @@ config_read_sessions(int file, struct config_sessions *se, struct list *param_n,
 
 /***************************************************************************//**
  *
- * @brief Reads sesman [X11rdp] configuration section
- * @param file configuration file descriptor
- * @param cs pointer to a config_sesman struct
- * @param param_n parameter name list
- * @param param_v parameter value list
- * @return 0 on success, 1 on failure
- *
- */
-static int
-config_read_rdp_params(int file, struct config_sesman *cs, struct list *param_n,
-                       struct list *param_v)
-{
-    int i;
-
-    list_clear(param_v);
-    list_clear(param_n);
-
-    cs->rdp_params = list_create();
-    cs->rdp_params->auto_free = 1;
-
-    file_read_section(file, SESMAN_CFG_RDP_PARAMS, param_n, param_v);
-
-    for (i = 0; i < param_n->count; i++)
-    {
-        list_add_item(cs->rdp_params, (long)g_strdup((char *)list_get_item(param_v, i)));
-    }
-
-    return 0;
-}
-
-/***************************************************************************//**
- *
  * @brief Reads sesman [Xorg] configuration section
  * @param file configuration file descriptor
  * @param cs pointer to a config_sesman struct
@@ -580,9 +548,8 @@ config_read(const char *sesman_ini)
                 /* read global config */
                 config_read_globals(fd, cfg, param_n, param_v);
 
-                /* read Xvnc/X11rdp/Xorg parameter list */
+                /* read Xvnc/Xorg parameter list */
                 config_read_vnc_params(fd, cfg, param_n, param_v);
-                config_read_rdp_params(fd, cfg, param_n, param_v);
                 config_read_xorg_params(fd, cfg, param_n, param_v);
 
                 /* read security config */
@@ -727,18 +694,6 @@ config_dump(struct config_sesman *config)
                   i, (char *)list_get_item(config->vnc_params, i));
     }
 
-    /* X11rdp */
-    if (config->rdp_params->count)
-    {
-        g_writeln("X11rdp parameters:");
-    }
-
-    for (i = 0; i < config->rdp_params->count; i++)
-    {
-        g_writeln("    Parameter %02d              %s",
-                  i, (char *)list_get_item(config->rdp_params, i));
-    }
-
     /* SessionVariables */
     if (config->env_names->count)
     {
@@ -763,7 +718,6 @@ config_free(struct config_sesman *cs)
         g_free(cs->default_wm);
         g_free(cs->reconnect_sh);
         g_free(cs->auth_file_path);
-        list_delete(cs->rdp_params);
         list_delete(cs->vnc_params);
         list_delete(cs->xorg_params);
         list_delete(cs->env_names);

--- a/sesman/config.h
+++ b/sesman/config.h
@@ -41,7 +41,6 @@
 #define SESMAN_CFG_AUTH_FILE_PATH    "AuthFilePath"
 #define SESMAN_CFG_RECONNECT_SH      "ReconnectScript"
 
-#define SESMAN_CFG_RDP_PARAMS        "X11rdp"
 #define SESMAN_CFG_XORG_PARAMS       "Xorg"
 #define SESMAN_CFG_VNC_PARAMS        "Xvnc"
 
@@ -227,11 +226,6 @@ struct config_sesman
      * @brief Xvnc additional parameter list
      */
     struct list *vnc_params;
-    /**
-     * @var rdp_params
-     * @brief X11rdp additional parameter list
-     */
-    struct list *rdp_params;
     /**
      * @var xorg_params
      * @brief Xorg additional parameter list

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -486,7 +486,7 @@ session_start(struct auth_info *auth_info,
     char text[256];
     char username[256];
     char execvpparams[2048];
-    char *xserver = NULL; /* absolute/relative path to Xorg/X11rdp/Xvnc */
+    char *xserver = NULL; /* absolute/relative path to Xorg/Xvnc */
     char *passwd_file;
     char **pp1 = (char **)NULL;
     struct session_chain *temp = (struct session_chain *)NULL;
@@ -872,33 +872,6 @@ session_start(struct auth_info *auth_info,
                     //config_read_xserver_params(SCP_SESSION_TYPE_XVNC,
                     //                           xserver_params);
                     list_append_list_strdup(g_cfg->vnc_params, xserver_params, 1);
-
-                    /* make sure it ends with a zero */
-                    list_add_item(xserver_params, 0);
-                    pp1 = (char **)xserver_params->items;
-                }
-                else if (s->type == SCP_SESSION_TYPE_XRDP)
-                {
-                    xserver_params = list_create();
-                    xserver_params->auto_free = 1;
-
-                    /* get path of X11rdp from config */
-                    xserver = g_strdup((const char *)list_get_item(g_cfg->rdp_params, 0));
-
-                    /* these are the must have parameters */
-                    list_add_item(xserver_params, (tintptr)g_strdup(xserver));
-                    list_add_item(xserver_params, (tintptr)g_strdup(screen));
-                    list_add_item(xserver_params, (tintptr)g_strdup("-auth"));
-                    list_add_item(xserver_params, (tintptr)g_strdup(authfile));
-                    list_add_item(xserver_params, (tintptr)g_strdup("-geometry"));
-                    list_add_item(xserver_params, (tintptr)g_strdup(geometry));
-                    list_add_item(xserver_params, (tintptr)g_strdup("-depth"));
-                    list_add_item(xserver_params, (tintptr)g_strdup(depth));
-
-                    /* additional parameters from sesman.ini file */
-                    //config_read_xserver_params(SCP_SESSION_TYPE_XRDP,
-                    //                           xserver_params);
-                    list_append_list_strdup(g_cfg->rdp_params, xserver_params, 1);
 
                     /* make sure it ends with a zero */
                     list_add_item(xserver_params, 0);

--- a/sesman/tools/sesrun.c
+++ b/sesman/tools/sesrun.c
@@ -77,7 +77,6 @@ static struct
 } type_map[] =
 {
     { "Xvnc", SCP_SESSION_TYPE_XVNC},
-    { "X11rdp", SCP_SESSION_TYPE_XRDP},
     { "Xorg", SCP_SESSION_TYPE_XORG},
     { NULL, (enum scp_session_type) - 1}
 };

--- a/xrdp/xrdp.ini.in
+++ b/xrdp/xrdp.ini.in
@@ -229,7 +229,7 @@ tcutils=true
 ; Session types
 ;
 
-; Some session types such as Xorg, X11rdp and Xvnc start a display server.
+; Some session types such as Xorg and Xvnc start a display server.
 ; Startup command-line parameters for the display server are configured
 ; in sesman.ini. See and configure also sesman.ini.
 [Xorg]

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -247,10 +247,6 @@ xrdp_mm_create_session(struct xrdp_mm *self)
             type = SCP_SESSION_TYPE_XVNC;
             break;
 
-        case XRDP_SESSION_CODE:
-            type = SCP_SESSION_TYPE_XRDP;
-            break;
-
         case  XORG_SESSION_CODE:
             type = SCP_SESSION_TYPE_XORG;
             break;
@@ -472,8 +468,7 @@ xrdp_mm_setup_mod2(struct xrdp_mm *self)
             {
                 g_snprintf(text, 255, "%d", 5900 + self->display);
             }
-            else if (self->code == XRDP_SESSION_CODE ||
-                     self->code == XORG_SESSION_CODE)
+            else if (self->code == XORG_SESSION_CODE)
             {
                 g_snprintf(text, 255, XRDP_X11RDP_STR, self->display);
             }
@@ -2392,8 +2387,7 @@ xrdp_mm_connect(struct xrdp_mm *self)
          * address that the X server is listening on */
         if (xrdp_mm_get_value(self, "ip") != NULL)
         {
-            if (self->code == XRDP_SESSION_CODE ||
-                    self->code == XORG_SESSION_CODE)
+            if (self->code == XORG_SESSION_CODE)
             {
                 xrdp_wm_log_msg(self->wm,
                                 LOG_LEVEL_WARNING,

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -34,7 +34,6 @@
 
 /* Code values used in 'xrdp_mm->code=' settings */
 #define XVNC_SESSION_CODE 0
-#define XRDP_SESSION_CODE 10
 #define XORG_SESSION_CODE 20
 
 /* To check whether touch events has been implemented on session type 'mm' */
@@ -370,7 +369,7 @@ struct xrdp_mm
     struct xrdp_mod *mod; /* module interface */
     int display; /* 10 for :10.0, 11 for :11.0, etc */
     struct guid guid; /* GUID for the session, or all zeros  */
-    int code; /* 0=Xvnc session, 10=X11rdp session, 20=xorg driver mode */
+    int code; /* 0=Xvnc session, 20=xorg driver mode */
     struct xrdp_encoder *encoder;
     int cs2xr_cid_map[256];
     int xr2cr_cid_map[256];

--- a/xup/xup.c
+++ b/xup/xup.c
@@ -74,7 +74,7 @@ lib_mod_log_peer(struct mod *mod)
     if (g_sck_get_peer_cred(mod->trans->sck, &pid, &uid, &gid) == 0)
     {
         LOG(LOG_LEVEL_INFO, "lib_mod_log_peer: xrdp_pid=%d connected "
-            "to X11rdp_pid=%d X11rdp_uid=%d X11rdp_gid=%d "
+            "to Xorg_pid=%d Xorg_uid=%d Xorg_gid=%d "
             "client=%s",
             my_pid, pid, uid, gid,
             mod->client_info.client_description);
@@ -205,7 +205,7 @@ lib_mod_connect(struct mod *mod)
     if (trans_connect(mod->trans, mod->ip, con_port, 30 * 1000) == 0)
     {
         LOG_DEVEL(LOG_LEVEL_INFO, "lib_mod_connect: connected to Xserver "
-                  "(Xorg or X11rdp) sck %lld",
+                  "(Xorg) sck %lld",
                   (long long) (mod->trans->sck));
     }
     else


### PR DESCRIPTION
See [this review comment](/neutrinolabs/xrdp/pull/2472#discussion_r1061989152)

X11rdp has been deprecated now since xrdp v0.9.7 (June 2018). This commit removes support for it from xrdp itself.