### PR TITLE
Support NetBSD, OpenIndiana, Gentoo Linux, and MacOS.

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -28,8 +28,7 @@ AM_CPPFLAGS = \
   -DXRDP_SHARE_PATH=\"${datadir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \
   -DXRDP_LOG_PATH=\"${localstatedir}/log\" \
-  -DXRDP_SOCKET_PATH=\"${socketdir}\" \
-  $(XOPEN_FLAGS)
+  -DXRDP_SOCKET_PATH=\"${socketdir}\" 
 
 # -no-suppress is an automake-specific flag which is needed
 # to prevent us missing compiler errors in some circumstances

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -28,7 +28,8 @@ AM_CPPFLAGS = \
   -DXRDP_SHARE_PATH=\"${datadir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \
   -DXRDP_LOG_PATH=\"${localstatedir}/log\" \
-  -DXRDP_SOCKET_PATH=\"${socketdir}\"
+  -DXRDP_SOCKET_PATH=\"${socketdir}\" \
+  $(XOPEN_FLAGS)
 
 # -no-suppress is an automake-specific flag which is needed
 # to prevent us missing compiler errors in some circumstances

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -3318,17 +3318,24 @@ g_waitpid(int pid, int *stat_loc, int options)
 #else
     int rv = 0;
 
-    again:
-        rv = waitpid(pid, stat_loc, options);
-	//retry EINTR.
-	if( rv == -1 && errno == EINTR )
-	{
-	    goto again;
-        }
+again:
+    rv = waitpid(pid, stat_loc, options);
+    //retry EINTR.
+    if( rv == -1 && errno == EINTR )
+    {
+        goto again;
+    }
 
     if( rv == -1 ) 
     {
-	LOG(LOG_LEVEL_ERROR, "waitpid returned %s", g_get_strerror());
+	if( errno == ECHILD )
+	{
+	    LOG(LOG_LEVEL_INFO, "waitpid returned %s", g_get_strerror());
+	}
+	else
+        {
+	    LOG(LOG_LEVEL_ERROR, "waitpid returned %s", g_get_strerror());
+	}
     }
 
     return rv;

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -3004,6 +3004,7 @@ g_set_alarm(void (*func)(int), unsigned int secs)
     /* Cancel any previous alarm to prevent a race */
     unsigned int rv = alarm(0);
     signal(SIGALRM, func);
+    signal(SIGINT, func);
     (void)alarm(secs);
     return rv;
 #endif
@@ -3356,7 +3357,11 @@ g_waitpid_status(int pid)
         }
         else
         {
-            LOG(LOG_LEVEL_WARNING, "wait for pid %d returned unknown result", pid);
+            LOG(LOG_LEVEL_WARNING, "wait for pid %d returned unknown result %s", pid, g_get_strerror());
+	    if( errno == EINTR )
+	    {
+		return g_waitpid_status(pid);
+            }
         }
     }
 

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -3278,7 +3278,7 @@ g_waitchild(struct exit_status *e)
     e->reason = E_XR_UNEXPECTED;
     e->val = 0;
 
