### PR TITLE
[WIP] use g_fork_execvp instead of g_fork 

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -100,10 +100,6 @@ extern char **environ;
 #include <sys/ucred.h>
 #endif
 
-#if defined(__APPLE__)
-#include <mach-o/dyld.h>
-#endif
-
 /* for solaris */
 #if !defined(PF_LOCAL)
 #define PF_LOCAL AF_UNIX
@@ -3081,25 +3077,6 @@ g_set_allusercontext(int uid)
 void
 g_get_executable_path(enum xrdp_exe xe, char *buf, int bufsize)
 {
-    int rv = -1;
-#if defined(__APPLE__)
-    uint32_t _bufsize = bufsize;
-#endif
-
-    g_memset(buf, '\0', bufsize);
-
-#if defined(__APPLE__)
-    rv = _NSGetExecutablePath(buf, &_bufsize);
-#elif defined(__linux__)
-    rv = readlink("/proc/self/exe", buf, bufsize);
-#endif
-
-    if (rv > 0)
-    {
-        return;
-    }
-
-    // build executable path manually
     switch (xe)
     {
         case E_XE_XRDP:

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -2922,6 +2922,21 @@ g_fork(void)
 }
 
 /*****************************************************************************/
+int
+g_fork_execvp(const char *p1, char *args[])
+{
+    int pid;
+
+    pid = g_fork();
+
+    if (pid == 0) {
+        g_execvp(p1, args);
+    }
+
+    return pid;
+}
+
+/*****************************************************************************/
 /* does not work in win32 */
 int
 g_setgid(int pid)

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -2932,9 +2932,16 @@ g_fork_execvp(const char *p1, char *args[])
     int pid;
 
     pid = g_fork();
-
+    
     if (pid == 0) {
         g_execvp(p1, args);
+        
+        /* should not get here */
+        LOG(LOG_LEVEL_ERROR,
+            "Failed to execute %s: execvp(3) failed with %s (%d)",
+            p1, g_get_strerror(), g_get_errno());
+        
+        exit(1);
     }
 
     return pid;

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -100,6 +100,10 @@ extern char **environ;
 #include <sys/ucred.h>
 #endif
 
+#if defined(__APPLE__)
+#include <mach-o/dyld.h>
+#endif
+
 /* for solaris */
 #if !defined(PF_LOCAL)
 #define PF_LOCAL AF_UNIX
@@ -3064,6 +3068,21 @@ g_set_allusercontext(int uid)
     return (rv != 0);  /* Return 0 or 1 */
 }
 #endif
+
+/*****************************************************************************/
+void
+g_get_executable_path(char *buf, int bufsize)
+{
+#if defined(__APPLE__)
+    uint32_t _bufsize = bufsize;
+    _NSGetExecutablePath(buf, &_bufsize);
+#else
+    LOG(LOG_LEVEL_WARN, "g_get_executable_path(): not implemented yet!");
+    buf = strdup("xrdp");
+#endif
+}
+
+
 /*****************************************************************************/
 /* does not work in win32
    returns pid of process that exits or zero if signal occurred */

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -2932,15 +2932,16 @@ g_fork_execvp(const char *p1, char *args[])
     int pid;
 
     pid = g_fork();
