### PR TITLE
[V0.9] Allow longer UserWindowManager strings

### DIFF
--- a/sesman/config.c
+++ b/sesman/config.c
@@ -61,7 +61,7 @@ config_read_globals(int file, struct config_sesman *cf, struct list *param_n,
     cf->listen_address[0] = '\0';
     cf->listen_port[0] = '\0';
     cf->enable_user_wm = 0;
-    cf->user_wm[0] = '\0';
+    cf->user_wm = g_strdup("");
     cf->default_wm = 0;
     cf->auth_file_path = 0;
     cf->reconnect_sh = 0;
@@ -78,7 +78,8 @@ config_read_globals(int file, struct config_sesman *cf, struct list *param_n,
         }
         else if (0 == g_strcasecmp(buf, SESMAN_CFG_USERWM))
         {
-            g_strncpy(cf->user_wm, (char *)list_get_item(param_v, i), 31);
+            g_free(cf->user_wm);
+            cf->user_wm = g_strdup((char *)list_get_item(param_v, i));
         }
         else if (0 == g_strcasecmp(buf, SESMAN_CFG_ENABLE_USERWM))
         {
@@ -721,6 +722,7 @@ config_free(struct config_sesman *cs)
     {
         g_free(cs->sesman_ini);
         g_free(cs->default_wm);
+        g_free(cs->user_wm);
         g_free(cs->reconnect_sh);
         g_free(cs->auth_file_path);
         list_delete(cs->rdp_params);

--- a/sesman/config.h
+++ b/sesman/config.h
@@ -233,9 +233,9 @@ struct config_sesman
     char *default_wm;
     /**
      * @var user_wm
-     * @brief Default window manager
+     * @brief Default window manager.
      */
-    char user_wm[32];
+    char *user_wm;
     /**
      * @var reconnect_sh
      * @brief Script executed when reconnected


### PR DESCRIPTION
Back-port of #2651 to v0.9

The UserWindowManager is limited to 31 characters. There appears to be no good reason for this.