### PR TITLE
Restructure session start

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -1398,6 +1398,13 @@ g_sleep(int msecs)
 
 /*****************************************************************************/
 int
+g_pipe(int fd[2])
+{
+    return pipe(fd);
+}
+
+/*****************************************************************************/
+int
 g_sck_last_error_would_block(int sck)
 {
 #if defined(_WIN32)
@@ -2345,6 +2352,24 @@ mode_t_to_hex(mode_t mode)
 #endif
 
 /*****************************************************************************/
+/* Duplicates a file descriptor onto another one using the semantics
+ * of dup2() */
+/* return boolean */
+int
+g_file_duplicate_on(int fd, int target_fd)
+{
+    int rv = (dup2(fd, target_fd) >= 0);
+
+    if (rv < 0)
+    {
+        LOG(LOG_LEVEL_ERROR, "Can't clone file %d as file %d [%s]",
+            fd, target_fd, g_get_strerror());
+    }
+
+    return rv;
+}
+
+/*****************************************************************************/
 /* returns error */
 int
 g_chmod_hex(const char *filename, int flags)
@@ -3051,9 +3076,11 @@ g_set_allusercontext(int uid)
 #endif
 /*****************************************************************************/
 /* does not work in win32
-   returns pid of process that exits or zero if signal occurred */
+   returns pid of process that exits or zero if signal occurred
+   an exit_status struct can optionally be passed in to get the
+   exit status of the child */
 int
-g_waitchild(void)
+g_waitchild(struct exit_status *e)
 {
 #if defined(_WIN32)
     return 0;
@@ -3061,14 +3088,35 @@ g_waitchild(void)
     int wstat;
     int rv;
 
+    struct exit_status dummy;
+
+    if (e == NULL)
+    {
+        e = &dummy;  // Set this, then throw it away
+    }
+
+    e->reason = E_XR_UNEXPECTED;
+    e->val = 0;
+
     rv = waitpid(0, &wstat, WNOHANG);
 
     if (rv == -1)
     {
-        if (errno == EINTR) /* signal occurred */
+        if (errno == EINTR)
         {
+            /* This shouldn't happen as signal handlers use SA_RESTART */
             rv = 0;
         }
+    }
+    else if (WIFEXITED(wstat))
+    {
+        e->reason = E_XR_STATUS_CODE;
+        e->val = WEXITSTATUS(wstat);
+    }
+    else if (WIFSIGNALED(wstat))
+    {
+        e->reason = E_XR_SIGNAL;
+        e->val = WTERMSIG(wstat);
     }
 
     return rv;
@@ -3077,7 +3125,10 @@ g_waitchild(void)
 
 /*****************************************************************************/
 /* does not work in win32
-   returns pid of process that exits or <= 0 if no process was found */
+   returns pid of process that exits or <= 0 if no process was found
+
+   Note that signal handlers are established with BSD-style semantics,
+   so this call is NOT interrupted by a signal  */
 int
 g_waitpid(int pid)
 {
@@ -3101,25 +3152,21 @@ g_waitpid(int pid)
 
 /*****************************************************************************/
 /* does not work in win32
-   returns exit status code of child process with pid */
+   returns exit status code of child process with pid
+
+   Note that signal handlers are established with BSD-style semantics,
+   so this call is NOT interrupted by a signal  */
 struct exit_status
 g_waitpid_status(int pid)
 {
-    struct exit_status exit_status;
+    struct exit_status exit_status = {.reason = E_XR_UNEXPECTED, .val = 0};
 
-#if defined(_WIN32)
-    exit_status.exit_code = -1;
-    exit_status.signal_no = 0;
-    return exit_status;
-#else
-    int rv;
-    int status;
-
-    exit_status.exit_code = -1;
-    exit_status.signal_no = 0;
-
+#if !defined(_WIN32)
     if (pid > 0)
     {
+        int rv;
+        int status;
+
         LOG(LOG_LEVEL_DEBUG, "waiting for pid %d to exit", pid);
         rv = waitpid(pid, &status, 0);
 
@@ -3127,11 +3174,13 @@ g_waitpid_status(int pid)
         {
             if (WIFEXITED(status))
             {
-                exit_status.exit_code = WEXITSTATUS(status);
+                exit_status.reason = E_XR_STATUS_CODE;
+                exit_status.val = WEXITSTATUS(status);
             }
             if (WIFSIGNALED(status))
             {
-                exit_status.signal_no = WTERMSIG(status);
+                exit_status.reason = E_XR_SIGNAL;
+                exit_status.val = WTERMSIG(status);
             }
         }
         else
@@ -3140,8 +3189,8 @@ g_waitpid_status(int pid)
         }
     }
 
-    return exit_status;
 #endif
+    return exit_status;
 }
 
 /*****************************************************************************/

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -23,13 +23,17 @@
 
 #include "arch.h"
 
+enum exit_reason
+{
+    E_XR_STATUS_CODE = 0, ///< 'val' contains exit status
+    E_XR_SIGNAL, ///< 'val' contains a signal number
+    E_XR_UNEXPECTED
+};
+
 struct exit_status
 {
-    /* set to -1 when the process exited via a signal */
-    uint8_t exit_code;
-
-    /* set to 0 when the process exited normally */
-    uint8_t signal_no;
+    enum exit_reason reason;
+    int val;
 };
 
 struct list;
@@ -178,6 +182,8 @@ const char *
 g_sck_get_peer_description(int sck,
                            char *desc, unsigned int bytes);
 void     g_sleep(int msecs);
+int      g_pipe(int fd[2]);
+
 tintptr  g_create_wait_obj(const char *name);
 tintptr  g_create_wait_obj_from_socket(tintptr socket, int write);
 void     g_delete_wait_obj_from_socket(tintptr wait_obj);
@@ -213,6 +219,7 @@ int      g_file_read(int fd, char *ptr, int len);
 int      g_file_write(int fd, const char *ptr, int len);
 int      g_file_seek(int fd, int offset);
 int      g_file_lock(int fd, int start, int len);
+int      g_file_duplicate_on(int fd, int target_fd);
 int      g_chmod_hex(const char *filename, int flags);
 int      g_umask_hex(int flags);
 int      g_chown(const char *name, int uid, int gid);
@@ -273,7 +280,7 @@ int      g_setlogin(const char *name);
  */
 int      g_set_allusercontext(int uid);
 #endif
-int      g_waitchild(void);
+int      g_waitchild(struct exit_status *e);
 int      g_waitpid(int pid);
 struct exit_status g_waitpid_status(int pid);
 void     g_clearenv(void);

--- a/libipm/scp_application_types.c
+++ b/libipm/scp_application_types.c
@@ -66,7 +66,8 @@ scp_screate_status_to_str(enum scp_screate_status n,
         (n == E_SCP_SCREATE_NO_MEMORY) ? "No memory for session" :
         (n == E_SCP_SCREATE_NOT_LOGGED_IN) ? "Connection is not logged in" :
         (n == E_SCP_SCREATE_MAX_REACHED) ? "Max session limit reached" :
-        (n == E_SCP_SCREATE_NO_DISPLAY) ? "No X displays are avaiable" :
+        (n == E_SCP_SCREATE_NO_DISPLAY) ? "No X displays are available" :
+        (n == E_SCP_SCREATE_X_SERVER_FAIL) ? "X server could not be started" :
         (n == E_SCP_SCREATE_GENERAL_ERROR) ? "General session creation error" :
         /* Default */ NULL;
 

--- a/libipm/scp_application_types.h
+++ b/libipm/scp_application_types.h
@@ -95,6 +95,7 @@ enum scp_screate_status
     E_SCP_SCREATE_NOT_LOGGED_IN, ///< Connection is not logged in
     E_SCP_SCREATE_MAX_REACHED, ///< Max number of sessions already reached
     E_SCP_SCREATE_NO_DISPLAY, ///< No X server display number is available
+    E_SCP_SCREATE_X_SERVER_FAIL, ///< X server could not be started
     E_SCP_SCREATE_GENERAL_ERROR ///< An unspecific error has occurred
 };
 

--- a/sesman/Makefile.am
+++ b/sesman/Makefile.am
@@ -33,6 +33,8 @@ xrdp_sesman_SOURCES = \
   sesman.h \
   session.c \
   session.h \
+  session_list.c \
+  session_list.h \
   sig.c \
   sig.h \
   xauth.c \

--- a/sesman/chansrv/chansrv.c
+++ b/sesman/chansrv/chansrv.c
@@ -1522,7 +1522,7 @@ child_signal_handler(int sig)
     LOG_DEVEL(LOG_LEVEL_INFO, "child_signal_handler:");
     do
     {
-        pid = g_waitchild();
+        pid = g_waitchild(NULL);
         LOG_DEVEL(LOG_LEVEL_INFO, "child_signal_handler: child pid %d", pid);
         if ((pid == g_exec_pid) && (pid > 0))
         {

--- a/sesman/scp_process.c
+++ b/sesman/scp_process.c
@@ -212,7 +212,7 @@ allocate_and_start_session(struct auth_info *auth_info,
     struct session_chain *temp = (struct session_chain *)NULL;
 
     /* check to limit concurrent sessions */
-    if (session_get_count() >= (unsigned int)g_cfg->sess.max_sessions)
+    if (session_list_get_count() >= (unsigned int)g_cfg->sess.max_sessions)
     {
         LOG(LOG_LEVEL_ERROR, "max concurrent session limit "
             "exceeded. login for user %s denied", username);
@@ -299,7 +299,7 @@ allocate_and_start_session(struct auth_info *auth_info,
     temp->item->type = params->type;
     temp->item->status = SESMAN_SESSION_STATUS_ACTIVE;
 
-    session_chain_add(temp);
+    session_list_add(temp);
 
     return E_SCP_SCREATE_OK;
 }
@@ -513,8 +513,8 @@ process_create_session_request(struct sesman_con *sc)
                 sc->peername, sc->username);
 
             struct session_item *s_item =
-                session_get_bydata(sc->uid, sp.type, sp.width, sp.height,
-                                   sp.bpp, sc->ip_addr);
+                session_list_get_bydata(sc->uid, sp.type, sp.width, sp.height,
+                                        sp.bpp, sc->ip_addr);
             if (s_item != 0)
             {
                 // Found an existing session
@@ -544,7 +544,7 @@ process_create_session_request(struct sesman_con *sc)
                 //
                 // Get the rest of the parameters for the session
                 guid = guid_new();
-                display = session_get_available_display();
+                display = session_list_get_available_display();
 
                 sp.guid = guid;
                 sp.display = display;
@@ -612,8 +612,8 @@ process_list_sessions_request(struct sesman_con *sc)
             "Received request from %s to list sessions for user %s",
             sc->peername, sc->username);
 
-        info = session_get_byuid(sc->uid, &cnt,
-                                 SESMAN_SESSION_STATUS_ALL);
+        info = session_list_get_byuid(sc->uid, &cnt,
+                                      SESMAN_SESSION_STATUS_ALL);
 
         for (i = 0; rv == 0 && i < cnt; ++i)
         {

--- a/sesman/scp_process.c
+++ b/sesman/scp_process.c
@@ -31,11 +31,14 @@
 #include "trans.h"
 #include "os_calls.h"
 #include "scp.h"
+#include "config.h"
 
 #include "scp_process.h"
 #include "access.h"
 #include "auth.h"
+#include "guid.h"
 #include "os_calls.h"
+#include "session_list.h"
 #include "session.h"
 #include "sesman.h"
 #include "string_calls.h"
@@ -193,6 +196,112 @@ process_set_peername_request(struct sesman_con *sc)
     }
 
     return rv;
+}
+
+/******************************************************************************/
+/**
+ * Allocates a chain item and starts the session
+ */
+static enum scp_screate_status
+allocate_and_start_session(struct auth_info *auth_info,
+                           const char *username,
+                           const char *ip_addr,
+                           const struct session_parameters *params)
+{
+    int pid = 0;
+    struct session_chain *temp = (struct session_chain *)NULL;
+
+    /* check to limit concurrent sessions */
+    if (session_get_count() >= (unsigned int)g_cfg->sess.max_sessions)
+    {
+        LOG(LOG_LEVEL_ERROR, "max concurrent session limit "
+            "exceeded. login for user %s denied", username);
+        return E_SCP_SCREATE_MAX_REACHED;
+    }
+
+    temp = (struct session_chain *)g_malloc(sizeof(struct session_chain), 0);
+
+    if (temp == 0)
+    {
+        LOG(LOG_LEVEL_ERROR, "Out of memory error: cannot create new session "
+            "chain element - user %s", username);
+        return E_SCP_SCREATE_NO_MEMORY;
+    }
+
+    temp->item = (struct session_item *)g_malloc(sizeof(struct session_item), 0);
+
+    if (temp->item == 0)
+    {
+        g_free(temp);
+        LOG(LOG_LEVEL_ERROR, "Out of memory error: cannot create new session "
+            "item - user %s", username);
+        return E_SCP_SCREATE_NO_MEMORY;
+    }
+
+    pid = g_fork();
+    if (pid == -1)
+    {
+        LOG(LOG_LEVEL_ERROR,
+            "[session start] (display %d): Failed to fork for scp with "
+            "errno: %d, description: %s",
+            params->display, g_get_errno(), g_get_strerror());
+        g_free(temp->item);
+        g_free(temp);
+        return E_SCP_SCREATE_GENERAL_ERROR;
+    }
+
+    if (pid == 0)
+    {
+        /**
+         * We're now forked from the main sesman process, so we
+         * can close file descriptors that we no longer need */
+
+        sesman_close_all(0);
+
+        /* Wait objects created in a parent are not valid in a child */
+        g_delete_wait_obj(g_reload_event);
+        g_delete_wait_obj(g_sigchld_event);
+        g_delete_wait_obj(g_term_event);
+
+        session_start(auth_info, params);
+        g_exit(1); /* Should not get here */
+    }
+
+    if (ip_addr[0] != '\0')
+    {
+        LOG(LOG_LEVEL_INFO, "++ created session: username %s, ip %s",
+            username, ip_addr);
+    }
+    else
+    {
+        LOG(LOG_LEVEL_INFO, "++ created session: username %s", username);
+    }
+
+    LOG(LOG_LEVEL_INFO, "Starting session: session_pid %d, "
+        "display :%d.0, width %d, height %d, bpp %d, client ip %s, "
+        "UID %d",
+        pid, params->display, params->width, params->height, params->bpp,
+        ip_addr, params->uid);
+
+    temp->item->pid = pid;
+    temp->item->display = params->display;
+    temp->item->width = params->width;
+    temp->item->height = params->height;
+    temp->item->bpp = params->bpp;
+    temp->item->auth_info = auth_info;
+    g_strncpy(temp->item->start_ip_addr, ip_addr,
+              sizeof(temp->item->start_ip_addr) - 1);
+    temp->item->uid = params->uid;
+    temp->item->guid = params->guid;
+
+    temp->item->start_time = g_time1();
+
+    temp->item->type = params->type;
+    temp->item->status = SESMAN_SESSION_STATUS_ACTIVE;
+
+    session_chain_add(temp);
+
+    return E_SCP_SCREATE_OK;
 }
 
 /******************************************************************************/
@@ -377,10 +486,13 @@ static int
 process_create_session_request(struct sesman_con *sc)
 {
     int rv;
-    struct session_parameters sp;
-    struct guid guid;
-    int display = 0;
+    // Parameters for a new session (if required). Filled in as
+    // we go along.
+    struct session_parameters sp = {0};
     enum scp_screate_status status = E_SCP_SCREATE_OK;
+
+    int display = 0;
+    struct guid guid;
 
     guid_clear(&guid);
 
@@ -400,60 +512,68 @@ process_create_session_request(struct sesman_con *sc)
                 "Received request from %s to create a session for user %s",
                 sc->peername, sc->username);
 
-            // Copy over the items we got from the login request,
-            // but which we need to describe the session
-            sp.uid = sc->uid;
-            sp.ip_addr = sc->ip_addr; //  Guaranteed to be non-NULL
-
-            struct session_item *s_item = session_get_bydata(&sp);
+            struct session_item *s_item =
+                session_get_bydata(sc->uid, sp.type, sp.width, sp.height,
+                                   sp.bpp, sc->ip_addr);
             if (s_item != 0)
             {
                 // Found an existing session
-                display = s_item->display;
-                guid = s_item->guid;
-                if (sp.ip_addr[0] != '\0')
+                if (sc->ip_addr[0] != '\0')
                 {
                     LOG( LOG_LEVEL_INFO, "++ reconnected session: username %s, "
                          "display :%d.0, session_pid %d, ip %s",
-                         sc->username, display, s_item->pid, sp.ip_addr);
+                         sc->username, s_item->display, s_item->pid,
+                         sc->ip_addr);
                 }
                 else
                 {
                     LOG(LOG_LEVEL_INFO, "++ reconnected session: username %s, "
                         "display :%d.0, session_pid %d",
-                        sc->username, display, s_item->pid);
+                        sc->username, s_item->display, s_item->pid);
                 }
 
-                session_reconnect(display, sc->uid, sc->auth_info);
+                // Get values for response to SCP client
+                display = s_item->display;
+                guid = s_item->guid;
+
+                session_reconnect(s_item->display, sc->uid, sc->auth_info);
             }
             else
             {
                 // Need to create a new session
-                if (sp.ip_addr[0] != '\0')
+                //
+                // Get the rest of the parameters for the session
+                guid = guid_new();
+                display = session_get_available_display();
+
+                sp.guid = guid;
+                sp.display = display;
+                sp.uid = sc->uid;
+
+                if (display == 0)
                 {
-                    LOG(LOG_LEVEL_INFO,
-                        "++ created session: username %s, ip %s",
-                        sc->username, sp.ip_addr);
+                    status = E_SCP_SCREATE_NO_DISPLAY;
                 }
                 else
                 {
-                    LOG(LOG_LEVEL_INFO,
-                        "++ created session: username %s", sc->username);
-                }
+                    // The new session will have a lifetime longer than
+                    // the sesman connection, and so needs to own
+                    // the auth_info struct.
+                    //
+                    // Copy the auth_info struct out of the connection and pass
+                    // it to the session
+                    struct auth_info *auth_info = sc->auth_info;
+                    sc->auth_info = NULL;
 
-                // The new session will have a lifetime longer than
-                // the sesman connection, and so needs to own
-                // the auth_info struct.
-                //
-                // Copy the auth_info struct out of the connection and pass
-                // it to the session
-                struct auth_info *auth_info = sc->auth_info;
-                sc->auth_info = NULL;
-                status = session_start(auth_info, &sp, &display, &guid);
-                if (status != E_SCP_SCREATE_OK)
-                {
-                    // Close the auth session down as it can't be re-used.
-                    auth_end(auth_info);
+                    status = allocate_and_start_session(auth_info,
+                                                        sc->username,
+                                                        sc->ip_addr,
+                                                        &sp);
+                    if (status != E_SCP_SCREATE_OK)
+                    {
+                        // Close the auth session down as it can't be re-used.
+                        auth_end(auth_info);
+                    }
                 }
             }
         }
@@ -462,7 +582,8 @@ process_create_session_request(struct sesman_con *sc)
          * connection, and results in automatic closure */
         sc->close_requested = 1;
 
-        rv = scp_send_create_session_response(sc->t, status, display, &guid);
+        rv = scp_send_create_session_response(sc->t, status,
+                                              display, &guid);
     }
 
     return rv;

--- a/sesman/sesman.c
+++ b/sesman/sesman.c
@@ -74,9 +74,9 @@ struct sesman_startup_params
 
 struct config_sesman *g_cfg;
 unsigned char g_fixedkey[8] = { 23, 82, 107, 6, 35, 78, 88, 7 };
-tintptr g_term_event = 0;
-tintptr g_sigchld_event = 0;
-tintptr g_reload_event = 0;
+static tintptr g_term_event = 0;
+static tintptr g_sigchld_event = 0;
+static tintptr g_reload_event = 0;
 
 static struct trans *g_list_trans;
 
@@ -320,6 +320,15 @@ sesman_close_all(unsigned int flags)
         delete_connection(sc);
     }
     return 0;
+}
+
+/******************************************************************************/
+void
+sesman_delete_wait_objects(void)
+{
+    g_delete_wait_obj(g_reload_event);
+    g_delete_wait_obj(g_sigchld_event);
+    g_delete_wait_obj(g_term_event);
 }
 
 /******************************************************************************/
@@ -965,9 +974,7 @@ main(int argc, char **argv)
         g_file_delete(pid_file);
     }
 
