### PR TITLE
[0.9] Remove size limit for PAM environment variables

### DIFF
--- a/sesman/verify_user_pam.c
+++ b/sesman/verify_user_pam.c
@@ -419,9 +419,6 @@ auth_set_env(long in_val)
     struct t_auth_info *auth_info;
     char **pam_envlist;
     char **pam_env;
-    char item[256];
-    char value[256];
-    int eq_pos;
 
     auth_info = (struct t_auth_info *)in_val;
 
@@ -434,16 +431,16 @@ auth_set_env(long in_val)
         {
             for (pam_env = pam_envlist; *pam_env != NULL; ++pam_env)
             {
-                eq_pos = g_pos(*pam_env, "=");
+                char *str = *pam_env;
+                int eq_pos = g_pos(str, "=");
 
-                if (eq_pos >= 0 && eq_pos < 250)
+                if (eq_pos > 0)
                 {
-                    g_strncpy(item, *pam_env, eq_pos);
-                    g_strncpy(value, (*pam_env) + eq_pos + 1, 255);
-                    g_setenv(item, value, 1);
+                    str[eq_pos] = '\0';
+                    g_setenv(str, str + eq_pos + 1, 1);
                 }
 
-                g_free(*pam_env);
+                g_free(str);
             }
 
             g_free(pam_envlist);


### PR DESCRIPTION
The current logic in auth_set_env() for PAM environments only allows environment variables to be around 256 characters in length.