### PR TITLE
Clipboard updates

### DIFF
--- a/sesman/chansrv/clipboard.c
+++ b/sesman/chansrv/clipboard.c
@@ -179,6 +179,7 @@ x-special/gnome-copied-files
 #include "xcommon.h"
 #include "chansrv_fuse.h"
 #include "ms-rdpeclip.h"
+#include "xrdp_constants.h"
 
 static char g_bmp_image_header[] =
 {
@@ -245,9 +246,21 @@ static int g_cliprdr_flags = CB_USE_LONG_FORMAT_NAMES |
 static int g_formatIds[16];
 static int g_num_formatIds = 0;
 
-static int g_file_format_id = -1;
+/* Format ID assigned to "FileGroupDescriptorW" by the client */
+static int g_file_group_descriptor_format_id = -1;
 
 static char g_last_atom_name[256] = "";
+
+/*
+ * Values for the named formats we send to the client in
+ * a Format List PDU
+ */
+
+enum
+{
+    CB_FORMAT_FILE_GROUP_DESCRIPTOR = 0xc0bc
+};
+
 
 /*****************************************************************************/
 static char *
@@ -646,7 +659,7 @@ clipboard_send_format_announce(int xrdp_clip_type)
             case XRDP_CB_FILE:
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_send_format_announce: XRDP_CB_FILE");
                 /* canned response for "file" */
-                out_uint32_le(s, 0x0000c0bc);
+                out_uint32_le(s, CB_FORMAT_FILE_GROUP_DESCRIPTOR);
                 clipboard_out_unicode(s, "FileGroupDescriptorW", 21);
                 out_uint32_le(s, 0x0000c0ba);
                 clipboard_out_unicode(s, "FileContents", 13);
@@ -690,7 +703,7 @@ clipboard_send_format_announce(int xrdp_clip_type)
             case XRDP_CB_FILE:
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_send_format_announce: XRDP_CB_FILE");
                 /* canned response for "file" */
-                out_uint32_le(s, 0x0000c0bc);
+                out_uint32_le(s, CB_FORMAT_FILE_GROUP_DESCRIPTOR);
                 out_uint8p(s, windows_native_format, sizeof(windows_native_format));
                 out_uint32_le(s, 0x0000c0ba);
                 out_uint8p(s, windows_native_format, sizeof(windows_native_format));
@@ -1028,11 +1041,11 @@ clipboard_process_format_announce(struct stream *s, int clip_msg_status,
             LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_format_announce: max formats");
         }
 
-        /* format id for file copy copy seems to keep changing */
-        /* seen 0x0000c0c8, 0x0000c0ed */
+        /* format id for file copy copy is dynamic and announced by the
+         * client */
         if (g_strcmp(desc, "FileGroupDescriptorW") == 0)
         {
-            g_file_format_id = formatId;
+            g_file_group_descriptor_format_id = formatId;
         }
     }
 
@@ -1100,48 +1113,48 @@ clipboard_process_data_request(struct stream *s, int clip_msg_status,
     in_uint32_le(s, requestedFormatId);
     switch (requestedFormatId)
     {
-        case CB_FORMAT_FILE: /* 0xC0BC */
+        case CB_FORMAT_FILE_GROUP_DESCRIPTOR:
             if ((g_clip_s2c.xrdp_clip_type == XRDP_CB_FILE) && g_clip_s2c.converted)
             {
-                LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_data_request: CB_FORMAT_FILE");
+                LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_data_request: CB_FORMAT_FILE_GROUP_DESCRIPTOR");
                 clipboard_send_data_response(XRDP_CB_FILE, g_clip_s2c.data,
                                              g_clip_s2c.total_bytes);
             }
             else
             {
-                LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_data_request: CB_FORMAT_FILE, "
+                LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_data_request: CB_FORMAT_FILE_GROUP_DESCRIPTOR, "
                           "calling XConvertSelection to g_utf8_atom");
                 g_clip_s2c.xrdp_clip_type = XRDP_CB_FILE;
                 XConvertSelection(g_display, g_clipboard_atom, g_clip_s2c.type,
                                   g_clip_property_atom, g_wnd, CurrentTime);
             }
             break;
-        case CB_FORMAT_DIB: /* 0x0008 */
+        case CF_DIB:
             if ((g_clip_s2c.xrdp_clip_type == XRDP_CB_BITMAP) && g_clip_s2c.converted)
             {
-                LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_data_request: CB_FORMAT_DIB");
+                LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_data_request: CF_DIB");
                 clipboard_send_data_response(XRDP_CB_BITMAP, g_clip_s2c.data,
                                              g_clip_s2c.total_bytes);
             }
             else
             {
-                LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_data_request: CB_FORMAT_DIB, "
+                LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_data_request: CF_DIB, "
                           "calling XConvertSelection to g_image_bmp_atom");
                 g_clip_s2c.xrdp_clip_type = XRDP_CB_BITMAP;
                 XConvertSelection(g_display, g_clipboard_atom, g_image_bmp_atom,
                                   g_clip_property_atom, g_wnd, CurrentTime);
             }
             break;
