### PR TITLE
Log xrdp termination signals

### DIFF
--- a/common/string_calls.c
+++ b/common/string_calls.c
@@ -21,6 +21,7 @@
 #if defined(HAVE_CONFIG_H)
 #include "config_ac.h"
 #endif
+#include <signal.h>
 #include <string.h>
 #include <strings.h>
 #include <stdlib.h>
@@ -420,30 +421,6 @@ g_atoi(const char *str)
     }
 
     return atoi(str);
-}
-
-/*****************************************************************************/
-char *
-g_strsignal(int signum)
-{
-    char *result = strsignal(signum);
-
-    if (result == NULL)
-    {
-        // Using a static buffer offers the same guarantees as the
-        // strsignal() call
-        static char buff[32];
-        unsigned int len;
-        len = g_snprintf(buff, sizeof(buff), "SIG#%d", signum);
-        if (len >= sizeof(buff))
-        {
-            // Buffer overflow
-            g_snprintf(buff, sizeof(buff), "SIG???");
-        }
-        result = buff;
-    }
-
-    return result;
 }
 
 /*****************************************************************************/
@@ -1167,3 +1144,147 @@ g_charstr_to_bitmask(const char *str, const struct bitmask_char bitdefs[],
     return bitmask;
 }
 
+/*****************************************************************************/
+/*
+ * Looks for a simple mapping of signal number to name
+ */
+static const char *
+find_sig_name(int signum)
+{
+    typedef struct
+    {
+        int num;
+        const char *name;
+    } sig_to_name_type;
+
+    // Map a string 'zzz' to { SIGzzz, "zzz"} for making
+    // typo-free sig_to_name_type objects
+#   define DEFSIG(sig) { SIG ## sig, # sig }
+
+    // Entries in this array are taken from
+    // The Single UNIX ® Specification, Version 2 (1997)
+    // plus additions from specific operating systems.
+    //
+    // The SUS requires these to be positive integer constants with a
+    // macro definition.  Note that SIGRTMIN and SIGRTMAX on Linux are
+    // NOT constants, so have to be handled separately.
+    static const sig_to_name_type sigmap[] =
+    {
+        // Names from SUS v2, in the order they are listed in that document
+        // that *should* be defined everywhere
+        //
+        // Commented out definitions below are NOT used everywhere
+        DEFSIG(ABRT), DEFSIG(ALRM), DEFSIG(FPE), DEFSIG(HUP),
+        DEFSIG(ILL), DEFSIG(INT), DEFSIG(KILL), DEFSIG(PIPE),
+        DEFSIG(QUIT), DEFSIG(SEGV), DEFSIG(TERM), DEFSIG(USR1),
+        DEFSIG(USR2), DEFSIG(CHLD), DEFSIG(CONT), DEFSIG(STOP),
+        DEFSIG(TSTP), DEFSIG(TTIN), DEFSIG(TTOU), DEFSIG(BUS),
+        /* DEFSIG(POLL), */ /* DEFSIG(PROF), */ DEFSIG(SYS), DEFSIG(TRAP),
+        DEFSIG(URG), DEFSIG(VTALRM), DEFSIG(XCPU), DEFSIG(XFSZ),
+
+        // SIGPOLL and SIGPROF are marked as obselescent in 1003.1-2017,
+        // Also SIGPOLL isn't in *BSD operating systems which use SIGIO
+#ifdef SIGPOLL
+        DEFSIG(POLL),
+#endif
+#ifdef SIGPROF
+        DEFSIG(PROF),
+#endif
+
+        // BSD signals (from FreeBSD/OpenBSD sys/signal.h and
+        // Darwin/Illumos signal.h)
+#ifdef SIGEMT
+        DEFSIG(EMT),
+#endif
+#ifdef SIGIO
+        DEFSIG(IO),
+#endif
+#ifdef SIGWINCH
+        DEFSIG(WINCH),
+#endif
+#ifdef SIGINFO
+        DEFSIG(INFO),
+#endif
+#ifdef SIGTHR
+        DEFSIG(THR),
+#endif
+#ifdef SIGLIBRT
+        DEFSIG(LIBRT),
+#endif
+#ifdef SIGPWR
+        DEFSIG(PWR),
+#endif
+#ifdef SIGWAITING
+        DEFSIG(WAITING),
+#endif
+#ifdef SIGLWP
+        DEFSIG(LWP),
+#endif
+
+        // Linux additions to *BSD (signal(7))
+#ifdef SIGLOST
+        DEFSIG(LOST),
+#endif
+#ifdef SIGSTKFLT
+        DEFSIG(STKFLT),
+#endif
+
+        // Terminator
+        {0, NULL}
+#undef DEFSIG
+    };
+
+    const sig_to_name_type *p;
+
+    for (p = &sigmap[0] ; p->name != NULL ; ++p)
+    {
+        if (p->num == signum)
+        {
+            return p->name;
+        }
+    }
+
+    // These aren't constants on Linux
+#ifdef SIGRTMIN
+    if (signum == SIGRTMIN)
+    {
+        return "RTMIN";
+    }
+#endif
+#ifdef SIGRTMAX
+    if (signum == SIGRTMAX)
+    {
+        return "RTMAX";
+    }
+#endif
+
+    return NULL;
+}
+
+/*****************************************************************************/
+char *
+g_sig2text(int signum, char sigstr[])
+{
+    if (signum >= 0)
+    {
+        const char *name = find_sig_name(signum);
+
+        if (name != NULL)
+        {
+            g_snprintf(sigstr, MAXSTRSIGLEN, "SIG%s", name);
+            return sigstr;
+        }
+
+#if defined(SIGRTMIN) && defined(SIGRTMAX)
+        if (signum > SIGRTMIN && signum < SIGRTMAX)
+        {
+            g_snprintf(sigstr, MAXSTRSIGLEN, "SIGRTMIN+%d", signum - SIGRTMIN);
+            return sigstr;
+        }
+#endif
+    }
+
+    // If all else fails...
+    g_snprintf(sigstr, MAXSTRSIGLEN, "SIG#%d", signum);
+    return sigstr;
+}

