### PR TITLE
Update sockdir security

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -27,8 +27,7 @@ AM_CPPFLAGS = \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
   -DXRDP_SHARE_PATH=\"${datadir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \
-  -DXRDP_LOG_PATH=\"${localstatedir}/log\" \
-  -DXRDP_SOCKET_PATH=\"${socketdir}\"
+  -DXRDP_LOG_PATH=\"${localstatedir}/log\"
 
 # -no-suppress is an automake-specific flag which is needed
 # to prevent us missing compiler errors in some circumstances

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -151,28 +151,6 @@ g_rm_temp_dir(void)
 }
 
 /*****************************************************************************/
-int
-g_mk_socket_path(void)
-{
-    if (!g_directory_exist(XRDP_SOCKET_PATH))
-    {
-        if (!g_create_path(XRDP_SOCKET_PATH"/"))
-        {
-            /* if failed, still check if it got created by someone else */
-            if (!g_directory_exist(XRDP_SOCKET_PATH))
-            {
-                LOG(LOG_LEVEL_ERROR,
-                    "g_mk_socket_path: g_create_path(%s) failed",
-                    XRDP_SOCKET_PATH);
-                return 1;
-            }
-        }
-        g_chmod_hex(XRDP_SOCKET_PATH, 0x1777);
-    }
-    return 0;
-}
-
-/*****************************************************************************/
 void
 g_init(const char *app_name)
 {
@@ -2666,7 +2644,7 @@ g_create_dir(const char *dirname)
 #if defined(_WIN32)
     return CreateDirectoryA(dirname, 0); // test this
 #else
-    return mkdir(dirname, (mode_t) - 1) == 0;
+    return mkdir(dirname, 0777) == 0;
 #endif
 }
 

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -53,7 +53,6 @@ struct list;
 #define g_close_wait_obj g_delete_wait_obj
 
 int      g_rm_temp_dir(void);
-int      g_mk_socket_path(void);
 void     g_init(const char *app_name);
 void     g_deinit(void);
 void g_printf(const char *format, ...) printflike(1, 2);

--- a/common/xrdp_sockets.h
+++ b/common/xrdp_sockets.h
@@ -21,16 +21,39 @@
 #if !defined(XRDP_SOCKETS_H)
 #define XRDP_SOCKETS_H
 
-/* basename of socket files */
+/* XRDP_SOCKET_ROOT_PATH must be defined to include this file */
+#ifdef __cppcheck__
+/*   avoid syntax errors */
+#  define XRDP_SOCKET_ROOT_PATH "/dummy"
+#elif !defined(XRDP_SOCKET_ROOT_PATH)
+#  error "XRDP_SOCKET_ROOT_PATH must be defined"
+#endif
+
+/* Buffer size for code for fullpath declarations
+ *
+ * This needs to fit in the sun_path field of a sockaddr_un. POSIX
+ * does not define this size, so the value below is the lower of
+ * the FreeBSD/OpenBSD/NetBSD(104) and Linux(108) values */
+#define XRDP_SOCKETS_MAXPATH 104
+
+/* The socketdir is rooted at XRDP_SOCKET_ROOT_PATH. User-specific
+ * sockets live in a user-specific sub-directory of this called
+ * XRDP_SOCKET_PATH. The sub-directory is the UID of the user */
+#define XRDP_SOCKET_PATH      XRDP_SOCKET_ROOT_PATH "/%d"
+
+/* Sockets in XRDP_SOCKET_ROOT_PATH */
+#define SCP_LISTEN_PORT_BASE_STR   "sesman.socket"
+
+/* names of socket files within XRDP_SOCKET_PATH, qualified by
+ * display number */
 #define XRDP_CHANSRV_BASE_STR      "xrdp_chansrv_socket_%d"
 #define CHANSRV_PORT_OUT_BASE_STR  "xrdp_chansrv_audio_out_socket_%d"
 #define CHANSRV_PORT_IN_BASE_STR   "xrdp_chansrv_audio_in_socket_%d"
 #define CHANSRV_API_BASE_STR       "xrdpapi_%d"
 #define XRDP_X11RDP_BASE_STR       "xrdp_display_%d"
 #define XRDP_DISCONNECT_BASE_STR   "xrdp_disconnect_display_%d"
-#define SCP_LISTEN_PORT_BASE_STR   "sesman.socket"
 
-/* fullpath of sockets */
+/* fullpath declarations */
 #define XRDP_CHANSRV_STR      XRDP_SOCKET_PATH "/" XRDP_CHANSRV_BASE_STR
 #define CHANSRV_PORT_OUT_STR  XRDP_SOCKET_PATH "/" CHANSRV_PORT_OUT_BASE_STR
 #define CHANSRV_PORT_IN_STR   XRDP_SOCKET_PATH "/" CHANSRV_PORT_IN_BASE_STR

--- a/configure.ac
+++ b/configure.ac
@@ -62,12 +62,6 @@ AC_ARG_WITH([socketdir],
                   [], [with_socketdir="$runstatedir/xrdp"])
 AC_SUBST([socketdir], [$with_socketdir])
 
