### PR TITLE
Add syscall filtering to xrdp systemd unit

### DIFF
--- a/instfiles/xrdp.service.in
+++ b/instfiles/xrdp.service.in
@@ -9,6 +9,8 @@ Type=exec
 EnvironmentFile=-@sysconfdir@/sysconfig/xrdp
 EnvironmentFile=-@sysconfdir@/default/xrdp
 ExecStart=@sbindir@/xrdp $XRDP_OPTIONS --nodaemon
+SystemCallArchitectures=native
+SystemCallFilter=@basic-io @file-system @io-event @ipc @network-io @process @signal ioctl madvise sysinfo uname
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This makes use of systemd's system-call filtering facility to add (Linux) seccomp support to the `xrdp` daemon in a non-invasive way. This implicitly also enables NoNewPrivileges. (See `SystemCallFilter=` in `systemd.exec(5)`)

This marks wide swaths of the Linux kernel API as off-limits, significantly reducing the attack surface of the system available to a baddie who manages to compromise the program. If a prohibited syscall is used, the program is immediately killed with SIGSYS.

I've put together this syscall filter through some trial and error, and am able to perform a full login/logout cycle without issue. If there are any unusual codepaths used by `xrdp`, then those should be tested to ensure the filter covers everything needed.

Some notes on testing the filter:

* When the process uses a prohibited syscall, in addition to the SIGSYS, a message like the following will appear in syslog:
  ```
  May 21 00:17:10 darkstar kernel: [ 4789.893316] audit: type=1326 audit(1684642630.723:258): auid=4294967295 uid=124 gid=130 ses=4294967295 subj=unconfined pid=28046 comm="xrdp" exe="/usr/sbin/xrdp" sig=31 arch=c000003e syscall=99 compat=0 ip=0x7fb9ee316f9b code=0x80000000
  ```
* The `syscall=99` bit is salient. The syscall number can be looked up using the `scmp_sys_resolver(1)` utility:
  ```
  $ scmp_sys_resolver 99
  sysinfo
  ```
* The syscall name can either be added to the filter directly, or if you want to use systemd's syscall sets, the sets can be listed with `systemd-analyze syscall-filter`. (I generally made use of the sets to keep things simple, save for a couple oddball cases.)
* Alternately, you can test without the threat of SIGSYS by using `SystemCallLog=`. Comment out `SystemCallFilter=`, and append its arguments to `SystemCallLog=~@default`. Then watch syslog for messages like the one above (only they will show `sig=0`).

Note: This approach to adding seccomp support is easy, but of course it is limited not only to systemd, but also to Linux. It should be considered a stopgap solution at best. A better one would be to add support in the code, making use of seccomp on Linux, [pledge](https://isopenbsdsecu.re/mitigations/pledge/) on OpenBSD, and similar facilities on other systems. That is what [OpenSSH](https://github.com/openssh/openssh-portable) does (see the `sandbox-*.c` source files).