### PR TITLE
Implement vsock support for FreeBSD

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -601,6 +601,9 @@ g_sck_vsock_socket(void)
 #elif defined(__FreeBSD__)
     LOG(LOG_LEVEL_DEBUG, "g_sck_vsock_socket: returning FreeBSD Hyper-V socket");
     return socket(AF_HYPERV, SOCK_STREAM, 0); // docs say to use AF_HYPERV here - PF_HYPERV does not exist
+#else
+    LOG(LOG_LEVEL_DEBUG, "g_sck_vsock_socket: vsock enabled at compile time, but platform is unsupported");
+    return -1;
 #endif
 #else
     LOG(LOG_LEVEL_DEBUG, "g_sck_vsock_socket: vsock disabled at compile time");
@@ -1086,6 +1089,8 @@ g_sck_vsock_bind(int sck, const char *port)
     s.hvs_port = atoi(port);
 
     return bind(sck, (struct sockaddr *)&s, sizeof(struct sockaddr_hvs));
+#else
+    return -1;
 #endif
 #else
     return -1;
@@ -1115,6 +1120,8 @@ g_sck_vsock_bind_address(int sck, const char *port, const char *address)
     // channel/address currently unsupported in FreeBSD 13.
 
     return bind(sck, (struct sockaddr *)&s, sizeof(struct sockaddr_hvs));
+#else
+    return -1;
 #endif
 #else
     return -1;

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -46,7 +46,8 @@
 #include <linux/vm_sockets.h>
 #elif defined(__FreeBSD__)
 // sockaddr_hvs is not available outside the kernel for whatever reason
