### PR TITLE
Allow longer UserWindowManager strings

### DIFF
--- a/sesman/libsesman/sesman_config.c
+++ b/sesman/libsesman/sesman_config.c
@@ -179,7 +179,7 @@ config_read_globals(int file, struct config_sesman *cf, struct list *param_n,
     /* resetting the struct */
     cf->listen_port[0] = '\0';
     cf->enable_user_wm = 0;
-    cf->user_wm[0] = '\0';
+    cf->user_wm = g_strdup("");
     cf->default_wm = 0;
     cf->auth_file_path = 0;
     cf->reconnect_sh = 0;
@@ -197,7 +197,8 @@ config_read_globals(int file, struct config_sesman *cf, struct list *param_n,
         }
         else if (0 == g_strcasecmp(param, SESMAN_CFG_USERWM))
         {
-            g_strncpy(cf->user_wm, val, sizeof(cf->user_wm) - 1);
+            g_free(cf->user_wm);
+            cf->user_wm = g_strdup(val);
         }
         else if (0 == g_strcasecmp(param, SESMAN_CFG_ENABLE_USERWM))
         {
@@ -726,6 +727,7 @@ config_free(struct config_sesman *cs)
     {
         g_free(cs->sesman_ini);
         g_free(cs->default_wm);
+        g_free(cs->user_wm);
         g_free(cs->reconnect_sh);
         g_free(cs->auth_file_path);
         list_delete(cs->vnc_params);

--- a/sesman/libsesman/sesman_config.h
+++ b/sesman/libsesman/sesman_config.h
@@ -175,9 +175,9 @@ struct config_sesman
     char *default_wm;
     /**
      * @var user_wm
-     * @brief Default window manager
+     * @brief Default window manager.
      */
-    char user_wm[32];
+    char *user_wm;
     /**
      * @var reconnect_sh
      * @brief Script executed when reconnected


### PR DESCRIPTION
Fixes #1150 

Needs back-port to v0.9

The UserWindowManager is limited to 31 characters. There appears to be no good reason for this.