### PR TITLE
Add GNOME/KDE keyring support for Debian/Arch

### DIFF
--- a/instfiles/pam.d/xrdp-sesman.arch
+++ b/instfiles/pam.d/xrdp-sesman.arch
@@ -1,5 +1,12 @@
 #%PAM-1.0
-auth        include     system-remote-login
-account     include     system-remote-login
-password    include     system-remote-login
-session     include     system-remote-login
+auth        include  system-remote-login
+-auth       optional pam_gnome_keyring.so
+-auth       optional pam_kwallet5.so
+
+account     include  system-remote-login
+
+password    include  system-remote-login
+
+session     include  system-remote-login
+-session    optional pam_gnome_keyring.so auto_start
+-session    optional pam_kwallet5.so auto_start

--- a/instfiles/pam.d/xrdp-sesman.debian
+++ b/instfiles/pam.d/xrdp-sesman.debian
@@ -1,5 +1,14 @@
 #%PAM-1.0
+auth     required  pam_env.so readenv=1
+auth     required  pam_env.so readenv=1 envfile=/etc/default/locale
 @include common-auth
+-auth    optional  pam_gnome_keyring.so
+-auth    optional  pam_kwallet5.so
+
 @include common-account
-@include common-session
+
 @include common-password
+
+@include common-session
+-session optional  pam_gnome_keyring.so auto_start
+-session optional  pam_kwallet5.so auto_start


### PR DESCRIPTION
Fixes #2776 

Makes the same modification for Arch Linux. This has not yet been requested but can be seen in [this comment](/neutrinolabs/xrdp/issues/1456#issuecomment-770323345) from @agowa

Also upstreams this Debian patch:-

https://salsa.debian.org/debian-remote-team/xrdp/-/blob/debian/0.9.21.1-1/debian/patches/fix-environment.diff

SuSE Tumbleweed and Red Hat do not need this functionality adding at this level because of the way they install and configure PAM.