### PR TITLE
Add xrdp-waitforx to wait for X to start with RandR outputs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -58,6 +58,7 @@ SUBDIRS = \
   xrdp \
   fontutils \
   keygen \
+  waitforx \
   docs \
   instfiles \
   genkeymap \

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -2810,6 +2810,22 @@ g_execlp3(const char *a1, const char *a2, const char *a3)
 
 /*****************************************************************************/
 /* does not work in win32 */
+unsigned int
+g_set_alarm(void (*func)(int), unsigned int secs)
+{
+#if defined(_WIN32)
+    return 0;
+#else
+    /* Cancel any previous alarm to prevent a race */
+    unsigned int rv = alarm(0);
+    signal(SIGALRM, func);
+    (void)alarm(secs);
+    return rv;
+#endif
+}
+
+/*****************************************************************************/
+/* does not work in win32 */
 void
 g_signal_child_stop(void (*func)(int))
 {

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -204,6 +204,7 @@ char    *g_get_strerror(void);
 int      g_get_errno(void);
 int      g_execvp(const char *p1, char *args[]);
 int      g_execlp3(const char *a1, const char *a2, const char *a3);
+unsigned int g_set_alarm(void (*func)(int), unsigned int secs);
 void     g_signal_child_stop(void (*func)(int));
 void     g_signal_segfault(void (*func)(int));
 void     g_signal_hang_up(void (*func)(int));

--- a/configure.ac
+++ b/configure.ac
@@ -575,6 +575,7 @@ AC_CONFIG_FILES([
   instfiles/pulse/Makefile
   instfiles/rc.d/Makefile
   keygen/Makefile
+  waitforx/Makefile
   libipm/Makefile
   libxrdp/Makefile
   Makefile

--- a/sesman/Makefile.am
+++ b/sesman/Makefile.am
@@ -5,6 +5,7 @@ AM_CPPFLAGS = \
   -DXRDP_SYSCONF_PATH=\"${sysconfdir}\" \
   -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
+  -DXRDP_BIN_PATH=\"${bindir}\" \
   -DXRDP_SHARE_PATH=\"${datadir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \
   -DXRDP_SOCKET_PATH=\"${socketdir}\" \
@@ -34,7 +35,9 @@ xrdp_sesman_SOURCES = \
   sig.c \
   sig.h \
   xauth.c \
-  xauth.h
+  xauth.h \
+  xwait.c \
+  xwait.h
 
 # Possible authentication modules
 # See https://www.gnu.org/software/automake/manual/html_node/Conditional-Sources.html

--- a/sesman/xwait.c
+++ b/sesman/xwait.c
@@ -1,0 +1,47 @@
+#if defined(HAVE_CONFIG_H)
+#include "config_ac.h"
+#endif
+
+#include "log.h"
+#include "os_calls.h"
+#include "string_calls.h"
+#include "xwait.h"
+
+#include <stdio.h>
+#include <string.h>
+
+/******************************************************************************/
+int
+wait_for_xserver(int display)
+{
+    FILE *dp = NULL;
+    int ret = 0;
+    char buffer[100];
+    char exe_cmd[262];
+
+    LOG(LOG_LEVEL_DEBUG, "Waiting for X server to start on display %d", display);
+
+    g_snprintf(exe_cmd, sizeof(exe_cmd), "%s/xrdp-waitforx", XRDP_BIN_PATH);
+    dp = popen(exe_cmd, "r");
+    if (dp == NULL)
+    {
+        LOG(LOG_LEVEL_ERROR, "Unable to launch xrdp-waitforx");
+        return 1;
+    }
+
+    while (fgets(buffer, 100, dp))
+    {
+        g_strtrim(buffer, 2);
+        LOG(LOG_LEVEL_DEBUG, "%s", buffer);
+    }
+
+    ret = pclose(dp);
+    if (ret != 0)
+    {
+        LOG(LOG_LEVEL_ERROR, "An error occurred while running xrdp-waitforx");
+        return 0;
+    }
+
+
+    return 1;
+}

--- a/sesman/xwait.h
+++ b/sesman/xwait.h
@@ -1,0 +1,12 @@
+#ifndef XWAIT_H
+#define XWAIT_H
+/**
+ *
+ * @brief waits for X to start
+ * @param display number
+ * @return 0 on error, 1 if X has outputs
+ *
+ */
+int
+wait_for_xserver(int display);
+#endif

--- a/waitforx/Makefile.am
+++ b/waitforx/Makefile.am
@@ -1,0 +1,10 @@
+bin_PROGRAMS = \
+  xrdp-waitforx
+
+AM_LDFLAGS = -lX11 -lXrandr
+AM_CFLAGS = -I$(top_srcdir)/common
+
+xrdp_waitforx_SOURCES = waitforx.c
+
+xrdp_waitforx_LDADD = \
+  $(top_builddir)/common/libcommon.la

--- a/waitforx/waitforx.c
+++ b/waitforx/waitforx.c
@@ -1,0 +1,96 @@
+#include <X11/extensions/Xrandr.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/signal.h>
+#include <unistd.h>
+
+#define ATTEMPTS 10
+#define ALARM_WAIT 30
+
+void
+alarm_handler(int signal_num)
+{
+    printf("Unable to find RandR outputs after %d seconds\n", ALARM_WAIT);
+    exit(1);
+}
+
+int
+main(int argc, char **argv)
+{
+    char *display = NULL;
+    int error_base = 0;
+    int event_base = 0;
+    int n = 0;
+    int outputs = 0;
+    int wait = ATTEMPTS;
+
+    Display *dpy = NULL;
+    XRRScreenResources *res = NULL;
+
+    display = getenv("DISPLAY");
+
+    signal(SIGALRM, alarm_handler);
+    alarm(ALARM_WAIT);
+
+    if (!display)
+    {
+        printf("DISPLAY is null");
+        exit(1);
+    }
+
+    for (n = 1; n <= wait; ++n)
+    {
+        dpy = XOpenDisplay(display);
+        printf("Opening display %s. Attempt %d of %d\n", display, n, wait);
+        if (dpy != NULL)
+        {
+            printf("Opened display %s\n", display);
+            break;
+        }
+        sleep(1);
+    }
+
+    if (!dpy)
+    {
+        printf("Unable to open display %s\n", display);
+        exit(1);
+    }
+
+    if (!XRRQueryExtension(dpy, &event_base, &error_base))
+    {
+        printf("RandR not supported on display %s", display);
+    }
+    else
+    {
+        for (n = 1; n <= wait; ++n)
+        {
+            res = XRRGetScreenResources(dpy, DefaultRootWindow(dpy));
+            printf("Waiting for outputs. Attempt %d of %d\n", n, wait);
+            if (res != NULL)
+            {
+                if (res->noutput > 0)
+                {
+                    outputs = res->noutput;
+                    XRRFreeScreenResources(res);
+                    printf("Found %d output[s]\n", outputs);
+                    break;
+                }
+                XRRFreeScreenResources(res);
+            }
+            sleep(1);
+        }
+
+        if (outputs > 0)
+        {
+            printf("display %s ready with %d outputs\n", display, res->noutput);
+        }
+        else
+        {
+            printf("Unable to find any outputs\n");
+            exit(1);
+        }
+    }
+
+    exit(0);
+}


### PR DESCRIPTION
For some window managers (fvwm2 and fvwm3) if the X server isn't
running and has output it's possible for the window manager to fail or
reconfigure randr incorrectly.

With xrdp-waitfox:
 - Install xrdp-waitfox to the BIN dir.
 - sesman will run xrdp-waitfox as the logged in user.
 - Set an alarm to exit after 30 seconds.
 - Try to open env DISPLAY value's display (10 seconds).
 - Test for RandR extension.
 - Wait for outputs to appear (10 seconds).

Fixes #2436