### PR TITLE
common: change g_malloc, g_free, g_memset, g_memcpy, and g_memmove to…

### DIFF
--- a/common/arch.h
+++ b/common/arch.h
@@ -20,6 +20,7 @@
 #define ARCH_H
 
 #include <stdlib.h>
+#include <string.h>
 
 #if defined(HAVE_STDINT_H)
 #include <stdint.h>

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -193,38 +193,6 @@ g_deinit(void)
 }
 
 /*****************************************************************************/
-/* allocate memory, returns a pointer to it, size bytes are allocated,
-   if zero is non zero, each byte will be set to zero */
-void *
-g_malloc(int size, int zero)
-{
-    char *rv;
-
-    rv = (char *)malloc(size);
-
-    if (zero)
-    {
-        if (rv != 0)
-        {
-            memset(rv, 0, size);
-        }
-    }
-
-    return rv;
-}
-
-/*****************************************************************************/
-/* free the memory pointed to by ptr, ptr can be zero */
-void
-g_free(void *ptr)
-{
-    if (ptr != 0)
-    {
-        free(ptr);
-    }
-}
-
-/*****************************************************************************/
 /* output text to stdout, try to use g_write / g_writeln instead to avoid
    linux / windows EOL problems */
 void
@@ -331,27 +299,6 @@ g_hexdump(const char *p, int len)
         offset += thisline;
         line += thisline;
     }
-}
-
-/*****************************************************************************/
-void
-g_memset(void *ptr, int val, int size)
-{
-    memset(ptr, val, size);
-}
-
-/*****************************************************************************/
-void
-g_memcpy(void *d_ptr, const void *s_ptr, int size)
-{
-    memcpy(d_ptr, s_ptr, size);
-}
-
-/*****************************************************************************/
-void
-g_memmove(void *d_ptr, const void *s_ptr, int size)
-{
-    memmove(d_ptr, s_ptr, size);
 }
 
 /*****************************************************************************/

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -52,8 +52,6 @@ int      g_rm_temp_dir(void);
 int      g_mk_socket_path(const char *app_name);
 void     g_init(const char *app_name);
 void     g_deinit(void);
-void    *g_malloc(int size, int zero);
-void     g_free(void *ptr);
 void g_printf(const char *format, ...) printflike(1, 2);
 void g_sprintf(char *dest, const char *format, ...) \
 printflike(2, 3);
@@ -62,9 +60,6 @@ printflike(3, 4);
 void g_writeln(const char *format, ...) printflike(1, 2);
 void g_write(const char *format, ...) printflike(1, 2);
 void     g_hexdump(const char *p, int len);
-void     g_memset(void *ptr, int val, int size);
-void     g_memcpy(void *d_ptr, const void *s_ptr, int size);
-void     g_memmove(void *d_ptr, const void *s_ptr, int size);
 int      g_getchar(void);
 int      g_tcp_set_no_delay(int sck);
 int      g_tcp_set_keepalive(int sck);
@@ -308,5 +303,12 @@ int      g_tcp6_bind_address(int sck, const char *port, const char *address);
     (struct_type *) malloc(sizeof(struct_type) * (n_structs))
 #define g_new0(struct_type, n_structs) \
     (struct_type *) calloc((n_structs), sizeof(struct_type))
+
+/* remove these when no longer used */
+#define g_malloc(_size, _zero) (_zero ? calloc(1, _size) : malloc(_size))
+#define g_free free
+#define g_memset memset
+#define g_memcpy memcpy
+#define g_memmove memmove
 
 #endif


### PR DESCRIPTION
… macros.  This should allow compilers to optimize these calls.