-AC_ARG_WITH([sesmanruntimedir],
-  [AS_HELP_STRING([--with-sesmanruntimedir=DIR],
-                  [Use directory for sesman runtime data (default: RUNSTATEDIR/xrdp-sesman)])],
-                  [], [with_sesmanruntimedir="$runstatedir/xrdp-sesman"])
-AC_SUBST([sesmanruntimedir], [$with_sesmanruntimedir])
-
 AC_ARG_WITH([systemdsystemunitdir],
         AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files, no to disable]),
         [], [
@@ -655,7 +649,6 @@ echo "  pamconfdir              $pamconfdir"
 echo "  localstatedir           $localstatedir"
 echo "  runstatedir             $runstatedir"
 echo "  socketdir               $socketdir"
-echo "  sesmanruntimedir        $sesmanruntimedir"
 echo ""
 echo "  unit tests performable  $perform_unit_tests"
 echo ""

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -27,7 +27,6 @@ SUBST_VARS = sed \
    -e 's|@localstatedir[@]|$(localstatedir)|g' \
    -e 's|@sysconfdir[@]|$(sysconfdir)|g' \
    -e 's|@socketdir[@]|$(socketdir)|g' \
-   -e 's|@sesmanruntimedir[@]|$(sesmanruntimedir)|g' \
    -e 's|@xrdpconfdir[@]|$(sysconfdir)/xrdp|g' \
    -e 's|@xrdpdatadir[@]|$(datadir)/xrdp|g' \
    -e 's|@xrdphomeurl[@]|http://www.xrdp.org/|g'

--- a/docs/man/sesman.ini.5.in
+++ b/docs/man/sesman.ini.5.in
@@ -57,7 +57,7 @@ In this instance, the system administrator is responsible for ensuring
 the socket can only be created by a suitably privileged process.
 .PP
 If the parameter does not start with a '/', a name within
-@sesmanruntimedir@ is used.
+@socketdir@ is used.
 .RE
 
 .TP

--- a/docs/man/sesman.ini.5.in
+++ b/docs/man/sesman.ini.5.in
@@ -312,6 +312,11 @@ to a setuid Xorg executable. However, if a kernel security module (such as
 AppArmor) is used to confine xrdp, \fIno_new_privs\fR may interfere with
 transitions between confinement domains.
 
+.TP
+\fBSessionSockdirGroup\fR=\fIgroup\fR
+Sets the group owner of the directories containing session sockets. This
+is normally the GID of the xrdp process so xrdp can connect to user sessions.
+
 .SH "X11 SERVER"
 Following parameters can be used in the \fB[Xvnc]\fR and
 \fB[Xorg]\fR sections.

--- a/docs/man/xrdp-sesadmin.8.in
+++ b/docs/man/xrdp-sesadmin.8.in
@@ -28,7 +28,7 @@ Retained for compatibility, but ignored.
 .BI \-i= port
 The sesman \fIUNIX domain socket\fP to connect to.
 Defaults to \fBsesman.socket\fP.
-If no path is specified for the socket, a default of @sesmanruntimedir@ is used.
+If no path is specified for the socket, a default of @socketdir@ is used.
 
 .TP
 .BI \-c= command

--- a/docs/man/xrdp-sesman.8.in
+++ b/docs/man/xrdp-sesman.8.in
@@ -70,7 +70,7 @@ not running \fBxrdp\-sesman\fR as a daemon.
 .br
 @localstatedir@/run/xrdp\-sesman.pid
 .br
-@sesmanruntimedir@/sesman.socket
+@socketdir@/sesman.socket
 
 .SH "AUTHORS"
 Jay Sorg <jsorg71@users.sourceforge.net>

--- a/libipm/Makefile.am
+++ b/libipm/Makefile.am
@@ -1,6 +1,5 @@
 
 AM_CPPFLAGS = \
-  -DSESMAN_RUNTIME_PATH=\"${sesmanruntimedir}\" \
   -DXRDP_SOCKET_ROOT_PATH=\"${socketdir}\" \
   -I$(top_srcdir)/common
 

--- a/libipm/Makefile.am
+++ b/libipm/Makefile.am
@@ -1,6 +1,7 @@
 
 AM_CPPFLAGS = \
   -DSESMAN_RUNTIME_PATH=\"${sesmanruntimedir}\" \
+  -DXRDP_SOCKET_ROOT_PATH=\"${socketdir}\" \
   -I$(top_srcdir)/common
 
 module_LTLIBRARIES = \

--- a/libipm/scp.c
+++ b/libipm/scp.c
@@ -27,6 +27,8 @@
 #include <config_ac.h>
 #endif
 
+#include <ctype.h>
+
 #include "scp.h"
 #include "libipm.h"
 #include "guid.h"
@@ -77,6 +79,23 @@ scp_msgno_to_str(enum scp_msg_code n, char *buff, unsigned int buff_size)
 }
 
 /*****************************************************************************/
