### PR TITLE
Fix (again) broken 32-bit CI

### DIFF
--- a/scripts/install_xrdp_build_dependencies_with_apt.sh
+++ b/scripts/install_xrdp_build_dependencies_with_apt.sh
@@ -102,7 +102,10 @@ in
                 exit 1;
                 ;;
         esac
+        apt-get update
+        apt-get upgrade
         ;;
+
     i386)
         # This list is not as complete as the amd64 list. It currently
         # supports 32-bit CI building only, rather than being a generic
@@ -135,6 +138,7 @@ in
         dpkg --print-foreign-architectures
         apt-get update
         remove_64bit_libdev_packages $PACKAGES
+        apt-get install libc6:i386 libgcc-s1:i386 libstdc++6:i386 libatomic1:i386
         ;;
     *)
         echo "unsupported architecture: $ARCH"
@@ -142,8 +146,6 @@ in
         ;;
 esac
 
-apt-get update
-apt-get upgrade
 apt-get -yq \
     --no-install-suggests \
     --no-install-recommends \


### PR DESCRIPTION
Fixes the 32-bit CI builds for now.

The `apt-get upgrade` introduced by #2534 has been removed from the 32-bit path, and the core C/C++ libraries have been explicitly installed to prevent these messages:-

```
libc6:i386 : Depends: libgcc-s1:i386 but it is not going to be installed
 libegl-mesa0:i386 : Depends: libgcc-s1:i386 (>= 4.2) but it is not going to be installed
 libgl1-mesa-dri:i386 : Depends: libgcc-s1:i386 (>= 7) but it is not going to be installed
                        Depends: libstdc++6:i386 (>= 11) but it is not going to be installed
 libglu1-mesa:i386 : Depends: libgcc-s1:i386 (>= 3.0) but it is not going to be installed
                     Depends: libstdc++6:i386 (>= 5) but it is not going to be installed
 libicu70:i386 : Depends: libgcc-s1:i386 (>= 7) but it is not going to be installed
                 Depends: libstdc++6:i386 (>= 5.2) but it is not going to be installed
 libllvm15:i386 : Depends: libatomic1:i386 (>= 4.8) but it is not going to be installed
                  Depends: libgcc-s1:i386 (>= 4.2) but it is not going to be installed
                  Depends: libstdc++6:i386 (>= 12) but it is not going to be installed
 libtiffxx5:i386 : Depends: libstdc++6:i386 (>= 5) but it is not going to be installed
```

At some stage we may have to remove this support, but this PR fixes it up again for the short-term.