--- a/common/string_calls.c
+++ b/common/string_calls.c
@@ -423,6 +423,30 @@ g_atoi(const char *str)
 }
 
 /*****************************************************************************/
+char *
+g_strsignal(int signum)
+{
+    char *result = strsignal(signum);
+
+    if (result == NULL)
+    {
+        // Using a static buffer offers the same guarantees as the
+        // strsignal() call
+        static char buff[32];
+        unsigned int len;
+        len = g_snprintf(buff, sizeof(buff), "SIG#%d", signum);
+        if (len >= sizeof(buff))
+        {
+            // Buffer overflow
+            g_snprintf(buff, sizeof(buff), "SIG???");
+        }
+        result = buff;
+    }
+
+    return result;
+}
+
+/*****************************************************************************/
 /* As g_atoi() but allows for hexadecimal too */
 int
 g_atoix(const char *str)

--- a/common/string_calls.h
+++ b/common/string_calls.h
@@ -267,6 +267,12 @@ int      g_strcasecmp(const char *c1, const char *c2);
 int      g_strncasecmp(const char *c1, const char *c2, int len);
 int      g_atoi(const char *str);
 /**
+ * Implements POSIX 1003.1 strsignal()
+ *
+ * This function never returns NULL
+ */
+char    *g_strsignal(int signum);
+/**
  * Extends g_atoi(), Converts decimal and hexadecimal number String to integer
  *
  * Prefix hexadecimal numbers with '0x'

--- a/common/string_calls.h
+++ b/common/string_calls.h
@@ -67,6 +67,26 @@ struct bitmask_char
 
 #define BITMASK_CHAR_END_OF_LIST { 0, '\0' }
 
+enum
+{
+    // See g_sig2text()
+    // Must be able to hold "SIG#%d" for INT_MIN
+    //
+    // ((sizeof(int) * 5 + 1) / 2) provides a very slight overestimate of
+    // the bytes requires to store a decimal expansion of 'int':-
+    // sizeof  INT_MAX     display bytes   ((sizeof(int) * 5 + 1)
+    // (int)               needed           / 2)
+    // ------  -------     -------------   ---------------------------
+    // 1       127         3                3
+    // 2       32767       5                5
+    // 3       8388607     7                8
+    // 4       2147483637  10              10
+    // 8       9*(10**18)  19              20
+    // 16      2*(10**38)  39              40
+    // 32      6*(10**76)  77              80
+    MAXSTRSIGLEN =  (3 + 1 + 1 + ((sizeof(int) * 5 + 1) / 2) + 1)
+};
+
 /**
  * Processes a format string for general info
  *
@@ -266,12 +286,7 @@ int      g_strncmp_d(const char *c1, const char *c2, const char delim, int len);
 int      g_strcasecmp(const char *c1, const char *c2);
 int      g_strncasecmp(const char *c1, const char *c2, int len);
 int      g_atoi(const char *str);
-/**
- * Implements POSIX 1003.1 strsignal()
- *
- * This function never returns NULL
- */
-char    *g_strsignal(int signum);
+
 /**
  * Extends g_atoi(), Converts decimal and hexadecimal number String to integer
  *
@@ -289,4 +304,17 @@ char    *g_strstr(const char *haystack, const char *needle);
 int      g_mbstowcs(twchar *dest, const char *src, int n);
 int      g_wcstombs(char *dest, const twchar *src, int n);
 int      g_strtrim(char *str, int trim_flags);
+
+/**
+ * Maps a signal number to a string, i.e. SIGHUP -> "SIGHUP"
+ *
+ * @param signum Signal number
+ * @param sigstr buffer for result
+ * @return sigstr, for convenience
+ *
+ * Buffer is assumed to be at least MAXSTRSIGLEN
+ *
+ * The string "SIG#<num>" is returned for unrecognised signums
+ */
+char    *g_sig2text(int signum, char sigstr[]);
 #endif

