### PR TITLE
remove unnecessary include `check.h`

### DIFF
--- a/tests/libxrdp/test_libxrdp_main.c
+++ b/tests/libxrdp/test_libxrdp_main.c
@@ -4,7 +4,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <check.h>
 #include "log.h"
 #include "test_libxrdp.h"
 


### PR DESCRIPTION
same problem as #2124

`check.h` removes `HAVE_STDINT_H`, `log.h` includes `arch.h` which requires `HAVE_STDINT_H` to be defined.

`test_libxrdp.h` already includes `check.h`. so just remove it.