-    g_delete_wait_obj(g_reload_event);
-    g_delete_wait_obj(g_sigchld_event);
-    g_delete_wait_obj(g_term_event);
+    sesman_delete_wait_objects();
 
     if (!daemon)
     {

--- a/sesman/sesman.h
+++ b/sesman/sesman.h
@@ -45,9 +45,6 @@ struct sesman_con
 /* Globals */
 extern struct config_sesman *g_cfg;
 extern unsigned char g_fixedkey[8];
-extern tintptr g_term_event;
-extern tintptr g_sigchld_event;
-extern tintptr g_reload_event;
 
 /**
  * Set the peername of a connection
@@ -58,7 +55,7 @@ extern tintptr g_reload_event;
 int
 sesman_set_connection_peername(struct sesman_con *sc, const char *name);
 
-/*
+/**
  * Close all file descriptors used by sesman.
  *
  * This is generally used after forking, to make sure the
@@ -74,6 +71,14 @@ sesman_set_connection_peername(struct sesman_con *sc, const char *name);
 #define SCA_CLOSE_AUTH_INFO (1<<0)
 int
 sesman_close_all(unsigned int flags);
+
+/**
+ * Delete sesman wait objects.
+ *
+ * Call after forking so we don't break sesman's wait objects
+ */
+void
+sesman_delete_wait_objects(void);
 
 /*
  * Remove the listening transport

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -37,6 +37,8 @@
 #include <sys/prctl.h>
 #endif
 
+#include <errno.h>
+
 #include "arch.h"
 #include "session.h"
 
@@ -56,6 +58,19 @@
 #ifndef PR_SET_NO_NEW_PRIVS
 #define PR_SET_NO_NEW_PRIVS 38
 #endif
+
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+#define USE_EXTRA_SESSION_FORK
+#define USE_BSD_SETLOGIN
+#endif
+
+/* Module globals */
+
+/* Currently, these duplicate module names in sesman.c. This is fine, and
+ * will be fully resolved when sesman is split into two separate excutables */
+static tintptr g_term_event = 0;
+static tintptr g_sigchld_event = 0;
+static int g_pid = 0; // PID of sesexec process (sesman sub-process)
 
 /**
  * Creates a string consisting of all parameters that is hosted in the param list
@@ -92,38 +107,61 @@ dumpItemsToString(struct list *self, char *outstr, int len)
 }
 
 /******************************************************************************/
-static int
-session_start_chansrv(int uid, int display)
+static void
+set_term_event(int sig)
 {
-    struct list *chansrv_params;
-    const char *exe_path = XRDP_SBIN_PATH "/xrdp-chansrv";
-    int chansrv_pid;
-
-    chansrv_pid = g_fork();
-    if (chansrv_pid == 0)
+    /* Don't try to use a wait obj in a child process */
+    if (g_getpid() == g_pid)
     {
-        chansrv_params = list_create();
+        g_set_wait_obj(g_term_event);
+    }
+}
+
+/******************************************************************************/
+static void
+set_sigchld_event(int sig)
+{
+    /* Don't try to use a wait obj in a child process */
+    if (g_getpid() == g_pid)
+    {
+        g_set_wait_obj(g_sigchld_event);
+    }
+}
+
+/******************************************************************************/
+static void
+start_chansrv(struct auth_info *auth_info,
+              const struct session_parameters *s)
+{
+    struct list *chansrv_params = list_create();
+    const char *exe_path = XRDP_SBIN_PATH "/xrdp-chansrv";
+
+    if (chansrv_params != NULL)
+    {
         chansrv_params->auto_free = 1;
+        if (!list_add_strdup(chansrv_params, exe_path))
+        {
+            list_delete(chansrv_params);
+            chansrv_params = NULL;
+        }
+    }
 
-        /* building parameters */
-
-        list_add_strdup(chansrv_params, exe_path);
-
-        env_set_user(uid, 0, display,
+    if (chansrv_params == NULL)
+    {
+        LOG(LOG_LEVEL_ERROR, "Out of memory starting chansrv");
+    }
+    else
+    {
+        env_set_user(s->uid, 0, s->display,
                      g_cfg->env_names,
                      g_cfg->env_values);
-
-        LOG(LOG_LEVEL_INFO,
-            "Starting the xrdp channel server for display %d", display);
 
         /* executing chansrv */
         g_execvp_list(exe_path, chansrv_params);
 
         /* should not get here */
         list_delete(chansrv_params);
-        g_exit(1);
     }
-    return chansrv_pid;
 }
 
 /******************************************************************************/
@@ -222,6 +260,294 @@ cleanup_sockets(int display)
 }
 
 /******************************************************************************/
+static void
+start_window_manager(struct auth_info *auth_info,
+                     const struct session_parameters *s)
+{
+    char text[256];
+
+    env_set_user(s->uid,
+                 0,
+                 s->display,
+                 g_cfg->env_names,
+                 g_cfg->env_values);
+
+    auth_set_env(auth_info);
+    if (s->directory[0] != '\0')
+    {
+        g_set_current_dir(s->directory);
+    }
+
+    if (s->shell[0] != '\0')
+    {
+        if (g_strchr(s->shell, ' ') != 0 || g_strchr(s->shell, '\t') != 0)
+        {
+            LOG(LOG_LEVEL_INFO,
+                "Using user requested window manager on "
+                "display %u with embedded arguments using a shell: %s",
+                s->display, s->shell);
+            const char *argv[] = {"sh", "-c", s->shell, NULL};
+            g_execvp("/bin/sh", (char **)argv);
+        }
+        else
+        {
+            LOG(LOG_LEVEL_INFO,
+                "Using user requested window manager on "
+                "display %d: %s", s->display, s->shell);
+            g_execlp3(s->shell, s->shell, 0);
+        }
+    }
+    else
+    {
+        LOG(LOG_LEVEL_DEBUG, "The user session on display %u did "
+            "not request a specific window manager", s->display);
+    }
+
+    /* try to execute user window manager if enabled */
+    if (g_cfg->enable_user_wm)
+    {
+        g_snprintf(text, sizeof(text), "%s/%s",
+                   g_getenv("HOME"), g_cfg->user_wm);
+        if (g_file_exist(text))
+        {
+            LOG(LOG_LEVEL_INFO,
+                "Using window manager on display %u"
+                " from user home directory: %s", s->display, text);
+            g_execlp3(text, g_cfg->user_wm, 0);
+        }
+        else
+        {
+            LOG(LOG_LEVEL_DEBUG,
+                "The user home directory window manager configuration "
+                "is enabled but window manager program does not exist: %s",
+                text);
+        }
+    }
+
+    LOG(LOG_LEVEL_INFO,
+        "Using the default window manager on display %u: %s",
+        s->display, g_cfg->default_wm);
+    g_execlp3(g_cfg->default_wm, g_cfg->default_wm, 0);
+
+    /* still a problem starting window manager just start xterm */
+    LOG(LOG_LEVEL_WARNING,
+        "No window manager on display %u started, "
+        "so falling back to starting xterm for user debugging",
+        s->display);
+    g_execlp3("xterm", "xterm", 0);
+
+    /* should not get here */
+    LOG(LOG_LEVEL_ERROR, "A fatal error has occurred attempting to start "
+        "the window manager on display %u, aborting connection",
+        s->display);
+}
+
+/******************************************************************************/
+static struct list *
+prepare_xorg_xserver_params(const struct session_parameters *s,
+                            const char *authfile)
+{
+
+    char screen[32]; /* display number */
+    char text[128];
+    const char *xserver;
+
+    struct list *params = list_create();
+    if (params != NULL)
+    {
+        params->auto_free = 1;
+
+#ifdef HAVE_SYS_PRCTL_H
+        /*
+         * Make sure Xorg doesn't run setuid root. Root access is not
+         * needed. Xorg can fail when run as root and the user has no
+         * console permissions.
+         * PR_SET_NO_NEW_PRIVS requires Linux kernel 3.5 and newer.
+         */
+        if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) < 0)
+        {
+            LOG(LOG_LEVEL_WARNING,
+                "[session start] (display %u): Failed to disable "
+                "setuid on X server: %s",
+                s->display, g_get_strerror());
+        }
+#endif
+
+        g_snprintf(screen, sizeof(screen), ":%u", s->display);
+
+        /* some args are passed via env vars */
+        g_snprintf(text, sizeof(text), "%d", s->width);
+        g_setenv("XRDP_START_WIDTH", text, 1);
+
+        g_snprintf(text, sizeof(text), "%d", s->height);
+        g_setenv("XRDP_START_HEIGHT", text, 1);
+
+        g_snprintf(text, sizeof(text), "%d", g_cfg->sess.max_idle_time);
+        g_setenv("XRDP_SESMAN_MAX_IDLE_TIME", text, 1);
+
+        g_snprintf(text, sizeof(text), "%d", g_cfg->sess.max_disc_time);
+        g_setenv("XRDP_SESMAN_MAX_DISC_TIME", text, 1);
+
+        g_snprintf(text, sizeof(text), "%d", g_cfg->sess.kill_disconnected);
+        g_setenv("XRDP_SESMAN_KILL_DISCONNECTED", text, 1);
+
+        g_setenv("XRDP_SOCKET_PATH", XRDP_SOCKET_PATH, 1);
+
+        /* get path of Xorg from config */
+        xserver = (const char *)list_get_item(g_cfg->xorg_params, 0);
+
+        /* these are the must have parameters */
+        list_add_strdup_multi(params,
+                              xserver, screen,
+                              "-auth", authfile,
+                              NULL);
+
+        /* additional parameters from sesman.ini file */
+        list_append_list_strdup(g_cfg->xorg_params, params, 1);
+    }
+
+    return params;
+}
+
+/******************************************************************************/
+static struct list *
+prepare_xvnc_xserver_params(const struct session_parameters *s,
+                            const char *authfile,
+                            const char *passwd_file)
+{
+    char screen[32] = {0}; /* display number */
+    char geometry[32] = {0};
+    char depth[32] = {0};
+    char guid_str[GUID_STR_SIZE];
+    const char *xserver;
+
+    struct list *params = list_create();
+    if (params != NULL)
+    {
+        params->auto_free = 1;
+
+        g_snprintf(screen, sizeof(screen), ":%u", s->display);
+        g_snprintf(geometry, sizeof(geometry), "%dx%d", s->width, s->height);
+        g_snprintf(depth, sizeof(depth), "%d", s->bpp);
+
+        guid_to_str(&s->guid, guid_str);
+        env_check_password_file(passwd_file, guid_str);
+
+        /* get path of Xvnc from config */
+        xserver = (const char *)list_get_item(g_cfg->vnc_params, 0);
+
+        /* these are the must have parameters */
+        list_add_strdup_multi(params,
+                              xserver, screen,
+                              "-auth", authfile,
+                              "-geometry", geometry,
+                              "-depth", depth,
+                              "-rfbauth", passwd_file,
+                              NULL);
+
+        /* additional parameters from sesman.ini file */
+        //config_read_xserver_params(SCP_SESSION_TYPE_XVNC,
+        //                           xserver_params);
+        list_append_list_strdup(g_cfg->vnc_params, params, 1);
+    }
+    return params;
+}
+
+/******************************************************************************/
+/* Either execs the X server, or returns */
+static void
+start_x_server(struct auth_info *auth_info,
+               const struct session_parameters *s)
+{
+    char authfile[256]; /* The filename for storing xauth information */
+    char execvpparams[2048];
+    char *passwd_file = NULL;
+    struct list *xserver_params = NULL;
+    int unknown_session_type = 0;
+
+    if (s->type == SCP_SESSION_TYPE_XVNC)
+    {
+        env_set_user(s->uid,
+                     &passwd_file,
+                     s->display,
+                     g_cfg->env_names,
+                     g_cfg->env_values);
+    }
+    else
+    {
+        env_set_user(s->uid,
+                     0,
+                     s->display,
+                     g_cfg->env_names,
+                     g_cfg->env_values);
+    }
+
+    /* prepare the Xauthority stuff */
+    if (g_getenv("XAUTHORITY") != NULL)
+    {
+        g_snprintf(authfile, sizeof(authfile), "%s",
+                   g_getenv("XAUTHORITY"));
+    }
+    else
+    {
+        g_snprintf(authfile, sizeof(authfile), "%s", ".Xauthority");
+    }
+
+    /* Add the entry in XAUTHORITY file or exit if error */
+    if (add_xauth_cookie(s->display, authfile) != 0)
+    {
+        LOG(LOG_LEVEL_ERROR,
+            "Error setting the xauth cookie for display %u in file %s",
+            s->display, authfile);
+    }
+    else
+    {
+        switch (s->type)
+        {
+            case SCP_SESSION_TYPE_XORG:
+                xserver_params = prepare_xorg_xserver_params(s, authfile);
+                break;
+
+            case SCP_SESSION_TYPE_XVNC:
+                xserver_params = prepare_xvnc_xserver_params(s, authfile,
+                                 passwd_file);
+                break;
+
+            default:
+                unknown_session_type = 1;
+        }
+
+        g_free(passwd_file);
+        passwd_file = NULL;
+
+        if (xserver_params == NULL)
+        {
+            LOG(LOG_LEVEL_ERROR, "Out of memory allocating X server params");
+        }
+        else if (unknown_session_type)
+        {
+            LOG(LOG_LEVEL_ERROR, "Unknown session type: %d",
+                s->type);
+        }
+        else
+        {
+            /* fire up X server */
+            LOG(LOG_LEVEL_INFO, "Starting X server on display %u: %s",
+                s->display,
+                dumpItemsToString(xserver_params, execvpparams, 2048));
+            g_execvp_list((const char *)xserver_params->items[0],
+                          xserver_params);
+        }
+    }
+
+    /* should not get here */
+    list_delete(xserver_params);
+    LOG(LOG_LEVEL_ERROR, "A fatal error has occurred attempting "
+        "to start the X server on display %u, aborting connection",
+        s->display);
+}
+
+/******************************************************************************/
 /**
  * Convert a UID to a username
  *
@@ -275,38 +601,228 @@ exit_status_to_str(const struct exit_status *e, char buff[], int bufflen)
     }
 }
 
+/******************************************************************************/
+static void
+run_xrdp_session(const struct session_parameters *s,
+                 struct auth_info *auth_info,
+                 int window_manager_pid,
+                 int display_pid,
+                 int chansrv_pid)
+{
+    int wm_wait_time;
+    struct exit_status wm_exit_status = {.reason = E_XR_UNEXPECTED, .val = 0};
+    int wm_running = 1;
+
+    /* Monitor the amount of time we wait for the
+     * window manager. This is approximately how long the window
+     * manager was running for */
+    LOG(LOG_LEVEL_INFO, "Session in progress on display :%d. Waiting "
+        "until the window manager (pid %d) exits to end the session",
+        s->display, window_manager_pid);
+    wm_wait_time = g_time1();
+
+    /* Wait for the window manager to terminate
+     *
+     * We can't use g_waitpid() variants for this, as these aren't
+     * interruptible by a SIGTERM */
+    while (wm_running)
+    {
+        int robjs_count;
+        intptr_t robjs[32];
+        int pid;
+        struct exit_status e;
+
+        robjs_count = 0;
+        robjs[robjs_count++] = g_term_event;
+        robjs[robjs_count++] = g_sigchld_event;
+
+        if (g_obj_wait(robjs, robjs_count, NULL, 0, 0) != 0)
+        {
+            /* should not get here */
+            LOG(LOG_LEVEL_WARNING, "run_xrdp_session: "
+                "Unexpected error from g_obj_wait()");
+            g_sleep(100);
+            continue;
+        }
+
+        if (g_is_wait_obj_set(g_term_event))
+        {
+            g_reset_wait_obj(g_term_event);
+            LOG(LOG_LEVEL_INFO, "Received SIGTERM");
+            // Pass it on to the window manager
+            g_sigterm(window_manager_pid);
+        }
+
+        // Check for any finished children
+        g_reset_wait_obj(g_sigchld_event);
+        while ((pid = g_waitchild(&e)) > 0)
+        {
+            if (pid == window_manager_pid)
+            {
+                wm_running = 0;
+                wm_exit_status = e;
+            }
+            else if (pid == display_pid)
+            {
+                LOG(LOG_LEVEL_INFO, "X server pid %d on display :%d finished",
+                    display_pid, s->display);
+                display_pid = -1;
+                // No other action - window manager should be going soon
+            }
+            else if (pid == chansrv_pid)
+            {
+                LOG(LOG_LEVEL_INFO,
+                    "xrdp channel server pid %d on display :%d finished",
+                    chansrv_pid, s->display);
+                chansrv_pid = -1;
+            }
+        }
+    }
+    wm_wait_time = g_time1() - wm_wait_time;
+
+    if (wm_exit_status.reason == E_XR_STATUS_CODE && wm_exit_status.val == 0)
+    {
+        LOG(LOG_LEVEL_INFO,
+            "Window manager (pid %d, display %d) finished normally in %d secs",
+            window_manager_pid, s->display, wm_wait_time);
+    }
+    else
+    {
+        char reason[128];
+        exit_status_to_str(&wm_exit_status, reason, sizeof(reason));
+
+        LOG(LOG_LEVEL_WARNING, "Window manager (pid %d, display %d) "
+            "exited with %s. This "
+            "could indicate a window manager config problem",
+            window_manager_pid, s->display, reason);
+    }
+    if (wm_wait_time < 10)
+    {
+        /* This could be a config issue. Log a significant error */
+        LOG(LOG_LEVEL_WARNING, "Window manager (pid %d, display %d) "
+            "exited quickly (%d secs). This could indicate a window "
+            "manager config problem",
+            window_manager_pid, s->display, wm_wait_time);
+    }
+
+    if (display_pid > 0)
+    {
+        LOG(LOG_LEVEL_INFO, "Terminating X server (pid %d) on display :%d",
+            display_pid, s->display);
+        g_sigterm(display_pid);
+    }
+
+    if (chansrv_pid > 0)
+    {
+        LOG(LOG_LEVEL_INFO, "Terminating the xrdp channel server (pid %d) "
+            "on display :%d", chansrv_pid, s->display);
+        g_sigterm(chansrv_pid);
+    }
+
+    /* make sure all children are gone before socket cleanup happens */
+    if (display_pid > 0)
+    {
+        g_waitpid(display_pid);
+        LOG(LOG_LEVEL_INFO, "X server pid %d on display :%d finished",
+            display_pid, s->display);
+    }
+
+    if (chansrv_pid > 0)
+    {
+        g_waitpid(chansrv_pid);
+        LOG(LOG_LEVEL_INFO,
+            "xrdp channel server pid %d on display :%d finished",
+            chansrv_pid, s->display);
+    }
+
+    cleanup_sockets(s->display);
+    g_deinit();
+}
 
 /******************************************************************************/
-void
-session_start(struct auth_info *auth_info,
-              const struct session_parameters *s)
+/*
+ * Simple helper process to fork a child and log errors */
+static int
+fork_child(
+    void (*runproc)(struct auth_info *, const struct session_parameters *),
+    struct auth_info *auth_info,
+    const struct session_parameters *s)
 {
-    char geometry[32];
-    char depth[32];
-    char screen[32]; /* display number */
-    char text[256];
+    int pid = g_fork();
+    if (pid == 0)
+    {
+        /* Child process */
+        runproc(auth_info, s);
+        g_exit(0);
+    }
+
+    if (pid < 0)
+    {
+        LOG(LOG_LEVEL_ERROR, "Fork failed [%s]", g_get_strerror());
+    }
+
+    return pid;
+}
+
+/******************************************************************************/
+/**
+ * Sub-process to start a session
+ *
+ * @param auth_info Authentication info
+ * @param s Session parameters
+ * @param success_fd File descriptor to write to on success
+ *
+ * @return status
+ *
+ * This routine returns a status on failure. On success, a character is
+ * written to the file descriptor to indicate a success, and then the
+ * routine runs for the lifetime of the session.
+ */
+enum scp_screate_status
+session_start_subprocess(struct auth_info *auth_info,
+                         const struct session_parameters *s,
+                         int success_fd)
+{
     char username[256];
-    char execvpparams[2048];
-    char *xserver = NULL; /* absolute/relative path to Xorg/Xvnc */
-    char *passwd_file = NULL;
-    struct list *xserver_params = (struct list *)NULL;
-    char authfile[256]; /* The filename for storing xauth information */
     int chansrv_pid;
     int display_pid;
     int window_manager_pid;
+    enum scp_screate_status status = E_SCP_SCREATE_GENERAL_ERROR;
+    char text[64];
 
-    /* initialize (zero out) local variables: */
-    g_memset(geometry, 0, sizeof(char) * 32);
-    g_memset(depth, 0, sizeof(char) * 32);
-    g_memset(screen, 0, sizeof(char) * 32);
-    g_memset(text, 0, sizeof(char) * 256);
+    /* Set up wait objects so we can detect signals */
+    g_pid = g_getpid();
+    g_snprintf(text, sizeof(text), "xrdp_sesexec_%8.8x_main_term",
+               g_pid);
+    g_term_event = g_create_wait_obj(text);
+    g_signal_terminate(set_term_event);
+    g_snprintf(text, sizeof(text), "xrdp_sesexec_%8.8x_sigchld",
+               g_pid);
+    g_sigchld_event = g_create_wait_obj(text);
+    g_signal_child_stop(set_sigchld_event);
 
     /* Get the username for display purposes */
     username_from_uid(s->uid, username, sizeof(username));
 
-    LOG(LOG_LEVEL_INFO,
-        "[session start] (display %d): calling auth_start_session from pid %d",
-        s->display, g_getpid());
+#ifdef USE_BSD_SETLOGIN
+    /**
+     * Create a new session and process group since the 4.4BSD
+     * setlogin() affects the entire process group
+     */
+    if (g_setsid() < 0)
+    {
+        LOG(LOG_LEVEL_WARNING,
+            "[session start] (display %d): setsid failed - pid %d",
+            s->display, g_getpid());
+    }
+
+    if (g_setlogin(username) < 0)
+    {
+        LOG(LOG_LEVEL_WARNING,
+            "[session start] (display %d): setlogin failed for user %s - pid %d",
+            s->display, username, g_getpid());
+    }
+#endif
 
     /* Set the secondary groups before starting the session to prevent
      * problems on PAM-based systems (see Linux pam_setcred(3)).
@@ -317,149 +833,20 @@ session_start(struct auth_info *auth_info,
         LOG(LOG_LEVEL_ERROR,
             "Failed to initialise secondary groups for %s: %s",
             username, g_get_strerror());
-        g_exit(1);
+        return E_SCP_SCREATE_GENERAL_ERROR;
     }
 #endif
 
-    auth_start_session(auth_info, s->display);
-    g_sprintf(geometry, "%dx%d", s->width, s->height);
-    g_sprintf(depth, "%d", s->bpp);
-    g_sprintf(screen, ":%d", s->display);
-#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
-    /*
-     * FreeBSD bug
-     * ports/157282: effective login name is not set by xrdp-sesman
-     * http://www.freebsd.org/cgi/query-pr.cgi?pr=157282
-     *
-     * from:
-     *  $OpenBSD: session.c,v 1.252 2010/03/07 11:57:13 dtucker Exp $
-     *  with some ideas about BSD process grouping to xrdp
-     */
-    pid_t bsdsespid = g_fork();
-
-    if (bsdsespid == -1)
-    {
-    }
-    else if (bsdsespid == 0) /* BSD session leader */
-    {
-        /**
-         * Create a new session and process group since the 4.4BSD
-         * setlogin() affects the entire process group
-         */
-        if (g_setsid() < 0)
-        {
-            LOG(LOG_LEVEL_WARNING,
-                "[session start] (display %d): setsid failed - pid %d",
-                s->display, g_getpid());
-        }
-
-        if (g_setlogin(username) < 0)
-        {
-            LOG(LOG_LEVEL_WARNING,
-                "[session start] (display %d): setlogin failed for user %s - pid %d",
-                s->display, username, g_getpid());
-        }
-    }
-
-    g_waitpid(bsdsespid);
-
-    if (bsdsespid > 0)
-    {
-        g_exit(0);
-        /*
-         * intermediate sesman should exit here after WM exits.
-         * do not execute the following codes.
-         */
-    }
-#endif
-    window_manager_pid = g_fork(); /* parent becomes X,
-                         child forks wm, and waits, todo */
-    if (window_manager_pid == -1)
-    {
-        LOG(LOG_LEVEL_ERROR,
-            "Failed to fork for the window manager on display %d", s->display);
-    }
-    else if (window_manager_pid == 0)
+    display_pid = fork_child(start_x_server, auth_info, s);
+    if (display_pid > 0)
     {
         enum xwait_status xws;
+        xws = wait_for_xserver(s->uid,
+                               g_cfg->env_names,
+                               g_cfg->env_values,
+                               s->display);
 
-        env_set_user(s->uid,
-                     0,
-                     s->display,
-                     g_cfg->env_names,
-                     g_cfg->env_values);
-        xws = wait_for_xserver(s->display);
-
-        if (xws == XW_STATUS_OK)
-        {
-            auth_set_env(auth_info);
-            if (s->directory != 0)
-            {
-                if (s->directory[0] != 0)
-                {
-                    g_set_current_dir(s->directory);
-                }
-            }
-            if (s->shell != 0 && s->shell[0] != 0)
-            {
-                if (g_strchr(s->shell, ' ') != 0 || g_strchr(s->shell, '\t') != 0)
-                {
-                    LOG(LOG_LEVEL_INFO,
-                        "Starting user requested window manager on "
-                        "display %d with embedded arguments using a shell: %s",
-                        s->display, s->shell);
-                    const char *argv[] = {"sh", "-c", s->shell, NULL};
-                    g_execvp("/bin/sh", (char **)argv);
-                }
-                else
-                {
-                    LOG(LOG_LEVEL_INFO,
-                        "Starting user requested window manager on "
-                        "display %d: %s", s->display, s->shell);
-                    g_execlp3(s->shell, s->shell, 0);
-                }
-            }
-            else
-            {
-                LOG(LOG_LEVEL_DEBUG, "The user session on display %d did "
-                    "not request a specific window manager", s->display);
-            }
-
-            /* try to execute user window manager if enabled */
-            if (g_cfg->enable_user_wm)
-            {
-                g_sprintf(text, "%s/%s", g_getenv("HOME"), g_cfg->user_wm);
-                if (g_file_exist(text))
-                {
-                    LOG(LOG_LEVEL_INFO,
-                        "Starting window manager on display %d"
-                        " from user home directory: %s", s->display, text);
-                    g_execlp3(text, g_cfg->user_wm, 0);
-                }
-                else
-                {
-                    LOG(LOG_LEVEL_DEBUG,
-                        "The user home directory window manager configuration "
-                        "is enabled but window manager program does not exist: %s",
-                        text);
-                }
-            }
-
-            LOG(LOG_LEVEL_INFO,
-                "Starting the default window manager on display %d: %s",
-                s->display, g_cfg->default_wm);
-            g_execlp3(g_cfg->default_wm, g_cfg->default_wm, 0);
-
-            /* still a problem starting window manager just start xterm */
-            LOG(LOG_LEVEL_WARNING,
-                "No window manager on display %d started, "
-                "so falling back to starting xterm for user debugging",
-                s->display);
-            g_execlp3("xterm", "xterm", 0);
-
-            /* should not get here */
-        }
-        else
+        if (xws != XW_STATUS_OK)
         {
             switch (xws)
             {
@@ -473,252 +860,217 @@ session_start(struct auth_info *auth_info,
                     LOG(LOG_LEVEL_ERROR,
                         "An error occurred waiting for the X server");
             }
-        }
-
-        LOG(LOG_LEVEL_ERROR, "A fatal error has occurred attempting to start "
-            "the window manager on display %d, aborting connection",
-            s->display);
-        g_exit(0);
-    }
-    else
-    {
-        display_pid = g_fork(); /* parent becomes scp,
-                            child becomes X */
-        if (display_pid == -1)
-        {
-            LOG(LOG_LEVEL_ERROR,
-                "Failed to fork for the X server on display %d", s->display);
-        }
-        else if (display_pid == 0) /* child */
-        {
-            if (s->type == SCP_SESSION_TYPE_XVNC)
-            {
-                env_set_user(s->uid,
-                             &passwd_file,
-                             s->display,
-                             g_cfg->env_names,
-                             g_cfg->env_values);
-            }
-            else
-            {
-                env_set_user(s->uid,
-                             0,
-                             s->display,
-                             g_cfg->env_names,
-                             g_cfg->env_values);
-            }
-
-            /* setting Xserver environment variables */
-            g_snprintf(text, 255, "%d", g_cfg->sess.max_idle_time);
-            g_setenv("XRDP_SESMAN_MAX_IDLE_TIME", text, 1);
-            g_snprintf(text, 255, "%d", g_cfg->sess.max_disc_time);
-            g_setenv("XRDP_SESMAN_MAX_DISC_TIME", text, 1);
-            g_snprintf(text, 255, "%d", g_cfg->sess.kill_disconnected);
-            g_setenv("XRDP_SESMAN_KILL_DISCONNECTED", text, 1);
-            g_setenv("XRDP_SOCKET_PATH", XRDP_SOCKET_PATH, 1);
-
-            /* prepare the Xauthority stuff */
-            if (g_getenv("XAUTHORITY") != NULL)
-            {
-                g_snprintf(authfile, 255, "%s", g_getenv("XAUTHORITY"));
-            }
-            else
-            {
-                g_snprintf(authfile, 255, "%s", ".Xauthority");
-            }
-
-            /* Add the entry in XAUTHORITY file or exit if error */
-            if (add_xauth_cookie(s->display, authfile) != 0)
-            {
-                LOG(LOG_LEVEL_ERROR,
-                    "Error setting the xauth cookie for display %d in file %s",
-                    s->display, authfile);
-
-                LOG(LOG_LEVEL_ERROR, "A fatal error has occurred attempting to start "
-                    "the X server on display %d, aborting connection",
-                    s->display);
-                g_exit(1);
-            }
-
-            if (s->type == SCP_SESSION_TYPE_XORG)
-            {
-#ifdef HAVE_SYS_PRCTL_H
-                /*
-                 * Make sure Xorg doesn't run setuid root. Root access is not
-                 * needed. Xorg can fail when run as root and the user has no
-                 * console permissions.
-                 * PR_SET_NO_NEW_PRIVS requires Linux kernel 3.5 and newer.
-                 */
-                if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) < 0)
-                {
-                    LOG(LOG_LEVEL_WARNING,
-                        "[session start] (display %d): Failed to disable "
-                        "setuid on X server: %s",
-                        s->display, g_get_strerror());
-                }
-#endif
-
-                xserver_params = list_create();
-                xserver_params->auto_free = 1;
-
-                /* get path of Xorg from config */
-                xserver = g_strdup((const char *)list_get_item(g_cfg->xorg_params, 0));
-
-                /* these are the must have parameters */
-                list_add_strdup_multi(xserver_params,
-                                      xserver, screen,
-                                      "-auth", authfile,
-                                      NULL);
-
-                /* additional parameters from sesman.ini file */
-                list_append_list_strdup(g_cfg->xorg_params, xserver_params, 1);
-
-                /* some args are passed via env vars */
-                g_sprintf(geometry, "%d", s->width);
-                g_setenv("XRDP_START_WIDTH", geometry, 1);
-
-                g_sprintf(geometry, "%d", s->height);
-                g_setenv("XRDP_START_HEIGHT", geometry, 1);
-            }
-            else if (s->type == SCP_SESSION_TYPE_XVNC)
-            {
-                char guid_str[GUID_STR_SIZE];
-                guid_to_str(&s->guid, guid_str);
-                env_check_password_file(passwd_file, guid_str);
-                xserver_params = list_create();
-                xserver_params->auto_free = 1;
-
-                /* get path of Xvnc from config */
-                xserver = g_strdup((const char *)list_get_item(g_cfg->vnc_params, 0));
-
-                /* these are the must have parameters */
-                list_add_strdup_multi(xserver_params,
-                                      xserver, screen,
-                                      "-auth", authfile,
-                                      "-geometry", geometry,
-                                      "-depth", depth,
-                                      "-rfbauth", passwd_file,
-                                      NULL);
-                g_free(passwd_file);
-
-                /* additional parameters from sesman.ini file */
-                //config_read_xserver_params(SCP_SESSION_TYPE_XVNC,
-                //                           xserver_params);
-                list_append_list_strdup(g_cfg->vnc_params, xserver_params, 1);
-            }
-            else
-            {
-                LOG(LOG_LEVEL_ERROR, "Unknown session type: %d",
-                    s->type);
-                LOG(LOG_LEVEL_ERROR, "A fatal error has occurred attempting "
-                    "to start the X server on display %d, aborting connection",
-                    s->display);
-                g_exit(1);
-            }
-
-            /* fire up X server */
-            LOG(LOG_LEVEL_INFO, "Starting X server on display %d: %s",
-                s->display, dumpItemsToString(xserver_params, execvpparams, 2048));
-            g_execvp_list(xserver, xserver_params);
-
-            /* should not get here */
-            LOG(LOG_LEVEL_ERROR,
-                "Error starting X server on display %d", s->display);
-            LOG(LOG_LEVEL_ERROR, "A fatal error has occurred attempting "
-                "to start the X server on display %d, aborting connection",
-                s->display);
-
-            list_delete(xserver_params);
-            g_exit(1);
+            status = E_SCP_SCREATE_X_SERVER_FAIL;
+            /* Kill it anyway in case it did start and we just failed to
+             * pick up on it */
+            g_sigterm(display_pid);
+            g_waitpid(display_pid);
         }
         else
         {
-            int wm_wait_time;
-            struct exit_status wm_exit_status;
-            struct exit_status xserver_exit_status;
-            struct exit_status chansrv_exit_status;
-            char reason[128];
+            LOG(LOG_LEVEL_INFO, "X server :%d is working", s->display);
+            LOG(LOG_LEVEL_INFO, "Starting window manager for display :%d",
+                s->display);
+            window_manager_pid = fork_child(start_window_manager,
+                                            auth_info, s);
+            if (window_manager_pid < 0)
+            {
+                g_sigterm(display_pid);
+                g_waitpid(display_pid);
+            }
+            else
+            {
+                LOG(LOG_LEVEL_INFO,
+                    "Starting the xrdp channel server for display :%d",
+                    s->display);
 
-            chansrv_pid = session_start_chansrv(s->uid, s->display);
+                chansrv_pid = fork_child(start_chansrv, auth_info, s);
+
+                // Tell the caller we've started
+                char zero = 0;
+                g_file_write(success_fd, &zero, 1);
+                status = E_SCP_SCREATE_OK;
+
+                /* This call does not return  until the session is done */
+                run_xrdp_session(s, auth_info, window_manager_pid,
+                                 display_pid, chansrv_pid);
+            }
+        }
+    }
+
+    return status;
+}
+
+#ifdef USE_EXTRA_SESSION_FORK
+/*
+ * FreeBSD bug
+ * ports/157282: effective login name is not set by xrdp-sesman
+ * http://www.freebsd.org/cgi/query-pr.cgi?pr=157282
+ *
+ * from:
+ *  $OpenBSD: session.c,v 1.252 2010/03/07 11:57:13 dtucker Exp $
+ *  with some ideas about BSD process grouping to xrdp
+ */
+static int
+run_extra_fork(void)
+{
+    char text[64];
+    struct exit_status e;
+    int stat;
+
+    pid_t bsdsespid = g_fork();
+
+    if (bsdsespid <= 0)
+    {
+        /* Error, or child */
+        return bsdsespid;
+    }
+    /*
+     * intermediate sesman should return the status of its own child, and
+     * kill the child if we get a sigterm
+     */
+
+    /* Set up wait objects so we can detect signals */
+    g_pid = g_getpid();
+    g_snprintf(text, sizeof(text), "xrdp_intermediate_%8.8x_main_term",
+               g_pid);
+    g_term_event = g_create_wait_obj(text);
+    g_signal_terminate(set_term_event);
+    g_snprintf(text, sizeof(text), "xrdp_intermediate_%8.8x_sigchld",
+               g_pid);
+    g_sigchld_event = g_create_wait_obj(text);
+    g_signal_child_stop(set_sigchld_event);
+
+    // Wait for a SIGCHLD event. We've only got one child so we know where
+    // it's come from!
+    while (!g_is_wait_obj_set(g_sigchld_event))
+    {
+        int robjs_count;
+        intptr_t robjs[4];
+
+        robjs_count = 0;
+        robjs[robjs_count++] = g_term_event;
+        robjs[robjs_count++] = g_sigchld_event;
+
+        if (g_obj_wait(robjs, robjs_count, NULL, 0, 0) != 0)
+        {
+            /* should not get here */
+            LOG(LOG_LEVEL_WARNING, "run_extra_fork: "
+                "Unexpected error from g_obj_wait()");
+            g_sleep(100);
+        }
+        else if (g_is_wait_obj_set(g_term_event))
+        {
+            g_reset_wait_obj(g_term_event);
+            LOG(LOG_LEVEL_INFO, "Received SIGTERM");
+            // Pass it on to the BSD session leader
+            g_sigterm(bsdsespid);
+        }
+    }
+
+    e = g_waitpid_status(bsdsespid);
+    stat = (e.reason == E_XR_STATUS_CODE) ? e.val : E_SCP_SCREATE_GENERAL_ERROR;
+    g_exit(stat);
+    return -1;
+}
+#endif
+
+/******************************************************************************/
+enum scp_screate_status
+session_start(struct auth_info *auth_info,
+              const struct session_parameters *s,
+              int *pid)
+{
+    int fd[2];
+    enum scp_screate_status status = E_SCP_SCREATE_GENERAL_ERROR;
+
+    if (g_pipe(fd) != 0)
+    {
+        LOG(LOG_LEVEL_ERROR, "Cant create a pipe [%s]", g_get_strerror());
+    }
+    else
+    {
+        *pid = g_fork();
+        if (*pid == 0)
+        {
+            /**
+             * We're now forked from the main sesman process, so we
+             * can close file descriptors that we no longer need */
+
+            g_file_close(fd[0]);
+
+            sesman_close_all(0);
+
+            /* Wait objects created in a parent are not valid in a child */
+            sesman_delete_wait_objects();
 
             LOG(LOG_LEVEL_INFO,
-                "Session started successfully for user %s on display %d",
-                username, s->display);
+                "calling auth_start_session for uid=%d from pid %d",
+                s->uid, g_getpid());
+            auth_start_session(auth_info, s->display);
 
-            /* Monitor the amount of time we wait for the
-             * window manager. This is approximately how long the window
-             * manager was running for */
-            LOG(LOG_LEVEL_INFO, "Session in progress on display %d, waiting "
-                "until the window manager (pid %d) exits to end the session",
-                s->display, window_manager_pid);
-            wm_wait_time = g_time1();
-            wm_exit_status = g_waitpid_status(window_manager_pid);
-            wm_wait_time = g_time1() - wm_wait_time;
-            if (wm_exit_status.reason == E_XR_STATUS_CODE &&
-                    wm_exit_status.val == 0)
+            /* Run the child */
+#ifdef USE_EXTRA_SESSION_FORK
+            if (run_extra_fork() < 0)
             {
-                // Normal exit
+                return E_SCP_SCREATE_GENERAL_ERROR;
             }
-            else
-            {
-                exit_status_to_str(&wm_exit_status, reason, sizeof(reason));
+#endif
+            status = session_start_subprocess(auth_info, s, fd[1]);
 
-                LOG(LOG_LEVEL_WARNING,
-                    "Window manager (pid %d, display %d) "
-                    "exited with %s. This "
-                    "could indicate a window manager config problem",
-                    window_manager_pid, s->display, reason);
-            }
-            if (wm_wait_time < 10)
-            {
-                /* This could be a config issue. Log a significant error */
-                LOG(LOG_LEVEL_WARNING, "Window manager (pid %d, display %d) "
-                    "exited quickly (%d secs). This could indicate a window "
-                    "manager config problem",
-                    window_manager_pid, s->display, wm_wait_time);
-            }
-            else
-            {
-                LOG(LOG_LEVEL_DEBUG, "Window manager (pid %d, display %d) "
-                    "was running for %d seconds.",
-                    window_manager_pid, s->display, wm_wait_time);
-            }
             LOG(LOG_LEVEL_INFO,
                 "Calling auth_stop_session from pid %d",
                 g_getpid());
             auth_stop_session(auth_info);
-            // auth_end() is called from the main process currently,
-            // as this called auth_start()
-            //auth_end(auth_info);
-
-            LOG(LOG_LEVEL_INFO,
-                "Terminating X server (pid %d) on display %d",
-                display_pid, s->display);
-            g_sigterm(display_pid);
-
-            LOG(LOG_LEVEL_INFO, "Terminating the xrdp channel server (pid %d) "
-                "on display %d", chansrv_pid, s->display);
-            g_sigterm(chansrv_pid);
-
-            /* make sure socket cleanup happen after child process exit */
-            xserver_exit_status = g_waitpid_status(display_pid);
-            exit_status_to_str(&xserver_exit_status, reason, sizeof(reason));
-            LOG(LOG_LEVEL_INFO,
-                "X server on display %d (pid %d) exited with %s",
-                s->display, display_pid, reason);
-
-            chansrv_exit_status = g_waitpid_status(chansrv_pid);
-            exit_status_to_str(&chansrv_exit_status, reason, sizeof(reason));
-            LOG(LOG_LEVEL_INFO,
-                "xrdp channel server for display %d (pid %d)"
-                " exited with %s",
-                s->display, chansrv_pid, reason);
-
-            cleanup_sockets(s->display);
-            g_deinit();
-            g_exit(0);
+            g_exit(status);
         }
+
+        g_file_close(fd[1]);
+        if (*pid == -1)
+        {
+            LOG(LOG_LEVEL_ERROR, "Cant fork [%s]", g_get_strerror());
+        }
+        else
+        {
+            /* Wait for the child to signal success, or return an error */
+            int err;
+            char buff;
+            do
+            {
+                err = g_file_read(fd[0], &buff, 1);
+            }
+            while (err == -1 && g_get_errno() == EINTR);
+            if (err < 0)
+            {
+                /* Read problem */
+                LOG(LOG_LEVEL_ERROR, "Can't read pipe [%s]", g_get_strerror());
+            }
+            else if (err > 0)
+            {
+                /* Session is up and running */
+                status = E_SCP_SCREATE_OK;
+            }
+            else
+            {
+                /* Process has failed. Get the exit status of the child */
+                struct exit_status e;
+                e = g_waitpid_status(*pid);
+                if (e.reason == E_XR_STATUS_CODE)
+                {
+                    status = (enum scp_screate_status)e.val;
+                }
+                else
+                {
+                    char reason[128];
+                    exit_status_to_str(&e, reason, sizeof(reason));
+                    LOG(LOG_LEVEL_ERROR, "Child exited with %s", reason);
+                }
+            }
+        }
+        g_file_close(fd[0]);
     }