--- a/sesman/sesexec/session.c
+++ b/sesman/sesexec/session.c
@@ -821,7 +821,7 @@ exit_status_to_str(const struct exit_status *e, char buff[], int bufflen)
             break;
 
         case E_XR_SIGNAL:
-            g_snprintf(buff, bufflen, "signal %d", e->val);
+            g_snprintf(buff, bufflen, "signal \"%s\"", g_strsignal(e->val));
             break;
 
         default:

--- a/sesman/sesexec/session.c
+++ b/sesman/sesexec/session.c
@@ -821,8 +821,12 @@ exit_status_to_str(const struct exit_status *e, char buff[], int bufflen)
             break;
 
         case E_XR_SIGNAL:
-            g_snprintf(buff, bufflen, "signal \"%s\"", g_strsignal(e->val));
-            break;
+        {
+            char sigstr[MAXSTRSIGLEN];
+            g_snprintf(buff, bufflen, "signal %s",
+                       g_sig2text(e->val, sigstr));
+        }
+        break;
 
         default:
             g_snprintf(buff, bufflen, "an unexpected error");

--- a/sesman/sesexec/xwait.c
+++ b/sesman/sesexec/xwait.c
@@ -155,10 +155,13 @@ wait_for_xserver(uid_t uid,
                         break;
 
                     case E_XR_SIGNAL:
+                    {
+                        char sigstr[MAXSTRSIGLEN];
                         LOG(LOG_LEVEL_ERROR,
-                            "waitforx failed with unexpected signal \"%s\"",
-                            g_strsignal(e.val));
-                        break;
+                            "waitforx failed with unexpected signal %s",
+                            g_sig2text(e.val, sigstr));
+                    }
+                    break;
 
                     default:
                         LOG(LOG_LEVEL_ERROR,

--- a/sesman/sesexec/xwait.c
+++ b/sesman/sesexec/xwait.c
@@ -156,8 +156,8 @@ wait_for_xserver(uid_t uid,
 
                     case E_XR_SIGNAL:
                         LOG(LOG_LEVEL_ERROR,
-                            "waitforx failed with unexpected signal %d",
-                            e.val);
+                            "waitforx failed with unexpected signal \"%s\"",
+                            g_strsignal(e.val));
                         break;
 
                     default:

--- a/xrdp/xrdp.c
+++ b/xrdp/xrdp.c
@@ -102,9 +102,7 @@ xrdp_shutdown(int sig)
 static void
 xrdp_child(int sig)
 {
-    while (g_waitchild(NULL) > 0)
-    {
-    }
+    g_set_sigchld(1);
 }
 
 /*****************************************************************************/
@@ -562,6 +560,14 @@ main(int argc, char **argv)
         LOG(LOG_LEVEL_WARNING, "error creating g_term_event");
     }
 
+    g_snprintf(text, 255, "xrdp_%8.8x_main_sigchld", pid);
+    g_set_sigchld_event(g_create_wait_obj(text));
+
+    if (g_get_sigchld() == 0)
+    {
+        LOG(LOG_LEVEL_WARNING, "error creating g_sigchld_event");
+    }
+
     g_snprintf(text, 255, "xrdp_%8.8x_main_sync", pid);
     g_set_sync_event(g_create_wait_obj(text));
 
@@ -582,6 +588,9 @@ main(int argc, char **argv)
 
     g_delete_wait_obj(g_get_term());
     g_set_term_event(0);
+
+    g_delete_wait_obj(g_get_sigchld());
+    g_set_sigchld_event(0);
 
     g_delete_wait_obj(g_get_sync_event());
     g_set_sync_event(0);

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -55,6 +55,8 @@ g_set_sync1_mutex(long mutex);
 void
 g_set_term_event(tbus event);
 void
