### PR TITLE
Support to set parameters for #2519

### DIFF
--- a/docs/man/sesman.ini.5.in
+++ b/docs/man/sesman.ini.5.in
@@ -359,6 +359,24 @@ GNOME 3 versions later than 3.29.92. Do not use this for any other reason.
 This setting will be removed in a later version of xrdp, when GNOME 3 is
 no longer supported.
 
+.TP
+\fBSoundNumSilentFramesAAC\fR=\fInumber\fR
+Sets the \fInumber\fR of silent frames which are sent to client before close
+message is sent, when AAC is selected. If set to 0, no silent frame is sent.
+If not specified, defaults to \fI4\fR.
+
+.TP
+\fBSoundNumSilentFramesMP3\fR=\fInumber\fR
+Sets the \fInumber\fR of silent frames which are sent to client before close
+message is sent, when MP3 is selected. If set to 0, no silent frame is sent.
+If not specified, defaults to \fI2\fR.
+
+.TP
+\fBSoundMsecDoNotSend\fR=\fInumber\fR
+Sets the duration(msec). Sound data is not send to client during \fInumber\fR
+millisecond(s) after close message is sent, when AAC/MP3 is selected.
+If set to 0, all the data is sent. If not specified, defaults to \fI1000\fR.
+
 .SH "SESSIONS VARIABLES"
 All entries in the \fB[SessionVariables]\fR section are set as
 environment variables in the user's session.

--- a/sesman/chansrv/chansrv_config.c
+++ b/sesman/chansrv/chansrv_config.c
@@ -41,6 +41,9 @@
 #define DEFAULT_FUSE_MOUNT_NAME             "xrdp-client"
 #define DEFAULT_FILE_UMASK                  077
 #define DEFAULT_USE_NAUTILUS3_FLIST_FORMAT  0
+#define DEFAULT_NUM_SILENT_FRAMES_AAC       4
+#define DEFAULT_NUM_SILENT_FRAMES_MP3       2
+#define DEFAULT_MSEC_DO_NOT_SEND            1000
 /**
  * Type used for passing a logging function about
  */
@@ -182,6 +185,18 @@ read_config_chansrv(log_func_t logmsg,
         {
             cfg->use_nautilus3_flist_format = g_text2bool(value);
         }
+        else if (g_strcasecmp(name, "SoundNumSilentFramesAAC") == 0)
+        {
+            cfg->num_silent_frames_aac = strtoul(value, NULL, 0);
+        }
+        else if (g_strcasecmp(name, "SoundNumSilentFramesMP3") == 0)
+        {
+            cfg->num_silent_frames_mp3 = strtoul(value, NULL, 0);
+        }
+        else if (g_strcasecmp(name, "SoundMsecDoNotSend") == 0)
+        {
+            cfg->msec_do_not_send = strtoul(value, NULL, 0);
+        }
     }
 
     return error;
@@ -213,6 +228,9 @@ new_config(void)
         cfg->fuse_mount_name = fuse_mount_name;
         cfg->file_umask = DEFAULT_FILE_UMASK;
         cfg->use_nautilus3_flist_format = DEFAULT_USE_NAUTILUS3_FLIST_FORMAT;
+        cfg->num_silent_frames_aac = DEFAULT_NUM_SILENT_FRAMES_AAC;
+        cfg->num_silent_frames_mp3 = DEFAULT_NUM_SILENT_FRAMES_MP3;
+        cfg->msec_do_not_send = DEFAULT_MSEC_DO_NOT_SEND;
     }
 
     return cfg;

--- a/sesman/chansrv/chansrv_config.h
+++ b/sesman/chansrv/chansrv_config.h
@@ -38,6 +38,12 @@ struct config_chansrv
 
     /** Whether to use nautilus3-compatible file lists for the clipboard */
     int use_nautilus3_flist_format;
+
+    /** Number of silent frames to send before SNDC_CLOSE is sent, setting from sesman.ini */
+    unsigned int num_silent_frames_aac;
+    unsigned int num_silent_frames_mp3;
+    /** Do net send sound data afer SNDC_CLOSE is sent. unit is millisecond, setting from sesman.ini */
+    unsigned int msec_do_not_send;
 };
 
 

--- a/sesman/sesman.ini.in
+++ b/sesman/sesman.ini.in
@@ -152,6 +152,16 @@ FileUmask=077
 ; and up, and you wish to cut-paste files between Nautilus and Windows. Do
 ; not use this setting for GNOME 4, or other file managers
 #UseNautilus3FlistFormat=true
+; sound redirection
+; workaround for Microsoft mstsc.exe to suppress noise.
+; SoundNumSilentFramesAAC | SoundNumSilentFramesMP3 silent frames are sent before SNDC_CLOSE is sent.
+; during SoundMsecDoNotSend mS after SNDC_CLOSE is sent, sound data is not send.
+; depending on the environment, it might be necessary to increase values.
+; Defaults: SoundNumSilentFramesAAC=4, SoundNumSilentFramesMP3=2, SoundMsecDoNotSend=1000
+; If set to 0, this workaround is not applied.
+#SoundNumSilentFramesAAC=4
+#SoundNumSilentFramesMP3=2
+#SoundMsecDoNotSend=1000
 
 [ChansrvLogging]
 ; Note: one log file is created per display and the LogFile config value


### PR DESCRIPTION
I tested #2519 in many desktops.
Noise is heard in some cases with current fixed parameters.
I think it is better to be able to set parameters in config file.
This patch adds three parameters in the [Chansrv] section in sessman.ini.
The Parameters are SoundNumSilentFramesAAC, SoundNumSilentFramesMP3 and SoundMsecDoNotSend.
SoundNumSilentFramesAAC | SoundNumSilentFramesMP3 silent frames are sent before SNDC_CLOSE is sent.
during SoundMsecDoNotSend mS after SNDC_CLOSE is sent, sound data is not send.