### PR TITLE
A simple working unit test for the newly introduced EGFX functions

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -1692,12 +1692,7 @@ int
 g_set_wait_obj(tintptr obj)
 {
 #ifdef _WIN32
-    if (obj == 0)
-    {
-        return 0;
-    }
-    SetEvent((HANDLE)obj);
-    return 0;
+#error "Win32 is no longer supported."
 #else
     int error;
     int fd;
@@ -1709,7 +1704,7 @@ g_set_wait_obj(tintptr obj)
     {
         return 0;
     }
-    fd = obj & 0xffff;
+    fd = obj & USHRT_MAX;
     if (g_fd_can_read(fd))
     {
         /* already signalled */

--- a/libxrdp/libxrdpinc.h
+++ b/libxrdp/libxrdpinc.h
@@ -23,6 +23,8 @@
 
 #include "xrdp_rail.h"
 
+struct list;
+
 /* struct xrdp_client_info moved to xrdp_client_info.h */
 
 struct xrdp_brush

--- a/libxrdp/xrdp_orders_rail.h
+++ b/libxrdp/xrdp_orders_rail.h
@@ -19,6 +19,8 @@
 #if !defined(_XRDP_ORDERS_RAIL_H)
 #define _XRDP_ORDERS_RAIL_H
 
+#include "libxrdp.h"
+
 int
 xrdp_orders_send_window_delete(struct xrdp_orders *self, int window_id);
 int

--- a/tests/xrdp/Makefile.am
+++ b/tests/xrdp/Makefile.am
@@ -26,6 +26,7 @@ check_PROGRAMS = test_xrdp
 test_xrdp_SOURCES = \
     test_xrdp.h \
     test_xrdp_main.c \
+    test_xrdp_egfx.c \
     test_bitmap_load.c
 
 test_xrdp_CFLAGS = \
@@ -37,5 +38,24 @@ test_xrdp_LDADD = \
     $(top_builddir)/xrdp/xrdp_bitmap_common.o \
     $(top_builddir)/xrdp/funcs.o \
     $(top_builddir)/common/libcommon.la \
+    $(top_builddir)/libipm/libipm.la \
+    $(top_builddir)/libxrdp/libxrdp.la \
+    $(top_builddir)/libpainter/src/libpainter.la \
+    $(top_builddir)/librfxcodec/src/librfxencode.la \
+    $(top_builddir)/xrdp/lang.o \
+    $(top_builddir)/xrdp/xrdp_mm.o \
+    $(top_builddir)/xrdp/xrdp_wm.o \
+    $(top_builddir)/xrdp/xrdp_font.o \
+    $(top_builddir)/xrdp/xrdp_egfx.o \
+    $(top_builddir)/xrdp/xrdp_cache.o \
+    $(top_builddir)/xrdp/xrdp_region.o \
+    $(top_builddir)/xrdp/xrdp_listen.o \
+    $(top_builddir)/xrdp/xrdp_bitmap.o \
+    $(top_builddir)/xrdp/xrdp_painter.o \
+    $(top_builddir)/xrdp/xrdp_encoder.o \
+    $(top_builddir)/xrdp/xrdp_process.o \
+    $(top_builddir)/xrdp/xrdp_login_wnd.o \
+    $(top_builddir)/xrdp/xrdp_main_utils.o \
+    $(PIXMAN_LIBS) \
     $(IMLIB2_LIBS) \
     @CHECK_LIBS@

--- a/tests/xrdp/test_xrdp.h
+++ b/tests/xrdp/test_xrdp.h
@@ -4,5 +4,6 @@
 #include <check.h>
 
 Suite *make_suite_test_bitmap_load(void);
+Suite *make_suite_egfx_base_functions(void);
 
 #endif /* TEST_XRDP_H */

--- a/xrdp/Makefile.am
+++ b/xrdp/Makefile.am
@@ -60,7 +60,8 @@ xrdp_SOURCES = \
   xrdp_types.h \
   xrdp_egfx.c \
   xrdp_egfx.h \
-  xrdp_wm.c
+  xrdp_wm.c \
+  xrdp_main_utils.c
 
 xrdp_LDADD = \
   $(top_builddir)/common/libcommon.la \

--- a/xrdp/xrdp.c
+++ b/xrdp/xrdp.c
@@ -33,21 +33,7 @@
 #define PACKAGE_VERSION "???"
 #endif
 
-#define THREAD_WAITING 100
-
 static struct xrdp_listen *g_listen = 0;
-static long g_threadid = 0; /* main threadid */
-
-static long g_sync_mutex = 0;
-static long g_sync1_mutex = 0;
-static tbus g_term_event = 0;
-static tbus g_sync_event = 0;
-/* synchronize stuff */
-static int g_sync_command = 0;
-static long g_sync_result = 0;
-static long g_sync_param1 = 0;
-static long g_sync_param2 = 0;
-static long (*g_sync_func)(long param1, long param2);
 
 /*****************************************************************************/
 static void
@@ -85,63 +71,6 @@ print_help(void)
 }
 
 /*****************************************************************************/
-/* This function is used to run a function from the main thread.
-   Sync_func is the function pointer that will run from main thread
-   The function can have two long in parameters and must return long */
-long
-g_xrdp_sync(long (*sync_func)(long param1, long param2), long sync_param1,
-            long sync_param2)
-{
-    long sync_result;
-    int sync_command;
-
-    /* If the function is called from the main thread, the function can
-     * be called directly. g_threadid= main thread ID*/
-    if (tc_threadid_equal(tc_get_threadid(), g_threadid))
-    {
-        /* this is the main thread, call the function directly */
-        /* in fork mode, this always happens too */
-        sync_result = sync_func(sync_param1, sync_param2);
-        LOG_DEVEL(LOG_LEVEL_DEBUG, "g_xrdp_sync processed IN main thread -> continue");
-    }
-    else
-    {
-        /* All threads have to wait here until the main thread
-         * process the function. g_process_waiting_function() is called
-         * from the listening thread. g_process_waiting_function() process the function*/
-        tc_mutex_lock(g_sync1_mutex);
-        tc_mutex_lock(g_sync_mutex);
-        g_sync_param1 = sync_param1;
-        g_sync_param2 = sync_param2;
-        g_sync_func = sync_func;
-        /* set a value THREAD_WAITING so the g_process_waiting_function function
-         * know if any function must be processed */
-        g_sync_command = THREAD_WAITING;
-        tc_mutex_unlock(g_sync_mutex);
-        /* set this event so that the main thread know if
-         * g_process_waiting_function() must be called */
-        g_set_wait_obj(g_sync_event);
-
-        do
-        {
-            g_sleep(100);
-            tc_mutex_lock(g_sync_mutex);
-            /* load new value from global to see if the g_process_waiting_function()
-             * function has processed the function */
-            sync_command = g_sync_command;
-            sync_result = g_sync_result;
-            tc_mutex_unlock(g_sync_mutex);
-        }
-        while (sync_command != 0); /* loop until g_process_waiting_function()
-                                * has processed the request */
-        tc_mutex_unlock(g_sync1_mutex);
-        LOG_DEVEL(LOG_LEVEL_DEBUG, "g_xrdp_sync processed BY main thread -> continue");
-    }
-
-    return sync_result;
-}
-
-/*****************************************************************************/
 /* Signal handler for SIGINT and SIGTERM
  * Note: only signal safe code (eg. setting wait event) should be executed in
  * this function. For more details see `man signal-safety`
@@ -149,10 +78,7 @@ g_xrdp_sync(long (*sync_func)(long param1, long param2), long sync_param1,
 static void
 xrdp_shutdown(int sig)
 {
-    if (!g_is_wait_obj_set(g_term_event))
-    {
-        g_set_wait_obj(g_term_event);
-    }
+    g_set_wait_obj(g_get_term());
 }
 
 /*****************************************************************************/
@@ -166,95 +92,6 @@ xrdp_child(int sig)
     while (g_waitchild() > 0)
     {
     }
-}
-
-/*****************************************************************************/
-/* No-op signal handler.
- * Note: only signal safe code (eg. setting wait event) should be executed in
- * this function. For more details see `man signal-safety`
- */
-static void
-xrdp_sig_no_op(int sig)
-{
-    /* no-op */
-}
-
-/*****************************************************************************/
-/* called in child just after fork */
-int
-xrdp_child_fork(void)
-{
-    int pid;
-    char text[256];
-
-    /* close, don't delete these */
-    g_close_wait_obj(g_term_event);
-    g_close_wait_obj(g_sync_event);
-    pid = g_getpid();
-    g_snprintf(text, 255, "xrdp_%8.8x_main_term", pid);
-    g_term_event = g_create_wait_obj(text);
-    g_snprintf(text, 255, "xrdp_%8.8x_main_sync", pid);
-    g_sync_event = g_create_wait_obj(text);
-    return 0;
-}
-
-/*****************************************************************************/
-int
-g_is_term(void)
-{
-    return g_is_wait_obj_set(g_term_event);
-}
-
-/*****************************************************************************/
-void
-g_set_term(int in_val)
-{
-    if (in_val)
-    {
-        g_set_wait_obj(g_term_event);
-    }
-    else
-    {
-        g_reset_wait_obj(g_term_event);
-    }
-}
-
-/*****************************************************************************/
-tbus
-g_get_term_event(void)
-{
-    return g_term_event;
-}
-
-/*****************************************************************************/
-tbus
-g_get_sync_event(void)
-{
-    return g_sync_event;
-}
-
-/*****************************************************************************/
-/*Some function must be called from the main thread.
- if g_sync_command==THREAD_WAITING a function is waiting to be processed*/
-void
-g_process_waiting_function(void)
-{
-    tc_mutex_lock(g_sync_mutex);
-
-    if (g_sync_command != 0)
-    {
-        if (g_sync_func != 0)
-        {
-            if (g_sync_command == THREAD_WAITING)
-            {
-                g_sync_result = g_sync_func(g_sync_param1, g_sync_param2);
-            }
-        }
-
-        g_sync_command = 0;
-    }
-
-    tc_mutex_unlock(g_sync_mutex);
 }
 
 /*****************************************************************************/