+/**
+ * Helper function returning 1 if the passed-in string is an integer >= 0
+ */
+static int is_positive_int(const char *s)
+{
+    for ( ; *s != '\0' ; ++s)
+    {
+        if (!isdigit(*s))
+        {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+/*****************************************************************************/
 int
 scp_port_to_unix_domain_path(const char *port, char *buff,
                              unsigned int bufflen)
@@ -111,7 +130,7 @@ scp_port_to_unix_domain_path(const char *port, char *buff,
         {
             port = SCP_LISTEN_PORT_BASE_STR;
         }
-        else if (g_strcmp(port, "3350") == 0)
+        else if (is_positive_int(port))
         {
             /* Version v0.9.x and earlier of xrdp used a TCP port
              * number. If we come across this, we'll ignore it for
@@ -121,7 +140,7 @@ scp_port_to_unix_domain_path(const char *port, char *buff,
             port = SCP_LISTEN_PORT_BASE_STR;
         }
 
-        result = g_snprintf(buff, bufflen, SESMAN_RUNTIME_PATH "/%s", port);
+        result = g_snprintf(buff, bufflen, XRDP_SOCKET_ROOT_PATH "/%s", port);
     }
 
     return result;

--- a/libipm/scp.h
+++ b/libipm/scp.h
@@ -284,12 +284,14 @@ scp_get_sys_login_request(struct trans *trans,
  * @param login_result What happened to the login
  * @param server_closed If login fails, whether server has closed connection.
  *        If not, a retry can be made.
+ * @param uid UID for a successful login
  * @return != 0 for error
  */
 int
 scp_send_login_response(struct trans *trans,
                         enum scp_login_status login_result,
-                        int server_closed);
+                        int server_closed,
+                        int uid);
 
 /**
  * Parses an incoming E_SCP_LOGIN_RESPONSE (SCP client)
@@ -298,12 +300,17 @@ scp_send_login_response(struct trans *trans,
  * @param[out] login_result 0 for success, PAM error code otherwise
  * @param[out] server_closed If login fails, whether server has closed
  *             connection. If not a retry can be made.
+ * @param[out] uid UID for a successful login
+ *
+ * server_closed and uid can be passed NULL if the caller isn't interested.
+ *
  * @return != 0 for error
  */
 int
 scp_get_login_response(struct trans *trans,
                        enum scp_login_status *login_result,
-                       int *server_closed);
+                       int *server_closed,
+                       int *uid);
 
 /**
  * Send an E_SCP_LOGOUT_REQUEST (SCP client)

--- a/sesman/Makefile.am
+++ b/sesman/Makefile.am
@@ -6,7 +6,7 @@ AM_CPPFLAGS = \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
   -DXRDP_LIBEXEC_PATH=\"${libexecdir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \
-  -DXRDP_SOCKET_PATH=\"${socketdir}\" \
+  -DXRDP_SOCKET_ROOT_PATH=\"${socketdir}\" \
   -DSESMAN_RUNTIME_PATH=\"${sesmanruntimedir}\" \
   -I$(top_srcdir)/sesman/libsesman \
   -I$(top_srcdir)/common \

--- a/sesman/Makefile.am
+++ b/sesman/Makefile.am
@@ -7,7 +7,6 @@ AM_CPPFLAGS = \
   -DXRDP_LIBEXEC_PATH=\"${libexecdir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \
   -DXRDP_SOCKET_ROOT_PATH=\"${socketdir}\" \
-  -DSESMAN_RUNTIME_PATH=\"${sesmanruntimedir}\" \
   -I$(top_srcdir)/sesman/libsesman \
   -I$(top_srcdir)/common \
   -I$(top_srcdir)/libipm

--- a/sesman/chansrv/Makefile.am
+++ b/sesman/chansrv/Makefile.am
@@ -8,7 +8,7 @@ AM_CPPFLAGS = \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
   -DXRDP_SHARE_PATH=\"${datadir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \
-  -DXRDP_SOCKET_PATH=\"${socketdir}\" \
+  -DXRDP_SOCKET_ROOT_PATH=\"${socketdir}\" \
   -I$(top_srcdir)/sesman/libsesman \
   -I$(top_srcdir)/common
 

--- a/sesman/chansrv/chansrv.c
+++ b/sesman/chansrv/chansrv.c
@@ -1238,7 +1238,7 @@ my_api_trans_conn_in(struct trans *trans, struct trans *new_trans)
 static int
 setup_listen(void)
 {
-    char port[256];
+    char port[XRDP_SOCKETS_MAXPATH];
     int error = 0;
 
     if (g_lis_trans != 0)
@@ -1248,7 +1248,7 @@ setup_listen(void)
 
     g_lis_trans = trans_create(TRANS_MODE_UNIX, 8192, 8192);
     g_lis_trans->is_term = g_is_term;
-    g_snprintf(port, 255, XRDP_CHANSRV_STR, g_display_num);
+    g_snprintf(port, sizeof(port), XRDP_CHANSRV_STR, g_getuid(), g_display_num);
 
     g_lis_trans->trans_conn_in = my_trans_conn_in;
     error = trans_listen(g_lis_trans, port);
@@ -1267,12 +1267,12 @@ setup_listen(void)
 static int
 setup_api_listen(void)
 {
-    char port[256];
+    char port[XRDP_SOCKETS_MAXPATH];
     int error = 0;
 
     g_api_lis_trans = trans_create(TRANS_MODE_UNIX, 8192 * 4, 8192 * 4);
     g_api_lis_trans->is_term = g_is_term;
-    g_snprintf(port, 255, CHANSRV_API_STR, g_display_num);
+    g_snprintf(port, sizeof(port), CHANSRV_API_STR, g_getuid(), g_display_num);
     g_api_lis_trans->trans_conn_in = my_api_trans_conn_in;
     error = trans_listen(g_api_lis_trans, port);
 

--- a/sesman/chansrv/sound.c
+++ b/sesman/chansrv/sound.c
@@ -1894,11 +1894,11 @@ sound_sndsrvr_source_data_in(struct trans *trans)
 static int
 sound_start_source_listener(void)
 {
-    char port[1024];
+    char port[XRDP_SOCKETS_MAXPATH];
 
     g_audio_l_trans_in = trans_create(TRANS_MODE_UNIX, 128 * 1024, 8192);
     g_audio_l_trans_in->is_term = g_is_term;
-    g_snprintf(port, 255, CHANSRV_PORT_IN_STR, g_display_num);
+    g_snprintf(port, sizeof(port), CHANSRV_PORT_IN_STR, g_getuid(), g_display_num);
     g_audio_l_trans_in->trans_conn_in = sound_sndsrvr_source_conn_in;
     if (trans_listen(g_audio_l_trans_in, port) != 0)
     {
@@ -1913,11 +1913,11 @@ sound_start_source_listener(void)
 static int
 sound_start_sink_listener(void)
 {
-    char port[1024];
+    char port[XRDP_SOCKETS_MAXPATH];
 
     g_audio_l_trans_out = trans_create(TRANS_MODE_UNIX, 128 * 1024, 8192);
     g_audio_l_trans_out->is_term = g_is_term;
-    g_snprintf(port, 255, CHANSRV_PORT_OUT_STR, g_display_num);
+    g_snprintf(port, sizeof(port), CHANSRV_PORT_OUT_STR, g_getuid(), g_display_num);
     g_audio_l_trans_out->trans_conn_in = sound_sndsrvr_sink_conn_in;
     if (trans_listen(g_audio_l_trans_out, port) != 0)
     {

--- a/sesman/libsesman/sesman_config.c
+++ b/sesman/libsesman/sesman_config.c
@@ -71,6 +71,7 @@
 #define SESMAN_CFG_SEC_RESTRICT_INBOUND_CLIPBOARD  "RestrictInboundClipboard"
 #define SESMAN_CFG_SEC_ALLOW_ALTERNATE_SHELL       "AllowAlternateShell"
 #define SESMAN_CFG_SEC_XORG_NO_NEW_PRIVILEGES      "XorgNoNewPrivileges"
+#define SESMAN_CFG_SEC_SESSION_SOCKDIR_GROUP       "SessionSockdirGroup"
 
 #define SESMAN_CFG_SESSIONS          "Sessions"
 #define SESMAN_CFG_SESS_MAX          "MaxSessions"
@@ -312,6 +313,7 @@ config_read_security(int file, struct config_security *sc,
     sc->xorg_no_new_privileges = 1;
     sc->ts_users = g_strdup("");
     sc->ts_admins = g_strdup("");
+    sc->session_sockdir_group = g_strdup("");
 
     file_read_section(file, SESMAN_CFG_SECURITY, param_n, param_v);
 
@@ -324,29 +326,25 @@ config_read_security(int file, struct config_security *sc,
         {
             sc->allow_root = g_text2bool(value);
         }
-
-        if (0 == g_strcasecmp(buf, SESMAN_CFG_SEC_LOGIN_RETRY))
+        else if (0 == g_strcasecmp(buf, SESMAN_CFG_SEC_LOGIN_RETRY))
         {
             sc->login_retry = g_atoi(value);
         }
-
-        if (0 == g_strcasecmp(buf, SESMAN_CFG_SEC_USR_GROUP))
+        else if (0 == g_strcasecmp(buf, SESMAN_CFG_SEC_USR_GROUP))
         {
             g_free(sc->ts_users);
             sc->ts_users = g_strdup(value);
         }
-
-        if (0 == g_strcasecmp(buf, SESMAN_CFG_SEC_ADM_GROUP))
+        else if (0 == g_strcasecmp(buf, SESMAN_CFG_SEC_ADM_GROUP))
         {
             g_free(sc->ts_admins);
             sc->ts_admins = g_strdup(value);
         }
-        if (0 == g_strcasecmp(buf, SESMAN_CFG_SEC_ALWAYSGROUPCHECK))
+        else if (0 == g_strcasecmp(buf, SESMAN_CFG_SEC_ALWAYSGROUPCHECK))
         {
             sc->ts_always_group_check = g_text2bool(value);
         }
-
-        if (0 == g_strcasecmp(buf, SESMAN_CFG_SEC_RESTRICT_OUTBOUND_CLIPBOARD))
+        else if (0 == g_strcasecmp(buf, SESMAN_CFG_SEC_RESTRICT_OUTBOUND_CLIPBOARD))
         {
             char unrecognised[256];
             sc->restrict_outbound_clipboard =
@@ -360,7 +358,7 @@ config_read_security(int file, struct config_security *sc,
                     unrecognised);
             }
         }
-        if (0 == g_strcasecmp(buf, SESMAN_CFG_SEC_RESTRICT_INBOUND_CLIPBOARD))
+        else if (0 == g_strcasecmp(buf, SESMAN_CFG_SEC_RESTRICT_INBOUND_CLIPBOARD))
         {
             char unrecognised[256];
             sc->restrict_inbound_clipboard =
@@ -374,16 +372,20 @@ config_read_security(int file, struct config_security *sc,
                     unrecognised);
             }
         }
-        if (0 == g_strcasecmp(buf, SESMAN_CFG_SEC_ALLOW_ALTERNATE_SHELL))
+        else if (0 == g_strcasecmp(buf, SESMAN_CFG_SEC_ALLOW_ALTERNATE_SHELL))
         {
             sc->allow_alternate_shell =
                 g_text2bool(value);
         }
-
-        if (0 == g_strcasecmp(buf, SESMAN_CFG_SEC_XORG_NO_NEW_PRIVILEGES))
+        else if (0 == g_strcasecmp(buf, SESMAN_CFG_SEC_XORG_NO_NEW_PRIVILEGES))
         {
             sc->xorg_no_new_privileges =
                 g_text2bool(value);
+        }
+        else if (0 == g_strcasecmp(buf, SESMAN_CFG_SEC_SESSION_SOCKDIR_GROUP))
+        {
+            g_free(sc->session_sockdir_group);
+            sc->session_sockdir_group = g_strdup(value);
         }
     }
 
@@ -684,6 +686,7 @@ config_dump(struct config_sesman *config)
     g_writeln("    RestrictInboundClipboard:  %s", restrict_s);
     g_writeln("    TSUsersGroup:              %s", sc->ts_users);
     g_writeln("    TSAdminsGroup:             %s", sc->ts_admins);
+    g_writeln("    SessionSockdirGroup:       %s", sc->session_sockdir_group);
 
 
     /* Xorg */
@@ -741,6 +744,7 @@ config_free(struct config_sesman *cs)
         list_delete(cs->env_values);
         g_free(cs->sec.ts_users);
         g_free(cs->sec.ts_admins);
+        g_free(cs->sec.session_sockdir_group);
         g_free(cs);
     }
 }

--- a/sesman/libsesman/sesman_config.h
+++ b/sesman/libsesman/sesman_config.h
@@ -107,6 +107,12 @@ struct config_security
      * @brief if the Xorg X11 server should be started with no_new_privs (Linux only)
      */
     int xorg_no_new_privileges;
+
+    /*
+     * @var session_sockdir_group
+     * @brief Group to have read access to the session sockdirs
+     */
+    char *session_sockdir_group;
 };
 
 /**

--- a/sesman/scp_process.c
+++ b/sesman/scp_process.c
@@ -44,6 +44,7 @@
 #include "session_list.h"
 #include "sesexec_control.h"
 #include "string_calls.h"
+#include "xrdp_sockets.h"
 
 /******************************************************************************/
 
