### PR TITLE
sound: logging improvements

### DIFF
--- a/sesman/chansrv/audin.c
+++ b/sesman/chansrv/audin.c
@@ -284,6 +284,7 @@ audin_process_formats(int chan_id, struct stream *s)
         in_uint16_le(s, wf->cbSize);
 
         LOG(LOG_LEVEL_INFO, "audin_process_formats:");
+        LOG(LOG_LEVEL_INFO, "      wFormatNo       %d", index);
         LOG(LOG_LEVEL_INFO, "      wFormatTag      %s", audin_wave_format_tag_to_str(wf->wFormatTag));
         LOG(LOG_LEVEL_INFO, "      nChannels       %d", wf->nChannels);
         LOG(LOG_LEVEL_INFO, "      nSamplesPerSec  %d", wf->nSamplesPerSec);

--- a/sesman/chansrv/audin.c
+++ b/sesman/chansrv/audin.c
@@ -282,9 +282,16 @@ audin_process_formats(int chan_id, struct stream *s)
         in_uint16_le(s, wf->nBlockAlign);
         in_uint16_le(s, wf->wBitsPerSample);
         in_uint16_le(s, wf->cbSize);
-        LOG_DEVEL(LOG_LEVEL_INFO, "audin_process_formats: recved format wFormatTag 0x%4.4x "
-                  "nChannels %d nSamplesPerSec %d",
-                  wf->wFormatTag, wf->nChannels, wf->nSamplesPerSec);
+
+        LOG(LOG_LEVEL_INFO, "audin_process_formats:");
+        LOG(LOG_LEVEL_INFO, "      wFormatTag      %s", audin_wave_format_tag_to_str(wf->wFormatTag));
+        LOG(LOG_LEVEL_INFO, "      nChannels       %d", wf->nChannels);
+        LOG(LOG_LEVEL_INFO, "      nSamplesPerSec  %d", wf->nSamplesPerSec);
+        LOG(LOG_LEVEL_INFO, "      nAvgBytesPerSec %d", wf->nAvgBytesPerSec);
+        LOG(LOG_LEVEL_INFO, "      nBlockAlign     %d", wf->nBlockAlign);
+        LOG(LOG_LEVEL_INFO, "      wBitsPerSample  %d", wf->wBitsPerSample);
+        LOG(LOG_LEVEL_INFO, "      cbSize          %d", wf->cbSize);
+
         if (wf->cbSize > 0)
         {
             if (!s_check_rem(s, wf->cbSize))

--- a/sesman/chansrv/audin.c
+++ b/sesman/chansrv/audin.c
@@ -106,7 +106,7 @@ audin_wave_format_tag_to_str(int tag)
         (tag == WAVE_FORMAT_MPEGLAYER3) ? "WAVE_FORMAT_MPEGLAYER3" :
         (tag == WAVE_FORMAT_OPUS)       ? "WAVE_FORMAT_OPUS" :
         (tag == WAVE_FORMAT_AAC)        ? "WAVE_FORMAT_AAC" :
-        NULL;
+        "UNKNOWN";
 }
 
 /*****************************************************************************/

--- a/sesman/chansrv/audin.c
+++ b/sesman/chansrv/audin.c
@@ -89,6 +89,27 @@ static struct xr_wave_format_ex **g_client_formats = NULL;
 static int g_current_format = 0; /* index in g_client_formats */
 
 /*****************************************************************************/