@@ -284,6 +121,16 @@ static int nocase_matches(const char *candidate, ...)
     return result;
 }
 
+/*****************************************************************************/
+/* No-op signal handler.
+ * Note: only signal safe code (eg. setting wait event) should be executed in
+ * this function. For more details see `man signal-safety`
+ */
+static void
+xrdp_sig_no_op(int sig)
+{
+    /* no-op */
+}
 
 /*****************************************************************************/
 /**
@@ -672,29 +519,29 @@ main(int argc, char **argv)
         /* end of daemonizing code */
     }
 
-    g_threadid = tc_get_threadid();
+    g_set_threadid(tc_get_threadid());
     g_listen = xrdp_listen_create();
     g_signal_user_interrupt(xrdp_shutdown); /* SIGINT */
     g_signal_pipe(xrdp_sig_no_op);          /* SIGPIPE */
     g_signal_terminate(xrdp_shutdown);      /* SIGTERM */
     g_signal_child_stop(xrdp_child);        /* SIGCHLD */
     g_signal_hang_up(xrdp_sig_no_op);       /* SIGHUP */
-    g_sync_mutex = tc_mutex_create();
-    g_sync1_mutex = tc_mutex_create();
+    g_set_sync_mutex(tc_mutex_create());
+    g_set_sync1_mutex(tc_mutex_create());
     pid = g_getpid();
     LOG(LOG_LEVEL_INFO, "starting xrdp with pid %d", pid);
     g_snprintf(text, 255, "xrdp_%8.8x_main_term", pid);
