### PR TITLE
fixed Cppcheck `unusedVariable` warnings

### DIFF
--- a/fontutils/windows/fontdump.c
+++ b/fontutils/windows/fontdump.c
@@ -466,8 +466,6 @@ create_window(void)
 {
     WNDCLASS wc;
     DWORD style;
-    HDC dc;
-    int height;
     int left;
     int top;
 

--- a/libxrdp/xrdp_surface.c
+++ b/libxrdp/xrdp_surface.c
@@ -94,10 +94,7 @@ xrdp_surface_send_surface_bits(struct xrdp_surface *self, int bpp, char *data,
                                int x, int y, int cx, int cy)
 {
     RFX_RECT rect;
-    char *buf;
     int Bpp;
-    int i;
-    int j;
     int codecId;
     uint32 bitmapDataLength;
     STREAM *s;

--- a/sesman/chansrv/pcsc/wrapper/winscard.c
+++ b/sesman/chansrv/pcsc/wrapper/winscard.c
@@ -723,7 +723,6 @@ SCardControl(SCARDHANDLE hCard, DWORD dwControlCode, LPCVOID lpInBuffer,
              DWORD nOutBufferSize, LPDWORD lpBytesReturned)
 {
     LONG rv;
-    char text[8148];
 
     LLOGLN(10, ("SCardControl:"));
     LLOGLN(10, ("  hCard %p", hCard));

--- a/tools/devel/gtcp_proxy/gtcp.c
+++ b/tools/devel/gtcp_proxy/gtcp.c
@@ -131,8 +131,6 @@ int tcp_listen(int skt)
 
 int tcp_accept(int skt)
 {
-    int ret ;
-    char ipAddr[256] ;
     struct sockaddr_in s;
     socklen_t i;
 

--- a/xrdpapi/vrplayer.c
+++ b/xrdpapi/vrplayer.c
@@ -56,14 +56,9 @@ extract_32(uint32_t *value, char *buf)
 int
 main(int argc, char **argv)
 {
-    char    *data;
-    char    *data1;
     void    *channel;
     int     written = 0;
-    int     rv;
     int     first_time = 1;
-    int     length;
-    int     bytes_read;
 
     if (argc < 2)
     {


### PR DESCRIPTION
This is part of the `style` checks in Cppcheck which are not enabled in the CI. Those are currently rather produce a lot of findings which might not be of interest but these are easy and safe cleanups.