### PR TITLE
waitforx: fix build

### DIFF
--- a/waitforx/Makefile.am
+++ b/waitforx/Makefile.am
@@ -1,7 +1,7 @@
 pkglibexec_PROGRAMS = \
   waitforx
 
-AM_LDFLAGS = -lX11 -lXrandr
+AM_LDFLAGS = $(X_LIBS) -lX11 -lXrandr
 
 AM_CPPFLAGS = \
   -I$(top_srcdir)/sesman/sesexec \


### PR DESCRIPTION
```
--- waitforx ---
CCLD     waitforx
ld: error: unable to find library -lX11
ld: error: unable to find library -lXrandr
cc: error: linker command failed with exit code 1 (use -v to see invocation)
*** [waitforx] Error code 1
```