-    g_term_event = g_create_wait_obj(text);
+    g_set_term_event(g_create_wait_obj(text));
 
-    if (g_term_event == 0)
+    if (g_get_term() == 0)
     {
         LOG(LOG_LEVEL_WARNING, "error creating g_term_event");
     }
 
     g_snprintf(text, 255, "xrdp_%8.8x_main_sync", pid);
-    g_sync_event = g_create_wait_obj(text);
+    g_set_sync_event(g_create_wait_obj(text));
 
-    if (g_sync_event == 0)
+    if (g_get_sync_event() == 0)
     {
         LOG(LOG_LEVEL_WARNING, "error creating g_sync_event");
     }
@@ -702,10 +549,18 @@ main(int argc, char **argv)
     g_listen->startup_params = &startup_params;
     exit_status = xrdp_listen_main_loop(g_listen);
     xrdp_listen_delete(g_listen);
-    tc_mutex_delete(g_sync_mutex);
-    tc_mutex_delete(g_sync1_mutex);
-    g_delete_wait_obj(g_term_event);
-    g_delete_wait_obj(g_sync_event);
+
+    tc_mutex_delete(g_get_sync_mutex());
+    g_set_sync_mutex(0);
+
+    tc_mutex_delete(g_get_sync1_mutex());
+    g_set_sync1_mutex(0);
+
+    g_delete_wait_obj(g_get_term());
+    g_set_term_event(0);
+
+    g_delete_wait_obj(g_get_sync_event());
+    g_set_sync_event(0);
 
     /* only main process should delete pid file */
     if (daemon && (pid == g_getpid()))

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -41,12 +41,28 @@ g_xrdp_sync(long (*sync_func)(long param1, long param2), long sync_param1,
             long sync_param2);
 int
 xrdp_child_fork(void);
