### PR TITLE
charsrv: Fix potential null dereference

### DIFF
--- a/sesman/chansrv/chansrv.c
+++ b/sesman/chansrv/chansrv.c
@@ -317,6 +317,10 @@ send_rail_drawing_orders(char *data, int size)
     int error;
 
     s = trans_get_out_s(g_con_trans, 8192);
+    if (s == NULL)
+    {
+        return 1;
+    }
     out_uint32_le(s, 0); /* version */
     out_uint32_le(s, 8 + 8 + size); /* size */
     out_uint32_le(s, 10); /* msg id */

--- a/sesman/chansrv/smartcard_pcsc.c
+++ b/sesman/chansrv/smartcard_pcsc.c
@@ -498,6 +498,10 @@ scard_function_establish_context_return(void *user_data,
                   "app_context %d", app_context);
     }
     out_s = trans_get_out_s(con, 8192);
+    if (out_s == NULL)
+    {
+        return 1;
+    }
     s_push_layer(out_s, iso_hdr, 8);
     out_uint32_le(out_s, app_context);
     out_uint32_le(out_s, status); /* SCARD_S_SUCCESS status */
@@ -564,6 +568,10 @@ scard_function_release_context_return(void *user_data,
     }
     con = uds_client->con;
     out_s = trans_get_out_s(con, 8192);
+    if (out_s == NULL)
+    {
+        return 1;
+    }
     s_push_layer(out_s, iso_hdr, 8);
     out_uint32_le(out_s, status); /* SCARD_S_SUCCESS status */
     s_mark_end(out_s);
@@ -723,6 +731,10 @@ scard_function_list_readers_return(void *user_data,
     }
 
     out_s = trans_get_out_s(con, 8192);
+    if (out_s == NULL)
+    {
+        return 1;
+    }
     s_push_layer(out_s, iso_hdr, 8);
     out_uint32_le(out_s, llen);
     out_uint32_le(out_s, readers);
@@ -826,6 +838,10 @@ scard_function_connect_return(void *user_data,
         }
     }
     out_s = trans_get_out_s(con, 8192);
+    if (out_s == NULL)
+    {
+        return 1;
+    }
     s_push_layer(out_s, iso_hdr, 8);
     out_uint32_le(out_s, hCard);
     out_uint32_le(out_s, dwActiveProtocol);
@@ -894,6 +910,10 @@ scard_function_disconnect_return(void *user_data,
     }
     con = uds_client->con;
     out_s = trans_get_out_s(con, 8192);
+    if (out_s == NULL)
+    {
+        return 1;
+    }
     s_push_layer(out_s, iso_hdr, 8);
     out_uint32_le(out_s, status); /* SCARD_S_SUCCESS status */
     s_mark_end(out_s);
@@ -960,6 +980,10 @@ scard_function_begin_transaction_return(void *user_data,
     }
     con = uds_client->con;
     out_s = trans_get_out_s(con, 8192);
+    if (out_s == NULL)
+    {
+        return 1;
+    }
     s_push_layer(out_s, iso_hdr, 8);
     out_uint32_le(out_s, status); /* SCARD_S_SUCCESS status */
     s_mark_end(out_s);