-    
-    if (pid == 0) {
+
+    if (pid == 0)
+    {
         g_execvp(p1, args);
-        
+
         /* should not get here */
         LOG(LOG_LEVEL_ERROR,
             "Failed to execute %s: execvp(3) failed with %s (%d)",
             p1, g_get_strerror(), g_get_errno());
-        
+
         exit(1);
     }
 
@@ -3084,20 +3085,20 @@ g_get_executable_path(enum xrdp_exe xe, char *buf, int bufsize)
 #if defined(__APPLE__)
     uint32_t _bufsize = bufsize;
 #endif
-    
+
     g_memset(buf, '\0', bufsize);
-    
+
 #if defined(__APPLE__)
     rv = _NSGetExecutablePath(buf, &_bufsize);
 #elif defined(__linux__)
     rv = readlink("/proc/self/exe", buf, bufsize);
 #endif
-    
+
     if (rv > 0)
     {
         return;
     }
-    
+
     // build executable path manually
     switch (xe)
     {
@@ -3107,7 +3108,7 @@ g_get_executable_path(enum xrdp_exe xe, char *buf, int bufsize)
         case E_XE_SESMAN:
             g_snprintf(buf, bufsize, XRDP_SBIN_PATH "/xrdp-sesman");
             break;
-            
+
         default:
             LOG(LOG_LEVEL_WARNING, "g_get_executable_path(): Unsupported exe %d", (int)xe);
     }

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -274,6 +274,7 @@ int      g_setlogin(const char *name);
  */
 int      g_set_allusercontext(int uid);
 #endif
+void     g_get_executable_path(char *buf, int bufsize);
 int      g_waitchild(void);
 int      g_waitpid(int pid);
 struct exit_status g_waitpid_status(int pid);

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -23,6 +23,14 @@
 
 #include "arch.h"
 
+enum xrdp_exe
+{
+    E_XE_XRDP = 0,
+    E_XE_SESMAN = 1,
+    
+    // TODO: add others below
+};
+
 struct exit_status
 {
     /* set to -1 when the process exited via a signal */
@@ -274,7 +282,7 @@ int      g_setlogin(const char *name);
  */
 int      g_set_allusercontext(int uid);
 #endif
-void     g_get_executable_path(char *buf, int bufsize);
+void     g_get_executable_path(enum xrdp_exe xe, char *buf, int bufsize);
 int      g_waitchild(void);
 int      g_waitpid(int pid);
 struct exit_status g_waitpid_status(int pid);

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -27,8 +27,8 @@ enum xrdp_exe
 {
     E_XE_XRDP = 0,
     E_XE_SESMAN = 1,
-    
-    // TODO: add others below
+
+    /* TODO: add others below */
 };
 
 struct exit_status

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -258,6 +258,7 @@ void     g_signal_terminate(void (*func)(int));
 void     g_signal_pipe(void (*func)(int));
 void     g_signal_usr1(void (*func)(int));
 int      g_fork(void);
+int      g_fork_execvp(const char *p1, char *args[]);
 int      g_setgid(int pid);
 int      g_initgroups(const char *user);
 int      g_getuid(void);

--- a/xrdp/xrdp.c
+++ b/xrdp/xrdp.c
@@ -403,6 +403,8 @@ main(int argc, char **argv)
         g_signal_child_stop(xrdp_child);        /* SIGCHLD */
         g_signal_hang_up(xrdp_sig_no_op);       /* SIGHUP */
 
+        g_listen->startup_params = &startup_params;
+
         xrdp_process_child_entrypoint(g_listen, startup_params.child_fd);
 
         g_deinit();

--- a/xrdp/xrdp.c
+++ b/xrdp/xrdp.c
@@ -386,31 +386,6 @@ main(int argc, char **argv)
         g_exit(0);
     }
 
-    if (startup_params.is_child)
-    {
-        if (startup_params.child_fd < 3)
-        {
-            g_writeln("requested act as child process, but --child-fd option is not given");
-            g_deinit();
-            g_exit(1);
-        }
-
-        g_set_threadid(tc_get_threadid());
-        g_listen = xrdp_listen_create();
-        g_signal_user_interrupt(xrdp_shutdown); /* SIGINT */
-        g_signal_pipe(xrdp_sig_no_op);          /* SIGPIPE */
-        g_signal_terminate(xrdp_shutdown);      /* SIGTERM */
-        g_signal_child_stop(xrdp_child);        /* SIGCHLD */
-        g_signal_hang_up(xrdp_sig_no_op);       /* SIGHUP */
-
-        g_listen->startup_params = &startup_params;
-
-        xrdp_process_child_entrypoint(g_listen, startup_params.child_fd);
-
-        g_deinit();
-        g_exit(0);
-    }
-
     /* starting logging subsystem */
     error = log_start(startup_params.xrdp_ini, "xrdp",
                       (startup_params.dump_config) ? LOG_START_DUMP_CONFIG : 0);
@@ -439,7 +414,30 @@ main(int argc, char **argv)
         g_exit(1);
     }
 
