### PR TITLE
Adding define guards to xrdp.h

### DIFF
--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -18,6 +18,9 @@
  * main include file
  */
 
+#ifndef _XRDP_XRDP_H_
+#define _XRDP_XRDP_H_
+
 /* include other h files */
 #include "arch.h"
 #include "parse.h"
@@ -595,3 +598,4 @@ server_add_char_alpha(struct xrdp_mod *mod, int font, int character,
 int
 server_session_info(struct xrdp_mod *mod, const char *data, int data_bytes);
 
+#endif


### PR DESCRIPTION
xrdp.h didn't have the standard define guards to prevent duplicate includes of a header. This broke the egfx prototype, so make sure we add this as it's important hygiene for the future.