@@ -139,7 +140,7 @@ process_sys_login_request(struct pre_session_item *psi)
         {
             /* We only get here if something has gone
              * wrong with the handover to sesexec */
-            rv = scp_send_login_response(psi->client_trans, errorcode, 1);
+            rv = scp_send_login_response(psi->client_trans, errorcode, 1, -1);
             psi->dispatcher_action = E_PSD_TERMINATE_PRE_SESSION;
         }
     }
@@ -219,15 +220,15 @@ process_uds_login_request(struct pre_session_item *psi)
     int uid;
     int pid;
     char *username = NULL;
-    int server_closed = 1;
+    int server_closed;
 
     rv = g_sck_get_peer_cred(psi->client_trans->sck, &pid, &uid, NULL);
     if (rv != 0)
     {
+        errorcode = E_SCP_LOGIN_GENERAL_ERROR;
         LOG(LOG_LEVEL_INFO,
             "Unable to get peer credentials for socket %d",
             (int)psi->client_trans->sck);
-        errorcode = E_SCP_LOGIN_GENERAL_ERROR;
     }
     else
     {
@@ -252,21 +253,26 @@ process_uds_login_request(struct pre_session_item *psi)
             errorcode = authenticate_and_authorize_uds_connection(
                             psi, uid, username);
             g_free(username);
-
-            if (errorcode == E_SCP_LOGIN_OK)
-            {
-                server_closed = 0;
-            }
         }
     }
 