+
+    return status;
 }
 
 /******************************************************************************/

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -43,6 +43,7 @@
 #include "auth.h"
 #include "config.h"
 #include "env.h"
+#include "guid.h"
 #include "list.h"
 #include "log.h"
 #include "os_calls.h"
@@ -55,9 +56,6 @@
 #ifndef PR_SET_NO_NEW_PRIVS
 #define PR_SET_NO_NEW_PRIVS 38
 #endif
-
-static struct session_chain *g_sessions;
-static int g_session_count;
 
 /**
  * Creates a string consisting of all parameters that is hosted in the param list
@@ -93,253 +91,7 @@ dumpItemsToString(struct list *self, char *outstr, int len)
     return outstr ;
 }
 
-
 /******************************************************************************/
-struct session_item *
-session_get_bydata(const struct session_parameters *sp)
-{
-    char policy_str[64];
-    struct session_chain *tmp;
-    int policy = g_cfg->sess.policy;
-
-    if ((policy & SESMAN_CFG_SESS_POLICY_DEFAULT) != 0)
-    {
-        /* In the past (i.e. xrdp before v0.9.14), the default
-         * session policy varied by sp->type. If this is needed again
-         * in the future, here is the place to add it */
-        policy = SESMAN_CFG_SESS_POLICY_U | SESMAN_CFG_SESS_POLICY_B;
-    }
-
-    config_output_policy_string(policy, policy_str, sizeof(policy_str));
-
-    LOG(LOG_LEVEL_DEBUG,
-        "%s: search policy=%s type=%s U=%d B=%d D=(%dx%d) I=%s",
-        __func__,
-        policy_str, SCP_SESSION_TYPE_TO_STR(sp->type),
-        sp->uid, sp->bpp, sp->width, sp->height,
-        sp->ip_addr);
-
-    /* 'Separate' policy never matches */
-    if (policy & SESMAN_CFG_SESS_POLICY_SEPARATE)
-    {
-        LOG(LOG_LEVEL_DEBUG, "%s: No matches possible", __func__);
-        return NULL;
-    }
-
-    for (tmp = g_sessions ; tmp != 0 ; tmp = tmp->next)
-    {
-        struct session_item *item = tmp->item;
-
-        LOG(LOG_LEVEL_DEBUG,
-            "%s: try %p type=%s U=%d B=%d D=(%dx%d) I=%s",
-            __func__,
-            item,
-            SCP_SESSION_TYPE_TO_STR(item->type),
-            item->uid,
-            item->bpp,
-            item->width, item->height,
-            item->start_ip_addr);
-
-        if (item->type != sp->type)
-        {
-            LOG(LOG_LEVEL_DEBUG, "%s: Type doesn't match", __func__);
-            continue;
-        }
-
-        if ((policy & SESMAN_CFG_SESS_POLICY_U) && sp->uid != item->uid)
-        {
-            LOG(LOG_LEVEL_DEBUG,
-                "%s: UID doesn't match for 'U' policy", __func__);
-            continue;
-        }
-
-        if ((policy & SESMAN_CFG_SESS_POLICY_B) && item->bpp != sp->bpp)
-        {
-            LOG(LOG_LEVEL_DEBUG,
-                "%s: bpp doesn't match for 'B' policy", __func__);
-            continue;
-        }
-
-        if ((policy & SESMAN_CFG_SESS_POLICY_D) &&
-                (item->width != sp->width || item->height != sp->height))
-        {
-            LOG(LOG_LEVEL_DEBUG,
-                "%s: Dimensions don't match for 'D' policy", __func__);
-            continue;
-        }
-
-        if ((policy & SESMAN_CFG_SESS_POLICY_I) &&
-                g_strcmp(item->start_ip_addr, sp->ip_addr) != 0)
-        {
-            LOG(LOG_LEVEL_DEBUG,
-                "%s: IPs don't match for 'I' policy", __func__);
-            continue;
-        }
-
-        LOG(LOG_LEVEL_DEBUG,
-            "%s: Got match, display=%d", __func__, item->display);
-        return item;
-    }
-
-    LOG(LOG_LEVEL_DEBUG, "%s: No matches found", __func__);
-    return 0;
-}
-
-/******************************************************************************/
-/**
- *
- * @brief checks if there's a server running on a display
- * @param display the display to check
- * @return 0 if there isn't a display running, nonzero otherwise
- *
- */
-static int
-x_server_running_check_ports(int display)
-{
-    char text[256];
-    int x_running;
-    int sck;
-
-    g_sprintf(text, "/tmp/.X11-unix/X%d", display);
-    x_running = g_file_exist(text);
-
-    if (!x_running)
-    {
-        LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
-        g_sprintf(text, "/tmp/.X%d-lock", display);
-        x_running = g_file_exist(text);
-    }
-
-    if (!x_running) /* check 59xx */
-    {
-        LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
-        if ((sck = g_tcp_socket()) != -1)
-        {
-            g_sprintf(text, "59%2.2d", display);
-            x_running = g_tcp_bind(sck, text);
-            g_tcp_close(sck);
-        }
-    }
-
-    if (!x_running) /* check 60xx */
-    {
-        LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
-        if ((sck = g_tcp_socket()) != -1)
-        {
-            g_sprintf(text, "60%2.2d", display);
-            x_running = g_tcp_bind(sck, text);
-            g_tcp_close(sck);
-        }
-    }
-
-    if (!x_running) /* check 62xx */
-    {
-        LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
-        if ((sck = g_tcp_socket()) != -1)
-        {
-            g_sprintf(text, "62%2.2d", display);
-            x_running = g_tcp_bind(sck, text);
-            g_tcp_close(sck);
-        }
-    }
-
-    if (!x_running)
-    {
-        LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
-        g_sprintf(text, XRDP_CHANSRV_STR, display);
-        x_running = g_file_exist(text);
-    }
-
-    if (!x_running)
-    {
-        LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
-        g_sprintf(text, CHANSRV_PORT_OUT_STR, display);
-        x_running = g_file_exist(text);
-    }
-
-    if (!x_running)
-    {
-        LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
-        g_sprintf(text, CHANSRV_PORT_IN_STR, display);
-        x_running = g_file_exist(text);
-    }
-
-    if (!x_running)
-    {
-        LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
-        g_sprintf(text, CHANSRV_API_STR, display);
-        x_running = g_file_exist(text);
-    }
-
-    if (!x_running)
-    {
-        LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
-        g_sprintf(text, XRDP_X11RDP_STR, display);
-        x_running = g_file_exist(text);
-    }
-
-    if (x_running)
-    {
-        LOG(LOG_LEVEL_INFO, "Found X server running at %s", text);
-    }
-
-    return x_running;
-}
-
-/******************************************************************************/
-/* called with the main thread
-   returns boolean */
-static int
-session_is_display_in_chain(int display)
-{
-    struct session_chain *chain;
-    struct session_item *item;
-
-    chain = g_sessions;
-
-    while (chain != 0)
-    {
-        item = chain->item;
-
-        if (item->display == display)
-        {
-            return 1;
-        }
-
-        chain = chain->next;
-    }
-
-    return 0;
-}
-
-/******************************************************************************/
-/* called with the main thread */
-static int
-session_get_avail_display_from_chain(void)
-{
-    int display;
-
-    display = g_cfg->sess.x11_display_offset;
-
-    while ((display - g_cfg->sess.x11_display_offset) <= g_cfg->sess.max_sessions)
-    {
-        if (!session_is_display_in_chain(display))
-        {
-            if (!x_server_running_check_ports(display))
-            {
-                return display;
-            }
-        }
-
-        display++;
-    }
-
-    LOG(LOG_LEVEL_ERROR, "X server -- no display in range (%d to %d) is available",
-        g_cfg->sess.x11_display_offset,
-        g_cfg->sess.x11_display_offset + g_cfg->sess.max_sessions);
-    return 0;
-}
-
 static int
 session_start_chansrv(int uid, int display)
 {
@@ -375,899 +127,7 @@ session_start_chansrv(int uid, int display)
 }
 
 /******************************************************************************/
-/**
- * Convert a UID to a username
- *
- * @param uid UID
- * @param uname pointer to output buffer
- * @param uname_len Length of output buffer
- * @return 0 for success.
- */
 static int