+long
+g_get_sync_mutex(void);
+void
+g_set_sync_mutex(long mutex);
+long
+g_get_sync1_mutex(void);
+void
+g_set_sync1_mutex(long mutex);
+void
+g_set_term_event(tbus event);
+void
+g_set_sync_event(tbus event);
+long
+g_get_threadid(void);
+void
+g_set_threadid(long id);
+tbus
+g_get_term(void);
 int
 g_is_term(void);
 void
 g_set_term(int in_val);
-tbus
-g_get_term_event(void);
 tbus
 g_get_sync_event(void);
 void

--- a/xrdp/xrdp_egfx.c
+++ b/xrdp/xrdp_egfx.c
@@ -18,6 +18,14 @@
  * MS-RDPEGFX
  */
 
+/**
+ *
+ * @file xrdp_egfx.c
+ * @brief Stream functions for the EGFX extension to the MSRDP protocol.
+ * @author Jay Sorg, Christopher Pitstick
+ *
+ */
+
 #if defined(HAVE_CONFIG_H)
 #include <config_ac.h>
 #endif
@@ -29,7 +37,6 @@
 #include "arch.h"
 #include "os_calls.h"
 #include "parse.h"
-#include "xrdp.h"
 #include "xrdp_egfx.h"
 #include "libxrdp.h"
 #include "xrdp_channel.h"

--- a/xrdp/xrdp_egfx.h
+++ b/xrdp/xrdp_egfx.h
@@ -18,8 +18,18 @@
  * MS-RDPEGFX
  */
 
+/**
+ *
+ * @file xrdp_egfx.h
+ * @brief Stream function headers for the EGFX extension to the MSRDP protocol.
+ * @author Jay Sorg, Christopher Pitstick
+ *
+ */
+
 #ifndef _XRDP_EGFX_H
 #define _XRDP_EGFX_H
+
+#include "xrdp.h"
 
 #define XR_RDPGFX_CAPVERSION_8      0x00080004
 #define XR_RDPGFX_CAPVERSION_81     0x00080105

--- a/xrdp/xrdp_encoder.c
+++ b/xrdp/xrdp_encoder.c
@@ -481,7 +481,7 @@ proc_enc_msg(void *arg)
     mutex = self->mutex;
     event_to_proc = self->xrdp_encoder_event_to_proc;
 
-    term_obj = g_get_term_event();
+    term_obj = g_get_term();
     lterm_obj = self->xrdp_encoder_term;
 
     cont = 1;

--- a/xrdp/xrdp_listen.c
+++ b/xrdp/xrdp_listen.c
@@ -875,7 +875,7 @@ xrdp_listen_main_loop(struct xrdp_listen *self)
         self->status = -1;
         return 1;
     }