-    if (server_closed)
+    if (errorcode == E_SCP_LOGIN_OK)
     {
+        server_closed = 0;
+    }
+    else
+    {
+        server_closed = 1;
+
         /* Close the connection after returning from this callback */
         psi->dispatcher_action = E_PSD_TERMINATE_PRE_SESSION;
+
+        /* Never return the UID if the server is closing */
+        uid = -1;
     }
 
-    return scp_send_login_response(psi->client_trans, errorcode, server_closed);
+    return scp_send_login_response(psi->client_trans, errorcode,
+                                   server_closed, uid);
 }
 
 /******************************************************************************/
@@ -300,6 +306,58 @@ process_logout_request(struct pre_session_item *psi)
     }
 
     return 0;
+}
+
+/******************************************************************************/
+/**
+ * Create xrdp socket path for the user
+ *
+ * We do this here rather than in sesexec as we're single-threaded here
+ * and so don't have to worry about race conditions
+ *
+ * Directory is owned by UID of session, but can be accessed by
+ * the group specified in the config.
+ *
+ * Errors are logged so the caller doesn't have to
+ */
+static int
+create_xrdp_socket_path(uid_t uid)
+{
+    int rv = 1;
+    const char *sockdir_group = g_cfg->sec.session_sockdir_group;
+    int gid = 0; // Default if no group specified
+
+    char sockdir[XRDP_SOCKETS_MAXPATH];
+    g_snprintf(sockdir, sizeof(sockdir), XRDP_SOCKET_PATH, (int)uid);
+
+    // Create directory permissions 0x750, if it doesn't exist already.
+    int old_umask = g_umask_hex(0x750 ^ 0x777);
+    if (!g_directory_exist(sockdir) && !g_create_dir(sockdir))
+    {
+        LOG(LOG_LEVEL_ERROR,
+            "create_xrdp_socket_path: Can't create %s [%s]",
+            sockdir, g_get_strerror());
+    }
+    else if (sockdir_group != NULL && sockdir_group[0] != '\0' &&
+             g_getgroup_info(sockdir_group, &gid) != 0)
+    {
+        LOG(LOG_LEVEL_ERROR,
+            "create_xrdp_socket_path: Can't get GID of group %s [%s]",
+            sockdir_group, g_get_strerror());
+    }
+    else if (g_chown(sockdir, uid, gid) != 0)
+    {
+        LOG(LOG_LEVEL_ERROR,
+            "create_xrdp_socket_path: Can't set owner of %s to %d:%d [%s]",
+            sockdir, uid, gid, g_get_strerror());
+    }
+    else
+    {
+        rv = 0;
+    }
+    (void)g_umask_hex(old_umask);
+
+    return rv;
 }
 
 /******************************************************************************/
@@ -384,6 +442,11 @@ process_create_session_request(struct pre_session_item *psi)
             else if ((s_item = session_list_new()) == NULL)
             {
                 status = E_SCP_SCREATE_NO_MEMORY;
+            }
+            // Create a socket dir for this user
+            else if (create_xrdp_socket_path(psi->uid) != 0)
+            {
+                status = E_SCP_SCREATE_GENERAL_ERROR;
             }
             // Create a sesexec process if we don't have one (UDS login)
             else if (psi->sesexec_trans == NULL && sesexec_start(psi) != 0)

--- a/sesman/scp_process.c
+++ b/sesman/scp_process.c
@@ -389,7 +389,7 @@ process_create_session_request(struct pre_session_item *psi)
             else if (psi->sesexec_trans == NULL && sesexec_start(psi) != 0)
             {
                 LOG(LOG_LEVEL_ERROR,
-                    "Can't start sesexec to authenticate user");
+                    "Can't start sesexec to manage session");
                 status = E_SCP_SCREATE_GENERAL_ERROR;
             }
             else

--- a/sesman/sesexec/Makefile.am
+++ b/sesman/sesexec/Makefile.am
@@ -2,7 +2,7 @@ AM_CPPFLAGS = \
   -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
   -DXRDP_LIBEXEC_PATH=\"${libexecdir}/xrdp\" \
-  -DXRDP_SOCKET_PATH=\"${socketdir}\" \
+  -DXRDP_SOCKET_ROOT_PATH=\"${socketdir}\" \
   -I$(top_srcdir)/sesman/libsesman \
   -I$(top_srcdir)/libipm \
   -I$(top_srcdir)/common

