### PR TITLE
sesman: Prevent the use of 'alternate shell'

### DIFF
--- a/docs/man/sesman.ini.5.in
+++ b/docs/man/sesman.ini.5.in
@@ -283,6 +283,10 @@ To keep compatibility, the following aliases are also available.
 If set to \fB1\fR, \fBtrue\fR or \fByes\fR, require group membership even
 if the group specified in \fBTerminalServerUsers\fR doesn't exist.
 
+.TP
+\fBAllowAlternateShell\fR=\fI[true|false]\fR
+If set to \fB0\fR, \fBfalse\fR or \fBno\fR, prevent usage of alternate shells by users.
+
 .SH "X11 SERVER"
 Following parameters can be used in the \fB[X11rdp]\fR, \fB[Xvnc]\fR and
 \fB[Xorg]\fR sections.

--- a/sesman/config.c
+++ b/sesman/config.c
@@ -212,6 +212,7 @@ config_read_security(int file, struct config_security *sc,
     sc->ts_admins_enable = 0;
     sc->restrict_outbound_clipboard = 0;
     sc->restrict_inbound_clipboard = 0;
+    sc->allow_alternate_shell = 1;
 
     file_read_section(file, SESMAN_CFG_SECURITY, param_n, param_v);
 
@@ -278,6 +279,11 @@ config_read_security(int file, struct config_security *sc,
                     "Unrecognised tokens parsing 'RestrictInboundClipboard' %s",
                     unrecognised);
             }
+        }
+        if (0 == g_strcasecmp(buf, SESMAN_CFG_SEC_ALLOW_ALTERNATE_SHELL))
+        {
+            sc->allow_alternate_shell =
+                g_text2bool((char *)list_get_item(param_v, i));
         }
 
     }
@@ -602,6 +608,7 @@ config_dump(struct config_sesman *config)
     g_writeln("    AllowRootLogin:            %d", sc->allow_root);
     g_writeln("    MaxLoginRetry:             %d", sc->login_retry);
     g_writeln("    AlwaysGroupCheck:          %d", sc->ts_always_group_check);
+    g_writeln("    AllowAlternateShell:       %d", sc->allow_alternate_shell);
     if (sc->restrict_outbound_clipboard == CLIP_RESTRICT_NONE)
     {
         g_writeln("    RestrictOutboundClipboard: %s", "none");

--- a/sesman/config.h
+++ b/sesman/config.h
@@ -62,6 +62,7 @@
 #define SESMAN_CFG_SEC_ALWAYSGROUPCHECK            "AlwaysGroupCheck"
 #define SESMAN_CFG_SEC_RESTRICT_OUTBOUND_CLIPBOARD "RestrictOutboundClipboard"
 #define SESMAN_CFG_SEC_RESTRICT_INBOUND_CLIPBOARD  "RestrictInboundClipboard"
+#define SESMAN_CFG_SEC_ALLOW_ALTERNATE_SHELL       "AllowAlternateShell"
 
 #define SESMAN_CFG_SESSIONS          "Sessions"
 #define SESMAN_CFG_SESS_MAX          "MaxSessions"
@@ -141,6 +142,15 @@ struct config_security
      * @brief if the clipboard should be enforced restricted. If true only allow server -> client, not vice versa.
      */
     int restrict_inbound_clipboard;
+
+    /**
+     * @var allow_alternate_shell
+     * @brief allow an user-supplied alternate shell.
+     * @details 'YES' for all programs allowed, 'NO' for disabling of alternate
+     *          shells.
+     *          If not specified, 'YES' is assumed.
+     */
+    int allow_alternate_shell;
 };
 
 /**

--- a/sesman/sesman.ini.in
+++ b/sesman/sesman.ini.in
@@ -37,6 +37,8 @@ RestrictOutboundClipboard=none
 ;   false: an alias of none
 ;   yes: an alias of all
 RestrictInboundClipboard=none
+; Set to 'no' to prevent users from logging in with alternate shells
+#AllowAlternateShell=true
 
 [Sessions]
 ;; X11DisplayOffset - x11 display number offset

--- a/sesman/session.c
+++ b/sesman/session.c
@@ -596,30 +596,47 @@ session_start_fork(tbus data, tui8 type, struct SCP_SESSION *s)
             if (x_server_running(display))
             {
                 auth_set_env(data);
-                if (s->directory != 0)
+                if (s->directory != 0 && s->directory[0] != 0)
                 {
-                    if (s->directory[0] != 0)
+                    if (g_cfg->sec.allow_alternate_shell)
                     {
                         g_set_current_dir(s->directory);
+                    }
+                    else
+                    {
+                        LOG(LOG_LEVEL_WARNING,
+                            "Directory change to %s requested, but not "
+                            "allowed by AllowAlternateShell config value.",
+                            s->directory);
                     }
                 }
                 if (s->program != 0 && s->program[0] != 0)
                 {
-                    if (g_strchr(s->program, ' ') != 0 || g_strchr(s->program, '\t') != 0)
+                    if (g_cfg->sec.allow_alternate_shell)
                     {
-                        LOG(LOG_LEVEL_INFO,
-                            "Starting user requested window manager on "
-                            "display %d with embedded arguments using a shell: %s",
-                            display, s->program);
-                        const char *params[] = {"sh", "-c", s->program, NULL};
-                        g_execvp("/bin/sh", (char **)params);
+                        if (g_strchr(s->program, ' ') != 0 || g_strchr(s->program, '\t') != 0)
+                        {
+                            LOG(LOG_LEVEL_INFO,
+                                "Starting user requested window manager on "
+                                "display %d with embedded arguments using a shell: %s",
+                                display, s->program);
+                            const char *params[] = {"sh", "-c", s->program, NULL};
+                            g_execvp("/bin/sh", (char **)params);
+                        }
+                        else
+                        {
+                            LOG(LOG_LEVEL_INFO,
+                                "Starting user requested window manager on "
+                                "display %d: %s", display, s->program);
+                            g_execlp3(s->program, s->program, 0);
+                        }
                     }
                     else
                     {
-                        LOG(LOG_LEVEL_INFO,
-                            "Starting user requested window manager on "
-                            "display %d: %s", display, s->program);
-                        g_execlp3(s->program, s->program, 0);
+                        LOG(LOG_LEVEL_WARNING,
+                            "Shell %s requested by user, but not allowed by "
+                            "AllowAlternateShell config value.",
+                            s->program);
                     }
                 }
                 else


### PR DESCRIPTION
By setting the new config value 'AllowedAlternateShells' to 'no' it is now possible to prevent the use of these alternate shells. The default remains unchanged and any shells are allowed if the config value is not specified. It can also be set explicitly to 'yes' to achieve the same outcome.

Fixes: #850