-        case CB_FORMAT_UNICODETEXT: /* 0x000D */
+        case CF_UNICODETEXT:
             if ((g_clip_s2c.xrdp_clip_type == XRDP_CB_TEXT) && g_clip_s2c.converted)
             {
-                LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_data_request: CB_FORMAT_UNICODETEXT");
+                LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_data_request: CF_UNICODETEXT");
                 clipboard_send_data_response(XRDP_CB_TEXT, g_clip_s2c.data,
                                              g_clip_s2c.total_bytes);
             }
             else
             {
-                LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_data_request: CB_FORMAT_UNICODETEXT, "
+                LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_process_data_request: CF_UNICODETEXT, "
                           "calling XConvertSelection to g_utf8_atom");
                 g_clip_s2c.xrdp_clip_type = XRDP_CB_TEXT;
                 XConvertSelection(g_display, g_clipboard_atom, g_utf8_atom,
@@ -2356,10 +2369,10 @@ clipboard_event_selection_request(XEvent *xevent)
 
         /* Only announce text if the client is advertising text, or
          * a file list */
-        if (clipboard_find_format_id(CB_FORMAT_UNICODETEXT) >= 0 ||
-                clipboard_find_format_id(CB_FORMAT_OEMTEXT) >= 0 ||
-                clipboard_find_format_id(CB_FORMAT_TEXT) >= 0 ||
-                clipboard_find_format_id(g_file_format_id) >= 0)
+        if (clipboard_find_format_id(CF_UNICODETEXT) >= 0 ||
+                clipboard_find_format_id(CF_OEMTEXT) >= 0 ||
+                clipboard_find_format_id(CF_TEXT) >= 0 ||
+                clipboard_find_format_id(g_file_group_descriptor_format_id) >= 0)
         {
             if ((g_cfg->restrict_inbound_clipboard & CLIP_RESTRICT_TEXT) == 0)
             {
@@ -2369,14 +2382,14 @@ clipboard_event_selection_request(XEvent *xevent)
                 atom_count++;
             }
         }
-        if (clipboard_find_format_id(CB_FORMAT_DIB) >= 0 &&
+        if (clipboard_find_format_id(CF_DIB) >= 0 &&
                 (g_cfg->restrict_inbound_clipboard & CLIP_RESTRICT_IMAGE) == 0)
         {
             LOG_DEVEL(LOG_LEVEL_DEBUG, "  reporting image/bmp");
             atom_buf[atom_count] = g_image_bmp_atom;
             atom_count++;
         }
-        if (clipboard_find_format_id(g_file_format_id) >= 0 &&
+        if (clipboard_find_format_id(g_file_group_descriptor_format_id) >= 0 &&
                 (g_cfg->restrict_inbound_clipboard & CLIP_RESTRICT_FILE) == 0)
         {
             LOG_DEVEL(LOG_LEVEL_DEBUG, "  reporting text/uri-list");
@@ -2420,7 +2433,7 @@ clipboard_event_selection_request(XEvent *xevent)
     }
     else if ((lxev->target == XA_STRING) || (lxev->target == g_utf8_atom))
     {
-        if (clipboard_find_format_id(g_file_format_id) >= 0)
+        if (clipboard_find_format_id(g_file_group_descriptor_format_id) >= 0)
         {
             LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_event_selection_request: "
                       "text requested when files available");
@@ -2438,7 +2451,7 @@ clipboard_event_selection_request(XEvent *xevent)
                          sizeof(g_saved_selection_req_event));
                 g_clip_c2s.type = lxev->target;
                 g_clip_c2s.xrdp_clip_type = XRDP_CB_FILE;
-                clipboard_send_data_request(g_file_format_id);
+                clipboard_send_data_request(g_file_group_descriptor_format_id);
             }
 
         }
@@ -2461,7 +2474,7 @@ clipboard_event_selection_request(XEvent *xevent)
                          sizeof(g_saved_selection_req_event));
                 g_clip_c2s.type = lxev->target;
                 g_clip_c2s.xrdp_clip_type = XRDP_CB_TEXT;