+    if (startup_params.is_child)
+    {
+        if (startup_params.child_fd < 3)
+        {
+            g_writeln("requested act as child process, but --child-fd option is not given");
+            g_deinit();
+            g_exit(1);
+        }
 
+        g_set_threadid(tc_get_threadid());
+        g_listen = xrdp_listen_create();
+        g_signal_user_interrupt(xrdp_shutdown); /* SIGINT */
+        g_signal_pipe(xrdp_sig_no_op);          /* SIGPIPE */
+        g_signal_terminate(xrdp_shutdown);      /* SIGTERM */
+        g_signal_child_stop(xrdp_child);        /* SIGCHLD */
+        g_signal_hang_up(xrdp_sig_no_op);       /* SIGHUP */
+
+        g_listen->startup_params = &startup_params;
+
+        xrdp_process_child_entrypoint(g_listen, startup_params.child_fd);
+
+        g_deinit();
+        g_exit(0);
+    }
 
     if (g_file_exist(pid_file)) /* xrdp.pid */
     {

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -185,7 +185,7 @@ xrdp_process_delete(struct xrdp_process *self);
 int
 xrdp_process_main_loop(struct xrdp_process *self);
 int
-xrdp_process_child_entrypoint(struct xrdp_listen *owner);
+xrdp_process_child_entrypoint(struct xrdp_listen *owner, int socket_fd);
 
 /* xrdp_listen.c */
 struct xrdp_listen *

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -184,6 +184,8 @@ void
 xrdp_process_delete(struct xrdp_process *self);
 int
 xrdp_process_main_loop(struct xrdp_process *self);
+int
+xrdp_process_child_entrypoint(struct xrdp_listen *owner);
 
 /* xrdp_listen.c */
 struct xrdp_listen *

--- a/xrdp/xrdp_listen.c
+++ b/xrdp/xrdp_listen.c
@@ -811,38 +811,6 @@ xrdp_listen_fork(struct xrdp_listen *self, struct trans *server_trans)
         list_delete(child_arguments);
     }
 
-
-    if (pid == 0)
-    {
-        /* child */
-        /* unreachable code */
-
-        /* recreate some main globals */
-        xrdp_child_fork();
-        /* recreate the process done wait object, not used in fork mode */
-        /* close, don't delete this */
-        g_close_wait_obj(self->pro_done_event);
-        xrdp_listen_create_pro_done(self);
-        /* delete listener, child need not listen */
-        for (index = 0; index < self->trans_list->count; index++)
-        {
-            ltrans = (struct trans *) list_get_item(self->trans_list, index);
-            trans_delete_from_child(ltrans);
-        }
-        list_delete(self->trans_list);
-        self->trans_list = NULL;
-        /* new connect instance */
-        process = xrdp_process_create(self, 0);
-        process->server_trans = server_trans;
-        g_process = process;
-        xrdp_process_run(0);
-        tc_sem_dec(g_process_sem);
-        xrdp_process_delete(process);
-        /* mark this process to exit */
-        g_set_term(1);
-        return 1;
-    }
-
     /* parent */
     trans_delete(server_trans);
     return 0;

--- a/xrdp/xrdp_listen.c
+++ b/xrdp/xrdp_listen.c
@@ -779,14 +779,15 @@ xrdp_listen_fork(struct xrdp_listen *self, struct trans *server_trans)
     int index;
     struct xrdp_process *process;
     struct trans *ltrans;
-    
+
     g_get_executable_path(E_XE_XRDP, executable_path, 4096);
     g_snprintf(server_trans_fd_str, 32, "%d", (int) server_trans->sck);
-    
+
     child_arguments = list_create();
