### PR TITLE
posix shm, can not unmap shmem_ptr until encoder is done with it

### DIFF
--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -528,7 +528,8 @@ server_paint_rects_ex(struct xrdp_mod *mod, int num_drects, short *drects,
                       int num_crects, short *crects,
                       char *data, int left, int top,
                       int width, int height,
-                      int flags, int frame_id);
+                      int flags, int frame_id,
+                      void *shmem_ptr, int shmem_bytes);
 int
 server_palette(struct xrdp_mod *mod, int *palette);
 int

--- a/xrdp/xrdp_encoder.h
+++ b/xrdp/xrdp_encoder.h
@@ -44,6 +44,8 @@ struct xrdp_enc_data
     int height;
     int flags;
     int frame_id;
+    void *shmem_ptr;
+    int shmem_bytes;
 };
 
 typedef struct xrdp_enc_data XRDP_ENC_DATA;

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -179,7 +179,8 @@ struct xrdp_mod
                                  int num_crects, short *crects,
                                  char *data, int left, int top,
                                  int width, int height,
-                                 int flags, int frame_id);
+                                 int flags, int frame_id,
+                                 void *shmem_ptr, int shmem_bytes);
     tintptr server_dumby[100 - 48]; /* align, 100 minus the number of server
                                      functions above */
     /* common */

--- a/xup/xup.c
+++ b/xup/xup.c
@@ -1386,11 +1386,14 @@ process_server_paint_rect_shmfd(struct mod *amod, struct stream *s)
             {
                 bmpdata = (char *)shmem_ptr;
                 bmpdata += shmem_offset;
+                /* we give up ownership of shmem_ptr
+                   will get cleaned up in server_paint_rects_ex or
+                   xrdp_mm_process_enc_done(rfx, gfx) */
                 rv = amod->server_paint_rects_ex(amod, num_drects, ldrects,
                                                  num_crects, lcrects, bmpdata,
                                                  left, top, width, height,
-                                                 flags, frame_id);
-                g_munmap(shmem_ptr, shmem_bytes);
+                                                 flags, frame_id,
+                                                 shmem_ptr, shmem_bytes);
             }
             g_file_close(fd);
         }

--- a/xup/xup.h
+++ b/xup/xup.h
@@ -165,7 +165,8 @@ struct mod
                                  int num_crects, short *crects,
                                  char *data, int left, int top,
                                  int width, int height,
-                                 int flags, int frame_id);
+                                 int flags, int frame_id,
+                                 void *shmem_ptr, int shmem_bytes);
     tintptr server_dumby[100 - 48]; /* align, 100 minus the number of server
                                      functions above */
     /* common */


### PR DESCRIPTION
Fix issue where main thread unmap shared memory before worker thread is done with it.