### PR TITLE
Use poll() instead of select()

### DIFF
--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -126,7 +126,23 @@ int      g_sck_send_fd_set(int sck, const void *ptr, unsigned int len,
                            int fds[], unsigned int fdcount);
 int      g_sck_last_error_would_block(int sck);
 int      g_sck_socket_ok(int sck);
+/**
+ * Checks socket writeability with an optional wait
+ *
+ * @param sck - Socket to check
+ * @param millis - Maximum milliseconds to wait for writeability to be true
+ *
+ * @note The wait time may not be reached in the event of an incoming signal
+ *       so do not use this call to impose a hard timeout */
 int      g_sck_can_send(int sck, int millis);
+/**
+ * Checks socket readability with an optional wait
+ *
+ * @param sck - Socket to check
+ * @param millis - Maximum milliseconds to wait for readability to be true
+ *
+ * @note The wait time may not be reached in the event of an incoming signal
+ *       so do not use this call to impose a hard timeout */
 int      g_sck_can_recv(int sck, int millis);
 int      g_sck_select(int sck1, int sck2);
 

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -167,6 +167,21 @@ int      g_set_wait_obj(tintptr obj);
 int      g_reset_wait_obj(tintptr obj);
 int      g_is_wait_obj_set(tintptr obj);
 int      g_delete_wait_obj(tintptr obj);
+/**
+ * Wait for the specified readable and writeable objs
+ *
+ * The wait finishes when at least one of the objects becomes
+ * readable or writeable
+ *
+ * @param read_objs Array of read objects
+ * @param rcount Number of elements in read_objs
+ * @param write_objs Array of write objects
+ * @param rcount Number of elements in write_objs
+ * @param mstimeout Timeout in milliseconds. <= 0 means an infinite timeout.
+ *
+ * @return 0 for success. The objects will need to be polled to
+ * find out what is readable or writeable.
+ */
 int      g_obj_wait(tintptr *read_objs, int rcount, tintptr *write_objs,
                     int wcount, int mstimeout);
 void     g_random(char *data, int len);

--- a/sesman/chansrv/chansrv_fuse.c
+++ b/sesman/chansrv/chansrv_fuse.c
@@ -675,7 +675,7 @@ int xfuse_check_wait_objs(void)
         return 0;
     }
 