--- a/sesman/sesexec/env.c
+++ b/sesman/sesexec/env.c
@@ -152,9 +152,10 @@ env_set_user(int uid, char **passwd_file, int display,
             // Use our PID as the XRDP_SESSION value
             g_snprintf(text, sizeof(text), "%d", g_pid);
             g_setenv("XRDP_SESSION", text, 1);
-            /* XRDP_SOCKET_PATH should be set even here. It's used by
+            /* XRDP_SOCKET_PATH should be set here. It's used by
              * xorgxrdp and the pulseaudio plugin */
-            g_setenv("XRDP_SOCKET_PATH", XRDP_SOCKET_PATH, 1);
+            g_snprintf(text, sizeof(text), XRDP_SOCKET_PATH, uid);
+            g_setenv("XRDP_SOCKET_PATH", text, 1);
             /* pulse sink socket */
             g_snprintf(text, sizeof(text), CHANSRV_PORT_OUT_BASE_STR, display);
             g_setenv("XRDP_PULSE_SINK_SOCKET", text, 1);

--- a/sesman/sesexec/login_info.c
+++ b/sesman/sesexec/login_info.c
@@ -280,7 +280,8 @@ login_info_sys_login_user(struct trans *scp_trans,
                 }
             }
 
-            if (scp_send_login_response(scp_trans, status, server_closed) != 0)
+            if (scp_send_login_response(scp_trans, status,
+                                        server_closed, result->uid) != 0)
             {
                 status = E_SCP_LOGIN_GENERAL_ERROR;
                 break;

--- a/sesman/sesexec/session.c
+++ b/sesman/sesexec/session.c
@@ -370,8 +370,6 @@ prepare_xorg_xserver_params(const struct session_parameters *s,
         g_snprintf(text, sizeof(text), "%d", g_cfg->sess.kill_disconnected);
         g_setenv("XRDP_SESMAN_KILL_DISCONNECTED", text, 1);
 
-        g_setenv("XRDP_SOCKET_PATH", XRDP_SOCKET_PATH, 1);
-
         /* get path of Xorg from config */
         xserver = (const char *)list_get_item(g_cfg->xorg_params, 0);
 
@@ -716,15 +714,14 @@ session_start(struct login_info *login_info,
 
 /******************************************************************************/
 static int
-cleanup_sockets(int display)
+cleanup_sockets(int uid, int display)
 {
-    LOG(LOG_LEVEL_INFO, "cleanup_sockets:");
-    char file[256];
-    int error;
+    LOG_DEVEL(LOG_LEVEL_INFO, "cleanup_sockets:");
 
-    error = 0;
+    char file[XRDP_SOCKETS_MAXPATH];
+    int error = 0;
 
-    g_snprintf(file, 255, CHANSRV_PORT_OUT_STR, display);
+    g_snprintf(file, sizeof(file), CHANSRV_PORT_OUT_STR, uid, display);
     if (g_file_exist(file))
     {
         LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
@@ -737,7 +734,7 @@ cleanup_sockets(int display)
         }
     }
 
-    g_snprintf(file, 255, CHANSRV_PORT_IN_STR, display);
+    g_snprintf(file, sizeof(file), CHANSRV_PORT_IN_STR, uid, display);
     if (g_file_exist(file))
     {
         LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
@@ -750,7 +747,7 @@ cleanup_sockets(int display)
         }
     }
 
-    g_snprintf(file, 255, XRDP_CHANSRV_STR, display);
+    g_snprintf(file, sizeof(file), XRDP_CHANSRV_STR, uid, display);
     if (g_file_exist(file))
     {
         LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
@@ -763,7 +760,7 @@ cleanup_sockets(int display)
         }
     }
 
-    g_snprintf(file, 255, CHANSRV_API_STR, display);
+    g_snprintf(file, sizeof(file), CHANSRV_API_STR, uid, display);
     if (g_file_exist(file))
     {
         LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
@@ -779,7 +776,7 @@ cleanup_sockets(int display)
     /* the following files should be deleted by xorgxrdp
      * but just in case the deletion failed */
 
-    g_snprintf(file, 255, XRDP_X11RDP_STR, display);
+    g_snprintf(file, sizeof(file), XRDP_X11RDP_STR, uid, display);
     if (g_file_exist(file))
     {
         LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
@@ -792,7 +789,7 @@ cleanup_sockets(int display)
         }
     }
 
-    g_snprintf(file, 255, XRDP_DISCONNECT_STR, display);
+    g_snprintf(file, sizeof(file), XRDP_DISCONNECT_STR, uid, display);
     if (g_file_exist(file))
     {
         LOG(LOG_LEVEL_DEBUG, "cleanup_sockets: deleting %s", file);
@@ -908,7 +905,7 @@ session_process_child_exit(struct session_data *sd,
 
     if (!session_active(sd))
     {
-        cleanup_sockets(sd->params.display);
+        cleanup_sockets(g_login_info->uid, sd->params.display);
     }
 }
 

--- a/sesman/sesman.c
+++ b/sesman/sesman.c
@@ -50,6 +50,7 @@
 #include "string_calls.h"
 #include "trans.h"
 #include "xrdp_configure_options.h"
+#include "xrdp_sockets.h"
 
 /**
  * Maximum number of pre-session items
@@ -688,9 +689,6 @@ read_pid_file(const char *pid_file, int *pid)
 static int
 create_xrdp_socket_root_path(void)
 {
-#ifndef XRDP_SOCKET_PATH
-#   error "XRDP_SOCKET_PATH must be defined"
-#endif
     int uid = g_getuid();
     int gid = g_getgid();
 

--- a/sesman/sesman.c
+++ b/sesman/sesman.c
@@ -194,45 +194,6 @@ sesman_process_params(int argc, char **argv,
 }
 
 /******************************************************************************/
-static int
-create_sesman_runtime_dir(void)
-{
-    int rv = -1;
-    /* Make sure if we create the directory, there's no gap where it
-    * may have the wrong permissions */
-    int entry_umask = g_umask_hex(0x755);
-
-    if (!g_directory_exist(SESMAN_RUNTIME_PATH) &&
-            !g_create_dir(SESMAN_RUNTIME_PATH))
-    {
-        LOG(LOG_LEVEL_ERROR,
-            "Can't create runtime directory '"
-            SESMAN_RUNTIME_PATH "' [%s]", g_get_strerror());
-    }
-    else if (g_chown(SESMAN_RUNTIME_PATH, g_getuid(), g_getuid()) != 0)
-    {
-        LOG(LOG_LEVEL_ERROR,
-            "Can't set ownership of sesman runtime directory [%s]",
-            g_get_strerror());
-    }
-    else if (g_chmod_hex(SESMAN_RUNTIME_PATH, 0x755) != 0)
-    {
-        /* This might seem redundant, but there's a chance the
-         * directory already exists */
-        LOG(LOG_LEVEL_ERROR,
-            "Can't set permissions of sesman runtime directory [%s]",
-            g_get_strerror());
-    }
-    else
-    {
-        rv = 0;
-    }
-    g_umask_hex(entry_umask);
-
-    return rv;
-}
-
-/******************************************************************************/
 static int sesman_listen_test(struct config_sesman *cfg)
 {
     int status = sesman_create_listening_transport(cfg);
@@ -694,24 +655,24 @@ create_xrdp_socket_root_path(void)
 
     /* Create the path using 0755 permissions */
     int old_umask = g_umask_hex(0x22);
-    (void)g_create_path(XRDP_SOCKET_PATH"/");
+    (void)g_create_path(XRDP_SOCKET_ROOT_PATH"/");
     (void)g_umask_hex(old_umask);
 
     /* Check the ownership and permissions on the last path element
      * are as expected */
-    if (g_chown(XRDP_SOCKET_PATH, uid, gid) != 0)
+    if (g_chown(XRDP_SOCKET_ROOT_PATH, uid, gid) != 0)
     {
         LOG(LOG_LEVEL_ERROR,
             "create_xrdp_socket_root_path: Can't set owner of %s to %d:%d",
-            XRDP_SOCKET_PATH, uid, gid);
+            XRDP_SOCKET_ROOT_PATH, uid, gid);
         return 1;
     }
 
-    if (g_chmod_hex(XRDP_SOCKET_PATH, 0x755) != 0)
+    if (g_chmod_hex(XRDP_SOCKET_ROOT_PATH, 0x755) != 0)
     {
         LOG(LOG_LEVEL_ERROR,
             "create_xrdp_socket_root_path: Can't set perms of %s to 0x755",
-            XRDP_SOCKET_PATH);
+            XRDP_SOCKET_ROOT_PATH);
         return 1;
     }
 
@@ -887,9 +848,9 @@ main(int argc, char **argv)
         }
     }
 
