### PR TITLE
Simplify interaction with systemd

### DIFF
--- a/instfiles/xrdp-sesman.service.in
+++ b/instfiles/xrdp-sesman.service.in
@@ -6,13 +6,11 @@ StopWhenUnneeded=true
 BindsTo=xrdp.service
 
 [Service]
-Type=forking
-PIDFile=@localstatedir@/run/xrdp-sesman.pid
+Type=exec
 EnvironmentFile=-@sysconfdir@/sysconfig/xrdp
 EnvironmentFile=-@sysconfdir@/default/xrdp
-ExecStart=@sbindir@/xrdp-sesman $SESMAN_OPTIONS
-ExecStop=@sbindir@/xrdp-sesman $SESMAN_OPTIONS --kill
-ExecReload=@sbindir@/xrdp-sesman $SESMAN_OPTIONS --reload
+ExecStart=@sbindir@/xrdp-sesman $SESMAN_OPTIONS --nodaemon
+ExecReload=kill -HUP $MAINPID
 
 [Install]
 WantedBy=multi-user.target

--- a/instfiles/xrdp.service.in
+++ b/instfiles/xrdp.service.in
@@ -5,12 +5,10 @@ Requires=xrdp-sesman.service
 After=network.target xrdp-sesman.service
 
 [Service]
-Type=forking
-PIDFile=@localstatedir@/run/xrdp.pid
+Type=exec
 EnvironmentFile=-@sysconfdir@/sysconfig/xrdp
 EnvironmentFile=-@sysconfdir@/default/xrdp
-ExecStart=@sbindir@/xrdp $XRDP_OPTIONS
-ExecStop=@sbindir@/xrdp $XRDP_OPTIONS --kill
+ExecStart=@sbindir@/xrdp $XRDP_OPTIONS --nodaemon
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When xrdp is being managed with systemd...

* Forking is not necessary, as systemd does not need the program to exit;
* PID files are not necessary, when the program does not fork;
* The `--kill` invocation is not needed, as systemd can send the SIGTERM itself;
* The `--reload` invocation is not needed, as systemd can send the SIGHUP itself.

This PR simplifies the systemd units accordingly. This will not only make managing the files in `/run` easier, it will also reduce the operating footprint that needs to be accounted for in AppArmor profiles and other security frameworks.