@@ -1030,6 +1054,10 @@ scard_function_end_transaction_return(void *user_data,
     con = uds_client->con;
 
     out_s = trans_get_out_s(con, 8192);
+    if (out_s == NULL)
+    {
+        return 1;
+    }
     s_push_layer(out_s, iso_hdr, 8);
     out_uint32_le(out_s, status); /* SCARD_S_SUCCESS status */
     s_mark_end(out_s);
@@ -1179,6 +1207,10 @@ scard_function_transmit_return(void *user_data,
     }
     LOG_DEVEL(LOG_LEVEL_DEBUG, "scard_function_transmit_return: cbRecvLength %d", cbRecvLength);
     out_s = trans_get_out_s(con, 8192);
+    if (out_s == NULL)
+    {
+        return 1;
+    }
     s_push_layer(out_s, iso_hdr, 8);
     out_uint32_le(out_s, recv_ior.dwProtocol);
     out_uint32_le(out_s, recv_ior.cbPciLength);
@@ -1274,6 +1306,10 @@ scard_function_control_return(void *user_data,
     }
     LOG_DEVEL(LOG_LEVEL_DEBUG, "scard_function_control_return: cbRecvLength %d", cbRecvLength);
     out_s = trans_get_out_s(con, 8192);
+    if (out_s == NULL)
+    {
+        return 1;
+    }
     s_push_layer(out_s, iso_hdr, 8);
     out_uint32_le(out_s, cbRecvLength);
     out_uint8a(out_s, recvBuf, cbRecvLength);
@@ -1447,6 +1483,10 @@ scard_function_status_return(void *user_data,
               "dwProtocol %d dwState %d name %s",
               dwAtrLen, dwReaderLen, dwProtocol, dwState, lreader_name);
     out_s = trans_get_out_s(con, 8192);
+    if (out_s == NULL)
+    {
+        return 1;
+    }
     s_push_layer(out_s, iso_hdr, 8);
     dwReaderLen = g_strlen(lreader_name);
     out_uint32_le(out_s, dwReaderLen);
@@ -1560,6 +1600,10 @@ scard_function_get_status_change_return(void *user_data,
     con = uds_client->con;
 
     out_s = trans_get_out_s(con, 8192);
+    if (out_s == NULL)
+    {
+        return 1;
+    }
     s_push_layer(out_s, iso_hdr, 8);
     if (status != 0)
     {
@@ -1650,6 +1694,10 @@ scard_function_cancel_return(void *user_data,
     }
     con = uds_client->con;
     out_s = trans_get_out_s(con, 8192);
+    if (out_s == NULL)
+    {
+        return 1;
+    }
     s_push_layer(out_s, iso_hdr, 8);
     out_uint32_le(out_s, status); /* SCARD_S_SUCCESS status */
     s_mark_end(out_s);


### PR DESCRIPTION
**Description**
Fix the null dereference warning detected by static analyse tool infer@facebook

**Warning Type**
Null Dereference

**Component Name**
xrdp/sesman/charsrv/charsrv.c (line:319)
xrdp/sesman/charsrv/smartcard_pcsc.c (line:500)
xrdp/sesman/charsrv/smartcard_pcsc.c (line:570)
xrdp/sesman/charsrv/smartcard_pcsc.c (line:733)
xrdp/sesman/charsrv/smartcard_pcsc.c (line:840)
xrdp/sesman/charsrv/smartcard_pcsc.c (line:912)
xrdp/sesman/charsrv/smartcard_pcsc.c (line:982)
xrdp/sesman/charsrv/smartcard_pcsc.c (line:1056)
xrdp/sesman/charsrv/smartcard_pcsc.c (line:1209)
xrdp/sesman/charsrv/smartcard_pcsc.c (line:1308)
xrdp/sesman/charsrv/smartcard_pcsc.c (line:1485)
xrdp/sesman/charsrv/smartcard_pcsc.c (line:1602)
xrdp/sesman/charsrv/smartcard_pcsc.c (line:1696)

**Additional Information**
pointer `s` last assigned on line 319 could be null and is dereferenced at line 320.
pointer `out_s` last assigned on line 500 could be null and is dereferenced at line 501.
pointer `out_s` last assigned on line 570 could be null and is dereferenced at line 571.
pointer `out_s` last assigned on line 733 could be null and is dereferenced at line 734.
pointer `out_s` last assigned on line 840 could be null and is dereferenced at line 841.
pointer `out_s` last assigned on line 912 could be null and is dereferenced at line 913.
pointer `out_s` last assigned on line 982 could be null and is dereferenced at line 983.
pointer `out_s` last assigned on line 1056 could be null and is dereferenced at line 1057.
pointer `out_s` last assigned on line 1209 could be null and is dereferenced at line 1210.
pointer `out_s` last assigned on line 1308 could be null and is dereferenced at line 1309.
pointer `out_s` last assigned on line 1485 could be null and is dereferenced at line 1486.
pointer `out_s` last assigned on line 1602 could be null and is dereferenced at line 1603.
pointer `out_s` last assigned on line 1696 could be null and is dereferenced at line 1697.