### PR TITLE
[refactoring] xrdp: enable loading any keymap files

### DIFF
--- a/xrdp/lang.c
+++ b/xrdp/lang.c
@@ -287,8 +287,8 @@ int km_load_file(const char *filename, struct xrdp_keymap *keymap)
 {
     int fd;
 
-    fd = g_file_open(filename);
     LOG(LOG_LEVEL_INFO, "Loading keymap file %s", filename);
+    fd = g_file_open(filename);
 
     if (fd != -1)
     {
@@ -306,6 +306,7 @@ int km_load_file(const char *filename, struct xrdp_keymap *keymap)
     }
     else
     {
+        LOG(LOG_LEVEL_ERROR, "Error loading keymap file %s (%s)", filename, g_get_strerror());
         return 1;
     }
 

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -411,6 +411,9 @@ get_char_from_scan_code(int device_flags, int scan_code, int *keys,
 int
 get_keymaps(int keylayout, struct xrdp_keymap *keymap);
 
+int
+km_load_file(const char *filename, struct xrdp_keymap *keymap);
+
 /* xrdp_login_wnd.c */
 /**
  * Gets the DPI of the login (primary) monitor


### PR DESCRIPTION
by separating functions. This makes it easier to create unit tests.

-------

## Background

I'm in the initial implementation stage of TOML config parser. Firstly, I started to TOML parser for keymap files.

I would like to confirm TOML parser is valid by comparing results of current INI parser and TOML parser are the same in unit tests.  For this purpose, I need functions that can load any keymap file.

Pseudo test code will be like this:

```C

struct xrdp_keymap *keymap_ini;
struct xrdp_keymap *keymap_toml;

get_keymaps_by_file("./km-00000409.ini", keymap_ini);
get_keymaps_by_file_toml("./km-00000409.toml", keymap_toml);

compare_xrdp_keymap(keymap_ini, keymap_toml);
```