-    rv = waitpid(-1, &wstat, WNOHANG);
+    rv = g_waitpid(-1, &wstat, WNOHANG);
 
     if (rv == -1)
     {

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -1409,7 +1409,16 @@ g_sleep(int msecs)
 #if defined(_WIN32)
     Sleep(msecs);
 #else
-    usleep(msecs * 1000);
+    //On NetBSD usleep can not be > 1000000, so use sleep instead.
+    if( msecs >= 1000 )
+    {
+        int remainder = msecs % 1000; 
+	sleep(msecs / 1000);
+        if( remainder != 0 )
+        {
+	   usleep(remainder * 1000);
+        } 
+    }
 #endif
 }
 

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -3024,6 +3024,7 @@ void
 g_signal_child_stop(void (*func)(int))
 {
 #if defined(_WIN32)
+    return; 
 #else
     signal(SIGCHLD, func);
 #endif
@@ -3317,19 +3318,17 @@ g_waitpid(int pid, int *stat_loc, int options)
 #else
     int rv = 0;
 
-    if (pid < 0)
-    {
-        rv = -1;
-    }
-    else
-    {
-	again:
+    again:
         rv = waitpid(pid, stat_loc, options);
 	//retry EINTR.
 	if( rv == -1 && errno == EINTR )
 	{
 	    goto again;
         }
+
+    if( rv == -1 ) 
+    {
+	LOG(LOG_LEVEL_ERROR, "waitpid returned %s", g_get_strerror());
     }
 
     return rv;

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -32,10 +32,6 @@
 #include <windows.h>
 #include <winsock.h>
 #else
-/* fix for solaris 10 with gcc 3.3.2 problem */
-#if defined(sun) || defined(__sun)
-#define ctid_t id_t
-#endif
 #include <unistd.h>
 #include <errno.h>
 #include <netinet/in.h>
@@ -44,6 +40,7 @@
 #if defined(XRDP_ENABLE_VSOCK)
 #include <linux/vm_sockets.h>
 #endif
+#include <limits.h>
 #include <poll.h>
 #include <sys/un.h>
 #include <sys/time.h>

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -300,7 +300,7 @@ int      g_setlogin(const char *name);
 int      g_set_allusercontext(int uid);
 #endif
 int      g_waitchild(struct exit_status *e);
-int      g_waitpid(int pid);
+int      g_waitpid(int pid, int *stat_loc, int options);
 struct exit_status g_waitpid_status(int pid);
 /*
  * Sets the process group ID of the indicated process to the specified value.

--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,7 @@ AC_CONFIG_SUBDIRS([libpainter librfxcodec])
 # Use silent rules by default if supported by Automake
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
+SDK_FLAGS=
 case $host_os in
 	*linux*)
 		linux=yes
@@ -38,6 +39,10 @@ case $host_os in
 		;;
 	*darwin*)
 		macos=yes
+		SDK_FLAGS="--sysroot $(xcrun --show-sdk-path)"
+		;;
+  *solaris*)
+		solaris=yes
 		;;
 esac
 
@@ -46,6 +51,8 @@ AM_CONDITIONAL(FREEBSD, [test "x$freebsd" = xyes])
 AM_CONDITIONAL(OPENBSD, [test "x$openbsd" = xyes])
 AM_CONDITIONAL(NETBSD, [test "x$netbsd" = xyes])
 AM_CONDITIONAL(MACOS, [test "x$macos" = xyes])
+AM_CONDITIONAL(SOLARIS, [test "x$solaris" = xyes])
+AC_SUBST(SDK_FLAGS)
 
 AC_CHECK_SIZEOF([int])
 AC_CHECK_SIZEOF([long])
@@ -110,6 +117,10 @@ AC_ARG_ENABLE(pamuserpass, AS_HELP_STRING([--enable-pamuserpass],
               [Build PAM userpass support (default: no)]),
               [], [enable_pamuserpass=no])
 AM_CONDITIONAL(SESMAN_PAMUSERPASS, [test x$enable_pamuserpass = xyes])
+AC_ARG_ENABLE(userpass, AS_HELP_STRING([--enable-userpass],
+              [Build userpass support (no pam) (default: no)]),
+              [], [enable_userpass=no])
+AM_CONDITIONAL(SESMAN_USERPASS, [test x$enable_userpass = xyes])
 AC_ARG_ENABLE(pam-config, AS_HELP_STRING([--enable-pam-config=CONF],
               [Select PAM config to install: arch, debian, redhat, suse, freebsd, macos, unix
                (default: autodetect)]))
@@ -187,6 +198,11 @@ AC_ARG_ENABLE(rdpsndaudin, AS_HELP_STRING([--enable-rdpsndaudin],
               [Use rdpsnd audio in (default: no)]),
               [], [enable_rdpsndaudin=no])
 AM_CONDITIONAL(XRDP_RDPSNDAUDIN, [test x$enable_rdpsndaudin = xyes])
+
+AC_ARG_ENABLE(openrc, AS_HELP_STRING([--enable-openrc],
+              [Use openrc in (default: no)]),
+              [], [enable_openrc=no])
+AM_CONDITIONAL(XRDP_OPENRC, [test x$enable_openrc = xyes])
 
 AC_ARG_WITH(imlib2, AS_HELP_STRING([--with-imlib2=ARG], [imlib2 library to use for non-BMP backgrounds (ARG=yes/no/<abs-path>)]),,)
 
@@ -360,6 +376,13 @@ then
   auth_mech="PAM userpass"
   AUTHMOD_OBJ=verify_user_pam_userpass.lo
   AUTHMOD_LIB="-lpam -lpam_userpass"
+fi
+if test x$enable_userpass = xyes
+then
+  auth_cnt=`expr $auth_cnt + 1`
+  auth_mech="Builtin"
+  AUTHMOD_OBJ=verify_user.lo
+  AUTHMOD_LIB=-lcrypt
 fi
 
 if test $auth_cnt -gt 1
@@ -574,6 +597,9 @@ AC_CONFIG_FILES([
   instfiles/pam.d/Makefile
   instfiles/pulse/Makefile
   instfiles/rc.d/Makefile
+  instfiles/openrc/Makefile
+  instfiles/method/Makefile
+  instfiles/manifest/Makefile
   keygen/Makefile
   waitforx/Makefile
   libipm/Makefile
@@ -628,6 +654,7 @@ echo "  ipv6only                $enable_ipv6only"
 echo "  vsock                   $enable_vsock"
 echo "  auth mechanism          $auth_mech"
 echo "  rdpsndaudin             $enable_rdpsndaudin"
+echo "  openrc                  $enable_openrc"
 echo
 echo "  with imlib2             $use_imlib2"
 echo "  with freetype2          $use_freetype2"

--- a/configure.ac
+++ b/configure.ac
@@ -591,6 +591,7 @@ AC_CONFIG_FILES([
   instfiles/openrc/Makefile
   instfiles/method/Makefile
   instfiles/manifest/Makefile
+  instfiles/launchdaemons/Makefile
   keygen/Makefile
   waitforx/Makefile
   libipm/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,6 @@ AC_CONFIG_SUBDIRS([libpainter librfxcodec])
 # Use silent rules by default if supported by Automake
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
-XOPEN_FLAGS=
 case $host_os in
 	*linux*)
 		linux=yes
@@ -42,7 +41,6 @@ case $host_os in
 		;;
         *solaris*)
 		solaris=yes
-		XOPEN_FLAGS="-D_XOPEN_SOURCE=600"
 		;;
 esac
 
@@ -52,7 +50,6 @@ AM_CONDITIONAL(OPENBSD, [test "x$openbsd" = xyes])
 AM_CONDITIONAL(NETBSD, [test "x$netbsd" = xyes])
 AM_CONDITIONAL(MACOS, [test "x$macos" = xyes])
 AM_CONDITIONAL(SOLARIS, [test "x$solaris" = xyes])
-AC_SUBST(XOPEN_FLAGS)
 
 AC_CHECK_SIZEOF([int])
 AC_CHECK_SIZEOF([long])
@@ -296,6 +293,11 @@ esac
 
 if test x$use_imlib2 = xyes; then
     AC_DEFINE([USE_IMLIB2],1, [Compile with imlib2 support])
+fi
+
+if test x$solaris = xyes; then
+    CFLAGS="${CFLAGS} -D_XOPEN_SOURCE=600"
+    AC_SUBST(CFLAGS)
 fi
 
 # Find freetype2
@@ -668,6 +670,7 @@ echo "  unit tests performable  $perform_unit_tests"
 echo ""
 echo "  CFLAGS = $CFLAGS"
 echo "  LDFLAGS = $LDFLAGS"
+echo "  CPPFLAGS = $CPPFLAGS"
 
 # xrdp_configure_options.h will be written to the build directory, not the source directory
 echo '#define XRDP_CONFIGURE_OPTIONS \' > ./xrdp_configure_options.h

--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@ AC_CONFIG_SUBDIRS([libpainter librfxcodec])
 # Use silent rules by default if supported by Automake
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
-SDK_FLAGS=
+XOPEN_FLAGS=
 case $host_os in
 	*linux*)
 		linux=yes
@@ -39,10 +39,10 @@ case $host_os in
 		;;
 	*darwin*)
 		macos=yes
-		SDK_FLAGS="--sysroot $(xcrun --show-sdk-path)"
 		;;
-  *solaris*)
+        *solaris*)
 		solaris=yes
+		XOPEN_FLAGS="-D_XOPEN_SOURCE=600"
 		;;
 esac
 
@@ -52,7 +52,7 @@ AM_CONDITIONAL(OPENBSD, [test "x$openbsd" = xyes])
 AM_CONDITIONAL(NETBSD, [test "x$netbsd" = xyes])
 AM_CONDITIONAL(MACOS, [test "x$macos" = xyes])
 AM_CONDITIONAL(SOLARIS, [test "x$solaris" = xyes])
-AC_SUBST(SDK_FLAGS)
+AC_SUBST(XOPEN_FLAGS)
 
 AC_CHECK_SIZEOF([int])
 AC_CHECK_SIZEOF([long])
@@ -93,8 +93,8 @@ AC_ARG_ENABLE(tests,
               [Ensure dependencies for the tests are installed]),
               [ensure_tests_deps=yes], [])
 AC_ARG_ENABLE(pam, AS_HELP_STRING([--enable-pam],
-              [Build PAM support (default: yes)]),
-              [], [enable_pam=yes])
+              [Build PAM support (default: no)]),
+              [], [enable_pam=no])
 AM_CONDITIONAL(SESMAN_NOPAM, [test x$enable_pam != xyes])
 AC_ARG_ENABLE(vsock, AS_HELP_STRING([--enable-vsock],
               [Build AF_VSOCK support (default: no)]),
@@ -117,10 +117,6 @@ AC_ARG_ENABLE(pamuserpass, AS_HELP_STRING([--enable-pamuserpass],
               [Build PAM userpass support (default: no)]),
               [], [enable_pamuserpass=no])
 AM_CONDITIONAL(SESMAN_PAMUSERPASS, [test x$enable_pamuserpass = xyes])
-AC_ARG_ENABLE(userpass, AS_HELP_STRING([--enable-userpass],
-              [Build userpass support (no pam) (default: no)]),
-              [], [enable_userpass=no])
-AM_CONDITIONAL(SESMAN_USERPASS, [test x$enable_userpass = xyes])
 AC_ARG_ENABLE(pam-config, AS_HELP_STRING([--enable-pam-config=CONF],
               [Select PAM config to install: arch, debian, redhat, suse, freebsd, macos, unix
                (default: autodetect)]))
@@ -376,13 +372,6 @@ then
   auth_mech="PAM userpass"
   AUTHMOD_OBJ=verify_user_pam_userpass.lo
   AUTHMOD_LIB="-lpam -lpam_userpass"
-fi
-if test x$enable_userpass = xyes
-then
-  auth_cnt=`expr $auth_cnt + 1`
-  auth_mech="Builtin"
-  AUTHMOD_OBJ=verify_user.lo
-  AUTHMOD_LIB=-lcrypt
 fi
 
 if test $auth_cnt -gt 1

--- a/instfiles/Makefile.am
+++ b/instfiles/Makefile.am
@@ -99,7 +99,8 @@ SUBDIRS += \
 endif
 
 if MACOS
-SUBDIRS += pam.d
+SUBDIRS += pam.d \
+  launchdaemons
 endif
 
 #

--- a/instfiles/Makefile.am
+++ b/instfiles/Makefile.am
@@ -99,7 +99,8 @@ SUBDIRS += \
 endif
 
 if MACOS
-SUBDIRS += pam.d \
+SUBDIRS += \
+  pam.d \
   launchdaemons
 endif
 

--- a/instfiles/Makefile.am
+++ b/instfiles/Makefile.am
@@ -66,9 +66,15 @@ systemdsystemunit_DATA = \
   xrdp-sesman.service \
   xrdp.service
 else
+if XRDP_OPENRC
+  SUBDIRS += \
+  default \
+  openrc
+else
 SUBDIRS += \
   default \
   init.d
+endif # XRDP_OPENRC
 endif # HAVE_SYSTEMD
 endif # LINUX
 
@@ -77,6 +83,19 @@ SUBDIRS += \
   pam.d \
   rc.d \
   pulse
+endif
+
+if NETBSD
+SUBDIRS += \
+  pam.d \
+  rc.d \
+  pulse
+endif
+
+if SOLARIS
+SUBDIRS += \
+  manifest \
+  method
 endif
 
 if MACOS
@@ -99,5 +118,15 @@ if FREEBSD
 # must be tab below
 install-data-hook:
 	sed -i '' 's|%%PREFIX%%|$(prefix)|g' $(DESTDIR)$(sysconfdir)/rc.d/xrdp \
+                                         $(DESTDIR)$(sysconfdir)/rc.d/xrdp-sesman
+endif
+
+
+if NETBSD
+# must be tab below
+install-data-hook:
+	sed -i 's|%%PREFIX%%/sbin|$(prefix)/sbin|g' $(DESTDIR)$(sysconfdir)/rc.d/xrdp \
+                                         $(DESTDIR)$(sysconfdir)/rc.d/xrdp-sesman
+	sed -i 's|%%PREFIX%%||g' $(DESTDIR)$(sysconfdir)/rc.d/xrdp \
                                          $(DESTDIR)$(sysconfdir)/rc.d/xrdp-sesman
 endif

--- a/instfiles/launchdaemons/Makefile.am
+++ b/instfiles/launchdaemons/Makefile.am
@@ -1,3 +1,3 @@
-startscriptdir = /Library/LaunchDaemons 
+startscriptdir = /Library/LaunchDaemons
 
 dist_startscript_SCRIPTS = org.xrdp.xrdp.plist org.xrdp.xrdp-sesman.plist

--- a/instfiles/launchdaemons/Makefile.am
+++ b/instfiles/launchdaemons/Makefile.am
@@ -1,0 +1,3 @@
+startscriptdir = /Library/LaunchDaemons 
+
+dist_startscript_SCRIPTS = org.xrdp.xrdp.plist org.xrdp.xrdp-sesman.plist

--- a/instfiles/launchdaemons/org.xrdp.xrdp-sesman.plist
+++ b/instfiles/launchdaemons/org.xrdp.xrdp-sesman.plist
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+"http://www.apple.com/DTDs/PropertyList-1.0.dtd" >
+<plist version='1.0'>
+<dict>
+<key>Label</key><string>org.xrdp.xrdp-sesman</string>
+<key>ProgramArguments</key>
+<array>
+	<string>/opt/local/bin/daemondo</string>
+	<string>--label=xrdp-sesman</string>
+	<string>--start-cmd</string>
+	<string>/usr/local/sbin/xrdp-sesman</string>
+	<string>-n</string>
+	<string>;</string>
+	<string>--pid=exec</string>
+</array>
+<key>Disabled</key><true/>
+<key>KeepAlive</key><true/>
+</dict>
+</plist>

--- a/instfiles/launchdaemons/org.xrdp.xrdp.plist
+++ b/instfiles/launchdaemons/org.xrdp.xrdp.plist
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+"http://www.apple.com/DTDs/PropertyList-1.0.dtd" >
+<plist version='1.0'>
+<dict>
+<key>Label</key><string>org.xrdp.xrdp</string>
+<key>ProgramArguments</key>
+<array>
+	<string>/opt/local/bin/daemondo</string>
+	<string>--label=xrdp</string>
+	<string>--start-cmd</string>
+	<string>/usr/local/sbin/xrdp</string>
+	<string>-n</string>
+	<string>;</string>
+	<string>--pid=exec</string>
+</array>
+<key>Disabled</key><true/>
+<key>KeepAlive</key><true/>
+</dict>
+</plist>

--- a/instfiles/manifest/Makefile.am
+++ b/instfiles/manifest/Makefile.am
@@ -1,0 +1,3 @@
+startscriptdir = /lib/svc/manifest/site
+
+dist_startscript_SCRIPTS = xrdp.xml xrdp-sesman.xml

--- a/instfiles/manifest/xrdp-sesman.xml
+++ b/instfiles/manifest/xrdp-sesman.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+
+<!--
+ Define a service to control the startup and shutdown of a database instance.
+-->
+
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+
+<service_bundle type="manifest" name="xrdp-sesman">
+<service name="site/application/network/xrdp-sesman" type="service" version="1">
+    <create_default_instance enabled="true" />
+
+    <!--
+         Wait for all local file systems to be mounted.
+         Wait for all network interfaces to be initialized.
+    -->
+
+    <dependency type="service"
+        name="fs-local"
+        grouping="require_all"
+        restart_on="none">
+        <service_fmri value="svc:/system/filesystem/local" />
+    </dependency>
+
+    <dependency type="service"
+        name="network"
+        grouping="require_all"
+        restart_on="none">
+        <service_fmri value="svc:/milestone/network:default" />
+    </dependency>
+
+    <!-- Define the methods. -->
+    <exec_method type="method"
+        name="start"
+        exec="/lib/svc/method/xrdp-sesman start"
+        timeout_seconds="120"/>
+
+    <exec_method type="method"
+        name="stop"
+        exec="/lib/svc/method/xrdp-sesman stop"
+        timeout_seconds="120" />
+
+    <exec_method type="method"
+        name="refresh"
+        exec="/lib/svc/method/xrdp-sesman refresh"
+        timeout_seconds="120"/>
+
+    <!--
+         What authorization is needed to allow the framework
+         general/enabled property to be changed when performing the
+         action (enable, disable, etc) on the service.
+    -->
+
+    <!-- Define an instance of the database. -->
+
+    <!--<instance name="default" enabled="true" />-->
+
+    <stability value="Evolving" />
+</service>
+</service_bundle>

--- a/instfiles/manifest/xrdp-sesman.xml
+++ b/instfiles/manifest/xrdp-sesman.xml
@@ -40,11 +40,6 @@
         exec="/lib/svc/method/xrdp-sesman stop"
         timeout_seconds="120" />
 
-    <exec_method type="method"
-        name="refresh"
-        exec="/lib/svc/method/xrdp-sesman refresh"
-        timeout_seconds="120"/>
-
     <!--
          What authorization is needed to allow the framework
          general/enabled property to be changed when performing the

--- a/instfiles/manifest/xrdp.xml
+++ b/instfiles/manifest/xrdp.xml
@@ -40,10 +40,6 @@
         exec="/lib/svc/method/xrdp stop"
         timeout_seconds="120" />
 
-    <exec_method type="method"
-        name="refresh"
-        exec="/lib/svc/method/xrdp refresh"
-        timeout_seconds="120" />
     <!--
          What authorization is needed to allow the framework
          general/enabled property to be changed when performing the

--- a/instfiles/manifest/xrdp.xml
+++ b/instfiles/manifest/xrdp.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+
+<!--
+ Define a service to control the startup and shutdown of a database instance.
+-->
+
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+
+<service_bundle type="manifest" name="xrdp">
+<service name="site/application/network/xrdp" type="service" version="1">
+    <create_default_instance enabled="true" />
+
+    <!--
+         Wait for all local file systems to be mounted.
+         Wait for all network interfaces to be initialized.
+    -->
+
+    <dependency type="service"
+        name="fs-local"
+        grouping="require_all"
+        restart_on="none">
+        <service_fmri value="svc:/system/filesystem/local" />
+    </dependency>
+
+    <dependency type="service"
+        name="network"
+        grouping="require_all"
+        restart_on="none">
+        <service_fmri value="svc:/milestone/network:default" />
+    </dependency>
+
+    <!-- Define the methods. -->
+    <exec_method type="method"
+        name="start"
+        exec="/lib/svc/method/xrdp start"
+        timeout_seconds="120"/>
+
+    <exec_method type="method"
+        name="stop"
+        exec="/lib/svc/method/xrdp stop"
+        timeout_seconds="120" />
+
+    <exec_method type="method"
+        name="refresh"
+        exec="/lib/svc/method/xrdp refresh"
+        timeout_seconds="120" />
+    <!--
+         What authorization is needed to allow the framework
+         general/enabled property to be changed when performing the
+         action (enable, disable, etc) on the service.
+    -->
+
+    <!-- Define an instance of the database. -->
+
+    <!--<instance name="default" enabled="true" />-->
+
+    <stability value="Evolving" />
+</service>
+</service_bundle>

--- a/instfiles/method/Makefile.am
+++ b/instfiles/method/Makefile.am
@@ -1,0 +1,3 @@
+startscriptdir = /lib/svc/method
+
+dist_startscript_SCRIPTS = xrdp xrdp-sesman

--- a/instfiles/method/xrdp
+++ b/instfiles/method/xrdp
@@ -1,0 +1,85 @@
+#!/bin/bash
+. /lib/svc/share/smf_include.sh
+
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ORACLE_HOME/lib
+export PATH=$PATH:$ORACLE_HOME/bin
+
+VERBOSE=
+NAME=xrdp
+FULLNAME=/usr/local/sbin/$NAME
+TIMEOUT=15
+
+log_if_verbose()
+{
+   if [ -n "$VERBOSE" ]; then
+        echo $@
+   fi
+}
+
+waitFor() {
+    name=$1
+    timeout=$2
+
+    let i=0
+
+    # Loop until we are certain that the process has been stopped
+    while [ $i -lt $timeout ]; do
+        pgrep -xf $name > /dev/null
+        if [ $? -ne 0 ]; then
+            break;
+        fi
+
+        let i=i+1
+        sleep 1
+        log_if_verbose "$i seconds"
+    done
+
+    pgrep -xf $name > /dev/null
+    return $?
+}
+
+function start
+{
+    $FULLNAME
+}
+
+function stop
+{
+    log_if_verbose "Sending TERM to $NAME"
+    pkill -TERM -xf $FULLNAME
+
+    waitFor $FULLNAME $TIMEOUT
+
+    if [ $? -eq 0 ]; then
+        log_if_verbose "Sending KILL to $NAME"
+	pkill -KILL -xf $FULLNAME
+	waitFor $FULLNAME 1
+        rm -f /var/run/$NAME.pid
+    fi
+
+    return $?
+}
+
+function refresh
+{
+   log_if_verbose "Refresh not implemented."
+   return 1;
+}
+
+case $1 in
+    start) start ;;
+    stop)  stop ;;
+    refresh)  refresh;;
+
+    *) echo "Usage: $0 { start | stop | refresh }" >&2
+       exit $SMF_EXIT_ERR_FATAL
+       ;;
+esac
+
+retval=$?
+
+if [ $? -eq 0 ]; then
+  retval=$SMF_EXIT_OK
+fi;
+
+exit $SMF_EXIT_OK

--- a/instfiles/method/xrdp-sesman
+++ b/instfiles/method/xrdp-sesman
@@ -49,15 +49,17 @@ function stop
     pkill -TERM -xf $FULLNAME
 
     waitFor $FULLNAME $TIMEOUT
+    retval=$?
 
     if [ $? -ne 0 ]; then
         log_if_verbose "Sending KILL to $NAME"
 	pkill -KILL -xf $FULLNAME
 	waitFor $FULLNAME 1
+        retval=$?
         rm -f /var/run/$NAME.pid
     fi
 
-    return $?
+    return $retval 
 }
 
 function refresh

--- a/instfiles/method/xrdp-sesman
+++ b/instfiles/method/xrdp-sesman
@@ -1,0 +1,85 @@
+#!/bin/bash
+. /lib/svc/share/smf_include.sh
+
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ORACLE_HOME/lib
+export PATH=$PATH:$ORACLE_HOME/bin
+
+VERBOSE=true
+NAME=xrdp-sesman
+FULLNAME=/usr/local/sbin/$NAME
+TIMEOUT=5
+
+log_if_verbose()
+{
+   if [ -n "$VERBOSE" ]; then
+        echo $@
+   fi
+}
+
+waitFor() {
+    name=$1
+    timeout=$2
+
+    let i=0
+
+    # Loop until we are certain that the process has been stopped
+    while [ $i -lt $timeout ]; do
+        pgrep -xf $name > /dev/null
+        if [ $? -eq 0 ]; then
+            break;
+        fi
+
+        let i=i+1
+        sleep 1
+        log_if_verbose "$i seconds"
+    done
+
+    pgrep -xf $name > /dev/null
+    return $?
+}
+
+function start
+{
+    $FULLNAME
+}
+
+function stop
+{
+    log_if_verbose "Sending TERM to $NAME"
+    pkill -TERM -xf $FULLNAME
+
+    waitFor $FULLNAME $TIMEOUT
+
+    if [ $? -ne 0 ]; then
+        log_if_verbose "Sending KILL to $NAME"
+	pkill -KILL -xf $FULLNAME
+	waitFor $FULLNAME 1
+        rm -f /var/run/$NAME.pid
+    fi
+
+    return $?
+}
+
+function refresh
+{
+   log_if_verbose "Refresh not implemented."
+   return 1;
+}
+
+case $1 in
+    start) start ;;
+    stop)  stop ;;
+    refresh)  refresh;;
+
+    *) echo "Usage: $0 { start | stop | refresh }" >&2
+       exit $SMF_EXIT_ERR_FATAL
+       ;;
+esac
+
+retval=$?
+
+if [ $? -eq 0 ]; then
+  retval=$SMF_EXIT_OK
+fi;
+
+exit $SMF_EXIT_OK

--- a/instfiles/openrc/Makefile.am
+++ b/instfiles/openrc/Makefile.am
@@ -1,0 +1,3 @@
+startscriptdir = $(sysconfdir)/init.d
+
+dist_startscript_SCRIPTS = xrdp xrdp-sesman

--- a/instfiles/openrc/xrdp
+++ b/instfiles/openrc/xrdp
@@ -1,0 +1,4 @@
+#!/sbin/openrc-run
+
+command="/usr/local/sbin/xrdp"
+pidfile="/run/${RC_SVCNAME}.pid"

--- a/instfiles/openrc/xrdp-sesman
+++ b/instfiles/openrc/xrdp-sesman
@@ -1,0 +1,4 @@
+#!/sbin/openrc-run
+
+command="/usr/local/sbin/xrdp-sesman"
+pidfile="/run/${RC_SVCNAME}.pid"

--- a/instfiles/pam.d/xrdp-sesman.macos
+++ b/instfiles/pam.d/xrdp-sesman.macos
@@ -5,7 +5,7 @@ auth       optional       pam_ntlm.so try_first_pass
 auth       optional       pam_mount.so try_first_pass
 auth       required       pam_opendirectory.so try_first_pass
 account    required       pam_nologin.so
-account    required       pam_sacl.so sacl_service=ssh
+account    required       pam_sacl.so sacl_service=xrdp-sesman
 account    required       pam_opendirectory.so
 password   required       pam_opendirectory.so
 session    required       pam_launchd.so

--- a/sesman/Makefile.am
+++ b/sesman/Makefile.am
@@ -10,7 +10,8 @@ AM_CPPFLAGS = \
   -DSESMAN_RUNTIME_PATH=\"${sesmanruntimedir}\" \
   -I$(top_srcdir)/sesman/libsesman \
   -I$(top_srcdir)/common \
-  -I$(top_srcdir)/libipm
+  -I$(top_srcdir)/libipm \
+  $(SDK_FLAGS)
 
 sbin_PROGRAMS = \
   xrdp-sesman
@@ -65,3 +66,10 @@ SUBDIRS = \
   sesexec \
   tools \
   chansrv
+
+if SOLARIS
+# must be tab below.  SOLARIS Xorg does not allow logfile parameter.
+install-data-hook:
+	sed -i 's|param=-logfile|;param=-logfile|g' $(DESTDIR)$(sysconfdir)/xrdp/sesman.ini
+	sed -i 's|param=.xorgxrdp.%s.log|;param=.xorgxrdp.%s.log|g' $(DESTDIR)$(sysconfdir)/xrdp/sesman.ini
+endif

--- a/sesman/Makefile.am
+++ b/sesman/Makefile.am
@@ -10,8 +10,7 @@ AM_CPPFLAGS = \
   -DSESMAN_RUNTIME_PATH=\"${sesmanruntimedir}\" \
   -I$(top_srcdir)/sesman/libsesman \
   -I$(top_srcdir)/common \
-  -I$(top_srcdir)/libipm \
-  $(SDK_FLAGS)
+  -I$(top_srcdir)/libipm 
 
 sbin_PROGRAMS = \
   xrdp-sesman

--- a/sesman/libsesman/verify_user_pam.c
+++ b/sesman/libsesman/verify_user_pam.c
@@ -117,6 +117,7 @@ static int
 verify_pam_conv(int num_msg, const struct pam_message **msg,
                 struct pam_response **resp, void *appdata_ptr)
 {
+    LOG(LOG_LEVEL_TRACE, "verify_pam_conv(%d, msg, resp, appdata_ptr)", num_msg);
     int i;
     struct pam_response *reply = NULL;
     struct conv_func_data *conv_func_data;
@@ -194,6 +195,7 @@ verify_pam_conv(int num_msg, const struct pam_message **msg,
         g_free(reply);
     }
 
+    LOG(LOG_LEVEL_TRACE, "verify_pam_conv() returned %d", rv);
     return rv;
 }
 
@@ -402,6 +404,7 @@ auth_start_session_private(struct auth_info *auth_info, int display_num)
 {
     int error;
     char display[256];
+    LOG(LOG_LEVEL_TRACE, "auth_start_session_private(auth_info, %d)", display_num);
 
     g_sprintf(display, ":%d", display_num);
     error = pam_set_item(auth_info->ph, PAM_TTY, display);
@@ -410,6 +413,7 @@ auth_start_session_private(struct auth_info *auth_info, int display_num)
     {
         LOG(LOG_LEVEL_ERROR, "pam_set_item failed: %s",
             pam_strerror(auth_info->ph, error));
+        LOG(LOG_LEVEL_TRACE, "auth_start_session_private() returned 1");
         return 1;
     }
 
@@ -419,6 +423,7 @@ auth_start_session_private(struct auth_info *auth_info, int display_num)
     {
         LOG(LOG_LEVEL_ERROR, "pam_setcred failed: %s",
             pam_strerror(auth_info->ph, error));
+        LOG(LOG_LEVEL_TRACE, "auth_start_session_private() returned 1");
         return 1;
     }
 
@@ -429,10 +434,12 @@ auth_start_session_private(struct auth_info *auth_info, int display_num)
     {
         LOG(LOG_LEVEL_ERROR, "pam_open_session failed: %s",
             pam_strerror(auth_info->ph, error));
+        LOG(LOG_LEVEL_TRACE, "auth_start_session_private() returned 1");
         return 1;
     }
 
     auth_info->session_opened = 1;
+    LOG(LOG_LEVEL_TRACE, "auth_start_session_private() returned 0");
     return 0;
 }
 
@@ -503,9 +510,10 @@ auth_end(struct auth_info *auth_info)
             pam_end(auth_info->ph, PAM_SUCCESS);
             auth_info->ph = 0;
         }
+        
+	    g_free(auth_info);
     }
 
-    g_free(auth_info);
     return 0;
 }
 

--- a/sesman/sesexec/sesexec.c
+++ b/sesman/sesexec/sesexec.c
@@ -220,6 +220,11 @@ set_sigchld_event(int sig)
     {
         g_set_wait_obj(g_sigchld_event);
     }
+
+#ifdef __sun
+/* On solaris we need to re-register for the signal hander. */
+    g_signal_child_stop(set_sigchld_event);
+#endif
 }
 
 /******************************************************************************/
@@ -241,6 +246,7 @@ sesexec_terminate_main_loop(int status)
 static void
 process_sigchld_event(void)
 {
+    LOG(LOG_LEVEL_TRACE, "process_sigchld_event()");
     struct exit_status e;
     int pid;
 
@@ -249,6 +255,7 @@ process_sigchld_event(void)
     {
         session_process_child_exit(g_session_data, pid, &e);
     }
+    LOG(LOG_LEVEL_TRACE, "process_sigchld_event() returned");
 }
 
 /******************************************************************************/

--- a/sesman/sesexec/session.c
+++ b/sesman/sesexec/session.c
@@ -641,7 +641,7 @@ session_start_wrapped(struct login_info *login_info,
             /* Kill it anyway in case it did start and we just failed to
              * pick up on it */
             g_sigterm(display_pid);
-            g_waitpid(display_pid);
+            g_waitpid(display_pid, 0, 0);
         }
         else
         {
@@ -654,7 +654,7 @@ session_start_wrapped(struct login_info *login_info,
             if (window_manager_pid < 0)
             {
                 g_sigterm(display_pid);
-                g_waitpid(display_pid);
+                g_waitpid(display_pid, 0, 0);
             }
             else
             {

--- a/sesman/sesexec/xwait.c
+++ b/sesman/sesexec/xwait.c
@@ -56,18 +56,20 @@ log_waitforx_messages(FILE *dp)
  * Contruct the command to run to check the X server
  */
 static struct list *
-make_xwait_command(int display)
+make_xwait_command(int display, int wait)
 {
     const char exe[] = XRDP_LIBEXEC_PATH "/waitforx";
     char displaystr[64];
+    char waitstr[64];
 
     struct list *cmd = list_create();
     if (cmd != NULL)
     {
         cmd->auto_free = 1;
         g_snprintf(displaystr, sizeof(displaystr), ":%d", display);
-
-        if (!list_add_strdup_multi(cmd, exe, "-d", displaystr, NULL))
+        g_snprintf(waitstr, sizeof(waitstr), "%d", wait);
+	
+        if (!list_add_strdup_multi(cmd, exe, "-d", displaystr, "-w", waitstr, NULL))
         {
             list_delete(cmd);
             cmd = NULL;
@@ -86,7 +88,7 @@ wait_for_xserver(uid_t uid,
 {
     enum xwait_status rv = XW_STATUS_MISC_ERROR;
     int fd[2] = {-1, -1};
-    struct list *cmd = make_xwait_command(display);
+    struct list *cmd = make_xwait_command(display, 10);
 
 
     // Construct the command to execute to check the display

--- a/sesman/tools/Makefile.am
+++ b/sesman/tools/Makefile.am
@@ -32,6 +32,10 @@ xrdp_dis_SOURCES = \
 xrdp_dis_LDADD = \
   $(top_builddir)/common/libcommon.la
 
+if SOLARIS
+  xrdp_dis_LDADD += -lsocket
+endif
+
 xrdp_xcon_SOURCES = \
   xcon.c
 
@@ -42,6 +46,10 @@ xrdp_sesrun_LDADD = \
   $(top_builddir)/sesman/libsesman/libsesman.la \
   $(top_builddir)/common/libcommon.la \
   $(top_builddir)/libipm/libipm.la
+
+if SOLARIS
+  xrdp_sesrun_LDADD += -lsocket
+endif
 
 xrdp_sesadmin_LDADD = \
   $(top_builddir)/sesman/libsesman/libsesman.la \

--- a/tools/devel/tcp_proxy/Makefile.am
+++ b/tools/devel/tcp_proxy/Makefile.am
@@ -11,3 +11,7 @@ tcp_proxy_SOURCES = \
 tcp_proxy_LDADD = \
   $(top_builddir)/common/libcommon.la \
   $(DLOPEN_LIBS)
+
+if SOLARIS
+  tcp_proxy_LDADD += -lsocket
+endif

--- a/waitforx/waitforx.c
+++ b/waitforx/waitforx.c
@@ -21,9 +21,13 @@ alarm_handler(int signal_num)
      *
      * Prefix the message with a newline in case another message
      * has been partly output */
+
+    if( signal_num == SIGALRM ) 
+    {
     const char msg[] = "\n<E>Timed out waiting for RandR outputs\n";
     g_file_write(1, msg, g_strlen(msg));
     exit(XW_STATUS_TIMED_OUT);
+    }
 }
 
 /*****************************************************************************/
@@ -102,7 +106,7 @@ wait_for_r_and_r(Display *dpy, int wait)
 static void
 usage(const char *argv0, int status)
 {
-    printf("Usage: %s -d display\n", argv0);
+    printf("Usage: %s -d display [-w waittime]\n", argv0);
     exit(status);
 }
 

--- a/xrdp/Makefile.am
+++ b/xrdp/Makefile.am
@@ -110,3 +110,9 @@ dist_xrdppkgdata_DATA = \
   sans-18.fv1 \
   cursor0.cur \
   cursor1.cur
+
+if MACOS
+# must be tab below. Common out Xorg and Xvnc since they don't work on MacOs. 
+install-data-hook:
+	sed -i '' '235,249s/^/;/g' $(DESTDIR)$(sysconfdir)/xrdp/xrdp.ini
+endif

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -2605,16 +2605,35 @@ xrdp_mm_connect_sm(struct xrdp_mm *self)
 
                     gw_username = xrdp_mm_get_value(self, "pamusername");
                     gw_password = xrdp_mm_get_value(self, "pampassword");
-                    if (!g_strcmp(gw_username, "same"))
-                    {
-                        gw_username = xrdp_mm_get_value(self, "username");
-                    }
+		            if( gw_username != NULL )
+		            {
+                        if (!g_strcmp(gw_username, "same"))
+                        {
+                            gw_username = xrdp_mm_get_value(self, "username");
+                  	    }
+		    
+		                if( !g_strncmp("ask", gw_username, 3))
+		                { 
+		                    gw_username = self->wm->session->client_info->username;
+		                }
+		            }
 
-                    if (gw_password == NULL ||
-                            !g_strcmp(gw_password, "same"))
-                    {
+                    if (gw_password != NULL ) 
+		    {
+                    	if( !g_strcmp(gw_password, "same"))
+                    	{
+                       	    gw_password = xrdp_mm_get_value(self, "password");
+                    	}
+		    	
+	                if( !g_strncmp("ask", gw_password, 3)) 
+		        {
+			    gw_password = self->wm->session->client_info->password;
+			}
+		    }
+		    else
+		    {
                         gw_password = xrdp_mm_get_value(self, "password");
-                    }
+		    }
 
                     if (gw_username == NULL || gw_password == NULL)
                     {


### PR DESCRIPTION
I use XRDP extensively on many different machines I manage, but had a few platforms where I couldn't get it to work.  So I went though the effort of getting these platforms to work, and wanted to offer the changes.  Almost all of the changes were focused on the os_calls file, and also added some additional startup configs for each platform.  I made these changes against the development branch, but I also have a working version against the last official release.  I originally had problems with shared memory and xorgxrdp, but looks like the posix changes in the current development branch fixed all of that, great work!  (Although OpenIndiana requires some build flags, will open a pull request for that ).

NetBSD:

-    g_sck_get_peer_cred:  Added NetBSDs flavor of this.
-    g_sleep:  NetBSD has a quirk where you can't usleep for more than 1,000,000 microseconds( 1 second ), so created a hybrid sleep, usleep method for netbsd.
-    service scripts are the same as for freebsd, added checks for this to install.
-    Note I used pkgsrc to install all required libraries.  Also note that building against native BSD pam libraries causes undefined symbols, so I built against openpam.  

OpenIndiana:

-    g_sck_get_peer_cred:  Added OpenIndiana's flavor of this.
-    Have to re-register for SIGCHLD after signal is handled.
-    Getting strange EINTRs, standard way of handling this is to retry on EINTR.  Modified the g_waitpid function to do the automatic retry.  This resolved a number of strange errors.  This should be a standard way to handle EINTR, so I did not #ifdef it.  I tried it on Linux platforms and did not see any issue with it.  Also modified a few calls doing a direct waitpid to call the g_waitpid instead.
-   Modified alarm registration to also handle SIGINT.  Again, believe this should not need to be #ifdef, but could be.
-   While testing, added an extra parameter to the new xwait program to allow the wait time to be configurable.
-   Build flags required -D_XOPEN_SOURCE=600 so posix calls are allowed.  Also need this for xorgxrdp.
-   Added manifest and method files for SMF for services.  
-   Note this code should work on Solaris, but I do not have access to any Solaris environments so can't test.  
-   Commented out line specifying config file when running Xorg, doesn't work on OpenIndiana.
-   One issue.  I could not get PAM to work on OpenIndiana, I had numerous problems.  It looks like enable-pam defaults to yes, and I couldn't find a way to turn it off.  So I changed enable-pam to default to no.  A second option would be to change this to --disable-pam if you want PAM to be the default, or add an explicit --enable-builtin option but I was getting tired of fighting with autoconf to get it right.  I can look at this change some more if it is an issue. 

GentooLinux:

-   Added support for OpenRC and startup files to the build.  Added --enable-openrc to install them.  

MacOS:

-    Added plist files to run xrdp and xrdp-sesman.  Note these rely on a tool available with the macports install, daemondo, which I find is really useful to get traditional services to play nicely with launchd.  But of course, user can just modify the installed files to run however they want.  All dependent libraries were installed via macports including build tools ( autoconf, automake, etc. )
-   Added install hook to comment out Xorg and Xvnc blocks automatically, since I believe the only way possible to run on MacOS is through vnc-any.  
-   Made minor enhancement to facilitate how I run it.  You have a nice gateway method where you can configure the sesman to act as a gateway for login. However, when I use this with the any-vnc configuration, I could not find a way to configure it because I need the gateway password to be the password the user entered, and the password to be the password for the VNC server.  So added the "ask" option for the gateway username and gateway password so they can use the rdp username and password.  Running this way, I don't have to rely on VNC with its low security password, and instead can do real authentication.  I can also lock down the VNC server to localhost only.  My current VNC server of choice is currently OSXvnc-server( now vine server ).  I find the performance is quite good.
-   I was getting a crash in the PAM code.  I found one issue where an object was being freed outside of a null check on it.  For some reason this only manifested on MacOS.

I believe I have summarized all of the changes.  I also added some additional logging various places while I was identifying the issues.  I can also offer to help support these in the future, since I plan to actively use xrdp on these platforms.  If you have any questions let me know.

  