-username_from_uid(int uid, char *uname, int uname_len)
-{
-    char *ustr;
-    int rv = g_getuser_info_by_uid(uid, &ustr, NULL, NULL, NULL, NULL);
-
-    if (rv == 0)
-    {
-        g_snprintf(uname, uname_len, "%s", ustr);
-        g_free(ustr);
-    }
-    else
-    {
-        g_snprintf(uname, uname_len, "<unknown>");
-    }
-    return rv;
-}
-
-/******************************************************************************/
-static void
-exit_status_to_str(const struct exit_status *e, char buff[], int bufflen)
-{
-    switch (e->reason)
-    {
-        case E_XR_STATUS_CODE:
-            if (e->val == 0)
-            {
-                g_snprintf(buff, bufflen, "exit code zero");
-            }
-            else
-            {
-                g_snprintf(buff, bufflen, "non-zero exit code %d", e->val);
-            }
-            break;
-
-        case E_XR_SIGNAL:
-            g_snprintf(buff, bufflen, "signal %d", e->val);
-            break;
-
-        default:
-            g_snprintf(buff, bufflen, "an unexpected error");
-            break;
-    }
-}
-
-/******************************************************************************/
-
-enum scp_screate_status
-session_start(struct auth_info *auth_info,
-              const struct session_parameters *s,
-              int *returned_display,
-              struct guid *guid)
-{
-    int display = 0;
-    int pid = 0;
-    char geometry[32];
-    char depth[32];
-    char screen[32]; /* display number */
-    char text[256];
-    char username[256];
-    char execvpparams[2048];
-    char *xserver = NULL; /* absolute/relative path to Xorg/Xvnc */
-    char *passwd_file;
-    struct session_chain *temp = (struct session_chain *)NULL;
-    struct list *xserver_params = (struct list *)NULL;
-    char authfile[256]; /* The filename for storing xauth information */
-    int chansrv_pid;
-    int display_pid;
-    int window_manager_pid;
-
-    /* initialize (zero out) local variables: */
-    g_memset(geometry, 0, sizeof(char) * 32);
-    g_memset(depth, 0, sizeof(char) * 32);
-    g_memset(screen, 0, sizeof(char) * 32);
-    g_memset(text, 0, sizeof(char) * 256);
-
-    passwd_file = 0;
-
-    /* Get the username for display purposes */
-    username_from_uid(s->uid, username, sizeof(username));
-
-    /* check to limit concurrent sessions */
-    if (g_session_count >= g_cfg->sess.max_sessions)
-    {
-        LOG(LOG_LEVEL_ERROR, "max concurrent session limit "
-            "exceeded. login for user %s denied", username);
-        return E_SCP_SCREATE_MAX_REACHED;
-    }
-
-    temp = (struct session_chain *)g_malloc(sizeof(struct session_chain), 0);
-
-    if (temp == 0)
-    {
-        LOG(LOG_LEVEL_ERROR, "Out of memory error: cannot create new session "
-            "chain element - user %s", username);
-        return E_SCP_SCREATE_NO_MEMORY;
-    }
-
-    temp->item = (struct session_item *)g_malloc(sizeof(struct session_item), 0);
-
-    if (temp->item == 0)
-    {
-        g_free(temp);
-        LOG(LOG_LEVEL_ERROR, "Out of memory error: cannot create new session "
-            "item - user %s", username);
-        return E_SCP_SCREATE_NO_MEMORY;
-    }
-
-    display = session_get_avail_display_from_chain();
-
-    if (display == 0)
-    {
-        g_free(temp->item);
-        g_free(temp);
-        return E_SCP_SCREATE_NO_DISPLAY;
-    }
-
-    /* Create a GUID for the new session before we fork */
-    *guid = guid_new();
-    *returned_display = display;
-
-    pid = g_fork(); /* parent is fork from tcp accept,
-                       child forks X and wm, then becomes scp */
-
-    if (pid == -1)
-    {
-        LOG(LOG_LEVEL_ERROR,
-            "[session start] (display %d): Failed to fork for scp with "
-            "errno: %d, description: %s",
-            display, g_get_errno(), g_get_strerror());
-        g_free(temp->item);
-        g_free(temp);
-        return E_SCP_SCREATE_GENERAL_ERROR;
-    }
-
-    if (pid == 0)
-    {
-        LOG(LOG_LEVEL_INFO,
-            "[session start] (display %d): calling auth_start_session from pid %d",
-            display, g_getpid());
-
-        /* Wait objects created in a parent are not valid in a child */
-        g_delete_wait_obj(g_reload_event);
-        g_delete_wait_obj(g_sigchld_event);
-        g_delete_wait_obj(g_term_event);
-
-        /* Set the secondary groups before starting the session to prevent
-         * problems on PAM-based systems (see Linux pam_setcred(3)).
-         * If we have *BSD setusercontext() this is not done here */
-#ifndef HAVE_SETUSERCONTEXT
-        if (g_initgroups(username) != 0)
-        {
-            LOG(LOG_LEVEL_ERROR,
-                "Failed to initialise secondary groups for %s: %s",
-                username, g_get_strerror());
-            g_exit(1);
-        }
-#endif
-
-        sesman_close_all(0);
-        auth_start_session(auth_info, display);
-        g_sprintf(geometry, "%dx%d", s->width, s->height);
-        g_sprintf(depth, "%d", s->bpp);
-        g_sprintf(screen, ":%d", display);
-#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
-        /*
-         * FreeBSD bug
-         * ports/157282: effective login name is not set by xrdp-sesman
-         * http://www.freebsd.org/cgi/query-pr.cgi?pr=157282
-         *
-         * from:
-         *  $OpenBSD: session.c,v 1.252 2010/03/07 11:57:13 dtucker Exp $
-         *  with some ideas about BSD process grouping to xrdp
-         */
-        pid_t bsdsespid = g_fork();
-
-        if (bsdsespid == -1)
-        {
-        }
-        else if (bsdsespid == 0) /* BSD session leader */
-        {
-            /**
-             * Create a new session and process group since the 4.4BSD
-             * setlogin() affects the entire process group
-             */
-            if (g_setsid() < 0)
-            {
-                LOG(LOG_LEVEL_WARNING,
-                    "[session start] (display %d): setsid failed - pid %d",
-                    display, g_getpid());
-            }
-
-            if (g_setlogin(username) < 0)
-            {
-                LOG(LOG_LEVEL_WARNING,
-                    "[session start] (display %d): setlogin failed for user %s - pid %d",
-                    display, username, g_getpid());
-            }
-        }
-
-        g_waitpid(bsdsespid);
-
-        if (bsdsespid > 0)
-        {
-            g_exit(0);
-            /*
-             * intermediate sesman should exit here after WM exits.
-             * do not execute the following codes.
-             */
-        }
-#endif
-        window_manager_pid = g_fork(); /* parent becomes X,
-                             child forks wm, and waits, todo */
-        if (window_manager_pid == -1)
-        {
-            LOG(LOG_LEVEL_ERROR,
-                "Failed to fork for the window manager on display %d", display);
-        }
-        else if (window_manager_pid == 0)
-        {
-            enum xwait_status xws;
-
-            env_set_user(s->uid,
-                         0,
-                         display,
-                         g_cfg->env_names,
-                         g_cfg->env_values);
-            xws = wait_for_xserver(display);
-
-            if (xws == XW_STATUS_OK)
-            {
-                auth_set_env(auth_info);
-                if (s->directory != 0)
-                {
-                    if (s->directory[0] != 0)
-                    {
-                        g_set_current_dir(s->directory);
-                    }
-                }
-                if (s->shell != 0 && s->shell[0] != 0)
-                {
-                    if (g_strchr(s->shell, ' ') != 0 || g_strchr(s->shell, '\t') != 0)
-                    {
-                        LOG(LOG_LEVEL_INFO,
-                            "Starting user requested window manager on "
-                            "display %d with embedded arguments using a shell: %s",
-                            display, s->shell);
-                        const char *argv[] = {"sh", "-c", s->shell, NULL};
-                        g_execvp("/bin/sh", (char **)argv);
-                    }
-                    else
-                    {
-                        LOG(LOG_LEVEL_INFO,
-                            "Starting user requested window manager on "
-                            "display %d: %s", display, s->shell);
-                        g_execlp3(s->shell, s->shell, 0);
-                    }
-                }
-                else
-                {
-                    LOG(LOG_LEVEL_DEBUG, "The user session on display %d did "
-                        "not request a specific window manager", display);
-                }
-
-                /* try to execute user window manager if enabled */
-                if (g_cfg->enable_user_wm)
-                {
-                    g_sprintf(text, "%s/%s", g_getenv("HOME"), g_cfg->user_wm);
-                    if (g_file_exist(text))
-                    {
-                        LOG(LOG_LEVEL_INFO,
-                            "Starting window manager on display %d"
-                            " from user home directory: %s", display, text);
-                        g_execlp3(text, g_cfg->user_wm, 0);
-                    }
-                    else
-                    {
-                        LOG(LOG_LEVEL_DEBUG,
-                            "The user home directory window manager configuration "
-                            "is enabled but window manager program does not exist: %s",
-                            text);
-                    }
-                }
-
-                LOG(LOG_LEVEL_INFO,
-                    "Starting the default window manager on display %d: %s",
-                    display, g_cfg->default_wm);
-                g_execlp3(g_cfg->default_wm, g_cfg->default_wm, 0);
-
-                /* still a problem starting window manager just start xterm */
-                LOG(LOG_LEVEL_WARNING,
-                    "No window manager on display %d started, "
-                    "so falling back to starting xterm for user debugging",
-                    display);
-                g_execlp3("xterm", "xterm", 0);
-
-                /* should not get here */
-            }
-            else
-            {
-                switch (xws)
-                {
-                    case XW_STATUS_TIMED_OUT:
-                        LOG(LOG_LEVEL_ERROR, "Timed out waiting for X server");
-                        break;
-                    case XW_STATUS_FAILED_TO_START:
-                        LOG(LOG_LEVEL_ERROR, "X server failed to start");
-                        break;
-                    default:
-                        LOG(LOG_LEVEL_ERROR,
-                            "An error occurred waiting for the X server");
-                }
-            }
-
-            LOG(LOG_LEVEL_ERROR, "A fatal error has occurred attempting to start "
-                "the window manager on display %d, aborting connection",
-                display);
-            g_exit(0);
-        }
-        else
-        {
-            display_pid = g_fork(); /* parent becomes scp,
-                                child becomes X */
-            if (display_pid == -1)
-            {
-                LOG(LOG_LEVEL_ERROR,
-                    "Failed to fork for the X server on display %d", display);
-            }
-            else if (display_pid == 0) /* child */
-            {
-                if (s->type == SCP_SESSION_TYPE_XVNC)
-                {
-                    env_set_user(s->uid,
-                                 &passwd_file,
-                                 display,
-                                 g_cfg->env_names,
-                                 g_cfg->env_values);
-                }
-                else
-                {
-                    env_set_user(s->uid,
-                                 0,
-                                 display,
-                                 g_cfg->env_names,
-                                 g_cfg->env_values);
-                }
-
-                /* setting Xserver environment variables */
-                g_snprintf(text, 255, "%d", g_cfg->sess.max_idle_time);
-                g_setenv("XRDP_SESMAN_MAX_IDLE_TIME", text, 1);
-                g_snprintf(text, 255, "%d", g_cfg->sess.max_disc_time);
-                g_setenv("XRDP_SESMAN_MAX_DISC_TIME", text, 1);
-                g_snprintf(text, 255, "%d", g_cfg->sess.kill_disconnected);
-                g_setenv("XRDP_SESMAN_KILL_DISCONNECTED", text, 1);
-                g_setenv("XRDP_SOCKET_PATH", XRDP_SOCKET_PATH, 1);
-
-                /* prepare the Xauthority stuff */
-                if (g_getenv("XAUTHORITY") != NULL)
-                {
-                    g_snprintf(authfile, 255, "%s", g_getenv("XAUTHORITY"));
-                }
-                else
-                {
-                    g_snprintf(authfile, 255, "%s", ".Xauthority");
-                }
-
-                /* Add the entry in XAUTHORITY file or exit if error */
-                if (add_xauth_cookie(display, authfile) != 0)
-                {
-                    LOG(LOG_LEVEL_ERROR,
-                        "Error setting the xauth cookie for display %d in file %s",
-                        display, authfile);
-
-                    LOG(LOG_LEVEL_ERROR, "A fatal error has occurred attempting to start "
-                        "the X server on display %d, aborting connection",
-                        display);
-                    g_exit(1);
-                }
-
-                if (s->type == SCP_SESSION_TYPE_XORG)
-                {
-#ifdef HAVE_SYS_PRCTL_H
-                    /*
-                     * Make sure Xorg doesn't run setuid root. Root access is not
-                     * needed. Xorg can fail when run as root and the user has no
-                     * console permissions.
-                     * PR_SET_NO_NEW_PRIVS requires Linux kernel 3.5 and newer.
-                     */
-                    if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) < 0)
-                    {
-                        LOG(LOG_LEVEL_WARNING,
-                            "[session start] (display %d): Failed to disable "
-                            "setuid on X server: %s",
-                            display, g_get_strerror());
-                    }
-#endif
-
-                    xserver_params = list_create();
-                    xserver_params->auto_free = 1;
-
-                    /* get path of Xorg from config */
-                    xserver = g_strdup((const char *)list_get_item(g_cfg->xorg_params, 0));
-
-                    /* these are the must have parameters */
-                    list_add_strdup_multi(xserver_params,
-                                          xserver, screen,
-                                          "-auth", authfile,
-                                          NULL);
-
-                    /* additional parameters from sesman.ini file */
-                    list_append_list_strdup(g_cfg->xorg_params, xserver_params, 1);
-
-                    /* some args are passed via env vars */
-                    g_sprintf(geometry, "%d", s->width);
-                    g_setenv("XRDP_START_WIDTH", geometry, 1);
-
-                    g_sprintf(geometry, "%d", s->height);
-                    g_setenv("XRDP_START_HEIGHT", geometry, 1);
-                }
-                else if (s->type == SCP_SESSION_TYPE_XVNC)
-                {
-                    char guid_str[GUID_STR_SIZE];
-                    guid_to_str(guid, guid_str);
-                    env_check_password_file(passwd_file, guid_str);
-                    xserver_params = list_create();
-                    xserver_params->auto_free = 1;
-
-                    /* get path of Xvnc from config */
-                    xserver = g_strdup((const char *)list_get_item(g_cfg->vnc_params, 0));
-
-                    /* these are the must have parameters */
-                    list_add_strdup_multi(xserver_params,
-                                          xserver, screen,
-                                          "-auth", authfile,
-                                          "-geometry", geometry,
-                                          "-depth", depth,
-                                          "-rfbauth", passwd_file,
-                                          NULL);
-                    g_free(passwd_file);
-
-                    /* additional parameters from sesman.ini file */
-                    //config_read_xserver_params(SCP_SESSION_TYPE_XVNC,
-                    //                           xserver_params);
-                    list_append_list_strdup(g_cfg->vnc_params, xserver_params, 1);
-                }
-                else
-                {
-                    LOG(LOG_LEVEL_ERROR, "Unknown session type: %d",
-                        s->type);
-                    LOG(LOG_LEVEL_ERROR, "A fatal error has occurred attempting "
-                        "to start the X server on display %d, aborting connection",
-                        display);
-                    g_exit(1);
-                }
-
-                /* fire up X server */
-                LOG(LOG_LEVEL_INFO, "Starting X server on display %d: %s",
-                    display, dumpItemsToString(xserver_params, execvpparams, 2048));
-                g_execvp_list(xserver, xserver_params);
-
-                /* should not get here */
-                LOG(LOG_LEVEL_ERROR,
-                    "Error starting X server on display %d", display);
-                LOG(LOG_LEVEL_ERROR, "A fatal error has occurred attempting "
-                    "to start the X server on display %d, aborting connection",
-                    display);
-
-                list_delete(xserver_params);
-                g_exit(1);
-            }
-            else
-            {
-                int wm_wait_time;
-                struct exit_status wm_exit_status;
-                struct exit_status xserver_exit_status;
-                struct exit_status chansrv_exit_status;
-                char reason[128];
-                chansrv_pid = session_start_chansrv(s->uid, display);
-
-                LOG(LOG_LEVEL_INFO,
-                    "Session started successfully for user %s on display %d",
-                    username, display);
-
-                /* Monitor the amount of time we wait for the
-                 * window manager. This is approximately how long the window
-                 * manager was running for */
-                LOG(LOG_LEVEL_INFO, "Session in progress on display %d, waiting "
-                    "until the window manager (pid %d) exits to end the session",
-                    display, window_manager_pid);
-                wm_wait_time = g_time1();
-                wm_exit_status = g_waitpid_status(window_manager_pid);
-                wm_wait_time = g_time1() - wm_wait_time;
-                if (wm_exit_status.reason == E_XR_STATUS_CODE &&
-                        wm_exit_status.val == 0)
-                {
-                    // Normal exit
-                }
-                else
-                {
-                    exit_status_to_str(&wm_exit_status, reason, sizeof(reason));
-
-                    LOG(LOG_LEVEL_WARNING,
-                        "Window manager (pid %d, display %d) "
-                        "exited with %s. This "
-                        "could indicate a window manager config problem",
-                        window_manager_pid, display, reason);
-                }
-                if (wm_wait_time < 10)
-                {
-                    /* This could be a config issue. Log a significant error */
-                    LOG(LOG_LEVEL_WARNING, "Window manager (pid %d, display %d) "
-                        "exited quickly (%d secs). This could indicate a window "
-                        "manager config problem",
-                        window_manager_pid, display, wm_wait_time);
-                }
-                else
-                {
-                    LOG(LOG_LEVEL_DEBUG, "Window manager (pid %d, display %d) "
-                        "was running for %d seconds.",
-                        window_manager_pid, display, wm_wait_time);
-                }
-                LOG(LOG_LEVEL_INFO,
-                    "Calling auth_stop_session from pid %d",
-                    g_getpid());
-                auth_stop_session(auth_info);
-                // auth_end() is called from the main process currently,
-                // as this called auth_start()
-                //auth_end(auth_info);
-
-                LOG(LOG_LEVEL_INFO,
-                    "Terminating X server (pid %d) on display %d",
-                    display_pid, display);
-                g_sigterm(display_pid);
-
-                LOG(LOG_LEVEL_INFO, "Terminating the xrdp channel server (pid %d) "
-                    "on display %d", chansrv_pid, display);
-                g_sigterm(chansrv_pid);
-
-                /* make sure socket cleanup happen after child process exit */
-                xserver_exit_status = g_waitpid_status(display_pid);
-                exit_status_to_str(&xserver_exit_status, reason, sizeof(reason));
-                LOG(LOG_LEVEL_INFO,
-                    "X server on display %d (pid %d) exited with %s",
-                    display, display_pid, reason);
-
-                chansrv_exit_status = g_waitpid_status(chansrv_pid);
-                exit_status_to_str(&chansrv_exit_status, reason, sizeof(reason));
-                LOG(LOG_LEVEL_INFO,
-                    "xrdp channel server for display %d (pid %d)"
-                    " exited with %s",
-                    display, chansrv_pid, reason);
-
-                cleanup_sockets(display);
-                g_deinit();
-                g_exit(0);
-            }
-        }
-    }
-    else
-    {
-        LOG(LOG_LEVEL_INFO, "Starting session: session_pid %d, "
-            "display :%d.0, width %d, height %d, bpp %d, client ip %s, "
-            "UID %d",
-            pid, display, s->width, s->height, s->bpp, s->ip_addr, s->uid);
-        temp->item->pid = pid;
-        temp->item->display = display;
-        temp->item->width = s->width;
-        temp->item->height = s->height;
-        temp->item->bpp = s->bpp;
-        temp->item->auth_info = auth_info;
-        g_strncpy(temp->item->start_ip_addr, s->ip_addr,
-                  sizeof(temp->item->start_ip_addr) - 1);
-        temp->item->uid = s->uid;
-        temp->item->guid = *guid;
-
-        temp->item->start_time = g_time1();
-
-        temp->item->type = s->type;
-        temp->item->status = SESMAN_SESSION_STATUS_ACTIVE;
-
-        temp->next = g_sessions;
-        g_sessions = temp;
-        g_session_count++;
-
-        return E_SCP_SCREATE_OK;
-    }
-
-    /* Shouldn't get here */
-    g_free(temp->item);
-    g_free(temp);
-    return E_SCP_SCREATE_GENERAL_ERROR;
-}
-
-/******************************************************************************/
-int
-session_reconnect(int display, int uid,
-                  struct auth_info *auth_info)
-{
-    int pid;
-
-    pid = g_fork();
-
-    if (pid == -1)
-    {
-        LOG(LOG_LEVEL_ERROR, "Failed to fork for session reconnection script");
-    }
-    else if (pid == 0)
-    {
-        env_set_user(uid,
-                     0,
-                     display,
-                     g_cfg->env_names,
-                     g_cfg->env_values);
-        auth_set_env(auth_info);
-
-        if (g_file_exist(g_cfg->reconnect_sh))
-        {
-            LOG(LOG_LEVEL_INFO,
-                "Starting session reconnection script on display %d: %s",
-                display, g_cfg->reconnect_sh);
-            g_execlp3(g_cfg->reconnect_sh, g_cfg->reconnect_sh, 0);
-
-            /* should not get here */
-            LOG(LOG_LEVEL_ERROR,
-                "Error starting session reconnection script on display %d: %s",
-                display, g_cfg->reconnect_sh);
-        }
-        else
-        {
-            LOG(LOG_LEVEL_WARNING,
-                "Session reconnection script file does not exist: %s",
-                g_cfg->reconnect_sh);
-        }
-
-        /* TODO: why is this existing with a success error code when the
-            reconnect script failed to be executed? */
-        g_exit(0);
-    }
-
-    return display;
-}
-
-/******************************************************************************/
-enum session_kill_status
-session_kill(int pid)
-{
-    struct session_chain *tmp;
-    struct session_chain *prev;
-
-    tmp = g_sessions;
-    prev = 0;
-
-    while (tmp != 0)
-    {
-        if (tmp->item == 0)
-        {
-            LOG(LOG_LEVEL_ERROR, "session descriptor for "
-                "pid %d is null!", pid);
-
-            if (prev == 0)
-            {
-                /* prev does no exist, so it's the first element - so we set
-                   g_sessions */
-                g_sessions = tmp->next;
-            }
-            else
-            {
-                prev->next = tmp->next;
-            }
-
-            return SESMAN_SESSION_KILL_NULLITEM;
-        }
-
-        if (tmp->item->pid == pid)
-        {
-            char username[256];
-            username_from_uid(tmp->item->uid, username, sizeof(username));
-
-            /* deleting the session */
-            if (tmp->item->auth_info != NULL)
-            {
-                LOG(LOG_LEVEL_INFO,
-                    "Calling auth_end for pid %d from pid %d",
-                    pid, g_getpid());
-                auth_end(tmp->item->auth_info);
-                tmp->item->auth_info = NULL;
-            }
-            LOG(LOG_LEVEL_INFO,
-                "++ terminated session: UID %d (%s), display :%d.0, "
-                "session_pid %d, ip %s",
-                tmp->item->uid, username, tmp->item->display,
-                tmp->item->pid, tmp->item->start_ip_addr);
-            g_free(tmp->item);
-
-            if (prev == 0)
-            {
-                /* prev does no exist, so it's the first element - so we set
-                   g_sessions */
-                g_sessions = tmp->next;
-            }
-            else
-            {
-                prev->next = tmp->next;
-            }
-
-            g_free(tmp);
-            g_session_count--;
-            return SESMAN_SESSION_KILL_OK;
-        }
-
-        /* go on */
-        prev = tmp;
-        tmp = tmp->next;
-    }
-
-    return SESMAN_SESSION_KILL_NOTFOUND;
-}
-
-/******************************************************************************/
-void
-session_sigkill_all(void)
-{
-    struct session_chain *tmp;
-
-    tmp = g_sessions;
-
-    while (tmp != 0)
-    {
-        if (tmp->item == 0)
-        {
-            LOG(LOG_LEVEL_ERROR, "found null session descriptor!");
-        }
-        else
-        {
-            g_sigterm(tmp->item->pid);
-        }
-
-        /* go on */
-        tmp = tmp->next;
-    }
-}
-
-/******************************************************************************/
-struct session_item *
-session_get_bypid(int pid)
-{
-    struct session_chain *tmp;
-    struct session_item *dummy;
-
-    dummy = g_new0(struct session_item, 1);
-
-    if (0 == dummy)
-    {
-        LOG(LOG_LEVEL_ERROR, "session_get_bypid: out of memory");
-        return 0;
-    }
-
-    tmp = g_sessions;
-
-    while (tmp != 0)
-    {
-        if (tmp->item == 0)
-        {
-            LOG(LOG_LEVEL_ERROR, "session descriptor for pid %d is null!", pid);
-            g_free(dummy);
-            return 0;
-        }
-
-        if (tmp->item->pid == pid)
-        {
-            g_memcpy(dummy, tmp->item, sizeof(struct session_item));
-            return dummy;
-        }
-
-        /* go on */
-        tmp = tmp->next;
-    }
-
-    g_free(dummy);
-    return 0;
-}
-
-/******************************************************************************/
-struct scp_session_info *
-session_get_byuid(int uid, unsigned int *cnt, unsigned char flags)
-{
-    struct session_chain *tmp;
-    struct scp_session_info *sess;
-    int count;
-    int index;
-
-    count = 0;
-
-    tmp = g_sessions;
-
-    LOG(LOG_LEVEL_DEBUG, "searching for session by UID: %d", uid);
-    while (tmp != 0)
-    {
-        if (uid == tmp->item->uid)
-        {
-            LOG(LOG_LEVEL_DEBUG, "session_get_byuser: status=%d, flags=%d, "
-                "result=%d", (tmp->item->status), flags,
-                ((tmp->item->status) & flags));
-
-            if ((tmp->item->status) & flags)
-            {
-                count++;
-            }
-        }
-
-        /* go on */
-        tmp = tmp->next;
-    }
-
-    if (count == 0)
-    {
-        (*cnt) = 0;
-        return 0;
-    }
-
-    /* malloc() an array of disconnected sessions */
-    sess = g_new0(struct scp_session_info, count);
-
-    if (sess == 0)
-    {
-        (*cnt) = 0;
-        return 0;
-    }
-
-    tmp = g_sessions;
-    index = 0;
-
-    while (tmp != 0 && index < count)
-    {
-        if (uid == tmp->item->uid)
-        {
-            if ((tmp->item->status) & flags)
-            {
-                (sess[index]).sid = tmp->item->pid;
-                (sess[index]).display = tmp->item->display;
-                (sess[index]).type = tmp->item->type;
-                (sess[index]).height = tmp->item->height;
-                (sess[index]).width = tmp->item->width;
-                (sess[index]).bpp = tmp->item->bpp;
-                (sess[index]).start_time = tmp->item->start_time;
-                (sess[index]).uid = tmp->item->uid;
-                (sess[index]).start_ip_addr = g_strdup(tmp->item->start_ip_addr);
-
-                /* Check for string allocation failures */
-                if ((sess[index]).start_ip_addr == NULL)
-                {
-                    free_session_info_list(sess, *cnt);
-                    (*cnt) = 0;
-                    return 0;
-                }
-                index++;
-            }
-        }
-
-        /* go on */
-        tmp = tmp->next;
-    }
-
-    (*cnt) = count;
-    return sess;
-}
-
-/******************************************************************************/
-void
-free_session_info_list(struct scp_session_info *sesslist, unsigned int cnt)
-{
-    if (sesslist != NULL && cnt > 0)
-    {
-        unsigned int i;
-        for (i = 0 ; i < cnt ; ++i)
-        {
-            g_free(sesslist[i].start_ip_addr);
-        }
-    }
-
-    g_free(sesslist);
-}
-
-/******************************************************************************/
-int
 cleanup_sockets(int display)
 {
     LOG(LOG_LEVEL_INFO, "cleanup_sockets:");
@@ -1359,4 +219,553 @@ cleanup_sockets(int display)
 
     return error;
 
+}
+
+/******************************************************************************/
+/**
+ * Convert a UID to a username
+ *
+ * @param uid UID
+ * @param uname pointer to output buffer
+ * @param uname_len Length of output buffer
+ * @return 0 for success.
+ */
+static int
+username_from_uid(int uid, char *uname, int uname_len)
+{
+    char *ustr;
+    int rv = g_getuser_info_by_uid(uid, &ustr, NULL, NULL, NULL, NULL);
+
+    if (rv == 0)
+    {
+        g_snprintf(uname, uname_len, "%s", ustr);
+        g_free(ustr);
+    }
+    else
+    {
+        g_snprintf(uname, uname_len, "<unknown>");
+    }
+    return rv;
+}
+
+/******************************************************************************/
+static void
+exit_status_to_str(const struct exit_status *e, char buff[], int bufflen)
+{
+    switch (e->reason)
+    {
+        case E_XR_STATUS_CODE:
+            if (e->val == 0)
+            {
+                g_snprintf(buff, bufflen, "exit code zero");
+            }
+            else
+            {
+                g_snprintf(buff, bufflen, "non-zero exit code %d", e->val);
+            }
+            break;
+
+        case E_XR_SIGNAL:
+            g_snprintf(buff, bufflen, "signal %d", e->val);
+            break;
+
+        default:
+            g_snprintf(buff, bufflen, "an unexpected error");
+            break;
+    }
+}
+
+
+/******************************************************************************/
+void
+session_start(struct auth_info *auth_info,
+              const struct session_parameters *s)
+{
+    char geometry[32];
+    char depth[32];
+    char screen[32]; /* display number */
+    char text[256];
+    char username[256];
+    char execvpparams[2048];
+    char *xserver = NULL; /* absolute/relative path to Xorg/Xvnc */
+    char *passwd_file = NULL;
+    struct list *xserver_params = (struct list *)NULL;
+    char authfile[256]; /* The filename for storing xauth information */
+    int chansrv_pid;
+    int display_pid;
+    int window_manager_pid;
+
+    /* initialize (zero out) local variables: */
+    g_memset(geometry, 0, sizeof(char) * 32);
+    g_memset(depth, 0, sizeof(char) * 32);
+    g_memset(screen, 0, sizeof(char) * 32);
+    g_memset(text, 0, sizeof(char) * 256);
+
+    /* Get the username for display purposes */
+    username_from_uid(s->uid, username, sizeof(username));
+
+    LOG(LOG_LEVEL_INFO,
+        "[session start] (display %d): calling auth_start_session from pid %d",
+        s->display, g_getpid());
+
+    /* Set the secondary groups before starting the session to prevent
+     * problems on PAM-based systems (see Linux pam_setcred(3)).
+     * If we have *BSD setusercontext() this is not done here */
+#ifndef HAVE_SETUSERCONTEXT
+    if (g_initgroups(username) != 0)
+    {
+        LOG(LOG_LEVEL_ERROR,
+            "Failed to initialise secondary groups for %s: %s",
+            username, g_get_strerror());
+        g_exit(1);
+    }
+#endif
+
+    auth_start_session(auth_info, s->display);
+    g_sprintf(geometry, "%dx%d", s->width, s->height);
+    g_sprintf(depth, "%d", s->bpp);
+    g_sprintf(screen, ":%d", s->display);
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+    /*
+     * FreeBSD bug
+     * ports/157282: effective login name is not set by xrdp-sesman
+     * http://www.freebsd.org/cgi/query-pr.cgi?pr=157282
+     *
+     * from:
+     *  $OpenBSD: session.c,v 1.252 2010/03/07 11:57:13 dtucker Exp $
+     *  with some ideas about BSD process grouping to xrdp
+     */
+    pid_t bsdsespid = g_fork();
+
+    if (bsdsespid == -1)
+    {
+    }
+    else if (bsdsespid == 0) /* BSD session leader */
+    {
+        /**
+         * Create a new session and process group since the 4.4BSD
+         * setlogin() affects the entire process group
+         */
+        if (g_setsid() < 0)
+        {
+            LOG(LOG_LEVEL_WARNING,
+                "[session start] (display %d): setsid failed - pid %d",
+                s->display, g_getpid());
+        }
+
+        if (g_setlogin(username) < 0)
+        {
+            LOG(LOG_LEVEL_WARNING,
+                "[session start] (display %d): setlogin failed for user %s - pid %d",
+                s->display, username, g_getpid());
+        }
+    }
+
+    g_waitpid(bsdsespid);
+
+    if (bsdsespid > 0)
+    {
+        g_exit(0);
+        /*
+         * intermediate sesman should exit here after WM exits.
+         * do not execute the following codes.
+         */
+    }
+#endif
+    window_manager_pid = g_fork(); /* parent becomes X,
+                         child forks wm, and waits, todo */
+    if (window_manager_pid == -1)
+    {
+        LOG(LOG_LEVEL_ERROR,
+            "Failed to fork for the window manager on display %d", s->display);
+    }
+    else if (window_manager_pid == 0)
+    {
+        enum xwait_status xws;
+
+        env_set_user(s->uid,
+                     0,
+                     s->display,
+                     g_cfg->env_names,
+                     g_cfg->env_values);
+        xws = wait_for_xserver(s->display);
+
+        if (xws == XW_STATUS_OK)
+        {
+            auth_set_env(auth_info);
+            if (s->directory != 0)
+            {
+                if (s->directory[0] != 0)
+                {
+                    g_set_current_dir(s->directory);
+                }
+            }
+            if (s->shell != 0 && s->shell[0] != 0)
+            {
+                if (g_strchr(s->shell, ' ') != 0 || g_strchr(s->shell, '\t') != 0)
+                {
+                    LOG(LOG_LEVEL_INFO,
+                        "Starting user requested window manager on "
+                        "display %d with embedded arguments using a shell: %s",
+                        s->display, s->shell);
+                    const char *argv[] = {"sh", "-c", s->shell, NULL};
+                    g_execvp("/bin/sh", (char **)argv);
+                }
+                else
+                {
+                    LOG(LOG_LEVEL_INFO,
+                        "Starting user requested window manager on "
+                        "display %d: %s", s->display, s->shell);
+                    g_execlp3(s->shell, s->shell, 0);
+                }
+            }
+            else
+            {
+                LOG(LOG_LEVEL_DEBUG, "The user session on display %d did "
+                    "not request a specific window manager", s->display);
+            }
+
+            /* try to execute user window manager if enabled */
+            if (g_cfg->enable_user_wm)
+            {
+                g_sprintf(text, "%s/%s", g_getenv("HOME"), g_cfg->user_wm);
+                if (g_file_exist(text))
+                {
+                    LOG(LOG_LEVEL_INFO,
+                        "Starting window manager on display %d"
+                        " from user home directory: %s", s->display, text);
+                    g_execlp3(text, g_cfg->user_wm, 0);
+                }
+                else
+                {
+                    LOG(LOG_LEVEL_DEBUG,
+                        "The user home directory window manager configuration "
+                        "is enabled but window manager program does not exist: %s",
+                        text);
+                }
+            }
+
+            LOG(LOG_LEVEL_INFO,
+                "Starting the default window manager on display %d: %s",
+                s->display, g_cfg->default_wm);
+            g_execlp3(g_cfg->default_wm, g_cfg->default_wm, 0);
+
+            /* still a problem starting window manager just start xterm */
+            LOG(LOG_LEVEL_WARNING,
+                "No window manager on display %d started, "
+                "so falling back to starting xterm for user debugging",
+                s->display);
+            g_execlp3("xterm", "xterm", 0);
+
+            /* should not get here */
+        }
+        else
+        {
+            switch (xws)
+            {
+                case XW_STATUS_TIMED_OUT:
+                    LOG(LOG_LEVEL_ERROR, "Timed out waiting for X server");
+                    break;
+                case XW_STATUS_FAILED_TO_START:
+                    LOG(LOG_LEVEL_ERROR, "X server failed to start");
+                    break;
+                default:
+                    LOG(LOG_LEVEL_ERROR,
+                        "An error occurred waiting for the X server");
+            }
+        }
+
+        LOG(LOG_LEVEL_ERROR, "A fatal error has occurred attempting to start "
+            "the window manager on display %d, aborting connection",
+            s->display);
+        g_exit(0);
+    }
+    else
+    {
+        display_pid = g_fork(); /* parent becomes scp,
+                            child becomes X */
+        if (display_pid == -1)
+        {
+            LOG(LOG_LEVEL_ERROR,
+                "Failed to fork for the X server on display %d", s->display);
+        }
+        else if (display_pid == 0) /* child */
+        {
+            if (s->type == SCP_SESSION_TYPE_XVNC)
+            {
+                env_set_user(s->uid,
+                             &passwd_file,
+                             s->display,
+                             g_cfg->env_names,
+                             g_cfg->env_values);
+            }
+            else
+            {
+                env_set_user(s->uid,
+                             0,
+                             s->display,
+                             g_cfg->env_names,
+                             g_cfg->env_values);
+            }
+
+            /* setting Xserver environment variables */
+            g_snprintf(text, 255, "%d", g_cfg->sess.max_idle_time);
+            g_setenv("XRDP_SESMAN_MAX_IDLE_TIME", text, 1);
+            g_snprintf(text, 255, "%d", g_cfg->sess.max_disc_time);
+            g_setenv("XRDP_SESMAN_MAX_DISC_TIME", text, 1);
+            g_snprintf(text, 255, "%d", g_cfg->sess.kill_disconnected);
+            g_setenv("XRDP_SESMAN_KILL_DISCONNECTED", text, 1);
+            g_setenv("XRDP_SOCKET_PATH", XRDP_SOCKET_PATH, 1);
+
+            /* prepare the Xauthority stuff */
+            if (g_getenv("XAUTHORITY") != NULL)
+            {
+                g_snprintf(authfile, 255, "%s", g_getenv("XAUTHORITY"));
+            }
+            else
+            {
+                g_snprintf(authfile, 255, "%s", ".Xauthority");
+            }
+
+            /* Add the entry in XAUTHORITY file or exit if error */
+            if (add_xauth_cookie(s->display, authfile) != 0)
+            {
+                LOG(LOG_LEVEL_ERROR,
+                    "Error setting the xauth cookie for display %d in file %s",
+                    s->display, authfile);
+
+                LOG(LOG_LEVEL_ERROR, "A fatal error has occurred attempting to start "
+                    "the X server on display %d, aborting connection",
+                    s->display);
+                g_exit(1);
+            }
+
+            if (s->type == SCP_SESSION_TYPE_XORG)
+            {
+#ifdef HAVE_SYS_PRCTL_H
+                /*
+                 * Make sure Xorg doesn't run setuid root. Root access is not
+                 * needed. Xorg can fail when run as root and the user has no
+                 * console permissions.
+                 * PR_SET_NO_NEW_PRIVS requires Linux kernel 3.5 and newer.
+                 */
+                if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) < 0)
+                {
+                    LOG(LOG_LEVEL_WARNING,
+                        "[session start] (display %d): Failed to disable "
+                        "setuid on X server: %s",
+                        s->display, g_get_strerror());
+                }
+#endif
+
+                xserver_params = list_create();
+                xserver_params->auto_free = 1;
+
+                /* get path of Xorg from config */
+                xserver = g_strdup((const char *)list_get_item(g_cfg->xorg_params, 0));
+
+                /* these are the must have parameters */
+                list_add_strdup_multi(xserver_params,
+                                      xserver, screen,
+                                      "-auth", authfile,
+                                      NULL);
+
+                /* additional parameters from sesman.ini file */
+                list_append_list_strdup(g_cfg->xorg_params, xserver_params, 1);
+
+                /* some args are passed via env vars */
+                g_sprintf(geometry, "%d", s->width);
+                g_setenv("XRDP_START_WIDTH", geometry, 1);
+
+                g_sprintf(geometry, "%d", s->height);
+                g_setenv("XRDP_START_HEIGHT", geometry, 1);
+            }
+            else if (s->type == SCP_SESSION_TYPE_XVNC)
+            {
+                char guid_str[GUID_STR_SIZE];
+                guid_to_str(&s->guid, guid_str);
+                env_check_password_file(passwd_file, guid_str);
+                xserver_params = list_create();
+                xserver_params->auto_free = 1;
+
+                /* get path of Xvnc from config */
+                xserver = g_strdup((const char *)list_get_item(g_cfg->vnc_params, 0));
+
+                /* these are the must have parameters */
+                list_add_strdup_multi(xserver_params,
+                                      xserver, screen,
+                                      "-auth", authfile,
+                                      "-geometry", geometry,
+                                      "-depth", depth,
+                                      "-rfbauth", passwd_file,
+                                      NULL);
+                g_free(passwd_file);
+
+                /* additional parameters from sesman.ini file */
+                //config_read_xserver_params(SCP_SESSION_TYPE_XVNC,
+                //                           xserver_params);
+                list_append_list_strdup(g_cfg->vnc_params, xserver_params, 1);
+            }
+            else
+            {
+                LOG(LOG_LEVEL_ERROR, "Unknown session type: %d",
+                    s->type);
+                LOG(LOG_LEVEL_ERROR, "A fatal error has occurred attempting "
+                    "to start the X server on display %d, aborting connection",
+                    s->display);
+                g_exit(1);
+            }
+
+            /* fire up X server */
+            LOG(LOG_LEVEL_INFO, "Starting X server on display %d: %s",
+                s->display, dumpItemsToString(xserver_params, execvpparams, 2048));
+            g_execvp_list(xserver, xserver_params);
+
+            /* should not get here */
+            LOG(LOG_LEVEL_ERROR,
+                "Error starting X server on display %d", s->display);
+            LOG(LOG_LEVEL_ERROR, "A fatal error has occurred attempting "
+                "to start the X server on display %d, aborting connection",
+                s->display);
+
+            list_delete(xserver_params);
+            g_exit(1);
+        }
+        else
+        {
+            int wm_wait_time;
+            struct exit_status wm_exit_status;
+            struct exit_status xserver_exit_status;
+            struct exit_status chansrv_exit_status;
+            char reason[128];
+
+            chansrv_pid = session_start_chansrv(s->uid, s->display);
+
+            LOG(LOG_LEVEL_INFO,
+                "Session started successfully for user %s on display %d",
+                username, s->display);
+
+            /* Monitor the amount of time we wait for the
+             * window manager. This is approximately how long the window
+             * manager was running for */
+            LOG(LOG_LEVEL_INFO, "Session in progress on display %d, waiting "
+                "until the window manager (pid %d) exits to end the session",
+                s->display, window_manager_pid);
+            wm_wait_time = g_time1();
+            wm_exit_status = g_waitpid_status(window_manager_pid);
+            wm_wait_time = g_time1() - wm_wait_time;
+            if (wm_exit_status.reason == E_XR_STATUS_CODE &&
+                    wm_exit_status.val == 0)
+            {
+                // Normal exit
+            }
+            else
+            {
+                exit_status_to_str(&wm_exit_status, reason, sizeof(reason));
+
+                LOG(LOG_LEVEL_WARNING,
+                    "Window manager (pid %d, display %d) "
+                    "exited with %s. This "
+                    "could indicate a window manager config problem",
+                    window_manager_pid, s->display, reason);
+            }
+            if (wm_wait_time < 10)
+            {
+                /* This could be a config issue. Log a significant error */
+                LOG(LOG_LEVEL_WARNING, "Window manager (pid %d, display %d) "
+                    "exited quickly (%d secs). This could indicate a window "
+                    "manager config problem",
+                    window_manager_pid, s->display, wm_wait_time);
+            }
+            else
+            {
+                LOG(LOG_LEVEL_DEBUG, "Window manager (pid %d, display %d) "
+                    "was running for %d seconds.",
+                    window_manager_pid, s->display, wm_wait_time);
+            }
+            LOG(LOG_LEVEL_INFO,
+                "Calling auth_stop_session from pid %d",
+                g_getpid());
+            auth_stop_session(auth_info);
+            // auth_end() is called from the main process currently,
+            // as this called auth_start()
+            //auth_end(auth_info);
+
+            LOG(LOG_LEVEL_INFO,
+                "Terminating X server (pid %d) on display %d",
+                display_pid, s->display);
+            g_sigterm(display_pid);
+
+            LOG(LOG_LEVEL_INFO, "Terminating the xrdp channel server (pid %d) "
+                "on display %d", chansrv_pid, s->display);
+            g_sigterm(chansrv_pid);
+
+            /* make sure socket cleanup happen after child process exit */
+            xserver_exit_status = g_waitpid_status(display_pid);
+            exit_status_to_str(&xserver_exit_status, reason, sizeof(reason));
+            LOG(LOG_LEVEL_INFO,
+                "X server on display %d (pid %d) exited with %s",
+                s->display, display_pid, reason);
+
+            chansrv_exit_status = g_waitpid_status(chansrv_pid);
+            exit_status_to_str(&chansrv_exit_status, reason, sizeof(reason));
+            LOG(LOG_LEVEL_INFO,
+                "xrdp channel server for display %d (pid %d)"
+                " exited with %s",
+                s->display, chansrv_pid, reason);
+
+            cleanup_sockets(s->display);
+            g_deinit();
+            g_exit(0);
+        }
+    }
+}
+
+/******************************************************************************/
+int
+session_reconnect(int display, int uid,
+                  struct auth_info *auth_info)
+{
+    int pid;
+
+    pid = g_fork();
+
+    if (pid == -1)
+    {
+        LOG(LOG_LEVEL_ERROR, "Failed to fork for session reconnection script");
+    }
+    else if (pid == 0)
+    {
+        env_set_user(uid,
+                     0,
+                     display,
+                     g_cfg->env_names,
+                     g_cfg->env_values);
+        auth_set_env(auth_info);
+
+        if (g_file_exist(g_cfg->reconnect_sh))
+        {
+            LOG(LOG_LEVEL_INFO,
+                "Starting session reconnection script on display %d: %s",
+                display, g_cfg->reconnect_sh);
+            g_execlp3(g_cfg->reconnect_sh, g_cfg->reconnect_sh, 0);
+
+            /* should not get here */
+            LOG(LOG_LEVEL_ERROR,
+                "Error starting session reconnection script on display %d: %s",
+                display, g_cfg->reconnect_sh);
+        }
+        else
+        {
+            LOG(LOG_LEVEL_WARNING,
+                "Session reconnection script file does not exist: %s",
+                g_cfg->reconnect_sh);
+        }
+
+        /* TODO: why is this existing with a success error code when the
+            reconnect script failed to be executed? */
+        g_exit(0);
+    }
+
+    return display;
 }

