### PR TITLE
Add file descriptor passing support for libipm

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -1408,7 +1408,7 @@ g_sck_last_error_would_block(int sck)
 
 /*****************************************************************************/
 int
-g_sck_recv(int sck, void *ptr, int len, int flags)
+g_sck_recv(int sck, void *ptr, unsigned int len, int flags)
 {
 #if defined(_WIN32)
     return recv(sck, (char *)ptr, len, flags);
@@ -1419,7 +1419,7 @@ g_sck_recv(int sck, void *ptr, int len, int flags)
 
 /*****************************************************************************/
 int
-g_sck_send(int sck, const void *ptr, int len, int flags)
+g_sck_send(int sck, const void *ptr, unsigned int len, int flags)
 {
 #if defined(_WIN32)
     return send(sck, (const char *)ptr, len, flags);

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -1429,6 +1429,145 @@ g_sck_send(int sck, const void *ptr, unsigned int len, int flags)
 }
 
 /*****************************************************************************/
+int
+g_sck_recv_fd_set(int sck, void *ptr, unsigned int len,
+                  int fds[], unsigned int maxfd,
+                  unsigned int *fdcount)
+{
+    int rv = -1;
+#if !defined(_WIN32)
+    // The POSIX API gives us no way to see how much ancillary data is
+    // present for recvmsg() - just use a big buffer.
+    //
+    // Use a union, so control_un.control is properly aligned.
+    union
+    {
+        struct cmsghdr cm;
+        unsigned char control[8192];
+    } control_un;
+    struct msghdr msg = {0};
+
+    *fdcount = 0;
+
+    /* Set up descriptor for vanilla data */
+    struct iovec iov[1] = { {ptr, len} };
+    msg.msg_iov = &iov[0];
+    msg.msg_iovlen = 1;
+
+    /* Add in the ancillary data buffer */
+    msg.msg_control = control_un.control;
+    msg.msg_controllen = sizeof(control_un.control);
+
+    if ((rv = recvmsg(sck, &msg, 0)) > 0)
+    {
+        struct cmsghdr *cmsg;
+        if ((msg.msg_flags & MSG_CTRUNC) != 0)
+        {
+            LOG(LOG_LEVEL_WARNING, "Ancillary data on recvmsg() was truncated");
+        }
+
+        // Iterate over the cmsghdr structures in the ancillary data
+        for (cmsg = CMSG_FIRSTHDR(&msg);
+                cmsg != NULL;
+                cmsg = CMSG_NXTHDR(&msg, cmsg))
+        {
+            if (cmsg->cmsg_level == SOL_SOCKET &&
+                    cmsg->cmsg_type == SCM_RIGHTS)
+            {
+                const unsigned char *data = CMSG_DATA(cmsg);
+                unsigned int data_len = cmsg->cmsg_len - CMSG_LEN(0);
+
+                // Check the data length doesn't point past the end of
+                // control_un.control (see below). This shouldn't happen,
+                // but is conceivable if the ancillary data is truncated
+                // and the OS doesn't handle that properly.
+                //
+                // <--  (sizeof(control_un.control)   -->
+                // +------------------------------------+
+                // |                                    |
+                // +------------------------------------+
+                // ^                       ^
+                // |                       | <- data_len ->
+                // |                       |
+                // control_un.control      data
+                unsigned int max_data_len =
+                    sizeof(control_un.control) - (data - control_un.control);
+                if (len > max_data_len)
+                {
+                    len = max_data_len;
+                }
+
+                // Process all the file descriptors in the structure
+                while (data_len >= sizeof(int))
+                {
+                    int fd;
+                    memcpy(&fd, data, sizeof(int));
+                    data += sizeof(int);
+                    data_len -= sizeof(int);
+
+                    if (*fdcount < maxfd)
+                    {
+                        fds[(*fdcount)++] = fd;
+                    }
+                    else
+                    {
+                        // No room in the user's buffer for this fd
+                        close(fd);
+                    }
+                }
+            }
+        }
+    }
+#endif /* !WIN32 */
+
+    return rv;
+}
+
+/*****************************************************************************/
+int
+g_sck_send_fd_set(int sck, const void *ptr, unsigned int len,
+                  int fds[], unsigned int fdcount)
+{
+    int rv = -1;
+#if !defined(_WIN32)
+    struct msghdr msg = {0};
+
+    /* Set up descriptor for vanilla data */
+    struct iovec iov[1] = { {(void *)ptr, len} };
+    msg.msg_iov = &iov[0];
+    msg.msg_iovlen = 1;
+
+    if (fdcount > 0)
+    {
+        unsigned int fdsize = sizeof(fds[0]) * fdcount; /* Payload size */
+        /* Allocate ancillary data structure */
+        msg.msg_controllen  = CMSG_SPACE(fdsize);
+        msg.msg_control = (struct cmsghdr *)g_malloc(msg.msg_controllen, 1);
+        if (msg.msg_control == NULL)
+        {
+            /* Memory allocation failure */
+            LOG(LOG_LEVEL_ERROR, "Error allocating buffer for %u fds",
+                fdcount);
+            return -1;
+        }
+
+        /* Fill in the ancillary data structure */
+        struct cmsghdr *cmptr = CMSG_FIRSTHDR(&msg);
+        cmptr->cmsg_len = CMSG_LEN(fdsize);
+        cmptr->cmsg_level = SOL_SOCKET;
+        cmptr->cmsg_type = SCM_RIGHTS;
+        memcpy(CMSG_DATA(cmptr), fds, fdsize);
+    }
+
+    rv = sendmsg(sck, &msg, 0);
+    g_free(msg.msg_control);
+
+#endif /* !WIN32 */
+
+    return rv;
+}
+
+/*****************************************************************************/
 /* returns boolean */
 int
 g_sck_socket_ok(int sck)

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -86,8 +86,8 @@ int      g_sck_vsock_bind_address(int sck, const char *port, const char *address
 int      g_tcp_bind_address(int sck, const char *port, const char *address);
 int      g_sck_listen(int sck);
 int      g_sck_accept(int sck);
-int      g_sck_recv(int sck, void *ptr, int len, int flags);
-int      g_sck_send(int sck, const void *ptr, int len, int flags);
+int      g_sck_recv(int sck, void *ptr, unsigned int len, int flags);
+int      g_sck_send(int sck, const void *ptr, unsigned int len, int flags);
 int      g_sck_last_error_would_block(int sck);
 int      g_sck_socket_ok(int sck);
 int      g_sck_can_send(int sck, int millis);

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -88,6 +88,42 @@ int      g_sck_listen(int sck);
 int      g_sck_accept(int sck);
 int      g_sck_recv(int sck, void *ptr, unsigned int len, int flags);
 int      g_sck_send(int sck, const void *ptr, unsigned int len, int flags);
+/**
+ * Receives data and file descriptors on a unix domain socket
+ *
+ * @param sck - Socket to receive data + file descriptors from
+ * @param ptr - Pointer to buffer for incoming data
+ * @param len - Length of data. Must be > 0
+ * @param[out] fds - Array of file descriptors
+ * @param [in] maxfd - Max number of elements in fds
+ * @param[out] fdcount - Actual number of file descriptors received
+ * @return Bytes received, or < 0 for error.
+ *
+ * If the result is > 0 but less than len, the file descriptors have
+ * been received. Get the rest of the data with normal g_sck_recv() calls.
+ *
+ * fdcount may be more that maxfd. This indicates that more file descriptors
+ * were received than there was space for. The excess file descriptors
+ * are closed and discarded.
+ */
+int      g_sck_recv_fd_set(int sck, void *ptr, unsigned int len,
+                           int fds[], unsigned int maxfd,
+                           unsigned int *fdcount);
+/**
+ * Sends data and file descriptors on a unix domain socket
+ *
+ * @param sck - Socket to send data + file descriptors on
+ * @param ptr - Data to send
+ * @param len - Length of data. Must be > 0
+ * @param fds - Array of file descriptors
+ * @param fdcount - Number of file descriptors
+ * @return Bytes sent, or < 0 for error.
+ *
+ * If the result is > 0 but less than len, the file descriptors have
+ * been sent. Send the rest of the data with normal g_sck_send() calls.
+ */
+int      g_sck_send_fd_set(int sck, const void *ptr, unsigned int len,
+                           int fds[], unsigned int fdcount);
 int      g_sck_last_error_would_block(int sck);
 int      g_sck_socket_ok(int sck);
 int      g_sck_can_send(int sck, int millis);

--- a/libipm/libipm.h
+++ b/libipm/libipm.h
@@ -300,8 +300,8 @@ libipm_msg_in_peek_type(struct trans *trans);
  *   x  | int64_t *  | Signed (two's complement) 64-bit integer
  *   t  | uint64_t * | Unsigned 64-bit integer
  *   s  | char **    | NULL-terminated string
+ *   h  | int *      | File descriptor
  *   d  |   -        | (reserved)
- *   h  |   -        | (reserved)
  *   o  |   -        | (reserved)
  *   g  |   -        | (reserved)
  *
@@ -314,6 +314,9 @@ libipm_msg_in_peek_type(struct trans *trans);
  * For the 's' type, a pointer into the string in the input buffer is
  * returned. This pointer will only be valid until the next call to
  * libipm_msg_in_reset()
+ *
+ * The 'h' type can only be used where the underlying transport is a
+ * UNIX domain socket.
  *
  * For the 'B' type, pass in the address of an initialised descriptor
  * containing the address and size of the object to copy the data
@@ -329,6 +332,9 @@ libipm_msg_in_parse(struct trans *trans, const char *format, ...);
  *
  * If the LIBIPM_E_MSG_IN_ERASE_AFTER_USE flag is set for the transport,
  * the entire buffer is erased, and the flag is cleared
+ *
+ * Any file descriptors received from the other end but not parsed
+ * by the application are closed.
  *
  * @param trans libipm transport
  */

--- a/libipm/libipm.h
+++ b/libipm/libipm.h
@@ -67,6 +67,7 @@ enum libipm_status
     E_LI_UNIMPLEMENTED_TYPE, /***< Specified type code is unimplemented */
     E_LI_UNEXPECTED_TYPE, /***< Encountered unexpected type on input */
     E_LI_BUFFER_OVERFLOW, /***< End of buffer reached unexpectedly */
+    E_LI_TOO_MANY_FDS, /***< Too many file descriptors encountered */
     E_LI_BAD_VALUE, /***< Specified (or incoming) value is out of range */
     E_LI_BAD_HEADER, /***< Bad incoming message header */
     E_LI_TRANSPORT_ERROR /***< Error detected at the transport level */
@@ -154,13 +155,16 @@ libipm_msg_out_init(struct trans *trans, unsigned short msgno,
  *   x  |int64_t  | Signed (two's complement) 64-bit integer
  *   t  |uint64_t | Unsigned 64-bit integer
  *   s  |char *   | NULL-terminated string
+ *   h  |int      | File descriptor
  *   d  |  -      | (reserved)
- *   h  |  -      | (reserved)
  *   o  |  -      | (reserved)
  *   g  |  -      | (reserved)
  *
  * For the 'b' type, only values 0 and 1 are allowed. Other values
  * generate an error.
+ *
+ * The 'h' type can only be used where the underlying transport is a
+ * UNIX domain socket.
  *
  *  The following additions to the D-Bus type system are also supported:-
  *

--- a/libipm/libipm.h
+++ b/libipm/libipm.h
@@ -219,6 +219,12 @@ libipm_msg_out_erase(struct trans *trans);
  * @param trans libipm transport
  * @param[out] available != 0 if a complete message is available
  * @return != 0 for error
+ *
+ * When 'available' becomes set, the buffer is guaranteed to
+ * be in a parseable state.
+ *
+ * The results of calling this function after starting to parse a message
+ * and before calling libipm_msg_in_reset() are undefined.
  */
 enum libipm_status
 libipm_msg_in_check_available(struct trans *trans, int *available);
@@ -233,6 +239,9 @@ libipm_msg_in_check_available(struct trans *trans, int *available);
  * While the call is active, data-in callbacks for the transport are
  * disabled.
  *
+ * The results of calling this function after starting to parse a message
+ * and before calling libipm_msg_in_reset() are undefined.
+ *
  * Only use this call if you have nothing to do until a message
  * arrives on the transport. If you have other transports to service, use
  * libipm_msg_in_check_available()
@@ -241,7 +250,7 @@ enum libipm_status
 libipm_msg_in_wait_available(struct trans *trans);
 
 /**
- * Start parsing a message
+ * Get the message number for a message in the input buffer.
  *
  * @param trans libipm transport
  * @return message number in the buffer
@@ -250,12 +259,9 @@ libipm_msg_in_wait_available(struct trans *trans);
  * libipm_msg_in_reset() and before a successful call to
  * libipm_msg_in_check_available() (or libipm_msg_wait_available())
  * are undefined.
- *
- * Calling this function resets the message parsing pointer to the start
- * of the message
  */
 unsigned short
-libipm_msg_in_start(struct trans *trans);
+libipm_msg_in_get_msgno(const struct trans *trans);
 
 /**
  * Returns a letter corresponding to the next available type in the

--- a/libipm/libipm_private.h
+++ b/libipm/libipm_private.h
@@ -61,6 +61,11 @@ struct libipm_priv
     int out_fds[MAX_FD_PER_MSG];
     unsigned short in_msgno;
     unsigned short in_param_count;
+    /** Pointer to next fd to be consumed by the app */
+    unsigned short in_fd_index;
+    /** Number of fds in the incoming message */
+    unsigned short in_fd_count;
+    int in_fds[MAX_FD_PER_MSG];
 };
 
 /**
@@ -70,5 +75,16 @@ struct libipm_priv
  * libipm_msg_in_parse()
  */
 extern const char *libipm_valid_type_chars;
+
+/**
+ * Close input file descriptors for an input message
+ *
+ * If file descriptors are read from the other end, but not passed to the
+ * application, they must be closed to prevent file descriptor leaks
+ *
+ * @param trans Transport to close file descriptors for
+ */
+void
+libipm_msg_in_close_file_descriptors(struct trans *self);
 
 #endif /* LIBIPM__PRIVATE_H */

--- a/libipm/libipm_private.h
+++ b/libipm/libipm_private.h
@@ -39,7 +39,12 @@ enum
     /**
      * Size of libipm header
      */
-    HEADER_SIZE = 12
+    HEADER_SIZE = 12,
+
+    /**
+     * Max number of file descriptors in a message
+     */
+    MAX_FD_PER_MSG = 8
 };
 
 /**
@@ -52,6 +57,8 @@ struct libipm_priv
     const char *(*msgno_to_str)(unsigned short msgno);
     unsigned short out_msgno;
     unsigned short out_param_count;
+    unsigned short out_fd_count;
+    int out_fds[MAX_FD_PER_MSG];
     unsigned short in_msgno;
     unsigned short in_param_count;
 };

--- a/libipm/libipm_recv.c
+++ b/libipm/libipm_recv.c
@@ -187,11 +187,10 @@ libipm_msg_in_wait_available(struct trans *trans)
 /*****************************************************************************/
 
 unsigned short
-libipm_msg_in_start(struct trans *trans)
+libipm_msg_in_get_msgno(const struct trans *trans)
 {
     struct libipm_priv *priv = (struct libipm_priv *)trans->extra_data;
 
-    trans->in_s->p = trans->in_s->data + HEADER_SIZE;
     return (priv == NULL) ? 0 : priv->in_msgno;
 }
 

--- a/libipm/scp.c
+++ b/libipm/scp.c
@@ -212,18 +212,18 @@ scp_msg_in_wait_available(struct trans *trans)
 
 /*****************************************************************************/
 
-void
-scp_msg_in_reset(struct trans *trans)
+enum scp_msg_code
+scp_msg_in_get_msgno(const struct trans *trans)
 {
-    libipm_msg_in_reset(trans);
+    return (enum scp_msg_code)libipm_msg_in_get_msgno(trans);
 }
 
 /*****************************************************************************/
 
-enum scp_msg_code
-scp_msg_in_start(struct trans *trans)
+void
+scp_msg_in_reset(struct trans *trans)
 {
-    return (enum scp_msg_code)libipm_msg_in_start(trans);
+    libipm_msg_in_reset(trans);
 }
 
 /*****************************************************************************/

--- a/libipm/scp.h
+++ b/libipm/scp.h
@@ -164,19 +164,16 @@ scp_msg_in_wait_available(struct trans *trans);
 
 
 /**
- * Start parsing an SCP message
+ * Gets the SCP message number of an incoming message
  *
  * @param trans SCP transport
  * @return message in the buffer
  *
  * The results of calling this routine before scp_msg_in_check_available()
  * states a message is available are undefined.
- *
- * Calling this function rests the message parsing pointer to the start
- * of the message
  */
 enum scp_msg_code
-scp_msg_in_start(struct trans *trans);
+scp_msg_in_get_msgno(const struct trans *trans);
 
 /**
  * Resets an SCP message buffer ready to receive the next message

--- a/sesman/scp_process.c
+++ b/sesman/scp_process.c
@@ -536,7 +536,7 @@ scp_process(struct sesman_con *sc)
     enum scp_msg_code msgno;
     int rv = 0;
 
-    switch ((msgno = scp_msg_in_start(sc->t)))
+    switch ((msgno = scp_msg_in_get_msgno(sc->t)))
     {
         case E_SCP_SET_PEERNAME_REQUEST:
             rv = process_set_peername_request(sc);

--- a/sesman/tools/tools_common.c
+++ b/sesman/tools/tools_common.c
@@ -50,7 +50,7 @@ wait_for_sesman_reply(struct trans *t, enum scp_msg_code wait_msgno)
         }
         else
         {
-            enum scp_msg_code reply_msgno = scp_msg_in_start(t);
+            enum scp_msg_code reply_msgno = scp_msg_in_get_msgno(t);
 
             available = 1;
             if (reply_msgno != wait_msgno)

--- a/tests/common/test_common_main.c
+++ b/tests/common/test_common_main.c
@@ -3,6 +3,7 @@
 #include "config_ac.h"
 #endif
 
+#include <stdio.h>
 #include <stdlib.h>
 
 #include "log.h"
@@ -58,6 +59,9 @@ int main (void)
     struct log_config *lc = log_config_init_for_console(LOG_LEVEL_INFO, NULL);
     log_start_from_param(lc);
     log_config_free(lc);
+    /* Disable stdout buffering, as this can confuse the error
+     * reporting when running in libcheck fork mode */
+    setvbuf(stdout, NULL, _IONBF, 0);
 
     /* Initialise the ssl module */
     ssl_init();

--- a/tests/libipm/test_libipm.h
+++ b/tests/libipm/test_libipm.h
@@ -11,6 +11,7 @@ enum
     LIBIPM_VERSION = 2,
     LIBIPM_HEADER_SIZE = 12,
     LIBIPM_MAX_MESSAGE_SIZE = 8192,
+    LIBIPM_MAX_FD_PER_MSG = 8,
     LIBIPM_MAX_PAYLOAD_SIZE = LIBIPM_MAX_MESSAGE_SIZE - LIBIPM_HEADER_SIZE
 };
 
@@ -18,6 +19,7 @@ enum
 extern struct trans *g_t_out;   /* Channel for outputting libipm messages */
 extern struct trans *g_t_in;    /* Channel for inputting libipm messages */
 extern struct trans *g_t_vanilla; /* Non-SCP channel */
+extern int g_fd;                /* An open file descriptor (/dev/zero) */
 
 extern const char *g_supported_types;  /* All recognised type codes */
 extern const char *g_unimplemented_types; /* recognised, unimplemented codes */
@@ -43,6 +45,14 @@ check_binary_data_eq(const void *actual_data,
                      unsigned int expected_len);
 
 /**
+ * Check the file descriptor specified is working as /dev/zero
+ *
+ * If it isn't, an exception is raised using ck_* calls
+ */
+void
+check_fd_is_dev_zero(int fd);
+
+/**
  * Looks for the specified string in the specified stream
  * @param s Stream to search
  * @param str Null-terminated string to look for
@@ -53,6 +63,11 @@ check_binary_data_eq(const void *actual_data,
  */
 int
 does_stream_contain_string(const struct stream *s, const char *str);
+
+/**
+ * Returns the number of open file descriptors in the process */
+unsigned int
+get_open_fd_count(void);
 
 Suite *make_suite_test_libipm_send_calls(void);
 Suite *make_suite_test_libipm_recv_calls(void);

--- a/tests/libipm/test_libipm_main.c
+++ b/tests/libipm/test_libipm_main.c
@@ -3,6 +3,7 @@
 #include "config_ac.h"
 #endif
 
+#include <stdio.h>
 #include <stdlib.h>
 
 #include "log.h"
@@ -177,6 +178,9 @@ int main (void)
     struct log_config *lc = log_config_init_for_console(LOG_LEVEL_INFO, NULL);
     log_start_from_param(lc);
     log_config_free(lc);
+    /* Disable stdout buffering, as this can confuse the error
+     * reporting when running in libcheck fork mode */
+    setvbuf(stdout, NULL, _IONBF, 0);
 
     /* Initialise modules */
     suite_test_libipm_calls_start();

--- a/tests/libipm/test_libipm_recv_calls.c
+++ b/tests/libipm/test_libipm_recv_calls.c
@@ -116,7 +116,7 @@ check_for_incoming_message(unsigned short expected_msgno)
     status = libipm_msg_in_wait_available(g_t_in);
     ck_assert_int_eq(status, E_LI_SUCCESS);
 
-    msgno = libipm_msg_in_start(g_t_in);
+    msgno = libipm_msg_in_get_msgno(g_t_in);
     ck_assert_int_eq(msgno, expected_msgno);
 }
 

--- a/tests/libipm/test_libipm_recv_calls.c
+++ b/tests/libipm/test_libipm_recv_calls.c
@@ -245,13 +245,14 @@ START_TEST(test_libipm_send_recv_all_test)
     int64_t x;
     uint64_t t;
     char *s;
+    int h = -1;
     char B[sizeof(bin_out)];
     char c;
 
     /* The message is small enough to fit in the socket buffer */
     status = libipm_msg_out_simple_send(
                  g_t_out, TEST_MESSAGE_NO,
-                 "ybnqiuxtsB",
+                 "ybnqiuxtshB",
                  TEST_y_VALUE,
                  TEST_b_VALUE,
                  TEST_n_VALUE,
@@ -261,6 +262,7 @@ START_TEST(test_libipm_send_recv_all_test)
                  TEST_x_VALUE,
                  TEST_t_VALUE,
                  TEST_s_VALUE,
+                 g_fd,
                  &binary_desc);
     ck_assert_int_eq(status, E_LI_SUCCESS);
 
@@ -273,8 +275,8 @@ START_TEST(test_libipm_send_recv_all_test)
 
     status = libipm_msg_in_parse(
                  g_t_in,
-                 "ybnqiuxtsB",
-                 &y, &b, &n, &q, &i, &u, &x, &t, &s, &binary_desc);
+                 "ybnqiuxtshB",
+                 &y, &b, &n, &q, &i, &u, &x, &t, &s, &h, &binary_desc);
 
     ck_assert_int_eq(status, E_LI_SUCCESS);
     ck_assert_int_eq(y, TEST_y_VALUE);
