### PR TITLE
Remove size limit for PAM environment variables

### DIFF
--- a/sesman/libsesman/verify_user_pam.c
+++ b/sesman/libsesman/verify_user_pam.c
@@ -497,9 +497,6 @@ auth_set_env(struct auth_info *auth_info)
 {
     char **pam_envlist;
     char **pam_env;
-    char item[256];
-    char value[256];
-    int eq_pos;
 
     if (auth_info != NULL)
     {
@@ -510,16 +507,16 @@ auth_set_env(struct auth_info *auth_info)
         {
             for (pam_env = pam_envlist; *pam_env != NULL; ++pam_env)
             {
-                eq_pos = g_pos(*pam_env, "=");
+                char *str = *pam_env;
+                int eq_pos = g_pos(str, "=");
 
-                if (eq_pos >= 0 && eq_pos < 250)
+                if (eq_pos > 0)
                 {
-                    g_strncpy(item, *pam_env, eq_pos);
-                    g_strncpy(value, (*pam_env) + eq_pos + 1, 255);
-                    g_setenv(item, value, 1);
+                    str[eq_pos] = '\0';
+                    g_setenv(str, str + eq_pos + 1, 1);
                 }
 
-                g_free(*pam_env);
+                g_free(str);
             }
 
             g_free(pam_envlist);

--- a/sesman/libsesman/verify_user_pam_userpass.c
+++ b/sesman/libsesman/verify_user_pam_userpass.c
@@ -307,9 +307,6 @@ auth_set_env(struct auth_info *auth_info)
 {
     char **pam_envlist;
     char **pam_env;
-    char item[256];
-    char value[256];
-    int eq_pos;
 
     if (auth_info != NULL)
     {
@@ -320,16 +317,16 @@ auth_set_env(struct auth_info *auth_info)
         {
             for (pam_env = pam_envlist; *pam_env != NULL; ++pam_env)
             {
-                eq_pos = g_pos(*pam_env, "=");
+                char *str = *pam_env;
+                int eq_pos = g_pos(str, "=");
 
-                if (eq_pos >= 0 && eq_pos < 250)
+                if (eq_pos > 0)
                 {
-                    g_strncpy(item, *pam_env, eq_pos);
-                    g_strncpy(value, (*pam_env) + eq_pos + 1, 255);
-                    g_setenv(item, value, 1);
+                    str[eq_pos] = '\0';
+                    g_setenv(str, str + eq_pos + 1, 1);
                 }
 
-                g_free(*pam_env);
+                g_free(str);
             }
 
             g_free(pam_envlist);


### PR DESCRIPTION
Fixes #2705 

The current logic in auth_set_env() for PAM environments only allows environment variables to be around 256 characters in length.