### PR TITLE
Clarify RHEL support options

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,7 +21,12 @@ body:
     attributes:
       label: Operating system & version
       placeholder: "Ubuntu 22.04 / AlmaLinux 9 / FreeBSD 13.2 / etc"
-      description: Tell us about your operating system. See PRETTY_NAME in /etc/os-release if you don't know.
+      description: Tell us about your operating system. See PRETTY_NAME
+        in /etc/os-release if you don't know.
+
+        Note we are currently unable to provide direct support for Red Hat
+        Enterprise Linux. Either reproduce the issue on CentOS/Alma/Rocky
+        OS, or contact Red Hat directly for support.
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
As someone who has worked as a professional RHEL sysadmin for a few years in the past, I've been following the recent developments around the availability of RHEL with some interest.

The announcement from Red Hat is [here](https://www.redhat.com/en/blog/furthering-evolution-centos-stream). A good quality discussion around the issues which covers both sides of the argument can be found in [this LWN article](https://lwn.net/Articles/935592/)

I'd like to focus on the implications of this announcement for this project in particular.

From our perspective, it's become a lot more complex to support RHEL directly, as an exact copy of a point-release of RHEL is no longer available for free.

I'm including the developer subscription for RHEL in this. Signing up for the developer subscription requires agreeing to the [Red Hat Developer Subscription for Individuals](https://developers.redhat.com/terms-and-conditions). This includes these paragraphs:-

> By accepting the Program Terms, you represent that you are acting on your own personal behalf and not as a representative or on behalf of an entity and will be using the Individual Developer Subscriptions solely as set forth in this document. Red Hat is relying on your representations as a condition of our providing you access.
. . .
> If you use the Individual Developer Subscriptions for any other purposes or beyond the parameters described in these Program Terms, you are in violation of Red Hat’s Enterprise Agreement and are required to pay the Subscription fees that would apply to such use, in addition to any and all other remedies available to Red Hat under applicable law. Examples of such violations include, but are not limited to,

Personally I'm not happy with signing up for this to support xrdp on RHEL, as I don't have any personal liability insurance which would cover me if I made a mistake in this area.

With all the above in mind, I'd like to propose a small change to @metalefty's issue template. Applying this change will result in the user being presented with the following:-

![image](https://github.com/neutrinolabs/xrdp/assets/30179339/a8084839-ed20-4dfb-8f32-8932d936c1ef)

Feedback is welcome. Does anyone think I'm over-reacting? Is the wording correct?