-    /* Create the runtime directory before we try to listen (or
+    /* Create the socket directory before we try to listen (or
      * test-listen), so there's somewhere for the default socket to live */
-    if (create_sesman_runtime_dir() != 0)
+    if (create_xrdp_socket_root_path() != 0)
     {
         config_free(g_cfg);
         log_end();
@@ -962,9 +923,6 @@ main(int argc, char **argv)
     /* start program main loop */
     LOG(LOG_LEVEL_INFO,
         "starting xrdp-sesman with pid %d", g_pid);
-
-    /* make sure the socket directory exists */
-    create_xrdp_socket_root_path();
 
     /* make sure the /tmp/.X11-unix directory exists */
     if (!g_directory_exist("/tmp/.X11-unix"))

--- a/sesman/sesman.ini.in
+++ b/sesman/sesman.ini.in
@@ -44,6 +44,12 @@ RestrictInboundClipboard=none
 ; however, interfere with the use of security modules such as AppArmor.
 ; Leave this unset unless you need to disable it.
 #XorgNoNewPrivileges=true
+; Specify the group which is to have read access to the directory where
+; local sockets for the session are created. This is normally the GID
+; which the xrdp process runs as.
+; Default is 'root'
+#SessionSockdirGroup=root
+
 
 [Sessions]
 ;; X11DisplayOffset - x11 display number offset

--- a/sesman/session_list.c
+++ b/sesman/session_list.c
@@ -198,41 +198,6 @@ x_server_running_check_ports(int display)
         }
     }
 
-    if (!x_running)
-    {
-        LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
-        g_sprintf(text, XRDP_CHANSRV_STR, display);
-        x_running = g_file_exist(text);
-    }
-
-    if (!x_running)
-    {
-        LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
-        g_sprintf(text, CHANSRV_PORT_OUT_STR, display);
-        x_running = g_file_exist(text);
-    }
-
-    if (!x_running)
-    {
-        LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
-        g_sprintf(text, CHANSRV_PORT_IN_STR, display);
-        x_running = g_file_exist(text);
-    }
-
-    if (!x_running)
-    {
-        LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
-        g_sprintf(text, CHANSRV_API_STR, display);
-        x_running = g_file_exist(text);
-    }
-
-    if (!x_running)
-    {
-        LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
-        g_sprintf(text, XRDP_X11RDP_STR, display);
-        x_running = g_file_exist(text);
-    }
-
     if (x_running)
     {
         LOG(LOG_LEVEL_INFO, "Found X server running at %s", text);

--- a/sesman/tools/Makefile.am
+++ b/sesman/tools/Makefile.am
@@ -1,6 +1,6 @@
 AM_CPPFLAGS = \
   -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
-  -DXRDP_SOCKET_PATH=\"${socketdir}\" \
+  -DXRDP_SOCKET_ROOT_PATH=\"${socketdir}\" \
   -I$(top_srcdir)/sesman/libsesman \
   -I$(top_srcdir)/common \
   -I$(top_srcdir)/libipm

--- a/sesman/tools/dis.c
+++ b/sesman/tools/dis.c
@@ -29,6 +29,7 @@
 #include <errno.h>
 
 #include "xrdp_sockets.h"
+#include "os_calls.h"
 #include "string_calls.h"
 
 int main(int argc, char **argv)
@@ -62,7 +63,7 @@ int main(int argc, char **argv)
     }
     memset(&sa, 0, sizeof(sa));
     sa.sun_family = AF_UNIX;
