### PR TITLE
Fix compile errors detected by the older gcc 4.8.5 compiler:-

### DIFF
--- a/sesman/chansrv/sound.c
+++ b/sesman/chansrv/sound.c
@@ -1118,9 +1118,10 @@ process_pcm_message(int id, int size, struct stream *s)
                 char *buf = (char *) g_malloc(g_bbuf_size, 0);
                 if (buf != NULL)
                 {
+                    int i;
                     silence_start_time = g_time3();
                     sending_silence = 1;
-                    for (int i = 0; i < send_silence_times; i++)
+                    for (i = 0; i < send_silence_times; i++)
                     {
                         g_memset(buf, 0, g_bbuf_size);
                         sound_send_wave_data_chunk(buf, g_bbuf_size);

--- a/sesman/sesexec/sesexec.c
+++ b/sesman/sesexec/sesexec.c
@@ -517,5 +517,5 @@ main(int argc, char **argv)
     }
 
     g_deinit();
-    g_exit(error);
+    return error;
 }


### PR DESCRIPTION
sesexec.c: In function ‘main’:
sesexec.c:521:1: error: control reaches end of non-void function [-Werror=return-type]

sound.c: In function ‘process_pcm_message’:
sound.c:1123:21: error: ‘for’ loop initial declarations are only allowed in C99 mode
                     for (int i = 0; i < send_silence_times; i++)
                     ^
sound.c:1123:21: note: use option -std=c99 or -std=gnu99 to compile your code

These fixes are in line with our coding standard and have no functional change.