### PR TITLE
Bump cppcheck to v2.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,7 +165,7 @@ jobs:
       CC: gcc
       # This is required to use a version of cppcheck other than that
       # supplied with the operating system
-      CPPCHECK_VER: "2.10"
+      CPPCHECK_VER: "2.11"
       CPPCHECK_REPO: https://github.com/danmar/cppcheck.git
     steps:
       # Set steps.os.outputs.image to the specific OS (e.g. 'ubuntu20')

--- a/scripts/install_cppcheck.sh
+++ b/scripts/install_cppcheck.sh
@@ -140,6 +140,14 @@ fi
             fi
     esac
 
+    # Use all available CPUs
+    if [ -f /proc/cpuinfo ]; then
+        cpus=`grep ^processor /proc/cpuinfo | wc -l`
+        if [ -n "$cpus" ]; then
+            make_args="$make_args -j $cpus"
+        fi
+    fi
+
     echo "Making cppcheck..."
     # CFGDIR is needed for cppcheck before 1.86
     call_make $make_args

--- a/scripts/run_cppcheck.sh
+++ b/scripts/run_cppcheck.sh
@@ -45,10 +45,16 @@ if [ -z "$CPPCHECK_FLAGS" ]; then
     CPPCHECK_FLAGS="--quiet --force --std=c11 --std=c++11 --inline-suppr \
                     --enable=warning --error-exitcode=1 -i third_party"
 fi
+CPPCHECK_FLAGS="$CPPCHECK_FLAGS -D__cppcheck__"
 
 # Any options/directories specified?
 if [ $# -eq 0 ]; then
-    set -- -j 2 .
+    if [ -f /proc/cpuinfo ]; then
+        cpus=$(grep '^processor' /proc/cpuinfo | wc -l)
+    else
+        cpus=2
+    fi
+    set -- -j $cpus .
 fi
 
 # Display the cppcheck version and command for debugging

--- a/sesman/tools/authtest.c
+++ b/sesman/tools/authtest.c
@@ -35,6 +35,11 @@
 #include "os_calls.h"
 #include "string_calls.h"
 
+// cppcheck doesn't always set this macro to something in double-quotes
+#if defined(__cppcheck__)
+#undef PACKAGE_VERSION
+#endif
+
 #if !defined(PACKAGE_VERSION)
 #define PACKAGE_VERSION "???"
 #endif

--- a/sesman/tools/sesrun.c
+++ b/sesman/tools/sesrun.c
@@ -42,6 +42,11 @@
 
 #include "tools_common.h"
 
+// cppcheck doesn't always set this macro to something in double-quotes
+#if defined(__cppcheck__)
+#undef PACKAGE_VERSION
+#endif
+
 #if !defined(PACKAGE_VERSION)
 #define PACKAGE_VERSION "???"
 #endif

--- a/vrplayer/decoder.h
+++ b/vrplayer/decoder.h
@@ -32,7 +32,7 @@ class Decoder : public QObject
 
     signals:
 
-    public slots:
+    public slots: // cppcheck-suppress unknownMacro
         void onGeometryChanged(QRect *geometry);
 };
 

--- a/vrplayer/dlgabout.h
+++ b/vrplayer/dlgabout.h
@@ -19,7 +19,7 @@ class DlgAbout : public QDialog
     private:
         Ui::DlgAbout *ui;
 
-    private slots:
+    private slots: // cppcheck-suppress unknownMacro
         void onOk();
 };
 

--- a/vrplayer/playaudio.h
+++ b/vrplayer/playaudio.h
@@ -42,7 +42,7 @@ class PlayAudio : public QObject
 
         void setVcrOp(int op);
 
-    public slots:
+    public slots: // cppcheck-suppress unknownMacro
         void play();
 
     private:

--- a/vrplayer/playvideo.h
+++ b/vrplayer/playvideo.h
@@ -46,7 +46,7 @@ class PlayVideo : public QObject
         //void setVcrOp(int op);
         //void onMediaRestarted();
 
-    public slots:
+    public slots: // cppcheck-suppress unknownMacro
         void play();
 
         //signals:


### PR DESCRIPTION
This fixes the following errors:-

sesman/tools/authtest.c:64:14: error: syntax error [syntaxError]
    g_printf("xrdp auth module tester v" PACKAGE_VERSION "\n");
             ^
sesman/tools/sesrun.c:165:14: error: syntax error [syntaxError]
    g_printf("xrdp session starter v" PACKAGE_VERSION "\n");
             ^
vrplayer/decoder.h:35:12: error: There is an unknown macro here somewhere. Configuration is required. If slots is a macro then please configure it. [unknownMacro]
    public slots:
           ^
vrplayer/playaudio.h:45:12: error: There is an unknown macro here somewhere. Configuration is required. If slots is a macro then please configure it. [unknownMacro]
    public slots:
           ^
vrplayer/dlgabout.h:22:13: error: There is an unknown macro here somewhere. Configuration is required. If slots is a macro then please configure it. [unknownMacro]
    private slots:
            ^
vrplayer/playvideo.h:49:12: error: There is an unknown macro here somewhere. Configuration is required. If slots is a macro then please configure it. [unknownMacro]
    public slots:
           ^
Additionally, cppcheck now makes use of all available CPUs