-struct sockaddr_hvs {
+struct sockaddr_hvs
+{
     unsigned char sa_len;
     sa_family_t   sa_family;
     unsigned int  hvs_port;

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -42,7 +42,17 @@
 #include <netinet/tcp.h>
 #include <sys/socket.h>
 #if defined(XRDP_ENABLE_VSOCK)
+#if defined(__linux__)
 #include <linux/vm_sockets.h>
+#elif defined(__FreeBSD__)
+// sockaddr_hvs is not available outside the kernel for whatever reason
+struct sockaddr_hvs {
+    unsigned char sa_len;
+    sa_family_t   sa_family;
+    unsigned int  hvs_port;
+    unsigned char hvs_zero[sizeof(struct sockaddr) -  sizeof(sa_family_t) - sizeof(unsigned char) - sizeof(unsigned int)];
+};
+#endif
 #endif
 #include <poll.h>
 #include <sys/un.h>
@@ -124,7 +134,11 @@ union sock_info
 #endif
     struct sockaddr_un sa_un;
 #if defined(XRDP_ENABLE_VSOCK)
+#if defined(__linux__)
     struct sockaddr_vm sa_vm;
+#elif defined(__FreeBSD__)
+    struct sockaddr_hvs sa_hvs;
+#endif
 #endif
 };
 
@@ -580,8 +594,15 @@ int
 g_sck_vsock_socket(void)
 {
 #if defined(XRDP_ENABLE_VSOCK)
+#if defined(__linux__)
+    LOG(LOG_LEVEL_DEBUG, "g_sck_vsock_socket: returning Linux vsock socket");
     return socket(PF_VSOCK, SOCK_STREAM, 0);
+#elif defined(__FreeBSD__)
+    LOG(LOG_LEVEL_DEBUG, "g_sck_vsock_socket: returning FreeBSD Hyper-V socket");
+    return socket(AF_HYPERV, SOCK_STREAM, 0); // docs say to use AF_HYPERV here - PF_HYPERV does not exist
+#endif
 #else
+    LOG(LOG_LEVEL_DEBUG, "g_sck_vsock_socket: vsock disabled at compile time");
     return -1;
 #endif
 }
@@ -702,6 +723,7 @@ get_peer_description(const union sock_info *sock_info,
             }
 
 #if defined(XRDP_ENABLE_VSOCK)
+#if defined(__linux__)
 
             case AF_VSOCK:
             {
@@ -713,6 +735,18 @@ get_peer_description(const union sock_info *sock_info,
                 break;
             }
 
+#elif defined(__FreeBSD__)
+
+            case AF_HYPERV:
+            {
+                const struct sockaddr_hvs *sa_hvs = &sock_info->sa_hvs;
+
+                g_snprintf(desc, bytes, "AF_HYPERV:port=%u", sa_hvs->hvs_port);
+
+                break;
+            }
+
+#endif
 #endif
             default:
                 g_snprintf(desc, bytes, "Unknown address family %d", family);
@@ -1034,6 +1068,7 @@ int
 g_sck_vsock_bind(int sck, const char *port)
 {
 #if defined(XRDP_ENABLE_VSOCK)
+#if defined(__linux__)
     struct sockaddr_vm s;
 
     g_memset(&s, 0, sizeof(struct sockaddr_vm));
@@ -1042,6 +1077,15 @@ g_sck_vsock_bind(int sck, const char *port)
     s.svm_cid = VMADDR_CID_ANY;
 
     return bind(sck, (struct sockaddr *)&s, sizeof(struct sockaddr_vm));
+#elif defined(__FreeBSD__)
+    struct sockaddr_hvs s;
+
+    g_memset(&s, 0, sizeof(struct sockaddr_hvs));
+    s.sa_family = AF_HYPERV;
+    s.hvs_port = atoi(port);
+
+    return bind(sck, (struct sockaddr *)&s, sizeof(struct sockaddr_hvs));
+#endif
 #else
     return -1;
 #endif
@@ -1052,6 +1096,7 @@ int
 g_sck_vsock_bind_address(int sck, const char *port, const char *address)
 {
 #if defined(XRDP_ENABLE_VSOCK)
+#if defined(__linux__)
     struct sockaddr_vm s;
 
     g_memset(&s, 0, sizeof(struct sockaddr_vm));
@@ -1060,6 +1105,16 @@ g_sck_vsock_bind_address(int sck, const char *port, const char *address)
     s.svm_cid = atoi(address);
 
     return bind(sck, (struct sockaddr *)&s, sizeof(struct sockaddr_vm));
+#elif defined(__FreeBSD__)
+    struct sockaddr_hvs s;
+
+    g_memset(&s, 0, sizeof(struct sockaddr_hvs));
+    s.sa_family = AF_HYPERV;
+    s.hvs_port = atoi(port);
+    // channel/address currently unsupported in FreeBSD 13.
+
+    return bind(sck, (struct sockaddr *)&s, sizeof(struct sockaddr_hvs));
+#endif
 #else
     return -1;
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -409,10 +409,8 @@ then
   enable_vsock=yes
   if test "x$freebsd" = "xyes"
   then
-    # unconditionally define XRDP_ENABLE_VSOCK because there are no headers
-    # to check for. AF_HYPERV is present in FreeBSD 13 and may be present in
-    # earlier versions.
-    AC_DEFINE([XRDP_ENABLE_VSOCK], 1, [Enable AF_HYPERV])
+    # Determine if we have AF_HYPERV defined (FreeBSD 13+)
+    AC_CHECK_DECL([AF_HYPERV], [AC_DEFINE([XRDP_ENABLE_VSOCK], 1, [Enable AF_HYPERV])], [], [#include <sys/socket.h>])
   else
     AC_CHECK_HEADERS([linux/socket.h linux/vm_sockets.h],
                     [AC_DEFINE([XRDP_ENABLE_VSOCK], 1, [Enable AF_VSOCK])],

--- a/configure.ac
+++ b/configure.ac
@@ -407,10 +407,18 @@ fi
 if test "x$enable_vsock" = "xyes"
 then
   enable_vsock=yes
-  AC_CHECK_HEADERS([linux/socket.h linux/vm_sockets.h],
-                   [AC_DEFINE([XRDP_ENABLE_VSOCK], 1, [Enable AF_VSOCK])],
-                   [],
-                   [#include <sys/socket.h>])
+  if test "x$freebsd" = "xyes"
+  then
+    # unconditionally define XRDP_ENABLE_VSOCK because there are no headers
+    # to check for. AF_HYPERV is present in FreeBSD 13 and may be present in
+    # earlier versions.
+    AC_DEFINE([XRDP_ENABLE_VSOCK], 1, [Enable AF_HYPERV])
+  else
+    AC_CHECK_HEADERS([linux/socket.h linux/vm_sockets.h],
+                    [AC_DEFINE([XRDP_ENABLE_VSOCK], 1, [Enable AF_VSOCK])],
+                    [],
+                    [#include <sys/socket.h>])
+  fi
 fi
 
 if test "x$enable_ipv6only" = "xyes"


### PR DESCRIPTION
FreeBSD supports something very nearly the same as Linux's vsock with Hyper-V, and this patch adds support for it to xrdp.

Practically speaking, this allows you to use enhanced session mode in Hyper-V, if you run `Set-VM -EnhancedSessionTransportType HvSocket` on the VM in PowerShell. That said, the performance is bad because it is fully software rendered, because the Hyper-V enhanced DRM/DRI driver hasn't been ported to FreeBSD yet (there's a pending change to implement the enhanced framebuffer, but I doubt that makes xorgxrdp able to use hardware accelerated rendering).

One bug is that when `g_sck_close` tries to run `getsockname`, `EINVAL` is returned and the socket is closed normally, but looking at the code, I think that also happens with Linux because `sock_info.sa` rather than `sock_info.sa_vm` or `sock_info.sa_hvs` are passed in, and `sa` is not the correct structure for the open vsock/hv_sock socket. Fixing this feels like it's probably out of scope for this change, since both Unix sockets and Linux vsocks would suffer from the same problem.

Here's a screenshot showing it in action, forgive the Windows DPI being messed up (I need to reboot, I think, to fix it):

![image](https://github.com/neutrinolabs/xrdp/assets/66674/15a7081e-1b0a-44ad-a2b6-940283219447)