--- a/sesman/session.h
+++ b/sesman/session.h
@@ -32,163 +32,39 @@
 
 #include "guid.h"
 #include "scp_application_types.h"
-#include "xrdp_constants.h"
 
-#define SESMAN_SESSION_STATUS_ACTIVE        0x01
-#define SESMAN_SESSION_STATUS_IDLE          0x02
-#define SESMAN_SESSION_STATUS_DISCONNECTED  0x04
-/* future expansion
-#define SESMAN_SESSION_STATUS_REMCONTROL    0x08
-*/
-#define SESMAN_SESSION_STATUS_ALL           0xFF
-
-enum session_kill_status
-{
-    SESMAN_SESSION_KILL_OK = 0,
-    SESMAN_SESSION_KILL_NULLITEM,
-    SESMAN_SESSION_KILL_NOTFOUND
-};
-
-struct scp_session_info;
-
-struct session_item
-{
-    int uid; /* UID of session */
-    int pid; /* pid of sesman waiting for wm to end */
-    int display;
-    int width;
-    int height;
-    int bpp;
-    struct auth_info *auth_info;
-
-    /* status info */
-    unsigned char status;
-    enum scp_session_type type;
-
-    /* time data  */
-    time_t start_time;
-    // struct session_date disconnect_time; // Currently unused
-    // struct session_date idle_time; // Currently unused
-    char start_ip_addr[MAX_PEER_ADDRSTRLEN];
-    struct guid guid;
-};
-
-struct session_chain
-{
-    struct session_chain *next;
-    struct session_item *item;
-};
-
+struct auth_info;
 
 /**
- * Information used to start or find a session
+ * Information used to start a session
  */
 struct session_parameters
 {
+    unsigned int display;
     int uid;
+    struct guid guid;
     enum scp_session_type type;
     unsigned short height;
     unsigned short width;
     unsigned char  bpp;
     const char *shell;
     const char *directory;
-    const char *ip_addr;
 };
-
-/**
- *
- * @brief finds a session matching the supplied parameters
- * @return session data or 0
- *
- */
-struct session_item *
-session_get_bydata(const struct session_parameters *params);
-#ifndef session_find_item
-#define session_find_item(a) session_get_bydata(a)
-#endif
 
 /**
  *
  * @brief starts a session
  *
+ * This call does not return.
+ *
  * @return Connection status.
  */
-enum scp_screate_status
+void
 session_start(struct auth_info *auth_info,
-              const struct session_parameters *params,
-              int *display,
-              struct guid *guid);
+              const struct session_parameters *s);
 
 int
 session_reconnect(int display, int uid,
                   struct auth_info *auth_info);
 
-/**
- *
- * @brief kills a session
- * @param pid the pid of the session to be killed
- * @return
- *
- */
-enum session_kill_status
-session_kill(int pid);
-
-/**
- *
- * @brief sends sigkill to all sessions
- * @return
- *
- */
-void
-session_sigkill_all(void);
-
-/**
- *
- * @brief retrieves a session's descriptor
- * @param pid the session pid
- * @return a pointer to the session descriptor on success, NULL otherwise
- *
- */
-struct session_item *
-session_get_bypid(int pid);
-
-/**
- *
- * @brief retrieves session descriptions
- * @param UID the UID for the descriptions
- * @return A block of session descriptions
- *
- * Pass the return result to free_session_info_list() after use
- *
- */
-struct scp_session_info *
-session_get_byuid(int uid, unsigned int *cnt, unsigned char flags);
-
-/**
- *
- * @brief Frees the result of session_get_byuser()
- * @param sesslist Resuit of session_get_byuser()
- * @param cnt  Number of entries in sess
- */
-void
-free_session_info_list(struct scp_session_info *sesslist, unsigned int cnt);
-
-/**
- *
- * @brief delete socket files
- * @param display number
- * @return non-zero value (number of errors) if failed
- */
-int cleanup_sockets(int display);
-
-/**
- * Clone a session_parameters structure
- *
- * @param sp Parameters to clone
- * @return Cloned parameters, or NULL if no memory
- *
- * The cloned structure can be free'd with a single call to g_free()
- */
-struct session_parameters *
-clone_session_params(const struct session_parameters *sp);
-#endif
+#endif // SESSION_H

--- a/sesman/session.h
+++ b/sesman/session.h
@@ -32,6 +32,7 @@
 
 #include "guid.h"
 #include "scp_application_types.h"
+#include "xrdp_constants.h"
 
 struct auth_info;
 
@@ -47,21 +48,26 @@ struct session_parameters
     unsigned short height;
     unsigned short width;
     unsigned char  bpp;
-    const char *shell;
-    const char *directory;
+    char shell[INFO_CLIENT_MAX_CB_LEN];
+    char directory[INFO_CLIENT_MAX_CB_LEN];
 };
 
 /**
  *
  * @brief starts a session
  *
- * This call does not return.
+ * @param auth_info Authentication info
+ * @param s Session parameters
+ * @param[out] pid PID of sub-process
+ * @return status
  *
- * @return Connection status.
+ * The returned PID is only valid if the status returned is
+ * E_SCP_SCREATE_OK
  */