-    if (g_tcp_select(g_fd, 0) & 1)
+    if (g_sck_can_recv(g_fd, 0))
     {
         tmpch = g_ch;
 

--- a/sesman/tools/xcon.c
+++ b/sesman/tools/xcon.c
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <errno.h>
 #include <poll.h>
 #include <X11/Xlib.h>
 #include <sys/select.h>
@@ -52,7 +53,11 @@ int main(int argc, char **argv)
         pollfd.fd = g_x_socket;
         pollfd.events = POLLIN;
         pollfd.revents = 0;
-        i1 = poll(&pollfd, 1, -1);
+        do
+        {
+            i1 = poll(&pollfd, 1, -1);
+        }
+        while (i1 < 0 && errno == EINTR);
 
         if (i1 < 0)
         {

--- a/sesman/tools/xcon.c
+++ b/sesman/tools/xcon.c
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <poll.h>
 #include <X11/Xlib.h>
 #include <sys/select.h>
 
@@ -32,7 +33,6 @@ int g_x_socket = 0;
 
 int main(int argc, char **argv)
 {
-    fd_set rfds;
     int i1;
     XEvent xevent;
 
@@ -48,9 +48,11 @@ int main(int argc, char **argv)
 
     while (1)
     {
-        FD_ZERO(&rfds);
-        FD_SET(g_x_socket, &rfds);
-        i1 = select(g_x_socket + 1, &rfds, 0, 0, 0);
+        struct pollfd pollfd;
+        pollfd.fd = g_x_socket;
+        pollfd.events = POLLIN;
+        pollfd.revents = 0;
+        i1 = poll(&pollfd, 1, -1);
 
         if (i1 < 0)
         {

--- a/xrdpapi/xrdpapi.c
+++ b/xrdpapi/xrdpapi.c
@@ -47,9 +47,9 @@ struct wts_obj
 
 /* helper functions used by WTSxxx API - do not invoke directly */
 static int
-can_send(int sck, int millis);
+can_send(int sck, int millis, int restart);
 static int
-can_recv(int sck, int millis);
+can_recv(int sck, int millis, int restart);
 static int
 mysend(int sck, const void *adata, int bytes);
 static int
@@ -161,7 +161,7 @@ WTSVirtualChannelOpenEx(unsigned int SessionId, const char *pVirtualName,
     }
 
     /* wait for connection to complete */
-    if (!can_send(wts->fd, 500))
+    if (!can_send(wts->fd, 500, 1))
     {
         LOG(LOG_LEVEL_ERROR, "WTSVirtualChannelOpenEx: can_send failed");
         free(wts);
@@ -213,7 +213,7 @@ WTSVirtualChannelOpenEx(unsigned int SessionId, const char *pVirtualName,
     }
     LOG_DEVEL(LOG_LEVEL_DEBUG, "WTSVirtualChannelOpenEx: sent ok");
 
-    if (!can_recv(wts->fd, 500))
+    if (!can_recv(wts->fd, 500, 1))
     {
         LOG(LOG_LEVEL_ERROR, "WTSVirtualChannelOpenEx: can_recv failed");
         free(wts);
@@ -264,7 +264,7 @@ mysend(int sck, const void *adata, int bytes)
     sent = 0;
     while (sent < bytes)
     {
-        if (can_send(sck, 100))
+        if (can_send(sck, 100, 0))
         {
             error = send(sck, data + sent, bytes - sent, MSG_NOSIGNAL);
             if (error < 1)
@@ -294,7 +294,7 @@ myrecv(int sck, void *adata, int bytes)
     recd = 0;
     while (recd < bytes)
     {
-        if (can_recv(sck, 100))
+        if (can_recv(sck, 100, 0))
         {
             error = recv(sck, data + recd, bytes - recd, MSG_NOSIGNAL);
             if (error < 1)
@@ -329,7 +329,7 @@ WTSVirtualChannelWrite(void *hChannelHandle, const char *Buffer,
         return 0;
     }
 
-    if (!can_send(wts->fd, 0))
+    if (!can_send(wts->fd, 0, 0))
     {
         return 1;    /* can't write now, ok to try again */
     }
@@ -370,7 +370,7 @@ WTSVirtualChannelRead(void *hChannelHandle, unsigned int TimeOut,
         return 0;
     }
 
-    if (can_recv(wts->fd, TimeOut))
+    if (can_recv(wts->fd, TimeOut, 0))
     {
         rv = recv(wts->fd, Buffer, BufferSize, 0);
 
@@ -475,20 +475,29 @@ WTSFreeMemory(void *pMemory)
  *
  * @param  sck    socket to check
  * @param  millis timeout value in milliseconds
+ * @param  restart Try again if interrupted, even if this exceeds the timeout
  *
  * @return 0 if write will block
  * @return 1 if write will not block
  ******************************************************************************/
 static int
-can_send(int sck, int millis)
+can_send(int sck, int millis, int restart)
 {
     int rv = 0;
     struct pollfd pollfd;
+    int status;
 
     pollfd.fd = sck;
     pollfd.events = POLLOUT;
     pollfd.revents = 0;
-    if (poll(&pollfd, 1, millis) > 0)
+
+    do
+    {
+        status = poll(&pollfd, 1, millis);
+    }
+    while (status < 0 && errno == EINTR && restart);
+
+    if (status > 0)
     {
         if ((pollfd.revents & POLLOUT) != 0)
         {
@@ -501,15 +510,22 @@ can_send(int sck, int millis)
 
 /*****************************************************************************/
 static int
-can_recv(int sck, int millis)
+can_recv(int sck, int millis, int restart)
 {
     int rv = 0;
     struct pollfd pollfd;
+    int status;
 
     pollfd.fd = sck;
     pollfd.events = POLLIN;
     pollfd.revents = 0;
-    if (poll(&pollfd, 1, millis) > 0)
+    do
+    {
+        status = poll(&pollfd, 1, millis);
+    }
+    while (status < 0 && errno == EINTR && restart);
+
+    if (status > 0)
     {
         if ((pollfd.revents & (POLLIN | POLLHUP)) != 0)
         {


### PR DESCRIPTION
poll() is specified in POSIX.1-2001 as a simpler interface for multiplexed file descriptors than select(). It also provides more
functionality than select()

This PR replaces the select() calls used in xrdp with poll() equivalents.

I'm seeing a 10-20% improvement in performance times using the file redirector with this (Windows laptop talking to Ubuntu 20.04 VM). This may be down to the increased efficiency with which poll() is able to check single file descriptors (which xrdp does a lot of). I haven't got any figures for graphical improvements.