### PR TITLE
Add AM_CPPFLAGS to makefile.am for waitforx

### DIFF
--- a/waitforx/Makefile.am
+++ b/waitforx/Makefile.am
@@ -2,7 +2,10 @@ bin_PROGRAMS = \
   xrdp-waitforx
 
 AM_LDFLAGS = -lX11 -lXrandr
-AM_CFLAGS = -I$(top_srcdir)/common
+
+AM_CPPFLAGS = -I$(top_srcdir)/common
+
+AM_CFLAGS = $(X_CFLAGS)
 
 xrdp_waitforx_SOURCES = waitforx.c
 


### PR DESCRIPTION
Without this, the compilation of waitforx can fail on FreeBSD with this error:-

waitforx.c:1:10: fatal error: 'X11/extensions/Xrandr.h' file not found

This PR makes the use of AM_CPPFLAGS and AM_CFLAGS the same as that for (e.g.) chansrv which also depends on X includes