-    sprintf(sa.sun_path, XRDP_DISCONNECT_STR, dis);
+    sprintf(sa.sun_path, XRDP_DISCONNECT_STR, g_getuid(), dis);
 
     if (access(sa.sun_path, F_OK) != 0)
     {

--- a/sesman/tools/sesadmin.c
+++ b/sesman/tools/sesadmin.c
@@ -95,7 +95,7 @@ int main(int argc, char **argv)
         if ((rv = scp_send_uds_login_request(t)) == 0 &&
                 (rv = wait_for_sesman_reply(t, E_SCP_LOGIN_RESPONSE)) == 0)
         {
-            rv = scp_get_login_response(t, &login_result, NULL);
+            rv = scp_get_login_response(t, &login_result, NULL, NULL);
             if (rv == 0)
             {
                 if (login_result != E_SCP_LOGIN_OK)

--- a/sesman/tools/sesrun.c
+++ b/sesman/tools/sesrun.c
@@ -460,7 +460,7 @@ handle_login_response(struct trans *t, int *server_closed)
     }
     else
     {
-        rv = scp_get_login_response(t, &login_result, server_closed);
+        rv = scp_get_login_response(t, &login_result, server_closed, NULL);
         if (rv == 0)
         {
             if (login_result != E_SCP_LOGIN_OK)

--- a/xrdp/Makefile.am
+++ b/xrdp/Makefile.am
@@ -9,7 +9,7 @@ AM_CPPFLAGS = \
   -DXRDP_SHARE_PATH=\"${datadir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \
   -DXRDP_MODULE_PATH=\"${moduledir}\" \
-  -DXRDP_SOCKET_PATH=\"${socketdir}\" \
+  -DXRDP_SOCKET_ROOT_PATH=\"${socketdir}\" \
   -I$(top_builddir) \
   -I$(top_srcdir)/common \
   -I$(top_srcdir)/libipm \

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -401,6 +401,7 @@ struct xrdp_mm
     int (*mod_exit)(struct xrdp_mod *);
     struct xrdp_mod *mod; /* module interface */
     int display; /* 10 for :10.0, 11 for :11.0, etc */
+    int uid; /* UID for a successful login, -1 otherwise */
     struct guid guid; /* GUID for the session, or all zeros  */
     int code; /* 0=Xvnc session, 20=xorg driver mode */
     struct xrdp_encoder *encoder;

--- a/xrdpapi/Makefile.am
+++ b/xrdpapi/Makefile.am
@@ -4,7 +4,7 @@ EXTRA_DIST = \
   vrplayer.mk
 
 AM_CPPFLAGS = \
-  -DXRDP_SOCKET_PATH=\"${socketdir}\" \
+  -DXRDP_SOCKET_ROOT_PATH=\"${socketdir}\" \
   -I$(top_srcdir)/common
 
 module_LTLIBRARIES = \

--- a/xrdpapi/xrdpapi.c
+++ b/xrdpapi/xrdpapi.c
@@ -140,7 +140,7 @@ WTSVirtualChannelOpenEx(unsigned int SessionId, const char *pVirtualName,
     memset(&s, 0, sizeof(struct sockaddr_un));
     s.sun_family = AF_UNIX;
     bytes = sizeof(s.sun_path);
-    snprintf(s.sun_path, bytes - 1, CHANSRV_API_STR, wts->display_num);
+    snprintf(s.sun_path, bytes - 1, CHANSRV_API_STR, getuid(), wts->display_num);
     s.sun_path[bytes - 1] = 0;
     bytes = sizeof(struct sockaddr_un);
 


### PR DESCRIPTION
This is one of two updates which (in total) will support running xrdp as a non-privileged user without needing to patch it, as Debian/Ubuntu does at present.

The main purpose of this update is to remove the need to use the sticky bit on the [socketdir](/neutrinolabs/xrdp/wiki/The-socketdir-directory) and simplify the security in this area.

#2472 changed sesman to identify sessions by UID rather than username. This fixed #1823. As a result, sesman is now UID aware.

This lets us insert a UID-specific directory into the socketdir. Now users can't see each others xrdp sockets, resulting in a small security improvement.

Once we've done this, we can get rid of the sesmanruntimedir introduced by #2472, as the socketdir is no longer world-writeable. This moves all the sockets back into a single directory.

As an example, if I log on to my development box using display 11, I now get this under `/run/xrdp`:-

```
$ sudo find /run/xrdp -ls
     1514      0 drwxr-xr-x   3 root     root          100 Jun 14 19:20 /run/xrdp
     1551      0 srw-rw-rw-   1 root     root            0 Jun 14 19:20 /run/xrdp/sesman.socket
     1530      0 drwxr-x---   2 testuser root          140 Jun 14 19:37 /run/xrdp/1001
     1790      0 srw-rw----   1 testuser testuser        0 Jun 14 19:37 /run/xrdp/1001/xrdp_chansrv_audio_in_socket_11
     1789      0 srw-rw----   1 testuser testuser        0 Jun 14 19:37 /run/xrdp/1001/xrdp_chansrv_audio_out_socket_11
     1780      0 srw-rw----   1 testuser testuser        0 Jun 14 19:37 /run/xrdp/1001/xrdpapi_11
     1770      0 srw-rw----   1 testuser testuser        0 Jun 14 19:37 /run/xrdp/1001/xrdp_disconnect_display_11
     1769      0 srw-rw----   1 testuser testuser        0 Jun 14 19:37 /run/xrdp/1001/xrdp_display_11
     1515      0 -rw-------   1 root     root            0 Jun 14 19:03 /run/xrdp/.sesman.socket.lock
```

At the moment the xrdp process is running as `root`, and can access sockets for user 1001 (testuser) by using group permissions.

There are also some tidy-ups in here, like introducing `XRDP_SOCKETS_MAXPATH` for the maximum length of a socket path name, and simplifying the parsing of the sesman.ini `[security]` section.

Currently draft as more testing is required. Comments welcome.