### PR TITLE
xrdp_types.h uses list16

### DIFF
--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -40,6 +40,7 @@
 #define XRDP_MM_IMPLEMENTS_TOUCH(mm) ((mm)->code != XVNC_SESSION_CODE)
 
 struct source_info;
+struct list16;
 
 /* lib */
 struct xrdp_mod


### PR DESCRIPTION
- Declare list16 explicitly as a type that's used so the header will compile standalone.