### PR TITLE
Fix CI build break

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,10 @@ jobs:
           echo "LDFLAGS=$LDFLAGS_${{ matrix.arch }}" >> $GITHUB_ENV
       - uses: actions/checkout@v3
       - name: "Install Dependencies"
-        run: sudo scripts/install_xrdp_build_dependencies_with_apt.sh ${{ matrix.feature_set }} ${{ matrix.arch }} --allow-downgrades --allow-remove-essential --allow-change-held-packages
+        # See https://github.com/actions/runner-images/issues/7192
+        run: |
+          echo RESET grub-efi/install_devices | sudo debconf-communicate grub-pc
+          sudo scripts/install_xrdp_build_dependencies_with_apt.sh ${{ matrix.feature_set }} ${{ matrix.arch }} --allow-downgrades --allow-remove-essential --allow-change-held-packages
       - name: Bootstrap
         run: ./bootstrap
       - name: configure


### PR DESCRIPTION
This is based on [this comment](/actions/runner-images/issues/7192#issuecomment-1445902492) which was posted in the middle on the night Eastern time. So you wont have seen this @Nexarian 

My own personal preference would be to remove the `apt-get upgrade` line as this is quicker, but this should do the job too.