-void
+enum scp_screate_status
 session_start(struct auth_info *auth_info,
-              const struct session_parameters *s);
+              const struct session_parameters *s,
+              int *pid);
 
 int
 session_reconnect(int display, int uid,

--- a/sesman/session_list.c
+++ b/sesman/session_list.c
@@ -49,14 +49,14 @@ static int g_session_count;
 
 /******************************************************************************/
 unsigned int
-session_get_count(void)
+session_list_get_count(void)
 {
     return g_session_count;
 }
 
 /******************************************************************************/
 void
-session_chain_add(struct session_chain *element)
+session_list_add(struct session_chain *element)
 {
     element->next = g_sessions;
     g_sessions = element;
@@ -65,12 +65,12 @@ session_chain_add(struct session_chain *element)
 
 /******************************************************************************/
 struct session_item *
-session_get_bydata(uid_t uid,
-                   enum scp_session_type type,
-                   unsigned short width,
-                   unsigned short height,
-                   unsigned char  bpp,
-                   const char *ip_addr)
+session_list_get_bydata(uid_t uid,
+                        enum scp_session_type type,
+                        unsigned short width,
+                        unsigned short height,
+                        unsigned char  bpp,
+                        const char *ip_addr)
 {
     char policy_str[64];
     struct session_chain *tmp;
@@ -264,7 +264,7 @@ x_server_running_check_ports(int display)
 /* called with the main thread
    returns boolean */
 static int
-session_is_display_in_chain(int display)
+is_display_in_chain(int display)
 {
     struct session_chain *chain;
     struct session_item *item;
@@ -288,7 +288,7 @@ session_is_display_in_chain(int display)
 
 /******************************************************************************/
 int
-session_get_available_display(void)
+session_list_get_available_display(void)
 {
     int display;
 
@@ -296,7 +296,7 @@ session_get_available_display(void)
 
     while ((display - g_cfg->sess.x11_display_offset) <= g_cfg->sess.max_sessions)
     {
-        if (!session_is_display_in_chain(display))
+        if (!is_display_in_chain(display))
         {
             if (!x_server_running_check_ports(display))
             {
@@ -342,7 +342,7 @@ username_from_uid(int uid, char *uname, int uname_len)
 
 /******************************************************************************/
 enum session_kill_status
-session_kill(int pid)
+session_list_kill(int pid)
 {
     struct session_chain *tmp;
     struct session_chain *prev;
@@ -418,7 +418,7 @@ session_kill(int pid)
 
 /******************************************************************************/
 void
-session_sigkill_all(void)
+session_list_sigkill_all(void)
 {
     struct session_chain *tmp;
 
@@ -442,7 +442,7 @@ session_sigkill_all(void)
 
 /******************************************************************************/
 struct session_item *
-session_get_bypid(int pid)
+session_list_get_bypid(int pid)
 {
     struct session_chain *tmp;
     struct session_item *dummy;
@@ -482,7 +482,7 @@ session_get_bypid(int pid)
 
 /******************************************************************************/
 struct scp_session_info *
-session_get_byuid(int uid, unsigned int *cnt, unsigned char flags)
+session_list_get_byuid(int uid, unsigned int *cnt, unsigned char flags)
 {
     struct session_chain *tmp;
     struct scp_session_info *sess;
@@ -498,7 +498,7 @@ session_get_byuid(int uid, unsigned int *cnt, unsigned char flags)
     {
         if (uid == tmp->item->uid)
         {
-            LOG(LOG_LEVEL_DEBUG, "session_get_byuser: status=%d, flags=%d, "
+            LOG(LOG_LEVEL_DEBUG, "session_list_get_byuid: status=%d, flags=%d, "
                 "result=%d", (tmp->item->status), flags,
                 ((tmp->item->status) & flags));
 

--- a/sesman/session_list.c
+++ b/sesman/session_list.c
@@ -23,8 +23,8 @@
 
 /**
  *
- * @file session.c
- * @brief Session management code
+ * @file session_list.c
+ * @brief Session list management code
  * @author Jay Sorg, Simone Fedele
  *
  */
@@ -33,70 +33,44 @@
 #include "config_ac.h"
 #endif
 
-#ifdef HAVE_SYS_PRCTL_H
-#include <sys/prctl.h>
-#endif
-
 #include "arch.h"
-#include "session.h"
+#include "session_list.h"
 
 #include "auth.h"
 #include "config.h"
-#include "env.h"
-#include "list.h"
 #include "log.h"
 #include "os_calls.h"
 #include "sesman.h"
 #include "string_calls.h"
-#include "xauth.h"
-#include "xwait.h"
 #include "xrdp_sockets.h"
-
-#ifndef PR_SET_NO_NEW_PRIVS
-#define PR_SET_NO_NEW_PRIVS 38
-#endif
 
 static struct session_chain *g_sessions;
 static int g_session_count;
 
-/**
- * Creates a string consisting of all parameters that is hosted in the param list
- * @param self
- * @param outstr, allocate this buffer before you use this function
- * @param len the allocated len for outstr
- * @return
- */
-char *
-dumpItemsToString(struct list *self, char *outstr, int len)
+/******************************************************************************/
+unsigned int
+session_get_count(void)
 {
-    int index;
-    int totalLen = 0;
-
-    g_memset(outstr, 0, len);
-    if (self->count == 0)
-    {
-        LOG_DEVEL(LOG_LEVEL_TRACE, "List is empty");
-    }
-
-    for (index = 0; index < self->count; index++)
-    {
-        /* +1 = one space*/
-        totalLen = totalLen + g_strlen((char *)list_get_item(self, index)) + 1;
-
-        if (len > totalLen)
-        {
-            g_strcat(outstr, (char *)list_get_item(self, index));
-            g_strcat(outstr, " ");
-        }
-    }
-
-    return outstr ;
+    return g_session_count;
 }
 
+/******************************************************************************/
+void
+session_chain_add(struct session_chain *element)
+{
+    element->next = g_sessions;
+    g_sessions = element;
+    g_session_count++;
+}
 
 /******************************************************************************/
 struct session_item *
-session_get_bydata(const struct session_parameters *sp)
+session_get_bydata(uid_t uid,
+                   enum scp_session_type type,
+                   unsigned short width,
+                   unsigned short height,
+                   unsigned char  bpp,
+                   const char *ip_addr)
 {
     char policy_str[64];
     struct session_chain *tmp;
@@ -105,7 +79,7 @@ session_get_bydata(const struct session_parameters *sp)
     if ((policy & SESMAN_CFG_SESS_POLICY_DEFAULT) != 0)
     {
         /* In the past (i.e. xrdp before v0.9.14), the default
-         * session policy varied by sp->type. If this is needed again
+         * session policy varied by type. If this is needed again
          * in the future, here is the place to add it */
         policy = SESMAN_CFG_SESS_POLICY_U | SESMAN_CFG_SESS_POLICY_B;
     }
@@ -115,9 +89,9 @@ session_get_bydata(const struct session_parameters *sp)
     LOG(LOG_LEVEL_DEBUG,
         "%s: search policy=%s type=%s U=%d B=%d D=(%dx%d) I=%s",
         __func__,
-        policy_str, SCP_SESSION_TYPE_TO_STR(sp->type),
-        sp->uid, sp->bpp, sp->width, sp->height,
-        sp->ip_addr);
+        policy_str, SCP_SESSION_TYPE_TO_STR(type),
+        uid, bpp, width, height,
+        ip_addr);
 
     /* 'Separate' policy never matches */
     if (policy & SESMAN_CFG_SESS_POLICY_SEPARATE)
@@ -140,20 +114,20 @@ session_get_bydata(const struct session_parameters *sp)
             item->width, item->height,
             item->start_ip_addr);
 
-        if (item->type != sp->type)
+        if (item->type != type)
         {
             LOG(LOG_LEVEL_DEBUG, "%s: Type doesn't match", __func__);
             continue;
         }
 
-        if ((policy & SESMAN_CFG_SESS_POLICY_U) && sp->uid != item->uid)
+        if ((policy & SESMAN_CFG_SESS_POLICY_U) && (int)uid != item->uid)
         {
             LOG(LOG_LEVEL_DEBUG,
                 "%s: UID doesn't match for 'U' policy", __func__);
             continue;
         }
 
-        if ((policy & SESMAN_CFG_SESS_POLICY_B) && item->bpp != sp->bpp)
+        if ((policy & SESMAN_CFG_SESS_POLICY_B) && item->bpp != bpp)
         {
             LOG(LOG_LEVEL_DEBUG,
                 "%s: bpp doesn't match for 'B' policy", __func__);
@@ -161,7 +135,7 @@ session_get_bydata(const struct session_parameters *sp)
         }
 
         if ((policy & SESMAN_CFG_SESS_POLICY_D) &&
-                (item->width != sp->width || item->height != sp->height))
+                (item->width != width || item->height != height))
         {
             LOG(LOG_LEVEL_DEBUG,
                 "%s: Dimensions don't match for 'D' policy", __func__);
@@ -169,7 +143,7 @@ session_get_bydata(const struct session_parameters *sp)
         }
 
         if ((policy & SESMAN_CFG_SESS_POLICY_I) &&
-                g_strcmp(item->start_ip_addr, sp->ip_addr) != 0)
+                g_strcmp(item->start_ip_addr, ip_addr) != 0)
         {
             LOG(LOG_LEVEL_DEBUG,
                 "%s: IPs don't match for 'I' policy", __func__);
@@ -313,9 +287,8 @@ session_is_display_in_chain(int display)
 }
 
 /******************************************************************************/
-/* called with the main thread */
-static int
-session_get_avail_display_from_chain(void)
+int
+session_get_available_display(void)
 {
     int display;
 
@@ -338,40 +311,6 @@ session_get_avail_display_from_chain(void)
         g_cfg->sess.x11_display_offset,
         g_cfg->sess.x11_display_offset + g_cfg->sess.max_sessions);
     return 0;
-}
-
-static int
-session_start_chansrv(int uid, int display)
-{
-    struct list *chansrv_params;
-    const char *exe_path = XRDP_SBIN_PATH "/xrdp-chansrv";
-    int chansrv_pid;
-
-    chansrv_pid = g_fork();
-    if (chansrv_pid == 0)
-    {
-        chansrv_params = list_create();
-        chansrv_params->auto_free = 1;
-
-        /* building parameters */
-
-        list_add_strdup(chansrv_params, exe_path);
-
-        env_set_user(uid, 0, display,
-                     g_cfg->env_names,
-                     g_cfg->env_values);
-
-        LOG(LOG_LEVEL_INFO,
-            "Starting the xrdp channel server for display %d", display);
-
-        /* executing chansrv */
-        g_execvp_list(exe_path, chansrv_params);
-
-        /* should not get here */
-        list_delete(chansrv_params);
-        g_exit(1);
-    }
-    return chansrv_pid;
 }
 
 /******************************************************************************/
@@ -399,630 +338,6 @@ username_from_uid(int uid, char *uname, int uname_len)
         g_snprintf(uname, uname_len, "<unknown>");
     }
     return rv;
-}
-
-/******************************************************************************/
-static void
-exit_status_to_str(const struct exit_status *e, char buff[], int bufflen)
-{
-    switch (e->reason)
-    {
-        case E_XR_STATUS_CODE:
-            if (e->val == 0)
-            {
-                g_snprintf(buff, bufflen, "exit code zero");
-            }
-            else
-            {
-                g_snprintf(buff, bufflen, "non-zero exit code %d", e->val);
-            }
-            break;
-
-        case E_XR_SIGNAL:
-            g_snprintf(buff, bufflen, "signal %d", e->val);
-            break;
-
-        default:
-            g_snprintf(buff, bufflen, "an unexpected error");
-            break;
-    }
-}
-
-/******************************************************************************/
-
-enum scp_screate_status
-session_start(struct auth_info *auth_info,
-              const struct session_parameters *s,
-              int *returned_display,
-              struct guid *guid)
-{
-    int display = 0;
-    int pid = 0;
-    char geometry[32];
-    char depth[32];
-    char screen[32]; /* display number */
-    char text[256];
-    char username[256];
-    char execvpparams[2048];
-    char *xserver = NULL; /* absolute/relative path to Xorg/Xvnc */
-    char *passwd_file;
-    struct session_chain *temp = (struct session_chain *)NULL;
-    struct list *xserver_params = (struct list *)NULL;
-    char authfile[256]; /* The filename for storing xauth information */
-    int chansrv_pid;
-    int display_pid;
-    int window_manager_pid;
-
-    /* initialize (zero out) local variables: */
-    g_memset(geometry, 0, sizeof(char) * 32);
-    g_memset(depth, 0, sizeof(char) * 32);
-    g_memset(screen, 0, sizeof(char) * 32);
-    g_memset(text, 0, sizeof(char) * 256);
-
-    passwd_file = 0;
-
-    /* Get the username for display purposes */
-    username_from_uid(s->uid, username, sizeof(username));
-
-    /* check to limit concurrent sessions */
-    if (g_session_count >= g_cfg->sess.max_sessions)
-    {
-        LOG(LOG_LEVEL_ERROR, "max concurrent session limit "
-            "exceeded. login for user %s denied", username);
-        return E_SCP_SCREATE_MAX_REACHED;
-    }
-
-    temp = (struct session_chain *)g_malloc(sizeof(struct session_chain), 0);
-
-    if (temp == 0)
-    {
-        LOG(LOG_LEVEL_ERROR, "Out of memory error: cannot create new session "
-            "chain element - user %s", username);
-        return E_SCP_SCREATE_NO_MEMORY;
-    }
-
-    temp->item = (struct session_item *)g_malloc(sizeof(struct session_item), 0);
-
-    if (temp->item == 0)
-    {
-        g_free(temp);
-        LOG(LOG_LEVEL_ERROR, "Out of memory error: cannot create new session "
-            "item - user %s", username);
-        return E_SCP_SCREATE_NO_MEMORY;
-    }
-
-    display = session_get_avail_display_from_chain();
-
-    if (display == 0)
-    {
-        g_free(temp->item);
-        g_free(temp);
-        return E_SCP_SCREATE_NO_DISPLAY;
-    }
-
-    /* Create a GUID for the new session before we fork */
-    *guid = guid_new();
-    *returned_display = display;
-
-    pid = g_fork(); /* parent is fork from tcp accept,
-                       child forks X and wm, then becomes scp */
-
-    if (pid == -1)
-    {
-        LOG(LOG_LEVEL_ERROR,
-            "[session start] (display %d): Failed to fork for scp with "
-            "errno: %d, description: %s",
-            display, g_get_errno(), g_get_strerror());
-        g_free(temp->item);
-        g_free(temp);
-        return E_SCP_SCREATE_GENERAL_ERROR;
-    }
-
-    if (pid == 0)
-    {
-        LOG(LOG_LEVEL_INFO,
-            "[session start] (display %d): calling auth_start_session from pid %d",
-            display, g_getpid());
-
-        /* Wait objects created in a parent are not valid in a child */
-        g_delete_wait_obj(g_reload_event);
-        g_delete_wait_obj(g_sigchld_event);
-        g_delete_wait_obj(g_term_event);
-
-        /* Set the secondary groups before starting the session to prevent
-         * problems on PAM-based systems (see Linux pam_setcred(3)).
-         * If we have *BSD setusercontext() this is not done here */
-#ifndef HAVE_SETUSERCONTEXT
-        if (g_initgroups(username) != 0)
-        {
-            LOG(LOG_LEVEL_ERROR,
-                "Failed to initialise secondary groups for %s: %s",
-                username, g_get_strerror());
-            g_exit(1);
-        }
-#endif
-
-        sesman_close_all(0);
-        auth_start_session(auth_info, display);
-        g_sprintf(geometry, "%dx%d", s->width, s->height);
-        g_sprintf(depth, "%d", s->bpp);
-        g_sprintf(screen, ":%d", display);
-#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
-        /*
-         * FreeBSD bug
-         * ports/157282: effective login name is not set by xrdp-sesman
-         * http://www.freebsd.org/cgi/query-pr.cgi?pr=157282
-         *
-         * from:
-         *  $OpenBSD: session.c,v 1.252 2010/03/07 11:57:13 dtucker Exp $
-         *  with some ideas about BSD process grouping to xrdp
-         */
-        pid_t bsdsespid = g_fork();
-
-        if (bsdsespid == -1)
-        {
-        }
-        else if (bsdsespid == 0) /* BSD session leader */
-        {
-            /**
-             * Create a new session and process group since the 4.4BSD
-             * setlogin() affects the entire process group
-             */
-            if (g_setsid() < 0)
-            {
-                LOG(LOG_LEVEL_WARNING,
-                    "[session start] (display %d): setsid failed - pid %d",
-                    display, g_getpid());
-            }
-
-            if (g_setlogin(username) < 0)
-            {
-                LOG(LOG_LEVEL_WARNING,
-                    "[session start] (display %d): setlogin failed for user %s - pid %d",
-                    display, username, g_getpid());
-            }
-        }
-
-        g_waitpid(bsdsespid);
-
-        if (bsdsespid > 0)
-        {
-            g_exit(0);
-            /*
-             * intermediate sesman should exit here after WM exits.
-             * do not execute the following codes.
-             */
-        }
-#endif
-        window_manager_pid = g_fork(); /* parent becomes X,
-                             child forks wm, and waits, todo */
-        if (window_manager_pid == -1)
-        {
-            LOG(LOG_LEVEL_ERROR,
-                "Failed to fork for the window manager on display %d", display);
-        }
-        else if (window_manager_pid == 0)
-        {
-            enum xwait_status xws;
-
-            env_set_user(s->uid,
-                         0,
-                         display,
-                         g_cfg->env_names,
-                         g_cfg->env_values);
-            xws = wait_for_xserver(display);
-
-            if (xws == XW_STATUS_OK)
-            {
-                auth_set_env(auth_info);
-                if (s->directory != 0)
-                {
-                    if (s->directory[0] != 0)
-                    {
-                        g_set_current_dir(s->directory);
-                    }
-                }
-                if (s->shell != 0 && s->shell[0] != 0)
-                {
-                    if (g_strchr(s->shell, ' ') != 0 || g_strchr(s->shell, '\t') != 0)
-                    {
-                        LOG(LOG_LEVEL_INFO,
-                            "Starting user requested window manager on "
-                            "display %d with embedded arguments using a shell: %s",
-                            display, s->shell);
-                        const char *argv[] = {"sh", "-c", s->shell, NULL};
-                        g_execvp("/bin/sh", (char **)argv);
-                    }
-                    else
-                    {
-                        LOG(LOG_LEVEL_INFO,
-                            "Starting user requested window manager on "
-                            "display %d: %s", display, s->shell);
-                        g_execlp3(s->shell, s->shell, 0);
-                    }
-                }
-                else
-                {
-                    LOG(LOG_LEVEL_DEBUG, "The user session on display %d did "
-                        "not request a specific window manager", display);
-                }
-
-                /* try to execute user window manager if enabled */
-                if (g_cfg->enable_user_wm)
-                {
-                    g_sprintf(text, "%s/%s", g_getenv("HOME"), g_cfg->user_wm);
-                    if (g_file_exist(text))
-                    {
-                        LOG(LOG_LEVEL_INFO,
-                            "Starting window manager on display %d"
-                            " from user home directory: %s", display, text);
-                        g_execlp3(text, g_cfg->user_wm, 0);
-                    }
-                    else
-                    {
-                        LOG(LOG_LEVEL_DEBUG,
-                            "The user home directory window manager configuration "
-                            "is enabled but window manager program does not exist: %s",
-                            text);
-                    }
-                }
-
-                LOG(LOG_LEVEL_INFO,
-                    "Starting the default window manager on display %d: %s",
-                    display, g_cfg->default_wm);
-                g_execlp3(g_cfg->default_wm, g_cfg->default_wm, 0);
-
-                /* still a problem starting window manager just start xterm */
-                LOG(LOG_LEVEL_WARNING,
-                    "No window manager on display %d started, "
-                    "so falling back to starting xterm for user debugging",
-                    display);
-                g_execlp3("xterm", "xterm", 0);
-
-                /* should not get here */
-            }
-            else
-            {
-                switch (xws)
-                {
-                    case XW_STATUS_TIMED_OUT:
-                        LOG(LOG_LEVEL_ERROR, "Timed out waiting for X server");
-                        break;
-                    case XW_STATUS_FAILED_TO_START:
-                        LOG(LOG_LEVEL_ERROR, "X server failed to start");
-                        break;
-                    default:
-                        LOG(LOG_LEVEL_ERROR,
-                            "An error occurred waiting for the X server");
-                }
-            }
-
-            LOG(LOG_LEVEL_ERROR, "A fatal error has occurred attempting to start "
-                "the window manager on display %d, aborting connection",
-                display);
-            g_exit(0);
-        }
-        else
-        {
-            display_pid = g_fork(); /* parent becomes scp,
-                                child becomes X */
-            if (display_pid == -1)
-            {
-                LOG(LOG_LEVEL_ERROR,
-                    "Failed to fork for the X server on display %d", display);
-            }
-            else if (display_pid == 0) /* child */
-            {
-                if (s->type == SCP_SESSION_TYPE_XVNC)
-                {
-                    env_set_user(s->uid,
-                                 &passwd_file,
-                                 display,
-                                 g_cfg->env_names,
-                                 g_cfg->env_values);
-                }
-                else
-                {
-                    env_set_user(s->uid,
-                                 0,
-                                 display,
-                                 g_cfg->env_names,
-                                 g_cfg->env_values);
-                }
-
-                /* setting Xserver environment variables */
-                g_snprintf(text, 255, "%d", g_cfg->sess.max_idle_time);
-                g_setenv("XRDP_SESMAN_MAX_IDLE_TIME", text, 1);
-                g_snprintf(text, 255, "%d", g_cfg->sess.max_disc_time);
-                g_setenv("XRDP_SESMAN_MAX_DISC_TIME", text, 1);
-                g_snprintf(text, 255, "%d", g_cfg->sess.kill_disconnected);
-                g_setenv("XRDP_SESMAN_KILL_DISCONNECTED", text, 1);
-                g_setenv("XRDP_SOCKET_PATH", XRDP_SOCKET_PATH, 1);
-
-                /* prepare the Xauthority stuff */
-                if (g_getenv("XAUTHORITY") != NULL)
-                {
-                    g_snprintf(authfile, 255, "%s", g_getenv("XAUTHORITY"));
-                }
-                else
-                {
-                    g_snprintf(authfile, 255, "%s", ".Xauthority");
-                }
-
-                /* Add the entry in XAUTHORITY file or exit if error */
-                if (add_xauth_cookie(display, authfile) != 0)
-                {
-                    LOG(LOG_LEVEL_ERROR,
-                        "Error setting the xauth cookie for display %d in file %s",
-                        display, authfile);
-
-                    LOG(LOG_LEVEL_ERROR, "A fatal error has occurred attempting to start "
-                        "the X server on display %d, aborting connection",
-                        display);
-                    g_exit(1);
-                }
-
-                if (s->type == SCP_SESSION_TYPE_XORG)
-                {
-#ifdef HAVE_SYS_PRCTL_H
-                    /*
-                     * Make sure Xorg doesn't run setuid root. Root access is not
-                     * needed. Xorg can fail when run as root and the user has no
-                     * console permissions.
-                     * PR_SET_NO_NEW_PRIVS requires Linux kernel 3.5 and newer.
-                     */
-                    if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) < 0)
-                    {
-                        LOG(LOG_LEVEL_WARNING,
-                            "[session start] (display %d): Failed to disable "
-                            "setuid on X server: %s",
-                            display, g_get_strerror());
-                    }
-#endif
-
-                    xserver_params = list_create();
-                    xserver_params->auto_free = 1;
-
-                    /* get path of Xorg from config */
-                    xserver = g_strdup((const char *)list_get_item(g_cfg->xorg_params, 0));
-
-                    /* these are the must have parameters */
-                    list_add_strdup_multi(xserver_params,
-                                          xserver, screen,
-                                          "-auth", authfile,
-                                          NULL);
-
-                    /* additional parameters from sesman.ini file */
-                    list_append_list_strdup(g_cfg->xorg_params, xserver_params, 1);
-
-                    /* some args are passed via env vars */
-                    g_sprintf(geometry, "%d", s->width);
-                    g_setenv("XRDP_START_WIDTH", geometry, 1);
-
-                    g_sprintf(geometry, "%d", s->height);
-                    g_setenv("XRDP_START_HEIGHT", geometry, 1);
-                }
-                else if (s->type == SCP_SESSION_TYPE_XVNC)
-                {
-                    char guid_str[GUID_STR_SIZE];
-                    guid_to_str(guid, guid_str);
-                    env_check_password_file(passwd_file, guid_str);
-                    xserver_params = list_create();
-                    xserver_params->auto_free = 1;
-
-                    /* get path of Xvnc from config */
-                    xserver = g_strdup((const char *)list_get_item(g_cfg->vnc_params, 0));
-
-                    /* these are the must have parameters */
-                    list_add_strdup_multi(xserver_params,
-                                          xserver, screen,
-                                          "-auth", authfile,
-                                          "-geometry", geometry,
-                                          "-depth", depth,
-                                          "-rfbauth", passwd_file,
-                                          NULL);
-                    g_free(passwd_file);
-
-                    /* additional parameters from sesman.ini file */
-                    //config_read_xserver_params(SCP_SESSION_TYPE_XVNC,
-                    //                           xserver_params);
-                    list_append_list_strdup(g_cfg->vnc_params, xserver_params, 1);
-                }
-                else
-                {
-                    LOG(LOG_LEVEL_ERROR, "Unknown session type: %d",
-                        s->type);
-                    LOG(LOG_LEVEL_ERROR, "A fatal error has occurred attempting "
-                        "to start the X server on display %d, aborting connection",
-                        display);
-                    g_exit(1);
-                }
-
-                /* fire up X server */
-                LOG(LOG_LEVEL_INFO, "Starting X server on display %d: %s",
-                    display, dumpItemsToString(xserver_params, execvpparams, 2048));
-                g_execvp_list(xserver, xserver_params);
-
-                /* should not get here */
-                LOG(LOG_LEVEL_ERROR,
-                    "Error starting X server on display %d", display);
-                LOG(LOG_LEVEL_ERROR, "A fatal error has occurred attempting "
-                    "to start the X server on display %d, aborting connection",
-                    display);
-
-                list_delete(xserver_params);
-                g_exit(1);
-            }
-            else
-            {
-                int wm_wait_time;
-                struct exit_status wm_exit_status;
-                struct exit_status xserver_exit_status;
-                struct exit_status chansrv_exit_status;
-                char reason[128];
-                chansrv_pid = session_start_chansrv(s->uid, display);
-
-                LOG(LOG_LEVEL_INFO,
-                    "Session started successfully for user %s on display %d",
-                    username, display);
-
-                /* Monitor the amount of time we wait for the
-                 * window manager. This is approximately how long the window
-                 * manager was running for */
-                LOG(LOG_LEVEL_INFO, "Session in progress on display %d, waiting "
-                    "until the window manager (pid %d) exits to end the session",
-                    display, window_manager_pid);
-                wm_wait_time = g_time1();
-                wm_exit_status = g_waitpid_status(window_manager_pid);
-                wm_wait_time = g_time1() - wm_wait_time;
-                if (wm_exit_status.reason == E_XR_STATUS_CODE &&
-                        wm_exit_status.val == 0)
-                {
-                    // Normal exit
-                }
-                else
-                {
-                    exit_status_to_str(&wm_exit_status, reason, sizeof(reason));
-
-                    LOG(LOG_LEVEL_WARNING,
-                        "Window manager (pid %d, display %d) "
-                        "exited with %s. This "
-                        "could indicate a window manager config problem",
-                        window_manager_pid, display, reason);
-                }
-                if (wm_wait_time < 10)
-                {
-                    /* This could be a config issue. Log a significant error */
-                    LOG(LOG_LEVEL_WARNING, "Window manager (pid %d, display %d) "
-                        "exited quickly (%d secs). This could indicate a window "
-                        "manager config problem",
-                        window_manager_pid, display, wm_wait_time);
-                }
-                else
-                {
-                    LOG(LOG_LEVEL_DEBUG, "Window manager (pid %d, display %d) "
-                        "was running for %d seconds.",
-                        window_manager_pid, display, wm_wait_time);
-                }
-                LOG(LOG_LEVEL_INFO,
-                    "Calling auth_stop_session from pid %d",
-                    g_getpid());
-                auth_stop_session(auth_info);
-                // auth_end() is called from the main process currently,
-                // as this called auth_start()
-                //auth_end(auth_info);
-
-                LOG(LOG_LEVEL_INFO,
-                    "Terminating X server (pid %d) on display %d",
-                    display_pid, display);
-                g_sigterm(display_pid);
-
-                LOG(LOG_LEVEL_INFO, "Terminating the xrdp channel server (pid %d) "
-                    "on display %d", chansrv_pid, display);
-                g_sigterm(chansrv_pid);
-
-                /* make sure socket cleanup happen after child process exit */
-                xserver_exit_status = g_waitpid_status(display_pid);
-                exit_status_to_str(&xserver_exit_status, reason, sizeof(reason));
-                LOG(LOG_LEVEL_INFO,
-                    "X server on display %d (pid %d) exited with %s",
-                    display, display_pid, reason);
-
-                chansrv_exit_status = g_waitpid_status(chansrv_pid);
-                exit_status_to_str(&chansrv_exit_status, reason, sizeof(reason));
-                LOG(LOG_LEVEL_INFO,
-                    "xrdp channel server for display %d (pid %d)"
-                    " exited with %s",
-                    display, chansrv_pid, reason);
-
-                cleanup_sockets(display);
-                g_deinit();
-                g_exit(0);
-            }
-        }
-    }
-    else
-    {
-        LOG(LOG_LEVEL_INFO, "Starting session: session_pid %d, "
-            "display :%d.0, width %d, height %d, bpp %d, client ip %s, "
-            "UID %d",
-            pid, display, s->width, s->height, s->bpp, s->ip_addr, s->uid);
-        temp->item->pid = pid;
-        temp->item->display = display;
-        temp->item->width = s->width;
-        temp->item->height = s->height;
-        temp->item->bpp = s->bpp;
-        temp->item->auth_info = auth_info;
-        g_strncpy(temp->item->start_ip_addr, s->ip_addr,
-                  sizeof(temp->item->start_ip_addr) - 1);
-        temp->item->uid = s->uid;
-        temp->item->guid = *guid;
-
-        temp->item->start_time = g_time1();
-
-        temp->item->type = s->type;
-        temp->item->status = SESMAN_SESSION_STATUS_ACTIVE;
-
-        temp->next = g_sessions;
-        g_sessions = temp;
-        g_session_count++;
-
-        return E_SCP_SCREATE_OK;
-    }
-
-    /* Shouldn't get here */
-    g_free(temp->item);
-    g_free(temp);
-    return E_SCP_SCREATE_GENERAL_ERROR;
-}
-
-/******************************************************************************/
-int
-session_reconnect(int display, int uid,
-                  struct auth_info *auth_info)
-{
-    int pid;
-
-    pid = g_fork();
-
-    if (pid == -1)
-    {
-        LOG(LOG_LEVEL_ERROR, "Failed to fork for session reconnection script");
-    }
-    else if (pid == 0)
-    {
-        env_set_user(uid,
-                     0,
-                     display,
-                     g_cfg->env_names,
-                     g_cfg->env_values);
-        auth_set_env(auth_info);
-
-        if (g_file_exist(g_cfg->reconnect_sh))
-        {
-            LOG(LOG_LEVEL_INFO,
-                "Starting session reconnection script on display %d: %s",
-                display, g_cfg->reconnect_sh);
-            g_execlp3(g_cfg->reconnect_sh, g_cfg->reconnect_sh, 0);
-
-            /* should not get here */
-            LOG(LOG_LEVEL_ERROR,
-                "Error starting session reconnection script on display %d: %s",
-                display, g_cfg->reconnect_sh);
-        }
-        else
-        {
-            LOG(LOG_LEVEL_WARNING,
-                "Session reconnection script file does not exist: %s",
-                g_cfg->reconnect_sh);
-        }
-
-        /* TODO: why is this existing with a success error code when the
-            reconnect script failed to be executed? */
-        g_exit(0);
-    }
-
-    return display;
 }
 
 /******************************************************************************/
@@ -1264,99 +579,4 @@ free_session_info_list(struct scp_session_info *sesslist, unsigned int cnt)
     }
 
     g_free(sesslist);
-}
-
-/******************************************************************************/
-int
-cleanup_sockets(int display)
-{
-    LOG(LOG_LEVEL_INFO, "cleanup_sockets:");
-    char file[256];
-    int error;
-
-    error = 0;
-
-    g_snprintf(file, 255, CHANSRV_PORT_OUT_STR, display);
-    if (g_file_exist(file))
-    {
-        LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
-        if (g_file_delete(file) == 0)
-        {
-            LOG(LOG_LEVEL_WARNING,
-                "cleanup_sockets: failed to delete %s (%s)",
-                file, g_get_strerror());
-            error++;
-        }
-    }
-
-    g_snprintf(file, 255, CHANSRV_PORT_IN_STR, display);
-    if (g_file_exist(file))
-    {
-        LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
-        if (g_file_delete(file) == 0)
-        {
-            LOG(LOG_LEVEL_WARNING,
-                "cleanup_sockets: failed to delete %s (%s)",
-                file, g_get_strerror());
-            error++;
-        }
-    }
-
-    g_snprintf(file, 255, XRDP_CHANSRV_STR, display);
-    if (g_file_exist(file))
-    {
-        LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
-        if (g_file_delete(file) == 0)
-        {
-            LOG(LOG_LEVEL_WARNING,
-                "cleanup_sockets: failed to delete %s (%s)",
-                file, g_get_strerror());
-            error++;
-        }
-    }
-
-    g_snprintf(file, 255, CHANSRV_API_STR, display);
-    if (g_file_exist(file))
-    {
-        LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
-        if (g_file_delete(file) == 0)
-        {
-            LOG(LOG_LEVEL_WARNING,
-                "cleanup_sockets: failed to delete %s (%s)",
-                file, g_get_strerror());
-            error++;
-        }
-    }
-
-    /* the following files should be deleted by xorgxrdp
-     * but just in case the deletion failed */
-
-    g_snprintf(file, 255, XRDP_X11RDP_STR, display);
-    if (g_file_exist(file))
-    {
-        LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
-        if (g_file_delete(file) == 0)
-        {
-            LOG(LOG_LEVEL_WARNING,
-                "cleanup_sockets: failed to delete %s (%s)",
-                file, g_get_strerror());
-            error++;
-        }
-    }
-
-    g_snprintf(file, 255, XRDP_DISCONNECT_STR, display);
-    if (g_file_exist(file))
-    {
-        LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
-        if (g_file_delete(file) == 0)
-        {
-            LOG(LOG_LEVEL_WARNING,
-                "cleanup_sockets: failed to delete %s (%s)",
-                file, g_get_strerror());
-            error++;
-        }
-    }
-
-    return error;
-
 }

--- a/sesman/session_list.c
+++ b/sesman/session_list.c
@@ -1,0 +1,1362 @@
+/**
+ * xrdp: A Remote Desktop Protocol server.
+ *
+ * Copyright (C) Jay Sorg 2004-2015
+ *
+ * BSD process grouping by:
+ * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland.
+ * Copyright (c) 2000-2001 Markus Friedl.
+ * Copyright (c) 2011-2015 Koichiro Iwao, Kyushu Institute of Technology.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *
+ * @file session.c
+ * @brief Session management code
+ * @author Jay Sorg, Simone Fedele
+ *
+ */
+
+#if defined(HAVE_CONFIG_H)
+#include "config_ac.h"
+#endif
+
+#ifdef HAVE_SYS_PRCTL_H
+#include <sys/prctl.h>
+#endif
+
+#include "arch.h"
+#include "session.h"
+
+#include "auth.h"
+#include "config.h"
+#include "env.h"
+#include "list.h"
+#include "log.h"
+#include "os_calls.h"
+#include "sesman.h"
+#include "string_calls.h"
+#include "xauth.h"
+#include "xwait.h"
+#include "xrdp_sockets.h"
+
+#ifndef PR_SET_NO_NEW_PRIVS
+#define PR_SET_NO_NEW_PRIVS 38
+#endif
+
+static struct session_chain *g_sessions;
+static int g_session_count;
+
+/**
+ * Creates a string consisting of all parameters that is hosted in the param list
+ * @param self
+ * @param outstr, allocate this buffer before you use this function
+ * @param len the allocated len for outstr
+ * @return
+ */
+char *
+dumpItemsToString(struct list *self, char *outstr, int len)
+{
+    int index;
+    int totalLen = 0;
+
+    g_memset(outstr, 0, len);
+    if (self->count == 0)
+    {
+        LOG_DEVEL(LOG_LEVEL_TRACE, "List is empty");
+    }
+
+    for (index = 0; index < self->count; index++)
+    {
+        /* +1 = one space*/
+        totalLen = totalLen + g_strlen((char *)list_get_item(self, index)) + 1;
+
+        if (len > totalLen)
+        {
+            g_strcat(outstr, (char *)list_get_item(self, index));
+            g_strcat(outstr, " ");
+        }
+    }
+
+    return outstr ;
+}
+
+
+/******************************************************************************/
+struct session_item *
+session_get_bydata(const struct session_parameters *sp)
+{
+    char policy_str[64];
+    struct session_chain *tmp;
+    int policy = g_cfg->sess.policy;
+
+    if ((policy & SESMAN_CFG_SESS_POLICY_DEFAULT) != 0)
+    {
+        /* In the past (i.e. xrdp before v0.9.14), the default
+         * session policy varied by sp->type. If this is needed again
+         * in the future, here is the place to add it */
+        policy = SESMAN_CFG_SESS_POLICY_U | SESMAN_CFG_SESS_POLICY_B;
+    }
+
+    config_output_policy_string(policy, policy_str, sizeof(policy_str));
+
+    LOG(LOG_LEVEL_DEBUG,
+        "%s: search policy=%s type=%s U=%d B=%d D=(%dx%d) I=%s",
+        __func__,
+        policy_str, SCP_SESSION_TYPE_TO_STR(sp->type),
+        sp->uid, sp->bpp, sp->width, sp->height,
+        sp->ip_addr);
+
+    /* 'Separate' policy never matches */
+    if (policy & SESMAN_CFG_SESS_POLICY_SEPARATE)
+    {
+        LOG(LOG_LEVEL_DEBUG, "%s: No matches possible", __func__);
+        return NULL;
+    }
+
+    for (tmp = g_sessions ; tmp != 0 ; tmp = tmp->next)
+    {
+        struct session_item *item = tmp->item;
+
+        LOG(LOG_LEVEL_DEBUG,
+            "%s: try %p type=%s U=%d B=%d D=(%dx%d) I=%s",
+            __func__,
+            item,
+            SCP_SESSION_TYPE_TO_STR(item->type),
+            item->uid,
+            item->bpp,
+            item->width, item->height,
+            item->start_ip_addr);
+
+        if (item->type != sp->type)
+        {
+            LOG(LOG_LEVEL_DEBUG, "%s: Type doesn't match", __func__);
+            continue;
+        }
+
+        if ((policy & SESMAN_CFG_SESS_POLICY_U) && sp->uid != item->uid)
+        {
+            LOG(LOG_LEVEL_DEBUG,
+                "%s: UID doesn't match for 'U' policy", __func__);
+            continue;
+        }
+
+        if ((policy & SESMAN_CFG_SESS_POLICY_B) && item->bpp != sp->bpp)
+        {
+            LOG(LOG_LEVEL_DEBUG,
+                "%s: bpp doesn't match for 'B' policy", __func__);
+            continue;
+        }
+
+        if ((policy & SESMAN_CFG_SESS_POLICY_D) &&
+                (item->width != sp->width || item->height != sp->height))
+        {
+            LOG(LOG_LEVEL_DEBUG,
+                "%s: Dimensions don't match for 'D' policy", __func__);
+            continue;
+        }
+
+        if ((policy & SESMAN_CFG_SESS_POLICY_I) &&
+                g_strcmp(item->start_ip_addr, sp->ip_addr) != 0)
+        {
+            LOG(LOG_LEVEL_DEBUG,
+                "%s: IPs don't match for 'I' policy", __func__);
+            continue;
+        }
+
+        LOG(LOG_LEVEL_DEBUG,
+            "%s: Got match, display=%d", __func__, item->display);
+        return item;
+    }
+
+    LOG(LOG_LEVEL_DEBUG, "%s: No matches found", __func__);
+    return 0;
+}
+
+/******************************************************************************/
+/**
+ *
+ * @brief checks if there's a server running on a display
+ * @param display the display to check
+ * @return 0 if there isn't a display running, nonzero otherwise
+ *
+ */
+static int
+x_server_running_check_ports(int display)
+{
+    char text[256];
+    int x_running;
+    int sck;
+
+    g_sprintf(text, "/tmp/.X11-unix/X%d", display);
+    x_running = g_file_exist(text);
+
+    if (!x_running)
+    {
+        LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
+        g_sprintf(text, "/tmp/.X%d-lock", display);
+        x_running = g_file_exist(text);
+    }
+
+    if (!x_running) /* check 59xx */
+    {
+        LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
+        if ((sck = g_tcp_socket()) != -1)
+        {
+            g_sprintf(text, "59%2.2d", display);
+            x_running = g_tcp_bind(sck, text);
+            g_tcp_close(sck);
+        }
+    }
+
+    if (!x_running) /* check 60xx */
+    {
+        LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
+        if ((sck = g_tcp_socket()) != -1)
+        {
+            g_sprintf(text, "60%2.2d", display);
+            x_running = g_tcp_bind(sck, text);
+            g_tcp_close(sck);
+        }
+    }
+
+    if (!x_running) /* check 62xx */
+    {
+        LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
+        if ((sck = g_tcp_socket()) != -1)
+        {
+            g_sprintf(text, "62%2.2d", display);
+            x_running = g_tcp_bind(sck, text);
+            g_tcp_close(sck);
+        }
+    }
+
+    if (!x_running)
+    {
+        LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
+        g_sprintf(text, XRDP_CHANSRV_STR, display);
+        x_running = g_file_exist(text);
+    }
+
+    if (!x_running)
+    {
+        LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
+        g_sprintf(text, CHANSRV_PORT_OUT_STR, display);
+        x_running = g_file_exist(text);
+    }
+
+    if (!x_running)
+    {
+        LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
+        g_sprintf(text, CHANSRV_PORT_IN_STR, display);
+        x_running = g_file_exist(text);
+    }
+
+    if (!x_running)
+    {
+        LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
+        g_sprintf(text, CHANSRV_API_STR, display);
+        x_running = g_file_exist(text);
+    }
+
+    if (!x_running)
+    {
+        LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
+        g_sprintf(text, XRDP_X11RDP_STR, display);
+        x_running = g_file_exist(text);
+    }
+
+    if (x_running)
+    {
+        LOG(LOG_LEVEL_INFO, "Found X server running at %s", text);
+    }
+
+    return x_running;
+}
+
+/******************************************************************************/
+/* called with the main thread
+   returns boolean */
+static int
+session_is_display_in_chain(int display)
+{
+    struct session_chain *chain;
+    struct session_item *item;
+
+    chain = g_sessions;
+
+    while (chain != 0)
+    {
+        item = chain->item;
+
+        if (item->display == display)
+        {
+            return 1;
+        }
+
+        chain = chain->next;
+    }
+
+    return 0;
+}
+
+/******************************************************************************/
+/* called with the main thread */
+static int
+session_get_avail_display_from_chain(void)
+{
+    int display;
+
+    display = g_cfg->sess.x11_display_offset;
+
+    while ((display - g_cfg->sess.x11_display_offset) <= g_cfg->sess.max_sessions)
+    {
+        if (!session_is_display_in_chain(display))
+        {
+            if (!x_server_running_check_ports(display))
+            {
+                return display;
+            }
+        }
+
+        display++;
+    }
+
+    LOG(LOG_LEVEL_ERROR, "X server -- no display in range (%d to %d) is available",
+        g_cfg->sess.x11_display_offset,
+        g_cfg->sess.x11_display_offset + g_cfg->sess.max_sessions);
+    return 0;
+}
+
+static int
+session_start_chansrv(int uid, int display)
+{
+    struct list *chansrv_params;
+    const char *exe_path = XRDP_SBIN_PATH "/xrdp-chansrv";
+    int chansrv_pid;
+
+    chansrv_pid = g_fork();
+    if (chansrv_pid == 0)
+    {
+        chansrv_params = list_create();
+        chansrv_params->auto_free = 1;
+
+        /* building parameters */
+
+        list_add_strdup(chansrv_params, exe_path);
+
+        env_set_user(uid, 0, display,
+                     g_cfg->env_names,
+                     g_cfg->env_values);
+
+        LOG(LOG_LEVEL_INFO,
+            "Starting the xrdp channel server for display %d", display);
+
+        /* executing chansrv */
+        g_execvp_list(exe_path, chansrv_params);
+
+        /* should not get here */
+        list_delete(chansrv_params);
+        g_exit(1);
+    }
+    return chansrv_pid;
+}
+
+/******************************************************************************/
+/**
+ * Convert a UID to a username
+ *
+ * @param uid UID
+ * @param uname pointer to output buffer
+ * @param uname_len Length of output buffer
+ * @return 0 for success.
+ */
+static int
+username_from_uid(int uid, char *uname, int uname_len)
+{
+    char *ustr;
+    int rv = g_getuser_info_by_uid(uid, &ustr, NULL, NULL, NULL, NULL);
+
+    if (rv == 0)
+    {
+        g_snprintf(uname, uname_len, "%s", ustr);
+        g_free(ustr);
+    }
+    else
+    {
+        g_snprintf(uname, uname_len, "<unknown>");
+    }
+    return rv;
+}
+
+/******************************************************************************/
+static void
+exit_status_to_str(const struct exit_status *e, char buff[], int bufflen)
+{
+    switch (e->reason)
+    {
+        case E_XR_STATUS_CODE:
+            if (e->val == 0)
+            {
+                g_snprintf(buff, bufflen, "exit code zero");
+            }
+            else
+            {
+                g_snprintf(buff, bufflen, "non-zero exit code %d", e->val);
+            }
+            break;
+
+        case E_XR_SIGNAL:
+            g_snprintf(buff, bufflen, "signal %d", e->val);
+            break;
+
+        default:
+            g_snprintf(buff, bufflen, "an unexpected error");
+            break;
+    }
+}
+
+/******************************************************************************/
+
+enum scp_screate_status
+session_start(struct auth_info *auth_info,
+              const struct session_parameters *s,
+              int *returned_display,
+              struct guid *guid)
+{
+    int display = 0;
+    int pid = 0;
+    char geometry[32];
+    char depth[32];
+    char screen[32]; /* display number */
+    char text[256];
+    char username[256];
+    char execvpparams[2048];
+    char *xserver = NULL; /* absolute/relative path to Xorg/Xvnc */
+    char *passwd_file;
+    struct session_chain *temp = (struct session_chain *)NULL;
+    struct list *xserver_params = (struct list *)NULL;
+    char authfile[256]; /* The filename for storing xauth information */
+    int chansrv_pid;
+    int display_pid;
+    int window_manager_pid;
+
+    /* initialize (zero out) local variables: */
+    g_memset(geometry, 0, sizeof(char) * 32);
+    g_memset(depth, 0, sizeof(char) * 32);
+    g_memset(screen, 0, sizeof(char) * 32);
+    g_memset(text, 0, sizeof(char) * 256);
+
+    passwd_file = 0;
+
+    /* Get the username for display purposes */
+    username_from_uid(s->uid, username, sizeof(username));
+
+    /* check to limit concurrent sessions */
+    if (g_session_count >= g_cfg->sess.max_sessions)
+    {
+        LOG(LOG_LEVEL_ERROR, "max concurrent session limit "
+            "exceeded. login for user %s denied", username);
+        return E_SCP_SCREATE_MAX_REACHED;
+    }
+
+    temp = (struct session_chain *)g_malloc(sizeof(struct session_chain), 0);
+
+    if (temp == 0)
+    {
+        LOG(LOG_LEVEL_ERROR, "Out of memory error: cannot create new session "
+            "chain element - user %s", username);
+        return E_SCP_SCREATE_NO_MEMORY;
+    }
+
+    temp->item = (struct session_item *)g_malloc(sizeof(struct session_item), 0);
+
+    if (temp->item == 0)
+    {
+        g_free(temp);
+        LOG(LOG_LEVEL_ERROR, "Out of memory error: cannot create new session "
+            "item - user %s", username);
+        return E_SCP_SCREATE_NO_MEMORY;
+    }
+
+    display = session_get_avail_display_from_chain();
+
+    if (display == 0)
+    {
+        g_free(temp->item);
+        g_free(temp);
+        return E_SCP_SCREATE_NO_DISPLAY;
+    }
+
+    /* Create a GUID for the new session before we fork */
+    *guid = guid_new();
+    *returned_display = display;
+
+    pid = g_fork(); /* parent is fork from tcp accept,
+                       child forks X and wm, then becomes scp */
+
+    if (pid == -1)
+    {
+        LOG(LOG_LEVEL_ERROR,
+            "[session start] (display %d): Failed to fork for scp with "
+            "errno: %d, description: %s",
+            display, g_get_errno(), g_get_strerror());
+        g_free(temp->item);
+        g_free(temp);
+        return E_SCP_SCREATE_GENERAL_ERROR;
+    }
+
+    if (pid == 0)
+    {
+        LOG(LOG_LEVEL_INFO,
+            "[session start] (display %d): calling auth_start_session from pid %d",
+            display, g_getpid());
+
+        /* Wait objects created in a parent are not valid in a child */
+        g_delete_wait_obj(g_reload_event);
+        g_delete_wait_obj(g_sigchld_event);
+        g_delete_wait_obj(g_term_event);
+
+        /* Set the secondary groups before starting the session to prevent
+         * problems on PAM-based systems (see Linux pam_setcred(3)).
+         * If we have *BSD setusercontext() this is not done here */
+#ifndef HAVE_SETUSERCONTEXT
+        if (g_initgroups(username) != 0)
+        {
+            LOG(LOG_LEVEL_ERROR,
+                "Failed to initialise secondary groups for %s: %s",
+                username, g_get_strerror());
+            g_exit(1);
+        }
+#endif
+
+        sesman_close_all(0);
+        auth_start_session(auth_info, display);
+        g_sprintf(geometry, "%dx%d", s->width, s->height);
+        g_sprintf(depth, "%d", s->bpp);
+        g_sprintf(screen, ":%d", display);
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+        /*
+         * FreeBSD bug
+         * ports/157282: effective login name is not set by xrdp-sesman
+         * http://www.freebsd.org/cgi/query-pr.cgi?pr=157282
+         *
+         * from:
+         *  $OpenBSD: session.c,v 1.252 2010/03/07 11:57:13 dtucker Exp $
+         *  with some ideas about BSD process grouping to xrdp
+         */
+        pid_t bsdsespid = g_fork();
+
+        if (bsdsespid == -1)
+        {
+        }
+        else if (bsdsespid == 0) /* BSD session leader */
+        {
+            /**
+             * Create a new session and process group since the 4.4BSD
+             * setlogin() affects the entire process group
+             */
+            if (g_setsid() < 0)
+            {
+                LOG(LOG_LEVEL_WARNING,
+                    "[session start] (display %d): setsid failed - pid %d",
+                    display, g_getpid());
+            }
+
+            if (g_setlogin(username) < 0)
+            {
+                LOG(LOG_LEVEL_WARNING,
+                    "[session start] (display %d): setlogin failed for user %s - pid %d",
+                    display, username, g_getpid());
+            }
+        }
+
+        g_waitpid(bsdsespid);
+
+        if (bsdsespid > 0)
+        {
+            g_exit(0);
+            /*
+             * intermediate sesman should exit here after WM exits.
+             * do not execute the following codes.
+             */
+        }
+#endif
+        window_manager_pid = g_fork(); /* parent becomes X,
+                             child forks wm, and waits, todo */
+        if (window_manager_pid == -1)
+        {
+            LOG(LOG_LEVEL_ERROR,
+                "Failed to fork for the window manager on display %d", display);
+        }
+        else if (window_manager_pid == 0)
+        {
+            enum xwait_status xws;
+
+            env_set_user(s->uid,
+                         0,
+                         display,
+                         g_cfg->env_names,
+                         g_cfg->env_values);
+            xws = wait_for_xserver(display);
+
+            if (xws == XW_STATUS_OK)
+            {
+                auth_set_env(auth_info);
+                if (s->directory != 0)
+                {
+                    if (s->directory[0] != 0)
+                    {
+                        g_set_current_dir(s->directory);
+                    }
+                }
+                if (s->shell != 0 && s->shell[0] != 0)
+                {
+                    if (g_strchr(s->shell, ' ') != 0 || g_strchr(s->shell, '\t') != 0)
+                    {
+                        LOG(LOG_LEVEL_INFO,
+                            "Starting user requested window manager on "
+                            "display %d with embedded arguments using a shell: %s",
+                            display, s->shell);
+                        const char *argv[] = {"sh", "-c", s->shell, NULL};
+                        g_execvp("/bin/sh", (char **)argv);
+                    }
+                    else
+                    {
+                        LOG(LOG_LEVEL_INFO,
+                            "Starting user requested window manager on "
+                            "display %d: %s", display, s->shell);
+                        g_execlp3(s->shell, s->shell, 0);
+                    }
+                }
+                else
+                {
+                    LOG(LOG_LEVEL_DEBUG, "The user session on display %d did "
+                        "not request a specific window manager", display);
+                }
+
+                /* try to execute user window manager if enabled */
+                if (g_cfg->enable_user_wm)
+                {
+                    g_sprintf(text, "%s/%s", g_getenv("HOME"), g_cfg->user_wm);
+                    if (g_file_exist(text))
+                    {
+                        LOG(LOG_LEVEL_INFO,
+                            "Starting window manager on display %d"
+                            " from user home directory: %s", display, text);
+                        g_execlp3(text, g_cfg->user_wm, 0);
+                    }
+                    else
+                    {
+                        LOG(LOG_LEVEL_DEBUG,
+                            "The user home directory window manager configuration "
+                            "is enabled but window manager program does not exist: %s",
+                            text);
+                    }
+                }
+
+                LOG(LOG_LEVEL_INFO,
+                    "Starting the default window manager on display %d: %s",
+                    display, g_cfg->default_wm);
+                g_execlp3(g_cfg->default_wm, g_cfg->default_wm, 0);
+
+                /* still a problem starting window manager just start xterm */
+                LOG(LOG_LEVEL_WARNING,
+                    "No window manager on display %d started, "
+                    "so falling back to starting xterm for user debugging",
+                    display);
+                g_execlp3("xterm", "xterm", 0);
+
+                /* should not get here */
+            }
+            else
+            {
+                switch (xws)
+                {
+                    case XW_STATUS_TIMED_OUT:
+                        LOG(LOG_LEVEL_ERROR, "Timed out waiting for X server");
+                        break;
+                    case XW_STATUS_FAILED_TO_START:
+                        LOG(LOG_LEVEL_ERROR, "X server failed to start");
+                        break;
+                    default:
+                        LOG(LOG_LEVEL_ERROR,
+                            "An error occurred waiting for the X server");
+                }
+            }
+
+            LOG(LOG_LEVEL_ERROR, "A fatal error has occurred attempting to start "
+                "the window manager on display %d, aborting connection",
+                display);
+            g_exit(0);
+        }
+        else
+        {
+            display_pid = g_fork(); /* parent becomes scp,
+                                child becomes X */
+            if (display_pid == -1)
+            {
+                LOG(LOG_LEVEL_ERROR,
+                    "Failed to fork for the X server on display %d", display);
+            }
+            else if (display_pid == 0) /* child */
+            {
+                if (s->type == SCP_SESSION_TYPE_XVNC)
+                {
+                    env_set_user(s->uid,
+                                 &passwd_file,
+                                 display,
+                                 g_cfg->env_names,
+                                 g_cfg->env_values);
+                }
+                else
+                {
+                    env_set_user(s->uid,
+                                 0,
+                                 display,
+                                 g_cfg->env_names,
+                                 g_cfg->env_values);
+                }
+
+                /* setting Xserver environment variables */
+                g_snprintf(text, 255, "%d", g_cfg->sess.max_idle_time);
+                g_setenv("XRDP_SESMAN_MAX_IDLE_TIME", text, 1);
+                g_snprintf(text, 255, "%d", g_cfg->sess.max_disc_time);
+                g_setenv("XRDP_SESMAN_MAX_DISC_TIME", text, 1);
+                g_snprintf(text, 255, "%d", g_cfg->sess.kill_disconnected);
+                g_setenv("XRDP_SESMAN_KILL_DISCONNECTED", text, 1);
+                g_setenv("XRDP_SOCKET_PATH", XRDP_SOCKET_PATH, 1);
+
+                /* prepare the Xauthority stuff */
+                if (g_getenv("XAUTHORITY") != NULL)
+                {
+                    g_snprintf(authfile, 255, "%s", g_getenv("XAUTHORITY"));
+                }
+                else
+                {
+                    g_snprintf(authfile, 255, "%s", ".Xauthority");
+                }
+
+                /* Add the entry in XAUTHORITY file or exit if error */
+                if (add_xauth_cookie(display, authfile) != 0)
+                {
+                    LOG(LOG_LEVEL_ERROR,
+                        "Error setting the xauth cookie for display %d in file %s",
+                        display, authfile);
+
+                    LOG(LOG_LEVEL_ERROR, "A fatal error has occurred attempting to start "
+                        "the X server on display %d, aborting connection",
+                        display);
+                    g_exit(1);
+                }
+
+                if (s->type == SCP_SESSION_TYPE_XORG)
+                {
+#ifdef HAVE_SYS_PRCTL_H
+                    /*
+                     * Make sure Xorg doesn't run setuid root. Root access is not
+                     * needed. Xorg can fail when run as root and the user has no
+                     * console permissions.
+                     * PR_SET_NO_NEW_PRIVS requires Linux kernel 3.5 and newer.
+                     */
+                    if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) < 0)
+                    {
+                        LOG(LOG_LEVEL_WARNING,
+                            "[session start] (display %d): Failed to disable "
+                            "setuid on X server: %s",
+                            display, g_get_strerror());
+                    }
+#endif
+
+                    xserver_params = list_create();
+                    xserver_params->auto_free = 1;
+
+                    /* get path of Xorg from config */
+                    xserver = g_strdup((const char *)list_get_item(g_cfg->xorg_params, 0));
+
+                    /* these are the must have parameters */
+                    list_add_strdup_multi(xserver_params,
+                                          xserver, screen,
+                                          "-auth", authfile,
+                                          NULL);
+
+                    /* additional parameters from sesman.ini file */
+                    list_append_list_strdup(g_cfg->xorg_params, xserver_params, 1);
+
+                    /* some args are passed via env vars */
+                    g_sprintf(geometry, "%d", s->width);
+                    g_setenv("XRDP_START_WIDTH", geometry, 1);
+
+                    g_sprintf(geometry, "%d", s->height);
+                    g_setenv("XRDP_START_HEIGHT", geometry, 1);
+                }
+                else if (s->type == SCP_SESSION_TYPE_XVNC)
+                {
+                    char guid_str[GUID_STR_SIZE];
+                    guid_to_str(guid, guid_str);
+                    env_check_password_file(passwd_file, guid_str);
+                    xserver_params = list_create();
+                    xserver_params->auto_free = 1;
+
+                    /* get path of Xvnc from config */
+                    xserver = g_strdup((const char *)list_get_item(g_cfg->vnc_params, 0));
+
+                    /* these are the must have parameters */
+                    list_add_strdup_multi(xserver_params,
+                                          xserver, screen,
+                                          "-auth", authfile,
+                                          "-geometry", geometry,
+                                          "-depth", depth,
+                                          "-rfbauth", passwd_file,
+                                          NULL);
+                    g_free(passwd_file);
+
+                    /* additional parameters from sesman.ini file */
+                    //config_read_xserver_params(SCP_SESSION_TYPE_XVNC,
+                    //                           xserver_params);
+                    list_append_list_strdup(g_cfg->vnc_params, xserver_params, 1);
+                }
+                else
+                {
+                    LOG(LOG_LEVEL_ERROR, "Unknown session type: %d",
+                        s->type);
+                    LOG(LOG_LEVEL_ERROR, "A fatal error has occurred attempting "
+                        "to start the X server on display %d, aborting connection",
+                        display);
+                    g_exit(1);
+                }
+
+                /* fire up X server */
+                LOG(LOG_LEVEL_INFO, "Starting X server on display %d: %s",
+                    display, dumpItemsToString(xserver_params, execvpparams, 2048));
+                g_execvp_list(xserver, xserver_params);
+
+                /* should not get here */
+                LOG(LOG_LEVEL_ERROR,
+                    "Error starting X server on display %d", display);
+                LOG(LOG_LEVEL_ERROR, "A fatal error has occurred attempting "
+                    "to start the X server on display %d, aborting connection",
+                    display);
+
+                list_delete(xserver_params);
+                g_exit(1);
+            }
+            else
+            {
+                int wm_wait_time;
+                struct exit_status wm_exit_status;
+                struct exit_status xserver_exit_status;
+                struct exit_status chansrv_exit_status;
+                char reason[128];
+                chansrv_pid = session_start_chansrv(s->uid, display);
+
+                LOG(LOG_LEVEL_INFO,
+                    "Session started successfully for user %s on display %d",
+                    username, display);
+
+                /* Monitor the amount of time we wait for the
+                 * window manager. This is approximately how long the window
+                 * manager was running for */
+                LOG(LOG_LEVEL_INFO, "Session in progress on display %d, waiting "
+                    "until the window manager (pid %d) exits to end the session",
+                    display, window_manager_pid);
+                wm_wait_time = g_time1();
+                wm_exit_status = g_waitpid_status(window_manager_pid);
+                wm_wait_time = g_time1() - wm_wait_time;
+                if (wm_exit_status.reason == E_XR_STATUS_CODE &&
+                        wm_exit_status.val == 0)
+                {
+                    // Normal exit
+                }
+                else
+                {
+                    exit_status_to_str(&wm_exit_status, reason, sizeof(reason));
+
+                    LOG(LOG_LEVEL_WARNING,
+                        "Window manager (pid %d, display %d) "
+                        "exited with %s. This "
+                        "could indicate a window manager config problem",
+                        window_manager_pid, display, reason);
+                }
+                if (wm_wait_time < 10)
+                {
+                    /* This could be a config issue. Log a significant error */
+                    LOG(LOG_LEVEL_WARNING, "Window manager (pid %d, display %d) "
+                        "exited quickly (%d secs). This could indicate a window "
+                        "manager config problem",
+                        window_manager_pid, display, wm_wait_time);
+                }
+                else
+                {
+                    LOG(LOG_LEVEL_DEBUG, "Window manager (pid %d, display %d) "
+                        "was running for %d seconds.",
+                        window_manager_pid, display, wm_wait_time);
+                }
+                LOG(LOG_LEVEL_INFO,
+                    "Calling auth_stop_session from pid %d",
+                    g_getpid());
+                auth_stop_session(auth_info);
+                // auth_end() is called from the main process currently,
+                // as this called auth_start()
+                //auth_end(auth_info);
+
+                LOG(LOG_LEVEL_INFO,
+                    "Terminating X server (pid %d) on display %d",
+                    display_pid, display);
+                g_sigterm(display_pid);
+
+                LOG(LOG_LEVEL_INFO, "Terminating the xrdp channel server (pid %d) "
+                    "on display %d", chansrv_pid, display);
+                g_sigterm(chansrv_pid);
+
+                /* make sure socket cleanup happen after child process exit */
+                xserver_exit_status = g_waitpid_status(display_pid);
+                exit_status_to_str(&xserver_exit_status, reason, sizeof(reason));
+                LOG(LOG_LEVEL_INFO,
+                    "X server on display %d (pid %d) exited with %s",
+                    display, display_pid, reason);
+
+                chansrv_exit_status = g_waitpid_status(chansrv_pid);
+                exit_status_to_str(&chansrv_exit_status, reason, sizeof(reason));
+                LOG(LOG_LEVEL_INFO,
+                    "xrdp channel server for display %d (pid %d)"
+                    " exited with %s",
+                    display, chansrv_pid, reason);
+
+                cleanup_sockets(display);
+                g_deinit();
+                g_exit(0);
+            }
+        }
+    }
+    else
+    {
+        LOG(LOG_LEVEL_INFO, "Starting session: session_pid %d, "
+            "display :%d.0, width %d, height %d, bpp %d, client ip %s, "
+            "UID %d",
+            pid, display, s->width, s->height, s->bpp, s->ip_addr, s->uid);
+        temp->item->pid = pid;
+        temp->item->display = display;
+        temp->item->width = s->width;
+        temp->item->height = s->height;
+        temp->item->bpp = s->bpp;
+        temp->item->auth_info = auth_info;
+        g_strncpy(temp->item->start_ip_addr, s->ip_addr,
+                  sizeof(temp->item->start_ip_addr) - 1);
+        temp->item->uid = s->uid;
+        temp->item->guid = *guid;
+
+        temp->item->start_time = g_time1();
+
+        temp->item->type = s->type;
+        temp->item->status = SESMAN_SESSION_STATUS_ACTIVE;
+
+        temp->next = g_sessions;
+        g_sessions = temp;
+        g_session_count++;
+
+        return E_SCP_SCREATE_OK;
+    }
+
+    /* Shouldn't get here */
+    g_free(temp->item);
+    g_free(temp);
+    return E_SCP_SCREATE_GENERAL_ERROR;
+}
+
+/******************************************************************************/
+int
+session_reconnect(int display, int uid,
+                  struct auth_info *auth_info)
+{
+    int pid;
+
+    pid = g_fork();
+
+    if (pid == -1)
+    {
+        LOG(LOG_LEVEL_ERROR, "Failed to fork for session reconnection script");
+    }
+    else if (pid == 0)
+    {
+        env_set_user(uid,
+                     0,
+                     display,
+                     g_cfg->env_names,
+                     g_cfg->env_values);
+        auth_set_env(auth_info);
+
+        if (g_file_exist(g_cfg->reconnect_sh))
+        {
+            LOG(LOG_LEVEL_INFO,
+                "Starting session reconnection script on display %d: %s",
+                display, g_cfg->reconnect_sh);
+            g_execlp3(g_cfg->reconnect_sh, g_cfg->reconnect_sh, 0);
+
+            /* should not get here */
+            LOG(LOG_LEVEL_ERROR,
+                "Error starting session reconnection script on display %d: %s",
+                display, g_cfg->reconnect_sh);
+        }
+        else
+        {
+            LOG(LOG_LEVEL_WARNING,
+                "Session reconnection script file does not exist: %s",
+                g_cfg->reconnect_sh);
+        }
+
+        /* TODO: why is this existing with a success error code when the
+            reconnect script failed to be executed? */
+        g_exit(0);
+    }
+
+    return display;
+}
+
+/******************************************************************************/
+enum session_kill_status
+session_kill(int pid)
+{
+    struct session_chain *tmp;
+    struct session_chain *prev;
+
+    tmp = g_sessions;
+    prev = 0;
+
+    while (tmp != 0)
+    {
+        if (tmp->item == 0)
+        {
+            LOG(LOG_LEVEL_ERROR, "session descriptor for "
+                "pid %d is null!", pid);
+
+            if (prev == 0)
+            {
+                /* prev does no exist, so it's the first element - so we set
+                   g_sessions */
+                g_sessions = tmp->next;
+            }
+            else
+            {
+                prev->next = tmp->next;
+            }
+
+            return SESMAN_SESSION_KILL_NULLITEM;
+        }
+
+        if (tmp->item->pid == pid)
+        {
+            char username[256];
+            username_from_uid(tmp->item->uid, username, sizeof(username));
+
+            /* deleting the session */
+            if (tmp->item->auth_info != NULL)
+            {
+                LOG(LOG_LEVEL_INFO,
+                    "Calling auth_end for pid %d from pid %d",
+                    pid, g_getpid());
+                auth_end(tmp->item->auth_info);
+                tmp->item->auth_info = NULL;
+            }
+            LOG(LOG_LEVEL_INFO,
+                "++ terminated session: UID %d (%s), display :%d.0, "
+                "session_pid %d, ip %s",
+                tmp->item->uid, username, tmp->item->display,
+                tmp->item->pid, tmp->item->start_ip_addr);
+            g_free(tmp->item);
+
+            if (prev == 0)
+            {
+                /* prev does no exist, so it's the first element - so we set
+                   g_sessions */
+                g_sessions = tmp->next;
+            }
+            else
+            {
+                prev->next = tmp->next;
+            }
+
+            g_free(tmp);
+            g_session_count--;
+            return SESMAN_SESSION_KILL_OK;
+        }
+
+        /* go on */
+        prev = tmp;
+        tmp = tmp->next;
+    }
+
+    return SESMAN_SESSION_KILL_NOTFOUND;
+}
+
+/******************************************************************************/
+void
+session_sigkill_all(void)
+{
+    struct session_chain *tmp;
+
+    tmp = g_sessions;
+
+    while (tmp != 0)
+    {
+        if (tmp->item == 0)
+        {
+            LOG(LOG_LEVEL_ERROR, "found null session descriptor!");
+        }
+        else
+        {
+            g_sigterm(tmp->item->pid);
+        }
+
+        /* go on */
+        tmp = tmp->next;
+    }
+}
+
+/******************************************************************************/
+struct session_item *
+session_get_bypid(int pid)
+{
+    struct session_chain *tmp;
+    struct session_item *dummy;
+
+    dummy = g_new0(struct session_item, 1);
+
+    if (0 == dummy)
+    {
+        LOG(LOG_LEVEL_ERROR, "session_get_bypid: out of memory");
+        return 0;
+    }
+
+    tmp = g_sessions;
+
+    while (tmp != 0)
+    {
+        if (tmp->item == 0)
+        {
+            LOG(LOG_LEVEL_ERROR, "session descriptor for pid %d is null!", pid);
+            g_free(dummy);
+            return 0;
+        }
+
+        if (tmp->item->pid == pid)
+        {
+            g_memcpy(dummy, tmp->item, sizeof(struct session_item));
+            return dummy;
+        }
+
+        /* go on */
+        tmp = tmp->next;
+    }
+
+    g_free(dummy);
+    return 0;
+}
+
+/******************************************************************************/
+struct scp_session_info *
+session_get_byuid(int uid, unsigned int *cnt, unsigned char flags)
+{
+    struct session_chain *tmp;
+    struct scp_session_info *sess;
+    int count;
+    int index;
+
+    count = 0;
+
+    tmp = g_sessions;
+
+    LOG(LOG_LEVEL_DEBUG, "searching for session by UID: %d", uid);
+    while (tmp != 0)
+    {
+        if (uid == tmp->item->uid)
+        {
+            LOG(LOG_LEVEL_DEBUG, "session_get_byuser: status=%d, flags=%d, "
+                "result=%d", (tmp->item->status), flags,
+                ((tmp->item->status) & flags));
+
+            if ((tmp->item->status) & flags)
+            {
+                count++;
+            }
+        }
+
+        /* go on */
+        tmp = tmp->next;
+    }
+
+    if (count == 0)
+    {
+        (*cnt) = 0;
+        return 0;
+    }
+
+    /* malloc() an array of disconnected sessions */
+    sess = g_new0(struct scp_session_info, count);
+
+    if (sess == 0)
+    {
+        (*cnt) = 0;
+        return 0;
+    }
+
+    tmp = g_sessions;
+    index = 0;
+
+    while (tmp != 0 && index < count)
+    {
+        if (uid == tmp->item->uid)
+        {
+            if ((tmp->item->status) & flags)
+            {
+                (sess[index]).sid = tmp->item->pid;
+                (sess[index]).display = tmp->item->display;
+                (sess[index]).type = tmp->item->type;
+                (sess[index]).height = tmp->item->height;
+                (sess[index]).width = tmp->item->width;
+                (sess[index]).bpp = tmp->item->bpp;
+                (sess[index]).start_time = tmp->item->start_time;
+                (sess[index]).uid = tmp->item->uid;
+                (sess[index]).start_ip_addr = g_strdup(tmp->item->start_ip_addr);
+
+                /* Check for string allocation failures */
+                if ((sess[index]).start_ip_addr == NULL)
+                {
+                    free_session_info_list(sess, *cnt);
+                    (*cnt) = 0;
+                    return 0;
+                }
+                index++;
+            }
+        }
+
+        /* go on */
+        tmp = tmp->next;
+    }
+
+    (*cnt) = count;
+    return sess;
+}
+
+/******************************************************************************/
+void
+free_session_info_list(struct scp_session_info *sesslist, unsigned int cnt)
+{
+    if (sesslist != NULL && cnt > 0)
+    {
+        unsigned int i;
+        for (i = 0 ; i < cnt ; ++i)
+        {
+            g_free(sesslist[i].start_ip_addr);
+        }
+    }
+
+    g_free(sesslist);
+}
+
+/******************************************************************************/
+int
+cleanup_sockets(int display)
+{
+    LOG(LOG_LEVEL_INFO, "cleanup_sockets:");
+    char file[256];
+    int error;
+
+    error = 0;
+
+    g_snprintf(file, 255, CHANSRV_PORT_OUT_STR, display);
+    if (g_file_exist(file))
+    {
+        LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
+        if (g_file_delete(file) == 0)
+        {
+            LOG(LOG_LEVEL_WARNING,
+                "cleanup_sockets: failed to delete %s (%s)",
+                file, g_get_strerror());
+            error++;
+        }
+    }
+
+    g_snprintf(file, 255, CHANSRV_PORT_IN_STR, display);
+    if (g_file_exist(file))
+    {
+        LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
+        if (g_file_delete(file) == 0)
+        {
+            LOG(LOG_LEVEL_WARNING,
+                "cleanup_sockets: failed to delete %s (%s)",
+                file, g_get_strerror());
+            error++;
+        }
+    }
+
+    g_snprintf(file, 255, XRDP_CHANSRV_STR, display);
+    if (g_file_exist(file))
+    {
+        LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
+        if (g_file_delete(file) == 0)
+        {
+            LOG(LOG_LEVEL_WARNING,
+                "cleanup_sockets: failed to delete %s (%s)",
+                file, g_get_strerror());
+            error++;
+        }
+    }
+
+    g_snprintf(file, 255, CHANSRV_API_STR, display);
+    if (g_file_exist(file))
+    {
+        LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
+        if (g_file_delete(file) == 0)
+        {
+            LOG(LOG_LEVEL_WARNING,
+                "cleanup_sockets: failed to delete %s (%s)",
+                file, g_get_strerror());
+            error++;
+        }
+    }
+
+    /* the following files should be deleted by xorgxrdp
+     * but just in case the deletion failed */
+
+    g_snprintf(file, 255, XRDP_X11RDP_STR, display);
+    if (g_file_exist(file))
+    {
+        LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
+        if (g_file_delete(file) == 0)
+        {
+            LOG(LOG_LEVEL_WARNING,
+                "cleanup_sockets: failed to delete %s (%s)",
+                file, g_get_strerror());
+            error++;
+        }
+    }
+
+    g_snprintf(file, 255, XRDP_DISCONNECT_STR, display);
+    if (g_file_exist(file))
+    {
+        LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
+        if (g_file_delete(file) == 0)
+        {
+            LOG(LOG_LEVEL_WARNING,
+                "cleanup_sockets: failed to delete %s (%s)",
+                file, g_get_strerror());
+            error++;
+        }
+    }
+
+    return error;
+
+}

--- a/sesman/session_list.h
+++ b/sesman/session_list.h
@@ -1,0 +1,194 @@
+/**
+ * xrdp: A Remote Desktop Protocol server.
+ *
+ * Copyright (C) Jay Sorg 2004-2013
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *
+ * @file session.h
+ * @brief Session management definitions
+ * @author Jay Sorg, Simone Fedele
+ *
+ */
+
+
+#ifndef SESSION_H
+#define SESSION_H
+
+#include <time.h>
+
+#include "guid.h"
+#include "scp_application_types.h"
+#include "xrdp_constants.h"
+
+#define SESMAN_SESSION_STATUS_ACTIVE        0x01
+#define SESMAN_SESSION_STATUS_IDLE          0x02
+#define SESMAN_SESSION_STATUS_DISCONNECTED  0x04
+/* future expansion
+#define SESMAN_SESSION_STATUS_REMCONTROL    0x08
+*/
+#define SESMAN_SESSION_STATUS_ALL           0xFF
+
+enum session_kill_status
+{
+    SESMAN_SESSION_KILL_OK = 0,
+    SESMAN_SESSION_KILL_NULLITEM,
+    SESMAN_SESSION_KILL_NOTFOUND
+};
+
+struct scp_session_info;
+
+struct session_item
+{
+    int uid; /* UID of session */
+    int pid; /* pid of sesman waiting for wm to end */
+    int display;
+    int width;
+    int height;
+    int bpp;
+    struct auth_info *auth_info;
+
+    /* status info */
+    unsigned char status;
+    enum scp_session_type type;
+
+    /* time data  */
+    time_t start_time;
+    // struct session_date disconnect_time; // Currently unused
+    // struct session_date idle_time; // Currently unused
+    char start_ip_addr[MAX_PEER_ADDRSTRLEN];
+    struct guid guid;
+};
+
+struct session_chain
+{
+    struct session_chain *next;
+    struct session_item *item;
+};
+
+
+/**
+ * Information used to start or find a session
+ */
+struct session_parameters
+{
+    int uid;
+    enum scp_session_type type;
+    unsigned short height;
+    unsigned short width;
+    unsigned char  bpp;
+    const char *shell;
+    const char *directory;
+    const char *ip_addr;
+};
+
+/**
+ *
+ * @brief finds a session matching the supplied parameters
+ * @return session data or 0
+ *
+ */
+struct session_item *
+session_get_bydata(const struct session_parameters *params);
+#ifndef session_find_item
+#define session_find_item(a) session_get_bydata(a)
+#endif
+
+/**
+ *
+ * @brief starts a session
+ *
+ * @return Connection status.
+ */
+enum scp_screate_status
+session_start(struct auth_info *auth_info,
+              const struct session_parameters *params,
+              int *display,
+              struct guid *guid);
+
+int
+session_reconnect(int display, int uid,
+                  struct auth_info *auth_info);
+
+/**
+ *
+ * @brief kills a session
+ * @param pid the pid of the session to be killed
+ * @return
+ *
+ */
+enum session_kill_status
+session_kill(int pid);
+
+/**
+ *
+ * @brief sends sigkill to all sessions
+ * @return
+ *
+ */
+void
+session_sigkill_all(void);
+
+/**
+ *
+ * @brief retrieves a session's descriptor
+ * @param pid the session pid
+ * @return a pointer to the session descriptor on success, NULL otherwise
+ *
+ */
+struct session_item *
+session_get_bypid(int pid);
+
+/**
+ *
+ * @brief retrieves session descriptions
+ * @param UID the UID for the descriptions
+ * @return A block of session descriptions
+ *
+ * Pass the return result to free_session_info_list() after use
+ *
+ */
+struct scp_session_info *
+session_get_byuid(int uid, unsigned int *cnt, unsigned char flags);
+
+/**
+ *
+ * @brief Frees the result of session_get_byuser()
+ * @param sesslist Resuit of session_get_byuser()
+ * @param cnt  Number of entries in sess
+ */
+void
+free_session_info_list(struct scp_session_info *sesslist, unsigned int cnt);
+
+/**
+ *
+ * @brief delete socket files
+ * @param display number
+ * @return non-zero value (number of errors) if failed
+ */
+int cleanup_sockets(int display);
+
+/**
+ * Clone a session_parameters structure
+ *
+ * @param sp Parameters to clone
+ * @return Cloned parameters, or NULL if no memory
+ *
+ * The cloned structure can be free'd with a single call to g_free()
+ */
+struct session_parameters *
+clone_session_params(const struct session_parameters *sp);
+#endif

--- a/sesman/session_list.h
+++ b/sesman/session_list.h
@@ -89,19 +89,19 @@ struct session_chain
  * @return Session count
  */
 unsigned int
-session_get_count(void);
+session_list_get_count(void);
 
 /**
  * Adds a new session item to the chain
  */
 void
-session_chain_add(struct session_chain *element);
+session_list_add(struct session_chain *element);
 
 /**
  * Get the next available display
  */
 int
-session_get_available_display(void);
+session_list_get_available_display(void);
 
 
 /**
@@ -111,12 +111,12 @@ session_get_available_display(void);
  *
  */
 struct session_item *
-session_get_bydata(uid_t uid,
-                   enum scp_session_type type,
-                   unsigned short width,
-                   unsigned short height,
-                   unsigned char  bpp,
-                   const char *ip_addr);
+session_list_get_bydata(uid_t uid,
+                        enum scp_session_type type,
+                        unsigned short width,
+                        unsigned short height,
+                        unsigned char  bpp,
+                        const char *ip_addr);
 
 /**
  *
@@ -126,7 +126,7 @@ session_get_bydata(uid_t uid,
  *
  */
 enum session_kill_status
-session_kill(int pid);
+session_list_kill(int pid);
 
 /**
  *
@@ -135,7 +135,7 @@ session_kill(int pid);
  *
  */
 void
-session_sigkill_all(void);
+session_list_sigkill_all(void);
 
 /**
  *
@@ -145,7 +145,7 @@ session_sigkill_all(void);
  *
  */
 struct session_item *
-session_get_bypid(int pid);
+session_list_get_bypid(int pid);
 
 /**
  *
@@ -157,7 +157,7 @@ session_get_bypid(int pid);
  *
  */
 struct scp_session_info *
-session_get_byuid(int uid, unsigned int *cnt, unsigned char flags);
+session_list_get_byuid(int uid, unsigned int *cnt, unsigned char flags);
 
 /**
  *

--- a/sesman/session_list.h
+++ b/sesman/session_list.h
@@ -18,21 +18,23 @@
 
 /**
  *
- * @file session.h
- * @brief Session management definitions
+ * @file session_list.h
+ * @brief Session list management definitions
  * @author Jay Sorg, Simone Fedele
  *
  */
 
 
-#ifndef SESSION_H
-#define SESSION_H
+#ifndef SESSION_LIST_H
+#define SESSION_LIST_H
 
 #include <time.h>
 
 #include "guid.h"
 #include "scp_application_types.h"
 #include "xrdp_constants.h"
+
+struct session_parameters;
 
 #define SESMAN_SESSION_STATUS_ACTIVE        0x01
 #define SESMAN_SESSION_STATUS_IDLE          0x02
@@ -51,6 +53,9 @@ enum session_kill_status
 
 struct scp_session_info;
 
+/**
+ * Object describing a session
+ */
 struct session_item
 {
     int uid; /* UID of session */
@@ -79,21 +84,25 @@ struct session_chain
     struct session_item *item;
 };
 
+/**
+ * Returns the number of sessions currently active
+ * @return Session count
+ */
+unsigned int
+session_get_count(void);
 
 /**
- * Information used to start or find a session
+ * Adds a new session item to the chain
  */
-struct session_parameters
-{
-    int uid;
-    enum scp_session_type type;
-    unsigned short height;
-    unsigned short width;
-    unsigned char  bpp;
-    const char *shell;
-    const char *directory;
-    const char *ip_addr;
-};
+void
+session_chain_add(struct session_chain *element);
+
+/**
+ * Get the next available display
+ */
+int
+session_get_available_display(void);
+
 
 /**
  *
@@ -102,26 +111,12 @@ struct session_parameters
  *
  */
 struct session_item *
-session_get_bydata(const struct session_parameters *params);
-#ifndef session_find_item
-#define session_find_item(a) session_get_bydata(a)
-#endif
-
-/**
- *
- * @brief starts a session
- *
- * @return Connection status.
- */
-enum scp_screate_status
-session_start(struct auth_info *auth_info,
-              const struct session_parameters *params,
-              int *display,
-              struct guid *guid);
-
-int
-session_reconnect(int display, int uid,
-                  struct auth_info *auth_info);
+session_get_bydata(uid_t uid,
+                   enum scp_session_type type,
+                   unsigned short width,
+                   unsigned short height,
+                   unsigned char  bpp,
+                   const char *ip_addr);
 
 /**
  *
@@ -173,22 +168,4 @@ session_get_byuid(int uid, unsigned int *cnt, unsigned char flags);
 void
 free_session_info_list(struct scp_session_info *sesslist, unsigned int cnt);
 
-/**
- *
- * @brief delete socket files
- * @param display number
- * @return non-zero value (number of errors) if failed
- */
-int cleanup_sockets(int display);
-
-/**
- * Clone a session_parameters structure
- *
- * @param sp Parameters to clone
- * @return Cloned parameters, or NULL if no memory
- *
- * The cloned structure can be free'd with a single call to g_free()
- */
-struct session_parameters *
-clone_session_params(const struct session_parameters *sp);
-#endif
+#endif // SESSION_LIST_H

--- a/sesman/sig.c
+++ b/sesman/sig.c
@@ -111,7 +111,7 @@ sig_sesman_session_end(void)
         {
             LOG(LOG_LEVEL_INFO, "Process %d has exited", pid);
 
-            session_kill(pid);
+            session_list_kill(pid);
         }
     }
     while (pid > 0);

--- a/sesman/sig.c
+++ b/sesman/sig.c
@@ -35,7 +35,7 @@
 #include "log.h"
 #include "os_calls.h"
 #include "sesman.h"
-#include "session.h"
+#include "session_list.h"
 #include "string_calls.h"
 
 /******************************************************************************/

--- a/sesman/sig.c
+++ b/sesman/sig.c
@@ -105,7 +105,7 @@ sig_sesman_session_end(void)
     LOG(LOG_LEVEL_DEBUG, "receiving SIGCHLD");
     do
     {
-        pid = g_waitchild();
+        pid = g_waitchild(NULL);
 
         if (pid > 0)
         {

--- a/sesman/xwait.h
+++ b/sesman/xwait.h
@@ -1,6 +1,8 @@
 #ifndef XWAIT_H
 #define XWAIT_H
 
+#include <sys/types.h>
+
 enum xwait_status
 {
     XW_STATUS_OK = 0,
@@ -12,10 +14,16 @@ enum xwait_status
 /**
  *
  * @brief waits for X to start
+ * @param uid User to run program under
+ * @param env_names Environment to set for user (names)
+ * @param env_values Environment to set for user (values)
  * @param display number
  * @return status
  *
  */
 enum xwait_status
-wait_for_xserver(int display);
+wait_for_xserver(uid_t uid,
+                 struct list *env_names,
+                 struct list *env_values,
+                 int display);
 #endif

--- a/xrdp/xrdp.c
+++ b/xrdp/xrdp.c
@@ -89,7 +89,7 @@ xrdp_shutdown(int sig)
 static void
 xrdp_child(int sig)
 {
-    while (g_waitchild() > 0)
+    while (g_waitchild(NULL) > 0)
     {
     }
 }


### PR DESCRIPTION
This is now ready for review, following my own testing.

This is a *major* change to sesman.

There are quite a few file changes, bu the main implementation points are:-
1) sesman/session.c is split into two files
    a) session_list.c contains all the list-handling code.
    b) session.c now contains just the code to manage a single session.
2) session starting logic is reworked to make it possible to detect X server failures as a separate class of error

I've split session.c into two with #1961 in mind - I'm getting close to the point where I can split sesman entirely. session_list.c contains all the code for sesman and session.c contains all the code for sesexec.

The reworking of session starting logic allows me to use @derekschrock's waitforx utility to check for a working X server before starting the session. If the X server isn't started, this is reported back to xrdp.

Not only is the log file more readable with this change, but error reporting is improved. If the X server can't be started, the logging window now looks like this, rather than blue-screening for a minute or so:-
![image](https://user-images.githubusercontent.com/30179339/224837480-44d9cc92-7e43-4a69-a61c-a5a1fa5fd1cf.png)

Also sesman logging is vastly improved on starting a session. Here's a development logging example:-

```
2023-03-13T21:36:13.871+0000] [INFO ] [g_sck_accept(os_calls.c:1297)] Socket 13: connection accepted from AF_UNIX
[2023-03-13T21:36:13.980+0000] [INFO ] [process_sys_login_request(scp_process.c:296)] Received system login request from xrdp for user: testuser IP: ::ffff:1.1.1.1
[2023-03-13T21:36:14.400+0000] [INFO ] [verify_pam_conv(verify_user_pam.c:138)] Handling struct pam_message { style = PAM_PROMPT_ECHO_OFF, msg = "Password: " }
[2023-03-13T21:36:14.198+0000] [INFO ] [access_login_allowed(access.c:56)] Terminal Server Users group is disabled, allowing authentication
[2023-03-13T21:36:14.246+0000] [INFO ] [authenticate_and_authorize_connection(scp_process.c:160)] Access permitted for user=testuser uid=1001
[2023-03-13T21:36:14.330+0000] [INFO ] [process_create_session_request(scp_process.c:483)] Received request from xrdp to create a session for user testuser type=Xorg geometry=1920x1080, bpp=24, shell="", dir=""
[2023-03-13T21:36:14.374+0000] [INFO ] [session_start(session.c:836)] calling auth_start_session for uid=1001 from pid 1621183
[2023-03-13T21:36:14.722+0000] [INFO ] [start_x_server(session.c:500)] Starting X server on display 10: /usr/lib/xorg/Xorg :10 -auth .Xauthority -config xrdp/xorg.conf -noreset -nolisten tcp -logfile .xorgxrdp.%s.log
[2023-03-13T21:36:15.819+0000] [INFO ] [session_start_subprocess(session.c:774)] X server :10 is working
[2023-03-13T21:36:15.867+0000] [INFO ] [session_start_subprocess(session.c:775)] Starting window manager for display :10
[2023-03-13T21:36:15.910+0000] [INFO ] [session_start_subprocess(session.c:786)] Starting the xrdp channel server for display :10
[2023-03-13T21:36:15.912+0000] [INFO ] [start_window_manager(session.c:292)] Using the default window manager on display 10: /etc/xrdp/startwm.sh
[2023-03-13T21:36:15.969+0000] [INFO ] [allocate_and_start_session(scp_process.c:247)] ++ created session: username testuser, ip ::ffff:172.19.73.10
[2023-03-13T21:36:15.970+0000] [INFO ] [run_xrdp_session(session.c:556)] Session in progress on display :10. Waiting until the window manager (pid 1621440) exits to end the session
```

and at session end:-

```
2023-03-13T21:36:37.351+0000] [INFO ] [run_xrdp_session(session.c:564)] Window manager (pid 1621440, display 10) finished normally in 21 secs
[2023-03-13T21:36:38.250+0000] [INFO ] [run_xrdp_session(session.c:596)] Terminating X server (pid 1621263) on display :10
[2023-03-13T21:36:38.322+0000] [INFO ] [run_xrdp_session(session.c:602)] Terminating the xrdp channel server (pid 1621441) on display :10
[2023-03-13T21:36:38.461+0000] [INFO ] [run_xrdp_session(session.c:609)] X server pid 1621263 on display :10 finished
[2023-03-13T21:36:38.700+0000] [INFO ] [run_xrdp_session(session.c:615)] xrdp channel server pid 1621441 on display :10 finished
[2023-03-13T21:36:38.778+0000] [INFO ] [cleanup_sockets(session.c:136)] cleanup_sockets:
[2023-03-13T21:36:38.841+0000] [INFO ] [session_start(session.c:844)] Calling auth_stop_session from pid 1621183
[2023-03-13T21:36:38.984+0000] [INFO ] [sig_sesman_session_end(sig.c:112)] Process 1621183 has exited
[2023-03-13T21:36:39.494+0000] [INFO ] [session_kill(session_list.c:382)] Calling auth_end for pid 1621183 from pid 1502282
[2023-03-13T21:36:39.133+0000] [INFO ] [session_kill(session_list.c:388)] ++ terminated session: UID 1001 (testuser), display :10.0, session_pid 1621183, ip ::ffff:172.19.73.10
```
