### PR TITLE
Fail xrdp immediately on sesman connection failure

### DIFF
--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -364,6 +364,8 @@ struct xrdp_mm
 {
     struct xrdp_wm *wm; /* owner */
     enum mm_connect_state connect_state; /* State of connection */
+    int mmcs_expecting_msg; /* Connect state machine is expecting
+                               a message from sesman */
     /* Other processes we connect to */
     int use_sesman; /* true if this is a sesman session */
     int use_gw_login; /* True if we're to login using  a gateway */


### PR DESCRIPTION
At present if sesman fails when processing an xrdp request, xrdp will sit forever at a blue screen.

This PR detects this situation, and immediately logs an error:-

![image](https://user-images.githubusercontent.com/30179339/233043968-971991a3-069a-4784-b54d-683266c8e04e.png)