@@ -287,6 +289,13 @@ START_TEST(test_libipm_send_recv_all_test)
     ck_assert_int_eq(t, TEST_t_VALUE);
     check_binary_data_eq(TEST_s_VALUE, sizeof(TEST_s_VALUE) - 1,
                          s, g_strlen(s));
+    /* The file descriptor should not be -1, neither should it be
+     * the value we sent. It should also point to /dev/zero */
+    ck_assert_int_ne(h, -1);
+    ck_assert_int_ne(h, g_fd);
+    check_fd_is_dev_zero(h);
+    g_file_close(h);
+
     check_binary_data_eq(bin_out, sizeof(bin_out), B, sizeof(B));
 
     /* Check we're at the end of the message */
@@ -540,8 +549,62 @@ START_TEST(test_libipm_receive_s_type)
 }
 END_TEST
 
+
 /***************************************************************************//**
- * Checks various receive errors for 's'
+ * Checks various receive errors for 'h'
+ */
+START_TEST(test_libipm_receive_h_type)
+{
+    enum libipm_status status;
+    int istatus;
+    unsigned int i;
+    int fd_count;
+
+    /* Get the number of open file descriptors */
+    int base_fd_count = get_open_fd_count();
+    ck_assert_int_gt(base_fd_count, 0);
+
+    /* Send the max number of copies of the /dev/zero
+     * file descriptor */
+    status = libipm_msg_out_init(g_t_out, TEST_MESSAGE_NO, NULL);
+    ck_assert_int_eq(status, E_LI_SUCCESS);
+
+    for (i = 0 ; i < LIBIPM_MAX_FD_PER_MSG; ++i)
+    {
+        status = libipm_msg_out_append(g_t_out, "h", g_fd);
+        ck_assert_int_eq(status, E_LI_SUCCESS);
+    }
+    libipm_msg_out_mark_end(g_t_out);
+    istatus = trans_force_write(g_t_out);
+    ck_assert_int_eq(istatus, 0);
+
+    check_for_incoming_message(TEST_MESSAGE_NO);
+
+    /* Check the number of file descriptors has gone up as expected */
+    fd_count = get_open_fd_count();
+    ck_assert_int_eq(fd_count, base_fd_count + LIBIPM_MAX_FD_PER_MSG);
+
+    /* Check half the descriptors work */
+    for (i = 0 ; i < LIBIPM_MAX_FD_PER_MSG / 2; ++i)
+    {
+        int h = -1;
+        status = libipm_msg_in_parse(g_t_in, "h", &h);
+        ck_assert_int_eq(status, E_LI_SUCCESS);
+        check_fd_is_dev_zero(h);
+        g_file_close(h);
+    }
+
+    /* Close the message without reading the other descriptors */
+    libipm_msg_in_reset(g_t_in);
+
+    /* Check all the file descriptors we received have been closed */
+    fd_count = get_open_fd_count();
+    ck_assert_int_eq(fd_count, base_fd_count);
+}
+END_TEST
+
+/***************************************************************************//**
+ * Checks various receive errors for 'B'
  */
 START_TEST(test_libipm_receive_B_type)
 {
@@ -844,6 +907,7 @@ make_suite_test_libipm_recv_calls(void)
     tcase_add_test(tc, test_libipm_receive_x_type);
     tcase_add_test(tc, test_libipm_receive_t_type);
     tcase_add_test(tc, test_libipm_receive_s_type);
+    tcase_add_test(tc, test_libipm_receive_h_type);
     tcase_add_test(tc, test_libipm_receive_B_type);
     tcase_add_test(tc, test_libipm_receive_no_type);
     tcase_add_test(tc, test_libipm_receive_unexpected_type);

--- a/tests/libxrdp/test_libxrdp_main.c
+++ b/tests/libxrdp/test_libxrdp_main.c
@@ -2,6 +2,7 @@
 #include "config_ac.h"
 #endif
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <check.h>
 #include "log.h"
@@ -22,6 +23,9 @@ int main (void)
     struct log_config *lc = log_config_init_for_console(LOG_LEVEL_INFO, NULL);
     log_start_from_param(lc);
     log_config_free(lc);
+    /* Disable stdout buffering, as this can confuse the error
+     * reporting when running in libcheck fork mode */
+    setvbuf(stdout, NULL, _IONBF, 0);
 
     srunner_run_all (sr, CK_ENV);
     number_failed = srunner_ntests_failed(sr);

--- a/tests/memtest/memtest.c
+++ b/tests/memtest/memtest.c
@@ -26,6 +26,9 @@ int main(int argc, char **argv)
     config = log_config_init_for_console(LOG_LEVEL_DEBUG, NULL);
     log_start_from_param(config);
     log_config_free(config);
+    /* Disable stdout buffering, as this can confuse the error
+     * reporting when running in libcheck fork mode */
+    setvbuf(stdout, NULL, _IONBF, 0);
 
     srand(time(0));
     obj = libmem_init(0x80000000, 64 * 1024 * 1024);

--- a/tests/xrdp/test_xrdp_main.c
+++ b/tests/xrdp/test_xrdp_main.c
@@ -33,6 +33,7 @@
 
 #include "log.h"
 #include "os_calls.h"
+#include <stdio.h>
 #include <stdlib.h>
 
 #include "test_xrdp.h"
@@ -49,6 +50,9 @@ int main (void)
                                           g_getenv("TEST_LOG_LEVEL"));
     log_start_from_param(logging);
     log_config_free(logging);