-    term_obj = g_get_term_event(); /*Global termination event */
+    term_obj = g_get_term(); /*Global termination event */
     sync_obj = g_get_sync_event();
     done_obj = self->pro_done_event;
     cont = 1;

--- a/xrdp/xrdp_main_utils.c
+++ b/xrdp/xrdp_main_utils.c
@@ -1,0 +1,239 @@
+/**
+ * xrdp: A Remote Desktop Protocol server.
+ *
+ * Copyright (C) Jay Sorg 2004-2014
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ *
+ * @file xrdp_main_utils.c
+ * @brief Functions used by XRDP's main() routine and needed elsewhere.
+ * @author Jay Sorg, Christopher Pitstick
+ *
+ */
+
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
+#include "xrdp.h"
+#include "log.h"
+
+#define THREAD_WAITING 100
+
+static long g_threadid = 0; /* main threadid */
+
+static long g_sync_mutex = 0;
+static long g_sync1_mutex = 0;
+static tbus g_term_event = 0;
+static tbus g_sync_event = 0;
+/* synchronize stuff */
+static int g_sync_command = 0;
+static long g_sync_result = 0;
+static long g_sync_param1 = 0;
+static long g_sync_param2 = 0;
+static long (*g_sync_func)(long param1, long param2);
+
+/*****************************************************************************/
+/* This function is used to run a function from the main thread.
+   Sync_func is the function pointer that will run from main thread
+   The function can have two long in parameters and must return long */
+long
+g_xrdp_sync(long (*sync_func)(long param1, long param2), long sync_param1,
+            long sync_param2)
+{
+    long sync_result;
+    int sync_command;
+
+    /* If the function is called from the main thread, the function can
+     * be called directly. g_threadid= main thread ID*/
+    if (tc_threadid_equal(tc_get_threadid(), g_threadid))
+    {
+        /* this is the main thread, call the function directly */
+        /* in fork mode, this always happens too */
+        sync_result = sync_func(sync_param1, sync_param2);
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "g_xrdp_sync processed IN main thread -> continue");
+    }
+    else
+    {
+        /* All threads have to wait here until the main thread
+         * process the function. g_process_waiting_function() is called
+         * from the listening thread. g_process_waiting_function() process the function*/
+        tc_mutex_lock(g_sync1_mutex);
+        tc_mutex_lock(g_sync_mutex);
+        g_sync_param1 = sync_param1;
+        g_sync_param2 = sync_param2;
+        g_sync_func = sync_func;
+        /* set a value THREAD_WAITING so the g_process_waiting_function function
+         * know if any function must be processed */
+        g_sync_command = THREAD_WAITING;
+        tc_mutex_unlock(g_sync_mutex);
+        /* set this event so that the main thread know if
+         * g_process_waiting_function() must be called */
+        g_set_wait_obj(g_sync_event);
+
+        do
+        {
+            g_sleep(100);
+            tc_mutex_lock(g_sync_mutex);
+            /* load new value from global to see if the g_process_waiting_function()
+             * function has processed the function */
+            sync_command = g_sync_command;
+            sync_result = g_sync_result;
+            tc_mutex_unlock(g_sync_mutex);
+        }
+        while (sync_command != 0); /* loop until g_process_waiting_function()
+                                * has processed the request */
+        tc_mutex_unlock(g_sync1_mutex);
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "g_xrdp_sync processed BY main thread -> continue");
+    }
+
+    return sync_result;
+}
+
+/*****************************************************************************/
+/* called in child just after fork */
+int
+xrdp_child_fork(void)
+{
+    int pid;
+    char text[256];
+
+    /* close, don't delete these */
+    g_close_wait_obj(g_term_event);
+    g_close_wait_obj(g_sync_event);
+    pid = g_getpid();
+    g_snprintf(text, 255, "xrdp_%8.8x_main_term", pid);
+    g_term_event = g_create_wait_obj(text);
+    g_snprintf(text, 255, "xrdp_%8.8x_main_sync", pid);
+    g_sync_event = g_create_wait_obj(text);
+    return 0;
+}
+
+/*****************************************************************************/
+long
+g_get_sync_mutex(void)
+{
+    return g_sync_mutex;
+}
+
+/*****************************************************************************/
+void
+g_set_sync_mutex(long mutex)
+{
+    g_sync_mutex = mutex;
+}
+
+/*****************************************************************************/
+long
+g_get_sync1_mutex(void)
+{
+    return g_sync1_mutex;
+}
+
+/*****************************************************************************/
+void
+g_set_sync1_mutex(long mutex)
+{
+    g_sync1_mutex = mutex;
+}
+
+/*****************************************************************************/
+void
+g_set_term_event(tbus event)
+{
+    g_term_event = event;
+}
+
+/*****************************************************************************/
+tbus
+g_get_sync_event(void)
+{
+    return g_sync_event;
+}
+
+/*****************************************************************************/
+void
+g_set_sync_event(tbus event)
+{
+    g_sync_event = event;
+}
+
+/*****************************************************************************/
+long
+g_get_threadid(void)
+{
+    return g_threadid;
+}
+
+/*****************************************************************************/
+void
+g_set_threadid(long id)
+{
+    g_threadid = id;
+}
+
+/*****************************************************************************/
+tbus
+g_get_term(void)
+{
+    return g_term_event;
+}
+
+/*****************************************************************************/
+int
+g_is_term(void)
+{
+    return g_is_wait_obj_set(g_term_event);
+}
+
+/*****************************************************************************/
+void
+g_set_term(int in_val)
+{
+    if (in_val)
+    {
+        g_set_wait_obj(g_term_event);
+    }
+    else
+    {
+        g_reset_wait_obj(g_term_event);
+    }
+}
+
+/*****************************************************************************/
+/*Some function must be called from the main thread.
+ if g_sync_command==THREAD_WAITING a function is waiting to be processed*/
+void
+g_process_waiting_function(void)
+{
+    tc_mutex_lock(g_sync_mutex);
+
+    if (g_sync_command != 0)
+    {
+        if (g_sync_func != 0)
+        {
+            if (g_sync_command == THREAD_WAITING)
+            {
+                g_sync_result = g_sync_func(g_sync_param1, g_sync_param2);
+            }
+        }
+
+        g_sync_command = 0;
+    }
+
+    tc_mutex_unlock(g_sync_mutex);
+}

