### PR TITLE
[V0.9] Don't try to listen on the scard socket if it isn't there

### DIFF
--- a/sesman/chansrv/devredir.c
+++ b/sesman/chansrv/devredir.c
@@ -803,8 +803,7 @@ devredir_proc_client_core_cap_resp(struct stream *s)
 
             case CAP_SMARTCARD_TYPE:
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "got CAP_SMARTCARD_TYPE");
-                g_is_smartcard_redir_supported = 1;
-                scard_init();
+                g_is_smartcard_redir_supported = (scard_init() == 0);
                 break;
         }
         xstream_seek(s, cap_len);

--- a/sesman/chansrv/smartcard_pcsc.c
+++ b/sesman/chansrv/smartcard_pcsc.c
@@ -1853,6 +1853,8 @@ scard_pcsc_init(void)
     if (g_lis == 0)
     {
         g_lis = trans_create(2, 8192, 8192);
+        // TODO: See #2501. Use needs a way to move PCSCLITE_CSOCK_NAME
+        // to a location not under $HOME.
         home = g_getenv("HOME");
         disp = g_display_num;
         g_snprintf(g_pcsclite_ipc_dir, 255, "%s/.pcsc%d", home, disp);


### PR DESCRIPTION
Port of #2504 to v0.9 branch.

If the scard local socket can't be created, there's no point in trying to listen on it. This will just fill the chansrv log file with errors.