### PR TITLE
improve "#2522 use startup command from /usr/share/xsession ..."

### DIFF
--- a/sesman/startwm.sh
+++ b/sesman/startwm.sh
@@ -85,13 +85,14 @@ wm_start()
   if [ -r /etc/X11/Xsession ]; then
     pre_start
 
-    # if /etc/xrdp/export_desktop_session file exists, souurce it.
-    # /etc/xrdp/export_desktop_session script exports DESKTOP_SESSION environment varible
-    # The value shall be one of "ls -1 /usr/share/xsessions|cut -d. -f1".
-    # e.g. export DESKTOP_SESSION=ubuntu
-    if [ -r /etc/xrdp/export_desktop_session ]; then
-      . /etc/xrdp/export_desktop_session
-    fi
+    # if you want to start preferred desktop environment,
+    # add following line,
+    #  [ -n "$XRDP_SESSION" ] && export DESKTOP_SESSION=<your preferred desktop>
+    # in either of following file.
+    # 1. ~/.profile
+    # 2. create a file (any filename is OK) in /etc/profile.d
+    # <your preferred desktop> shall be one of "ls -1 /usr/share/xsessions/"
+    # e.g.  [ -n "$XRDP_SESSION" ] && export DESKTOP_SESSION==ubuntu
 
     # STARTUP is the default startup command.
     # if $1 is empty and STARTUP was not set

--- a/sesman/startwm.sh
+++ b/sesman/startwm.sh
@@ -57,8 +57,7 @@ post_start()
 
 get_xdg_session_startupcmd()
 {
-  # DESKTOP_SESSION should be set in sesman.ini in the SessionVariables section.
-  # If set and valid then the STARTUP command will be taken from there
+  # If DESKTOP_SESSION is set and valid then the STARTUP command will be taken from there
   # GDM exports environment variables XDG_CURRENT_DESKTOP and XDG_SESSION_DESKTOP.
   # This follows it.
   if [ -n "$1" ] && [ -d /usr/share/xsessions ] \
@@ -90,7 +89,7 @@ wm_start()
     #  [ -n "$XRDP_SESSION" ] && export DESKTOP_SESSION=<your preferred desktop>
     # in either of following file.
     # 1. ~/.profile
-    # 2. create a file (any filename is OK) in /etc/profile.d
+    # 2. create a file (any_filename.sh is OK) in /etc/profile.d
     # <your preferred desktop> shall be one of "ls -1 /usr/share/xsessions/|cut -d. -f1"
     # e.g.  [ -n "$XRDP_SESSION" ] && export DESKTOP_SESSION=ubuntu
 

--- a/sesman/startwm.sh
+++ b/sesman/startwm.sh
@@ -91,8 +91,8 @@ wm_start()
     # in either of following file.
     # 1. ~/.profile
     # 2. create a file (any filename is OK) in /etc/profile.d
-    # <your preferred desktop> shall be one of "ls -1 /usr/share/xsessions/"
-    # e.g.  [ -n "$XRDP_SESSION" ] && export DESKTOP_SESSION==ubuntu
+    # <your preferred desktop> shall be one of "ls -1 /usr/share/xsessions/|cut -d. -f1"
+    # e.g.  [ -n "$XRDP_SESSION" ] && export DESKTOP_SESSION=ubuntu
 
     # STARTUP is the default startup command.
     # if $1 is empty and STARTUP was not set

--- a/sesman/startwm.sh
+++ b/sesman/startwm.sh
@@ -59,13 +59,17 @@ get_xdg_session_startupcmd()
 {
   # DESKTOP_SESSION should be set in sesman.ini in the SessionVariables section.
   # If set and valid then the STARTUP command will be taken from there
+  # GDM exports environment variables XDG_CURRENT_DESKTOP and XDG_SESSION_DESKTOP.
+  # This follows it.
   if [ -n "$1" ] && [ -d /usr/share/xsessions ] \
     && [ -f "/usr/share/xsessions/$1.desktop" ]; then
     STARTUP=$(grep ^Exec= "/usr/share/xsessions/$1.desktop")
     STARTUP=${STARTUP#Exec=*}
     XDG_CURRENT_DESKTOP=$(grep ^DesktopNames= "/usr/share/xsessions/$1.desktop")
     XDG_CURRENT_DESKTOP=${XDG_CURRENT_DESKTOP#DesktopNames=*}
-    echo "env XDG_CURRENT_DESKTOP=\"$XDG_CURRENT_DESKTOP\" $STARTUP"
+    XDG_CURRENT_DESKTOP=${XDG_CURRENT_DESKTOP//;/:}
+    export XDG_CURRENT_DESKTOP
+    export XDG_SESSION_DESKTOP="$DESKTOP_SESSION"
   fi
 }
 
@@ -80,15 +84,23 @@ wm_start()
   # debian
   if [ -r /etc/X11/Xsession ]; then
     pre_start
-    
+
+    # if /etc/xrdp/export_desktop_session file exists, souurce it.
+    # /etc/xrdp/export_desktop_session script exports DESKTOP_SESSION environment varible
+    # The value shall be one of "ls -1 /usr/share/xsessions|cut -d. -f1".
+    # e.g. export DESKTOP_SESSION=ubuntu
+    if [ -r /etc/xrdp/export_desktop_session ]; then
+      . /etc/xrdp/export_desktop_session
+    fi
+
     # STARTUP is the default startup command.
     # if $1 is empty and STARTUP was not set
     # /etc/X11/Xsession.d/50x11-common_determine-startup will fallback to
     # x-session-manager
     if [ -z "$STARTUP" ] && [ -n "$DESKTOP_SESSION" ]; then
-      STARTUP="$(get_xdg_session_startupcmd "$DESKTOP_SESSION")"
+      get_xdg_session_startupcmd "$DESKTOP_SESSION"
     fi
-    
+
     . /etc/X11/Xsession
     post_start
     exit 0


### PR DESCRIPTION
It is good way to set STARTUP in startwm.sh.
Many desktop environments do not start wthout it on debian/ubuntu.
Users need to write lines in .xsessionrc/.xsession., however it is difficult to set environment variables correctly.

This fixes an issue in #2522 and adds some improvements.
- Escape of double quote in following line does not work as expected.
```
    echo "env XDG_CURRENT_DESKTOP=\"$XDG_CURRENT_DESKTOP\" $STARTUP"
```
- replace ';' to ':',  if ';' exists in XDG_CURRENT_DESKTOP. 
This is a workaround for some desktop environments. e.g. gnome-flashback-metacity.
- add to source the file "/etc/xrdp/export_desktop_session", if exists.
#2522 expects DESKTOP_SESSION is set in sesman.ini in the SessionVariables section.
I think it is a bit inconvenient for users to modify sesman.ini.
I added to source the file /etc/xrdp/export_desktop_session, if exists.
Simplest content in /etc/xrdp/export_desktop_session is to just one line to export DESKTOP_SESSION environment variable as follows.
```
export DESKTOP_SESSION=ubuntu
```
Because /etc/xrdp/export_desktop_session is shell script, more functionality can be added.
For example, if multiple users use the server and only userA wants to use gnome-flashback-metacity, and others want to use ubuntu, following /etc/xrdp/export_desktop_session works.
```
if [ "$USER" = "userA" ]; then
  export DESKTOP_SESSION=gnome-flashback-metacity
else
  export DESKTOP_SESSION=ubuntu
fi
```