### PR TITLE
Use config_ac.h consistently and correctly

### DIFF
--- a/common/pixman-region.c
+++ b/common/pixman-region.c
@@ -63,8 +63,11 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
-#if defined(HAVE_CONFIG_H)
-#include <config_ac.h>
+#ifndef PIXMAN_REGION_MAX
+#error "This file should be #included from pixman-region16.c, not compiled directly"
+#endif
+#ifndef CONFIG_AC_H
+#error "config_ac.h not visible in pixman-region.c"
 #endif
 
 #define PIXREGION_NIL(reg) ((reg)->data && !(reg)->data->numRects)

--- a/genkeymap/evdev-map.c
+++ b/genkeymap/evdev-map.c
@@ -22,6 +22,10 @@
  * xfree86(base)->evdev keycode mapping
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 int xfree86_to_evdev[137 - 8 + 1] =
 {
     /* MDSW */ 203,

--- a/libipm/libipm.h
+++ b/libipm/libipm.h
@@ -26,10 +26,6 @@
 #if !defined(LIBIPM_H)
 #define LIBIPM_H
 
-#if defined(HAVE_CONFIG_H)
-#include <config_ac.h>
-#endif
-
 #include "arch.h"
 #include "libipm_facilities.h"
 

--- a/sesman/chansrv/pcsc/wrapper/winscard.c
+++ b/sesman/chansrv/pcsc/wrapper/winscard.c
@@ -1,3 +1,6 @@
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/sesman/chansrv/pcsc/xrdp_pcsc.c
+++ b/sesman/chansrv/pcsc/xrdp_pcsc.c
@@ -1,3 +1,6 @@
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tools/devel/gtcp_proxy/gtcp-proxy.c
+++ b/tools/devel/gtcp_proxy/gtcp-proxy.c
@@ -16,6 +16,10 @@
  * limitations under the License.
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include <stdio.h>
 #include <gtk/gtk.h>
 #include <pthread.h>

--- a/tools/devel/gtcp_proxy/gtcp.c
+++ b/tools/devel/gtcp_proxy/gtcp.c
@@ -16,6 +16,10 @@
  * limitations under the License.
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include "gtcp.h"
 
 /**

--- a/tools/devel/gtcp_proxy/hexdump.c
+++ b/tools/devel/gtcp_proxy/hexdump.c
@@ -16,6 +16,10 @@
  * limitations under the License.
  */
 
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>


### PR DESCRIPTION
This is a cleanup in the vein of #647.

Not all `.c` files were #including `config_ac.h` directly, and due to the way the #include was handled, some files were seeing the config definitions twice:

* `common/pixman-region16.c`
* `libipm/libipm.c`
* `libipm/libipm_send.c`
* `libipm/libipm_recv.c`
* `libipm/eicp.c`
* `libipm/ercp.c`
* `libipm/scp.c`

This PR makes everything consistent.

(It might be desirable to give `common/pixman-region.c` a different filename extension, perhaps `.inc`, to make clear that it is not meant to be compiled directly.)