### PR TITLE
log: fix syslog glitch after #2386

### DIFF
--- a/common/log.c
+++ b/common/log.c
@@ -1084,7 +1084,7 @@ internal_log_message(const enum logLevels lvl,
     {
         /* log to syslog*/
         /* %s fix compiler warning 'not a string literal' */
-        syslog(internal_log_xrdp2syslog(lvl), "%s", buff + 20);
+        syslog(internal_log_xrdp2syslog(lvl), "%s", buff + 31);
     }
 
     if (g_staticLogConfig->enable_console


### PR DESCRIPTION
The tail of new datetime format was sticking out.

----

## Before

```
Feb  9 09:14:12 icepick xrdp-sesman[1885]: .473+0900] [ERROR] sesman_main_loop: trans_check_wait_objs failed, removing trans
Feb  9 09:17:44 icepick xrdp-sesman[1885]: .728+0900] [ERROR] sesman_main_loop: trans_check_wait_objs failed, removing trans
Feb  9 09:19:59 icepick xrdp-sesman[1885]: .860+0900] [ERROR] pam_authenticate failed: Authentication error
```


## After
```
Feb  9 10:53:18 icepick xrdp-sesman[53377]: [ERROR] pam_authenticate failed: Authentication error
Feb  9 10:53:18 icepick xrdp-sesman[53377]: [ERROR] sesman_main_loop: trans_check_wait_objs failed, removing trans
```