+    /* Disable stdout buffering, as this can confuse the error
+     * reporting when running in libcheck fork mode */
+    setvbuf(stdout, NULL, _IONBF, 0);
 
     sr = srunner_create (make_suite_test_bitmap_load());
     srunner_add_suite(sr, make_suite_egfx_base_functions());

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -2145,7 +2145,7 @@ xrdp_mm_scp_data_in(struct trans *trans)
         struct xrdp_mm *self = (struct xrdp_mm *)(trans->callback_data);
         enum scp_msg_code msgno;
 
-        switch ((msgno = scp_msg_in_start(trans)))
+        switch ((msgno = scp_msg_in_get_msgno(trans)))
         {
             case E_SCP_LOGIN_RESPONSE:
                 rv = xrdp_mm_process_login_response(self);


### PR DESCRIPTION
Add file descriptor passing to libipm.

Additional type 'h' added to libipm types to allow file descriptors to be passed between processes. This is compatible with the D-Bus specification at https://dbus.freedesktop.org/doc/dbus-specification.html

Example send code for an int and a file descriptor:-

```c
int my_int = 10;
int my_fd = g_file_open("/dev/zero");
. . .
status = libipm_msg_out_simple_send(
                 trans,
                 MSG_NO,
                 "ih", my_int, my_fd);
```

Parse with:-

```c
    int32_t my_int;
    int my_fd;
    . . .
    status = libipm_msg_in_parse(
                 trans,
                 "ih",
                 &my_int, &my_fd);
```

Wrapper functions are added to os_calls to do the hard work, and to wrap POSIX `sendmsg()` and `recvmsg()`

Unit tests also added.

This functionality will make implementing the rest of #1961 a bit easier.