### PR TITLE
Cppcheck 2.8 removed the dependency on z3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,7 @@ jobs:
         with:
           path: ~/cppcheck.local
           key: ${{ steps.os.outputs.image }}-build-${{ env.cache-name }}-${{ env.CPPCHECK_VER }}
-      - run: sudo scripts/install_cppcheck_dependencies_with_apt.sh
+      - run: sudo scripts/install_cppcheck_dependencies_with_apt.sh $CPPCHECK_VER
       - run: ./bootstrap
       - run: scripts/install_cppcheck.sh $CPPCHECK_REPO $CPPCHECK_VER
       - run: scripts/run_cppcheck.sh -v $CPPCHECK_VER

--- a/scripts/install_cppcheck.sh
+++ b/scripts/install_cppcheck.sh
@@ -128,7 +128,12 @@ fi
             # CFGDIR is needed for cppcheck before 1.86
             make_args="FILESDIR=$FILESDIR PREFIX=$FILESDIR CFGDIR=$FILESDIR"
             ;;
-        *)  make_args="FILESDIR=$FILESDIR PREFIX=$FILESDIR USE_Z3=yes"
+        2.8 | 2.9 | 2.1*)
+            # Cppcheck 2.8 removed the dependency on z3
+            make_args="FILESDIR=$FILESDIR PREFIX=$FILESDIR"
+            ;;
+        2.*)
+            make_args="FILESDIR=$FILESDIR PREFIX=$FILESDIR USE_Z3=yes"
             # Check that the Z3 development files appear to be installed
             # before trying to create z3_version.h. Otherwise we may
             # mislead the user as to what needs to be done.
@@ -138,6 +143,7 @@ fi
             if [ ! -f /usr/include/z3_version.h ]; then
                 create_z3_version_h
             fi
+            ;;
     esac
 
     # Use all available CPUs

--- a/scripts/install_cppcheck_dependencies_with_apt.sh
+++ b/scripts/install_cppcheck_dependencies_with_apt.sh
@@ -3,5 +3,27 @@ set -eufx
 
 PACKAGES="libz3-dev z3"
 
-apt-get update
-apt-get -yq --no-install-suggests --no-install-recommends install $PACKAGES
+usage()
+{
+    echo "** Usage: $0 <version-tag>"
+    echo "   e.g. $0 1.90"
+} >&2
+
+if [ $# -ne 1 ]; then
+    usage
+    exit 1
+fi
+CPPCHECK_VER="$1"
+
+case "$CPPCHECK_VER" in
+        1.*)
+            # no dependencies
+            ;;
+        2.8 | 2.9 | 2.1*)
+            # Cppcheck 2.8 removed the dependency on z3
+            ;;
+        2.*)
+            apt-get update
+            apt-get -yq --no-install-suggests --no-install-recommends install $PACKAGES
+            ;;
+esac


### PR DESCRIPTION
Cppcheck removed the z3 dependency in https://github.com/danmar/cppcheck/commit/8f386e15fdedff37486c683d933ccc9a1e307388 so only perform the related steps if necessary.