-    
+
     if (child_arguments != NULL)
     {
+        /* FIXME: pass log_fd to child */
         child_arguments->auto_free = 1;
         if (!list_add_strdup_multi(child_arguments,
                                    "--child-process",
@@ -797,7 +798,7 @@ xrdp_listen_fork(struct xrdp_listen *self, struct trans *server_trans)
             child_arguments = NULL;
         }
     }
-    
+
     if (!child_arguments)
     {
         LOG(LOG_LEVEL_ERROR, "xrdp_listen_fork(): could not prepare arguments list for child process");
@@ -808,7 +809,7 @@ xrdp_listen_fork(struct xrdp_listen *self, struct trans *server_trans)
         pid = g_fork_execvp(executable_path, (char **) child_arguments->items);
         list_delete(child_arguments);
     }
-   
+
 
     if (pid == 0)
     {

--- a/xrdp/xrdp_listen.c
+++ b/xrdp/xrdp_listen.c
@@ -790,6 +790,7 @@ xrdp_listen_fork(struct xrdp_listen *self, struct trans *server_trans)
         /* FIXME: pass log_fd to child */
         child_arguments->auto_free = 1;
         if (!list_add_strdup_multi(child_arguments,
+                                   "xrdp",
                                    "--child-process",
                                    "--child-fd", server_trans_fd_str,
                                    NULL))

--- a/xrdp/xrdp_listen.c
+++ b/xrdp/xrdp_listen.c
@@ -787,7 +787,7 @@ xrdp_listen_fork(struct xrdp_listen *self, struct trans *server_trans)
     list_add_item(child_arguments, (intptr_t) g_strdup("--child-fd"));
     list_add_item(child_arguments, (intptr_t) g_strdup(server_trans_fd_str));
 
-    g_get_executable_path(executable_path, 4096);
+    g_get_executable_path(E_XE_XRDP, executable_path, 4096);
 
     pid = g_fork_execvp(executable_path, (char **) child_arguments->items);
 

--- a/xrdp/xrdp_process.c
+++ b/xrdp/xrdp_process.c
@@ -312,3 +312,22 @@ xrdp_process_main_loop(struct xrdp_process *self)
     g_set_wait_obj(self->done_event);
     return 0;
 }
+
+/*****************************************************************************/
+int
+xrdp_process_child_entrypoint(struct xrdp_listen *owner)
+{
+    struct trans *server_trans;
+    struct xrdp_process *process;
+
+    // FIXME
+    server_trans = trans_create(TRANS_MODE_TCP, 16, 16);
+    server_trans->sck = 0;
+
+    process = xrdp_process_create(owner, 0);
+    process->server_trans = server_trans;
+
+    xrdp_process_main_loop(process);
+
+    return 0;
+}

--- a/xrdp/xrdp_process.c
+++ b/xrdp/xrdp_process.c
@@ -321,6 +321,7 @@ xrdp_process_child_entrypoint(struct xrdp_listen *owner, int socket_fd)
     struct xrdp_process *process;
 
     server_trans = trans_create(TRANS_MODE_TCP, 16, 16);
+    server_trans->status = TRANS_STATUS_UP;
     server_trans->sck = socket_fd;
 
     process = xrdp_process_create(owner, 0);
@@ -328,5 +329,7 @@ xrdp_process_child_entrypoint(struct xrdp_listen *owner, int socket_fd)
 
     xrdp_process_main_loop(process);
 
+    xrdp_process_delete(process);
+    g_set_term(1);
     return 0;
 }

--- a/xrdp/xrdp_process.c
+++ b/xrdp/xrdp_process.c
@@ -315,14 +315,13 @@ xrdp_process_main_loop(struct xrdp_process *self)
 
 /*****************************************************************************/
 int
-xrdp_process_child_entrypoint(struct xrdp_listen *owner)
+xrdp_process_child_entrypoint(struct xrdp_listen *owner, int socket_fd)
 {
     struct trans *server_trans;
     struct xrdp_process *process;
 
-    // FIXME
     server_trans = trans_create(TRANS_MODE_TCP, 16, 16);
-    server_trans->sck = 0;
+    server_trans->sck = socket_fd;
 
     process = xrdp_process_create(owner, 0);
     process->server_trans = server_trans;

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -684,6 +684,8 @@ struct xrdp_startup_params
     int tcp_nodelay;
     int tcp_keepalive;
     int use_vsock;
+    int is_child;
+    int child_fd;
 };
 
 /*


### PR DESCRIPTION
# DESCRIPTION
- This PR moved from https://github.com/team-unstablers/xrdp-tumod/pull/1
- On macOS, some System APIs (including VideoToolbox) which communicates with Mach/XPC services stops working after `fork()`.
  - This PR fixes problem that initialization of VTCompressionSession fails after `fork()`.
- However, I think there is only one of the above items that will be improved, even though quite a bit of core code has been modified, so you may feel free to close this PR if you don't think it will be necessary. <sup>[machine-translated](#__translated)</sup>

# CHANGES
- `g_fork_execvp(exec, argv)` has added
- `g_get_executable_path(exectype, buf, bufsize)` has added
- `xrdp` now accepts `--child-process` and `--child-fd [fd]`, entrypoint for child process also added
- `xrdp` will use `g_fork_execvp()` instead of `g_fork()` for accepting new connections

# TODO

- [ ] rollback 4d1b20a : should i reconstruct logger by passing `logger->fd` to child process (via argv, or ...), as i reconstructed `struct trans`?
- [x] remove unreachable / unused code: `xrdp_listen.c:814` ... 
- [ ] clean-up `struct xrdp_process *`, `struct trans *` after `xrdp_process_main_loop`

____

<a name="__translated"><sup>translated from: `ですが、かなりコアなコードが修正されたのに、改善される事項は上記の一つしかいないと思うので、もし必要にならないと思われた場合は気楽にこのPRをクローズしても結構です。`</sup></a>