### PR TITLE
Poll regression

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -2059,6 +2059,17 @@ g_obj_wait(tintptr *read_objs, int rcount, tintptr *write_objs, int wcount,
         }
 
         rv = (poll(pollfd, j, mstimeout) < 0);
+        if (rv != 0)
+        {
+            /* these are not really errors */
+            if ((errno == EAGAIN) ||
+                    (errno == EWOULDBLOCK) ||
+                    (errno == EINPROGRESS) ||
+                    (errno == EINTR)) /* signal occurred */
+            {
+                rv = 0;
+            }
+        }
     }
 
     return rv;


### PR DESCRIPTION
Following #2497, sending a HUP to sesman produces an extra unwanted logging line:-

<pre>
[2023-02-27T10:57:46.221+0000] [INFO ] [sesman_main_loop(sesman.c:513)] Sesman now listening on /var/run/xrdp-sesman/sesman.socket
<b>[2023-02-27T10:58:10.255+0000] [WARN ] [sesman_main_loop(sesman.c:561)] sesman_main_loop: Unexpected error from g_obj_wait()</b>
[2023-02-27T10:58:10.865+0000] [INFO ] [sig_sesman_reload_cfg(sig.c:48)] receiving SIGHUP
[2023-02-27T10:58:10.915+0000] [INFO ] [sig_sesman_reload_cfg(sig.c:96)] configuration reloaded, log subsystem restarted
</pre>

This is a drop-off on my part. I'd neglected to port the check for a signal return from the system call from the previous code.

Draft for now until we've sorted out the ongoing CI issues.