### PR TITLE
Included os_calls.h first in unit tests

### DIFF
--- a/tests/common/test_fifo_calls.c
+++ b/tests/common/test_fifo_calls.c
@@ -4,8 +4,8 @@
 
 #include "fifo.h"
 
-#include "test_common.h"
 #include "os_calls.h"
+#include "test_common.h"
 #include "string_calls.h"
 
 static const char *strings[] =

--- a/tests/common/test_list_calls.c
+++ b/tests/common/test_list_calls.c
@@ -4,8 +4,8 @@
 
 #include "list.h"
 
-#include "test_common.h"
 #include "os_calls.h"
+#include "test_common.h"
 #include "string_calls.h"
 
 #define TEST_LIST_SIZE 1000


### PR DESCRIPTION
Same problem as mentioned in these issues: #2124 #2649 

I reordered the includes in `test_fifo_calls.c` and `test_list_calls.c` for `test_common.h` and `os_calls.h`, which allows me to compile successfully using Arch Linux.