### PR TITLE
Add waitforx/xrdp-waitforx to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ tests/memtest/memtest
 tests/xrdp/test_xrdp
 tools/devel/tcp_proxy/tcp_proxy
 *.trs
+waitforx/xrdp-waitforx
 xrdp/xrdp
 xrdp/xrdp.ini
 xrdp_configure_options.h


### PR DESCRIPTION
Follow-up to #2492 so executable doesn't show in `git status` output