### PR TITLE
Bump FreeBSD image to 12.4

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@ FreeBSD_task:
       SSL: libressl
   matrix:
     freebsd_instance:
-      image_family: freebsd-12-3
+      image_family: freebsd-12-4
   prepare_script:
     - pkg install -y $SSL git autoconf automake libtool pkgconf opus jpeg-turbo fdk-aac pixman libX11 libXfixes libXrandr nasm fusefs-libs check imlib2 freetype2 cmocka
     - git submodule update --init --recursive


### PR DESCRIPTION
Now FreeBSD 12.4 has been out, FreeBSD 12.3 is EOL:-

```
$ sudo /usr/sbin/freebsd-update fetch
src component not installed, skipped
Looking up update.FreeBSD.org mirrors... 2 mirrors found.
Fetching metadata signature for 12.3-RELEASE from update1.freebsd.org... done.
Fetching metadata index... done.
Inspecting system... done.
Preparing to download files... done.

No updates needed to update system to 12.3-RELEASE-p12.

WARNING: FreeBSD 12.3-RELEASE-p11 HAS PASSED ITS END-OF-LIFE DATE.
Any security issues discovered after Fri Mar 31 01:00:00 BST 2023
will not have been corrected.
```