### PR TITLE
Add missing include guards

### DIFF
--- a/mc/mc.h
+++ b/mc/mc.h
@@ -18,6 +18,9 @@
  * media center
  */
 
+#ifndef MC_H
+#define MC_H
+
 /* include other h files */
 #include "arch.h"
 #include "parse.h"
@@ -102,3 +105,5 @@ struct mod
     int height;
     int bpp;
 };
+
+#endif // MC_H

--- a/neutrinordp/xrdp-neutrinordp.h
+++ b/neutrinordp/xrdp-neutrinordp.h
@@ -17,6 +17,9 @@
  * limitations under the License.
  */
 
+#ifndef XRDP_NEUTRINORDP_H
+#define XRDP_NEUTRINORDP_H
+
 /* include other h files */
 #include "arch.h"
 #include "parse.h"
@@ -235,3 +238,5 @@ struct mod
     int allow_client_kbd_settings;
     struct kbd_overrides kbd_overrides; /* neutrinordp.overide_kbd_* values */
 };
+
+#endif // XRDP_NEUTRINORDP_H

--- a/sesman/chansrv/fifo.h
+++ b/sesman/chansrv/fifo.h
@@ -16,6 +16,9 @@
  * limitations under the License.
  */
 
+#ifndef FIFO_H
+#define FIFO_H
+
 /* FIFO implementation to store a pointer to a user struct */
 
 typedef struct fifo
@@ -33,3 +36,4 @@ int   fifo_insert(FIFO *fp, void *data);
 void *fifo_remove(FIFO *fp);
 void *fifo_peek(FIFO *fp);
 
+#endif // FIFO_H

--- a/xup/xup.h
+++ b/xup/xup.h
@@ -18,6 +18,9 @@
  * libxup main header file
  */
 
+#ifndef XUP_H
+#define XUP_H
+
 /* include other h files */
 #include "arch.h"
 #include "parse.h"
@@ -176,3 +179,5 @@ struct mod
     char *screen_shmem_pixels;
     struct trans *trans;
 };
+
+#endif // XUP_H


### PR DESCRIPTION
Prompted by #2523 

I noted while I was doing this, that we have two fifo.h files:-
- [common/fifo.h](https://github.com/neutrinolabs/xrdp/blob/devel/common/fifo.h)
- [sesman/chansrv/fifo.h](https://github.com/neutrinolabs/xrdp/blob/devel/sesman/chansrv/fifo.h)

I have no idea why this is, but it may be related to performance. It looks like the first one will be consistent, and the second one will be very fast with occasional hiccups if the fifo needs to be resized.

Anyone get any comments on this?