+g_set_sigchld_event(tbus event);
+void
 g_set_sync_event(tbus event);
 long
 g_get_threadid(void);
@@ -62,10 +64,14 @@ void
 g_set_threadid(long id);
 tbus
 g_get_term(void);
+tbus
+g_get_sigchld(void);
 int
 g_is_term(void);
 void
 g_set_term(int in_val);
+void
+g_set_sigchld(int in_val);
 tbus
 g_get_sync_event(void);
 void

--- a/xrdp/xrdp_listen.c
+++ b/xrdp/xrdp_listen.c
@@ -847,6 +847,29 @@ xrdp_listen_conn_in(struct trans *self, struct trans *new_self)
 }
 
 /*****************************************************************************/
+/**
+ * Process pending SIGCHLD events in the listen process
+ *
+ * The main reason for this is to log children which fail
+ * on a signal. This should be investigated.
+ */
+static void
+process_pending_sigchld_events(void)
+{
+    struct exit_status e;
+    int pid;
+
+    while ((pid = g_waitchild(&e)) > 0)
+    {
+        if (e.reason == E_XR_SIGNAL)
+        {
+            LOG(LOG_LEVEL_ERROR,
+                "Child %d terminated unexpectedly with signal \"%s\"",
+                pid, g_strsignal(e.val));
+        }
+    }
+}
+/*****************************************************************************/
 /* wait for incoming connections
    passes through trans_listen_address return value */
 int
@@ -858,6 +881,7 @@ xrdp_listen_main_loop(struct xrdp_listen *self)
     int timeout;
     intptr_t robjs[32];
     intptr_t term_obj;
+    intptr_t sigchld_obj;
     intptr_t sync_obj;
     intptr_t done_obj;
     struct trans *ltrans;
@@ -876,6 +900,7 @@ xrdp_listen_main_loop(struct xrdp_listen *self)
         return 1;
     }
     term_obj = g_get_term(); /*Global termination event */
+    sigchld_obj = g_get_sigchld();
     sync_obj = g_get_sync_event();
     done_obj = self->pro_done_event;
     cont = 1;
@@ -884,6 +909,7 @@ xrdp_listen_main_loop(struct xrdp_listen *self)
         /* build the wait obj list */
         robjs_count = 0;
         robjs[robjs_count++] = term_obj;
+        robjs[robjs_count++] = sigchld_obj;
         robjs[robjs_count++] = sync_obj;
         robjs[robjs_count++] = done_obj;
         timeout = -1;
@@ -916,6 +942,12 @@ xrdp_listen_main_loop(struct xrdp_listen *self)
                 "Received termination signal, stopping the server accept new "
                 "connections thread");
             break;
+        }
+
+        if (g_is_wait_obj_set(sigchld_obj)) /* SIGCHLD caught */
+        {
+            g_set_sigchld(0);
+            process_pending_sigchld_events();
         }
 
         /* some function must be processed by this thread */

--- a/xrdp/xrdp_listen.c
+++ b/xrdp/xrdp_listen.c
@@ -863,9 +863,10 @@ process_pending_sigchld_events(void)
     {
         if (e.reason == E_XR_SIGNAL)
         {
+            char sigstr[MAXSTRSIGLEN];
             LOG(LOG_LEVEL_ERROR,
-                "Child %d terminated unexpectedly with signal \"%s\"",
-                pid, g_strsignal(e.val));
+                "Child %d terminated unexpectedly with signal %s",
+                pid, g_sig2text(e.val, sigstr));
         }
     }
 }


### PR DESCRIPTION
I've made some changes to xrdp so that when a sub-process terminates on an unexpected signal, a message is logged.

This is primarily to support #2697. Without this, there is no log message generated if xrdp encounters a SECCOMP violation unless the user looks in the system or audit log.

With this change, messages like the following appear in xrdp.log:-

```
[2023-06-08T16:27:59.780+0100] [ERROR] [process_pending_sigchld_events(xrdp_listen.c:866)] Child 11738 terminated unexpectedly with signal "Bad system call"
```

and in xrdp-sesman.log, for a SIGKILL:-

```
[2023-06-08T16:39:35.869+0100] [WARN ] [pid:14702 tid:140681994113152] [session_process_child_exit(session.c:869)] Window manager (pid 14911, display 12) exited with signal "Killed". This could indicate a window manager config problem
```

I have a question though. I've used g_strsignal() which returns strings like "Bad system call" or "Killed". I can't help feeling that the symbolic names SIGSYS, SIGKILL, etc might be more informative for these errors.

Thoughts please? @iskunk - do you have any opinions on this?
