### PR TITLE
Fix regression in list module

### DIFF
--- a/common/list.c
+++ b/common/list.c
@@ -204,6 +204,7 @@ list_remove_item(struct list *self, int index)
 int
 list_insert_item(struct list *self, int index, tbus item)
 {
+    int i;
 
     if (index > self->count)
     {
@@ -219,15 +220,13 @@ list_insert_item(struct list *self, int index, tbus item)
         return 0;
     }
 
-    self->count++;
-    if (self->count >= 2)
+    // Move all the items above this location up one
+    for (i = self->count ; i > index ; --i)
     {
-        unsigned int i;
-        for (i = (self->count - 2); i >= (unsigned int)index; i--)
-        {
-            self->items[i + 1] = self->items[i];
-        }
+        self->items[i] = self->items[i - 1];
     }
+
+    self->count++;
 
     self->items[index] = item;
     return 1;

--- a/tests/common/test_list_calls.c
+++ b/tests/common/test_list_calls.c
@@ -42,6 +42,11 @@ START_TEST(test_list__simple)
     val = list_get_item(lst, 10);
     ck_assert_int_eq(val, 10);
 
+    list_insert_item(lst, 0, 99);
+    ck_assert_int_eq(lst->count, TEST_LIST_SIZE + 1);
+    val = list_get_item(lst, 10);
+    ck_assert_int_eq(val, 9);
+
     list_clear(lst);
     ck_assert_int_eq(lst->count, 0);
     list_delete(lst);


### PR DESCRIPTION
Changes I made to the list module recently caused problems when inserting an element at position 0 in a list.

This PR fixes the regression and introduces a unit test that fails without the fix.