--- a/xrdp/xrdp_process.c
+++ b/xrdp/xrdp_process.c
@@ -249,7 +249,7 @@ xrdp_process_main_loop(struct xrdp_process *self)
     {
         init_stream(self->server_trans->in_s, 32 * 1024);
 
-        term_obj = g_get_term_event();
+        term_obj = g_get_term();
         cont = 1;
 
         while (cont)

--- a/xrdp/xrdpwin.c
+++ b/xrdp/xrdpwin.c
@@ -124,13 +124,6 @@ g_set_term(int in_val)
 
 /*****************************************************************************/
 tbus
-g_get_term_event(void)
-{
-    return g_term_event;
-}
-
-/*****************************************************************************/
-tbus
 g_get_sync_event(void)
 {
     return g_sync_event;


### PR DESCRIPTION
To maintain good hygiene, we should unit test these EGFX functions.

Doing so was harder than I thought at first. Mainly because EGFX relies on a lot of parts of XRDP that previously haven't been tested before. This means that some headers need to be updated to be more atomic (actually include the data types they use, rather than assume that the C files that include them will happen to have them included elsewhere).

The biggest change, however, involves xrdp.c. Because parts of EGFX eventually pull in parts of the system that pull in xrdp.o, that means the unit tests are at risk of having 2 main functions. I couldn't figure out how to prevent the linker from using that as a conflict, so instead I pulled out the utilities that EGFX needs into a separate utility file, and left everything that xrdp's main function needs in xrdp.c, then included the util file instead of xrdp.c. This should help more broadly with unit testing.

The unit test I actually wrote for EGFX is about as simple as it gets, a simple verification that the first part of one stream is built correctly, but the idea here is to leave this as a first step to write more now that the framework is in place.