### PR TITLE
Add core cmocka framework

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,7 @@ FreeBSD_task:
     freebsd_instance:
       image_family: freebsd-12-3
   prepare_script:
-    - pkg install -y $SSL git autoconf automake libtool pkgconf opus jpeg-turbo fdk-aac pixman libX11 libXfixes libXrandr nasm fusefs-libs check imlib2 freetype2
+    - pkg install -y $SSL git autoconf automake libtool pkgconf opus jpeg-turbo fdk-aac pixman libX11 libXfixes libXrandr nasm fusefs-libs check imlib2 freetype2 cmocka
     - git submodule update --init --recursive
   configure_script:
     - ./bootstrap

--- a/configure.ac
+++ b/configure.ac
@@ -519,14 +519,22 @@ AC_CHECK_HEADER([X11/extensions/Xrandr.h], [],
 
 CFLAGS="$save_CFLAGS"
 
-# perform unit tests if libcheck found
+# perform unit tests if libcheck and libmocka found
+perform_unit_tests=yes; # Assume packages will be found
 if test "x$ensure_tests_deps" == "xyes"; then
     PKG_CHECK_MODULES([CHECK], [check >= 0.10.0],
-        [perform_unit_tests=yes],
+        [],
         [AC_MSG_ERROR([please install check, the unit test framework])])
+    # Check if cmocka is available - needed for unit testing
+    PKG_CHECK_MODULES([CMOCKA], [cmocka],
+        [],
+        [AC_MSG_ERROR([please install cmocka, the mocking framework])])
 else
     PKG_CHECK_MODULES([CHECK], [check >= 0.10.0],
-        [perform_unit_tests=yes],
+        [],
+        [perform_unit_tests=no])
+    PKG_CHECK_MODULES([CMOCKA], [cmocka],
+        [],
         [perform_unit_tests=no])
 fi
 
@@ -643,4 +651,3 @@ echo "  LDFLAGS = $LDFLAGS"
 echo '#define XRDP_CONFIGURE_OPTIONS \' > ./xrdp_configure_options.h
 ./config.status --config | xargs -n 1 | sed -e 's/^/"      /' -e 's/$/\\n" \\/' >> ./xrdp_configure_options.h
 echo '""' >> ./xrdp_configure_options.h
-

--- a/scripts/install_xrdp_build_dependencies_with_apt.sh
+++ b/scripts/install_xrdp_build_dependencies_with_apt.sh
@@ -59,6 +59,7 @@ PACKAGES=" \
     nasm \
     pkg-config \
     check \
+    libcmocka-dev
     "
 
 # libfreetype-dev package was renamed from libfreetype6-dev in older
@@ -86,7 +87,7 @@ in
                 ;;
             max)
                 PACKAGES="$PACKAGES \
-                    $PACKAGES_AMD64_MIN
+                    $PACKAGES_AMD64_MIN \
                     $LIBFREETYPE_DEV \
                     libfuse-dev \
                     libjpeg-dev \
@@ -139,6 +140,7 @@ in
 esac
 
 apt-get update
+apt-get upgrade
 apt-get -yq \
     --no-install-suggests \
     --no-install-recommends \


### PR DESCRIPTION
Initial integration with cmocka.

The intent is to first apply this to the xrdp unit tests, but until something uses it directly we'll hold off on updating the Makefile.