### PR TITLE
Add planar compression

### DIFF
--- a/libxrdp/libxrdp.c
+++ b/libxrdp/libxrdp.c
@@ -2094,7 +2094,9 @@ libxrdp_process_monitor_stream(struct stream *s,
         }
     }
 
-    /* set wm geometry if the encompassing area is well formed. Otherwise, log and return an error.*/
+    /* set wm geometry if the encompassing area is well formed.
+       Otherwise, log and return an error.
+    */
     if (all_monitors_encompassing_bounds.right
             > all_monitors_encompassing_bounds.left
             && all_monitors_encompassing_bounds.bottom
@@ -2269,4 +2271,16 @@ libxrdp_process_monitor_ex_stream(struct stream *s,
     }
 
     return 0;
+}
+/*****************************************************************************/
+int EXPORT_CC
+libxrdp_planar_compress(char *in_data, int width, int height,
+                        struct stream *s, int bpp, int byte_limit,
+                        int start_line, struct stream *temp_s,
+                        int e, int flags)
+{
+    return xrdp_bitmap32_compress(in_data, width, height,
+                                  s, bpp, byte_limit,
+                                  start_line, temp_s,
+                                  e, flags);
 }

--- a/libxrdp/libxrdpinc.h
+++ b/libxrdp/libxrdpinc.h
@@ -308,7 +308,11 @@ libxrdp_fastpath_send_frame_marker(struct xrdp_session *session,
 int EXPORT_CC
 libxrdp_send_session_info(struct xrdp_session *session, const char *data,
                           int data_bytes);
-
+int EXPORT_CC
+libxrdp_planar_compress(char *in_data, int width, int height,
+                        struct stream *s, int bpp, int byte_limit,
+                        int start_line, struct stream *temp_s,
+                        int e, int flags);
 /**
  * Processes a stream that is based on either
  *  2.2.1.3.6 Client Monitor Data (TS_UD_CS_MONITOR) or 2.2.2.2 DISPLAYCONTROL_MONITOR_LAYOUT_PDU

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -469,6 +469,10 @@ xrdp_mm_check_wait_objs(struct xrdp_mm *self);
 int
 xrdp_mm_frame_ack(struct xrdp_mm *self, int frame_id);
 int
+xrdp_mm_egfx_send_planar_bitmap(struct xrdp_mm *self,
+                                struct xrdp_bitmap *bitmap,
+                                struct xrdp_rect *rect);
+int
 server_begin_update(struct xrdp_mod *mod);
 int
 server_end_update(struct xrdp_mod *mod);

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -392,6 +392,7 @@ struct xrdp_mm
     int xr2cr_cid_map[256];
     int dynamic_monitor_chanid;
     struct xrdp_egfx *egfx;
+    int egfx_up;
 
     /* Resize on-the-fly control */
     struct display_control_monitor_layout_data *resize_data;
@@ -519,6 +520,9 @@ struct xrdp_wm
 
     /* configuration derived from xrdp.ini */
     struct xrdp_config *xrdp_config;
+
+    struct xrdp_region *screen_dirty_region;
+    int last_screen_draw_time;
 };
 
 /* rdp process */

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -81,6 +81,7 @@ xrdp_wm_delete(struct xrdp_wm *self)
         return;
     }
 
+    xrdp_region_delete(self->screen_dirty_region);
     xrdp_mm_delete(self->mm);
     xrdp_cache_delete(self->cache);
     xrdp_painter_delete(self->painter);


### PR DESCRIPTION
Used for the bitmaps transmitted for the login screen over the egfx channels.

This leverages standard bitmap planar compression. See these references:
- https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpegdi/9b422f69-8e05-4c6d-b6fb-fa02ef75a8f2
- https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpegdi/0d2e1a03-e123-46b2-b2b8-ed730a794ae4
- https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpegdi/749fa4d4-0d88-4fe5-bf4c-914cd05776cb

Of course I should add that I didn't write this. The credit for that goes to @jsorg71 -- I'm packaging it up and helping merge it.

I probably should write unit tests for this, but I'm not actually sure how...