### PR TITLE
Add free to egfx unit tests

### DIFF
--- a/tests/xrdp/test_xrdp_egfx.c
+++ b/tests/xrdp/test_xrdp_egfx.c
@@ -53,6 +53,8 @@ START_TEST(test_xrdp_egfx_send_create_surface__happy_path)
     unsigned char descriptor;
     in_uint8(s, descriptor);
     ck_assert_int_eq(0xE0, descriptor);
+
+    g_free(bulk);
 }
 END_TEST
 


### PR DESCRIPTION
Missed a free on this unit test. Doesn't directly affect performance or memory leakage, but it's good hygiene to clean this up.