+
+/*
+ * This can be called from sound.c because it includes audin.h.
+ */
+
+const char *
+audin_wave_format_tag_to_str(int tag)
+{
+    return
+        (tag == WAVE_FORMAT_PCM)        ? "WAVE_FORMAT_PCM" :
+        (tag == WAVE_FORMAT_ADPCM)      ? "WAVE_FORMAT_ADPCM" :
+        (tag == WAVE_FORMAT_ALAW)       ? "WAVE_FORMAT_ALAW" :
+        (tag == WAVE_FORMAT_MULAW)      ? "WAVE_FORMAT_MULAW" :
+        (tag == WAVE_FORMAT_MULAW)      ? "WAVE_FORMAT_MULAW" :
+        (tag == WAVE_FORMAT_MPEGLAYER3) ? "WAVE_FORMAT_MPEGLAYER3" :
+        (tag == WAVE_FORMAT_OPUS)       ? "WAVE_FORMAT_OPUS" :
+        (tag == WAVE_FORMAT_AAC)        ? "WAVE_FORMAT_AAC" :
+        NULL;
+}
+
+/*****************************************************************************/
 static int
 cleanup_client_formats(void)
 {

--- a/sesman/chansrv/audin.h
+++ b/sesman/chansrv/audin.h
@@ -22,6 +22,8 @@
 #ifndef _AUDIN_H_
 #define _AUDIN_H_
 
+const char *
+audin_wave_format_tag_to_str(int tag);
 int
 audin_init(void);
 int

--- a/sesman/chansrv/sound.c
+++ b/sesman/chansrv/sound.c
@@ -370,6 +370,7 @@ sound_process_output_format(int aindex, int wFormatTag, int nChannels,
                             int cbSize, char *data)
 {
     LOG(LOG_LEVEL_INFO, "sound_process_output_format:");
+    LOG(LOG_LEVEL_INFO, "      wFormatNo       %d", aindex);
     LOG(LOG_LEVEL_INFO, "      wFormatTag      %s", audin_wave_format_tag_to_str(wFormatTag));
     LOG(LOG_LEVEL_INFO, "      nChannels       %d", nChannels);
     LOG(LOG_LEVEL_INFO, "      nSamplesPerSec  %d", nSamplesPerSec);
@@ -898,6 +899,8 @@ sound_send_wave_data_chunk(char *data, int data_bytes)
     format_index = g_current_client_format_index;
     data_bytes = sound_wave_compress(data, data_bytes, &format_index);
 
+    LOG(LOG_LEVEL_TRACE, "sound_send_wave_data_chunk: wFormatNo %d", format_index);
+
     /* part one of 2 PDU wave info */
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "sound_send_wave_data_chunk: sending %d bytes", data_bytes);
@@ -1057,7 +1060,7 @@ sound_process_wave_confirm(struct stream *s, int size)
     in_uint8(s, cConfirmedBlockNo);
     time_diff = time - g_sent_time[cConfirmedBlockNo & 0xff];
 
-    LOG(LOG_LEVEL_DEBUG, "sound_process_wave_confirm: wTimeStamp %d, "
+    LOG(LOG_LEVEL_TRACE, "sound_process_wave_confirm: wTimeStamp %d, "
         "cConfirmedBlockNo %d time diff %d",
         wTimeStamp, cConfirmedBlockNo, time_diff);
 

--- a/sesman/chansrv/sound.c
+++ b/sesman/chansrv/sound.c
@@ -369,14 +369,14 @@ sound_process_output_format(int aindex, int wFormatTag, int nChannels,
                             int nBlockAlign, int wBitsPerSample,
                             int cbSize, char *data)
 {
-    LOG_DEVEL(LOG_LEVEL_INFO, "sound_process_output_format:");
-    LOG_DEVEL(LOG_LEVEL_INFO, "      wFormatTag      %d", wFormatTag);
-    LOG_DEVEL(LOG_LEVEL_INFO, "      nChannels       %d", nChannels);
-    LOG_DEVEL(LOG_LEVEL_INFO, "      nSamplesPerSec  %d", nSamplesPerSec);
-    LOG_DEVEL(LOG_LEVEL_INFO, "      nAvgBytesPerSec %d", nAvgBytesPerSec);
-    LOG_DEVEL(LOG_LEVEL_INFO, "      nBlockAlign     %d", nBlockAlign);
-    LOG_DEVEL(LOG_LEVEL_INFO, "      wBitsPerSample  %d", wBitsPerSample);
-    LOG_DEVEL(LOG_LEVEL_INFO, "      cbSize          %d", cbSize);
+    LOG(LOG_LEVEL_INFO, "sound_process_output_format:");
+    LOG(LOG_LEVEL_INFO, "      wFormatTag      %s", audin_wave_format_tag_to_str(wFormatTag));
+    LOG(LOG_LEVEL_INFO, "      nChannels       %d", nChannels);
+    LOG(LOG_LEVEL_INFO, "      nSamplesPerSec  %d", nSamplesPerSec);
+    LOG(LOG_LEVEL_INFO, "      nAvgBytesPerSec %d", nAvgBytesPerSec);
+    LOG(LOG_LEVEL_INFO, "      nBlockAlign     %d", nBlockAlign);
+    LOG(LOG_LEVEL_INFO, "      wBitsPerSample  %d", wBitsPerSample);
+    LOG(LOG_LEVEL_INFO, "      cbSize          %d", cbSize);
 
     LOG_DEVEL_HEXDUMP(LOG_LEVEL_TRACE, "", data, cbSize);
 


### PR DESCRIPTION
I realized audio formats disappeared in chansrv log while I was testing #2519. It turned out log levels are too much decreased unintendedly during reworking logging. 

This PR increases the log level of some audio-redirection-related logs. And also improves human readability by converting some constants to strings.