-                clipboard_send_data_request(CB_FORMAT_UNICODETEXT);
+                clipboard_send_data_request(CF_UNICODETEXT);
             }
 
         }
@@ -2500,7 +2513,7 @@ clipboard_event_selection_request(XEvent *xevent)
                      sizeof(g_saved_selection_req_event));
             g_clip_c2s.type = g_image_bmp_atom;
             g_clip_c2s.xrdp_clip_type = XRDP_CB_BITMAP;
-            clipboard_send_data_request(CB_FORMAT_DIB);
+            clipboard_send_data_request(CF_DIB);
         }
         return 0;
 
@@ -2537,7 +2550,7 @@ clipboard_event_selection_request(XEvent *xevent)
                      sizeof(g_saved_selection_req_event));
             g_clip_c2s.type = g_file_atom1;
             g_clip_c2s.xrdp_clip_type = XRDP_CB_FILE;
-            clipboard_send_data_request(g_file_format_id);
+            clipboard_send_data_request(g_file_group_descriptor_format_id);
             return 0;
         }
 
@@ -2575,7 +2588,7 @@ clipboard_event_selection_request(XEvent *xevent)
                      sizeof(g_saved_selection_req_event));
             g_clip_c2s.type = g_file_atom2;
             g_clip_c2s.xrdp_clip_type = XRDP_CB_FILE;
-            clipboard_send_data_request(g_file_format_id);
+            clipboard_send_data_request(g_file_group_descriptor_format_id);
             return 0;
         }
     }

--- a/sesman/chansrv/clipboard_common.h
+++ b/sesman/chansrv/clipboard_common.h
@@ -22,20 +22,6 @@
 #include "arch.h"
 #include "parse.h"
 
-/*
- * TODO : Replace these with the definitions in xrdp_constants.h
- * where possible */
-#define CB_FORMAT_RAW                   0x0000
-#define CB_FORMAT_TEXT                  0x0001
-#define CB_FORMAT_OEMTEXT               0x0007
-#define CB_FORMAT_DIB                   0x0008
-#define CB_FORMAT_UNICODETEXT           0x000D
-#define CB_FORMAT_HTML                  0xD010
-#define CB_FORMAT_PNG                   0xD011
-#define CB_FORMAT_JPEG                  0xD012
-#define CB_FORMAT_GIF                   0xD013
-#define CB_FORMAT_FILE                  0xC0BC
-
 /* these are the supported general types */
 #define XRDP_CB_TEXT   1
 #define XRDP_CB_BITMAP 2

--- a/sesman/chansrv/clipboard_common.h
+++ b/sesman/chansrv/clipboard_common.h
@@ -27,6 +27,7 @@
  * where possible */
 #define CB_FORMAT_RAW                   0x0000
 #define CB_FORMAT_TEXT                  0x0001
+#define CB_FORMAT_OEMTEXT               0x0007
 #define CB_FORMAT_DIB                   0x0008
 #define CB_FORMAT_UNICODETEXT           0x000D
 #define CB_FORMAT_HTML                  0xD010


### PR DESCRIPTION
Fixes #2763 

This PR contains three commits
1) The first of these adds more checking to a [Format Data Response PDU](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/21cda270-0923-4302-898a-1b89f4c4904d). In particular, if the client responds with CB_RESPONSE_FAIL for any requested format, the X11 client is informed that the requested selection is not available, rather than the message being ignored. Additionally, pasted text is now given its own function, and more error checking is added.
2) The second of these only advertises text to the X11 clients when a text format (or a file list) is advertised by the Windows client.
3) The third of these is a tidy-up. There's a lot more that can be done in this area, but I've stuck with the minimum so that a backport to v0.9.x is feasible.

With these commits, when a picture is selected on the Windows client, the following can be seen using `xclip`:-

```
$ xclip -o -selection clipboard -t TARGETS
TARGETS
TIMESTAMP
MULTIPLE
image/bmp
$ xclip -o -selection clipboard -t STRING
Error: target STRING not available
```