### PR TITLE
Support NetBsd and OpenIndiana

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -28,7 +28,7 @@ AM_CPPFLAGS = \
   -DXRDP_SHARE_PATH=\"${datadir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \
   -DXRDP_LOG_PATH=\"${localstatedir}/log\" \
-  -DXRDP_SOCKET_PATH=\"${socketdir}\" 
+  -DXRDP_SOCKET_PATH=\"${socketdir}\"
 
 # -no-suppress is an automake-specific flag which is needed
 # to prevent us missing compiler errors in some circumstances

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -28,7 +28,7 @@ AM_CPPFLAGS = \
   -DXRDP_SHARE_PATH=\"${datadir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \
   -DXRDP_LOG_PATH=\"${localstatedir}/log\" \
-  -DXRDP_SOCKET_PATH=\"${socketdir}\"
+  -DXRDP_SOCKET_PATH=\"${socketdir}\" 
 
 # -no-suppress is an automake-specific flag which is needed
 # to prevent us missing compiler errors in some circumstances

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -3483,8 +3483,9 @@ g_waitpid(int pid, int *stat_loc, int options)
     return 0;
 #else
     int rv = 0;
-
+#if defined(__NetBSD__) || defined(__sun)
 again:
+#endif
     rv = waitpid(pid, stat_loc, options);
 #if defined(__NetBSD__) || defined(__sun)
     //Retry EINTR for NetBSD and OpenIndiana.

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -300,7 +300,7 @@ int      g_setlogin(const char *name);
 int      g_set_allusercontext(int uid);
 #endif
 int      g_waitchild(struct exit_status *e);
-int      g_waitpid(int pid);
+int      g_waitpid(int pid, int *stat_loc, int options);
 struct exit_status g_waitpid_status(int pid);
 /*
  * Sets the process group ID of the indicated process to the specified value.

--- a/configure.ac
+++ b/configure.ac
@@ -89,10 +89,10 @@ AC_ARG_ENABLE(tests,
               AS_HELP_STRING([--enable-tests],
               [Ensure dependencies for the tests are installed]),
               [ensure_tests_deps=yes], [])
-AC_ARG_ENABLE(pam, AS_HELP_STRING([--enable-pam],
+AC_ARG_ENABLE(nopam, AS_HELP_STRING([--enable-nopam],
               [Build PAM support (default: no)]),
-              [], [enable_pam=no])
-AM_CONDITIONAL(SESMAN_NOPAM, [test x$enable_pam != xyes])
+              [enable_nopam=yes], [enable_nopam=no])
+AM_CONDITIONAL(SESMAN_NOPAM, [test x$enable_nopam = xyes])
 AC_ARG_ENABLE(vsock, AS_HELP_STRING([--enable-vsock],
               [Build AF_VSOCK support (default: no)]),
               [], [enable_vsock=no])
@@ -103,7 +103,7 @@ AC_ARG_ENABLE(ipv6only, AS_HELP_STRING([--enable-ipv6only],
               [Build IPv6-only (default: no)]),
               [], [enable_ipv6only=no])
 AC_ARG_ENABLE(kerberos, AS_HELP_STRING([--enable-kerberos],
-              [Build kerberos support (prefer --enable-pam if available) (default: no)]),
+              [Build kerberos support (default: no)]),
               [], [enable_kerberos=no])
 AC_ARG_ENABLE(bsd, AS_HELP_STRING([--enable-bsd],
               [Build BSD auth support (default: no)]),
@@ -345,12 +345,12 @@ auth_cnt=0
 auth_mech="Builtin"
 AUTHMOD_OBJ=verify_user.lo
 AUTHMOD_LIB=-lcrypt
-if test x$enable_pam = xyes
+if test x$enable_nopam = xyes
 then
   auth_cnt=`expr $auth_cnt + 1`
-  auth_mech="PAM"
-  AUTHMOD_OBJ=verify_user_pam.lo
-  AUTHMOD_LIB=-lpam
+  auth_mech="No PAM"
+  AUTHMOD_OBJ=verify_user.lo
+  AUTHMOD_LIB=
 fi
 if test x$bsd = xtrue
 then
@@ -373,17 +373,23 @@ then
   AUTHMOD_OBJ=verify_user_pam_userpass.lo
   AUTHMOD_LIB="-lpam -lpam_userpass"
 fi
-
+if test $auth_cnt -eq 0
+then
+  auth_cnt=`expr $auth_cnt + 1`
+  auth_mech="Enable PAM"
+  AUTHMOD_OBJ=verify_user_pam.lo
+  AUTHMOD_LIB=-lpam
+fi
 if test $auth_cnt -gt 1
 then
-  AC_MSG_ERROR([--enable-pam, --enable-bsd, --enable-pamuserpass and --enable-kerberos are mutually exclusive])
+  AC_MSG_ERROR([--enable-nopam, --enable-bsd, --enable-pamuserpass and --enable-kerberos are mutually exclusive])
 fi
 
 AC_SUBST([AUTHMOD_OBJ])
 AC_SUBST([AUTHMOD_LIB])
 
 # checking if pam should be autodetected.
-if test "x$enable_pam" = "xyes"
+if test "x$enable_nopam" != "xyes"
 then
   if test -z "$enable_bsd"
   then

--- a/configure.ac
+++ b/configure.ac
@@ -89,10 +89,10 @@ AC_ARG_ENABLE(tests,
               AS_HELP_STRING([--enable-tests],
               [Ensure dependencies for the tests are installed]),
               [ensure_tests_deps=yes], [])
-AC_ARG_ENABLE(pam, AS_HELP_STRING([--enable-pam],
+AC_ARG_ENABLE(nopam, AS_HELP_STRING([--enable-nopam],
               [Build PAM support (default: no)]),
-              [], [enable_pam=no])
-AM_CONDITIONAL(SESMAN_NOPAM, [test x$enable_pam != xyes])
+              [enable_nopam=yes], [enable_nopam=no])
+AM_CONDITIONAL(SESMAN_NOPAM, [test x$enable_nopam = xyes])
 AC_ARG_ENABLE(vsock, AS_HELP_STRING([--enable-vsock],
               [Build AF_VSOCK support (default: no)]),
               [], [enable_vsock=no])
@@ -103,7 +103,7 @@ AC_ARG_ENABLE(ipv6only, AS_HELP_STRING([--enable-ipv6only],
               [Build IPv6-only (default: no)]),
               [], [enable_ipv6only=no])
 AC_ARG_ENABLE(kerberos, AS_HELP_STRING([--enable-kerberos],
-              [Build kerberos support (prefer --enable-pam if available) (default: no)]),
+              [Build kerberos support (default: no)]),
               [], [enable_kerberos=no])
 AC_ARG_ENABLE(bsd, AS_HELP_STRING([--enable-bsd],
               [Build BSD auth support (default: no)]),
@@ -345,12 +345,12 @@ auth_cnt=0
 auth_mech="Builtin"
 AUTHMOD_OBJ=verify_user.lo
 AUTHMOD_LIB=-lcrypt
-if test x$enable_pam = xyes
+if test x$enable_nopam = xyes
 then
   auth_cnt=`expr $auth_cnt + 1`
-  auth_mech="PAM"
-  AUTHMOD_OBJ=verify_user_pam.lo
-  AUTHMOD_LIB=-lpam
+  auth_mech="No PAM"
+  AUTHMOD_OBJ=verify_user.lo
+  AUTHMOD_LIB=
 fi
 if test x$bsd = xtrue
 then
@@ -373,17 +373,23 @@ then
   AUTHMOD_OBJ=verify_user_pam_userpass.lo
   AUTHMOD_LIB="-lpam -lpam_userpass"
 fi
-
+if test $auth_cnt -eq 0
+then
+  auth_cnt=`expr $auth_cnt + 1`
+  auth_mech="Enable PAM"
+  AUTHMOD_OBJ=verify_user_pam.lo
+  AUTHMOD_LIB=-lpam
+fi
 if test $auth_cnt -gt 1
 then
-  AC_MSG_ERROR([--enable-pam, --enable-bsd, --enable-pamuserpass and --enable-kerberos are mutually exclusive])
+  AC_MSG_ERROR([--enable-nopam, --enable-bsd, --enable-pamuserpass and --enable-kerberos are mutually exclusive])
 fi
 
 AC_SUBST([AUTHMOD_OBJ])
 AC_SUBST([AUTHMOD_LIB])
 
 # checking if pam should be autodetected.
-if test "x$enable_pam" = "xyes"
+if test "x$enable_nopam" = "xno"
 then
   if test -z "$enable_bsd"
   then

--- a/configure.ac
+++ b/configure.ac
@@ -39,6 +39,9 @@ case $host_os in
 	*darwin*)
 		macos=yes
 		;;
+        *solaris*)
+		solaris=yes
+		;;
 esac
 
 AM_CONDITIONAL(LINUX, [test "x$linux" = xyes])
@@ -46,6 +49,7 @@ AM_CONDITIONAL(FREEBSD, [test "x$freebsd" = xyes])
 AM_CONDITIONAL(OPENBSD, [test "x$openbsd" = xyes])
 AM_CONDITIONAL(NETBSD, [test "x$netbsd" = xyes])
 AM_CONDITIONAL(MACOS, [test "x$macos" = xyes])
+AM_CONDITIONAL(SOLARIS, [test "x$solaris" = xyes])
 
 AC_CHECK_SIZEOF([int])
 AC_CHECK_SIZEOF([long])
@@ -86,8 +90,8 @@ AC_ARG_ENABLE(tests,
               [Ensure dependencies for the tests are installed]),
               [ensure_tests_deps=yes], [])
 AC_ARG_ENABLE(pam, AS_HELP_STRING([--enable-pam],
-              [Build PAM support (default: yes)]),
-              [], [enable_pam=yes])
+              [Build PAM support (default: no)]),
+              [], [enable_pam=no])
 AM_CONDITIONAL(SESMAN_NOPAM, [test x$enable_pam != xyes])
 AC_ARG_ENABLE(vsock, AS_HELP_STRING([--enable-vsock],
               [Build AF_VSOCK support (default: no)]),
@@ -284,6 +288,11 @@ esac
 
 if test x$use_imlib2 = xyes; then
     AC_DEFINE([USE_IMLIB2],1, [Compile with imlib2 support])
+fi
+
+if test x$solaris = xyes; then
+    CFLAGS="${CFLAGS} -D_XOPEN_SOURCE=600"
+    AC_SUBST(CFLAGS)
 fi
 
 # Find freetype2
@@ -580,6 +589,8 @@ AC_CONFIG_FILES([
   instfiles/pam.d/Makefile
   instfiles/pulse/Makefile
   instfiles/rc.d/Makefile
+  instfiles/method/Makefile
+  instfiles/manifest/Makefile
   keygen/Makefile
   waitforx/Makefile
   libipm/Makefile
@@ -658,6 +669,7 @@ echo "  unit tests performable  $perform_unit_tests"
 echo ""
 echo "  CFLAGS = $CFLAGS"
 echo "  LDFLAGS = $LDFLAGS"
+echo "  CPPFLAGS = $CPPFLAGS"
 
 # xrdp_configure_options.h will be written to the build directory, not the source directory
 echo '#define XRDP_CONFIGURE_OPTIONS \' > ./xrdp_configure_options.h

--- a/configure.ac
+++ b/configure.ac
@@ -389,7 +389,7 @@ AC_SUBST([AUTHMOD_OBJ])
 AC_SUBST([AUTHMOD_LIB])
 
 # checking if pam should be autodetected.
-if test "x$enable_nopam" != "xyes"
+if test "x$enable_nopam" = "xno"
 then
   if test -z "$enable_bsd"
   then

--- a/instfiles/Makefile.am
+++ b/instfiles/Makefile.am
@@ -79,6 +79,19 @@ SUBDIRS += \
   pulse
 endif
 
+if NETBSD
+SUBDIRS += \
+  pam.d \
+  rc.d \
+  pulse
+endif
+
+if SOLARIS
+SUBDIRS += \
+  manifest \
+  method
+endif
+
 if MACOS
 SUBDIRS += pam.d
 endif
@@ -99,5 +112,14 @@ if FREEBSD
 # must be tab below
 install-data-hook:
 	sed -i '' 's|%%PREFIX%%|$(prefix)|g' $(DESTDIR)$(sysconfdir)/rc.d/xrdp \
+                                         $(DESTDIR)$(sysconfdir)/rc.d/xrdp-sesman
+endif
+
+if NETBSD
+# must be tab below
+install-data-hook:
+	sed -i 's|%%PREFIX%%/sbin|$(prefix)/sbin|g' $(DESTDIR)$(sysconfdir)/rc.d/xrdp \
+                                         $(DESTDIR)$(sysconfdir)/rc.d/xrdp-sesman
+	sed -i 's|%%PREFIX%%||g' $(DESTDIR)$(sysconfdir)/rc.d/xrdp \
                                          $(DESTDIR)$(sysconfdir)/rc.d/xrdp-sesman
 endif

--- a/instfiles/manifest/Makefile.am
+++ b/instfiles/manifest/Makefile.am
@@ -1,0 +1,3 @@
+startscriptdir = /lib/svc/manifest/site
+
+dist_startscript_SCRIPTS = xrdp.xml xrdp-sesman.xml

--- a/instfiles/manifest/xrdp-sesman.xml
+++ b/instfiles/manifest/xrdp-sesman.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+
+<!--
+ Define a service to control the startup and shutdown of a database instance.
+-->
+
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+
+<service_bundle type="manifest" name="xrdp-sesman">
+<service name="site/application/network/xrdp-sesman" type="service" version="1">
+    <create_default_instance enabled="true" />
+
+    <!--
+         Wait for all local file systems to be mounted.
+         Wait for all network interfaces to be initialized.
+    -->
+
+    <dependency type="service"
+        name="fs-local"
+        grouping="require_all"
+        restart_on="none">
+        <service_fmri value="svc:/system/filesystem/local" />
+    </dependency>
+
+    <dependency type="service"
+        name="network"
+        grouping="require_all"
+        restart_on="none">
+        <service_fmri value="svc:/milestone/network:default" />
+    </dependency>
+
+    <!-- Define the methods. -->
+    <exec_method type="method"
+        name="start"
+        exec="/lib/svc/method/xrdp-sesman start"
+        timeout_seconds="120"/>
+
+    <exec_method type="method"
+        name="stop"
+        exec="/lib/svc/method/xrdp-sesman stop"
+        timeout_seconds="120" />
+
+    <!--
+         What authorization is needed to allow the framework
+         general/enabled property to be changed when performing the
+         action (enable, disable, etc) on the service.
+    -->
+
+    <!-- Define an instance of the database. -->
+
+    <!--<instance name="default" enabled="true" />-->
+
+    <stability value="Evolving" />
+</service>
+</service_bundle>

--- a/instfiles/manifest/xrdp.xml
+++ b/instfiles/manifest/xrdp.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+
+<!--
+ Define a service to control the startup and shutdown of a database instance.
+-->
+
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+
+<service_bundle type="manifest" name="xrdp">
+<service name="site/application/network/xrdp" type="service" version="1">
+    <create_default_instance enabled="true" />
+
+    <!--
+         Wait for all local file systems to be mounted.
+         Wait for all network interfaces to be initialized.
+    -->
+
+    <dependency type="service"
+        name="fs-local"
+        grouping="require_all"
+        restart_on="none">
+        <service_fmri value="svc:/system/filesystem/local" />
+    </dependency>
+
+    <dependency type="service"
+        name="network"
+        grouping="require_all"
+        restart_on="none">
+        <service_fmri value="svc:/milestone/network:default" />
+    </dependency>
+
+    <!-- Define the methods. -->
+    <exec_method type="method"
+        name="start"
+        exec="/lib/svc/method/xrdp start"
+        timeout_seconds="120"/>
+
+    <exec_method type="method"
+        name="stop"
+        exec="/lib/svc/method/xrdp stop"
+        timeout_seconds="120" />
+
+    <!--
+         What authorization is needed to allow the framework
+         general/enabled property to be changed when performing the
+         action (enable, disable, etc) on the service.
+    -->
+
+    <!-- Define an instance of the database. -->
+
+    <!--<instance name="default" enabled="true" />-->
+
+    <stability value="Evolving" />
+</service>
+</service_bundle>

--- a/instfiles/method/Makefile.am
+++ b/instfiles/method/Makefile.am
@@ -1,0 +1,3 @@
+startscriptdir = /lib/svc/method
+
+dist_startscript_SCRIPTS = xrdp xrdp-sesman

--- a/instfiles/method/xrdp
+++ b/instfiles/method/xrdp
@@ -1,0 +1,85 @@
+#!/bin/bash
+. /lib/svc/share/smf_include.sh
+
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ORACLE_HOME/lib
+export PATH=$PATH:$ORACLE_HOME/bin
+
+VERBOSE=
+NAME=xrdp
+FULLNAME=/usr/local/sbin/$NAME
+TIMEOUT=15
+
+log_if_verbose()
+{
+   if [ -n "$VERBOSE" ]; then
+        echo $@
+   fi
+}
+
+waitFor() {
+    name=$1
+    timeout=$2
+
+    let i=0
+
+    # Loop until we are certain that the process has been stopped
+    while [ $i -lt $timeout ]; do
+        pgrep -xf $name > /dev/null
+        if [ $? -ne 0 ]; then
+            break;
+        fi
+
+        let i=i+1
+        sleep 1
+        log_if_verbose "$i seconds"
+    done
+
+    pgrep -xf $name > /dev/null
+    return $?
+}
+
+function start
+{
+    $FULLNAME
+}
+
+function stop
+{
+    log_if_verbose "Sending TERM to $NAME"
+    pkill -TERM -xf $FULLNAME
+
+    waitFor $FULLNAME $TIMEOUT
+
+    if [ $? -eq 0 ]; then
+        log_if_verbose "Sending KILL to $NAME"
+	pkill -KILL -xf $FULLNAME
+	waitFor $FULLNAME 1
+        rm -f /var/run/$NAME.pid
+    fi
+
+    return $?
+}
+
+function refresh
+{
+   log_if_verbose "Refresh not implemented."
+   return 1;
+}
+
+case $1 in
+    start) start ;;
+    stop)  stop ;;
+    refresh)  refresh;;
+
+    *) echo "Usage: $0 { start | stop | refresh }" >&2
+       exit $SMF_EXIT_ERR_FATAL
+       ;;
+esac
+
+retval=$?
+
+if [ $? -eq 0 ]; then
+  retval=$SMF_EXIT_OK
+fi;
+
+exit $SMF_EXIT_OK

--- a/instfiles/method/xrdp-sesman
+++ b/instfiles/method/xrdp-sesman
@@ -1,0 +1,87 @@
+#!/bin/bash
+. /lib/svc/share/smf_include.sh
+
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ORACLE_HOME/lib
+export PATH=$PATH:$ORACLE_HOME/bin
+
+VERBOSE=true
+NAME=xrdp-sesman
+FULLNAME=/usr/local/sbin/$NAME
+TIMEOUT=5
+
+log_if_verbose()
+{
+   if [ -n "$VERBOSE" ]; then
+        echo $@
+   fi
+}
+
+waitFor() {
+    name=$1
+    timeout=$2
+
+    let i=0
+
+    # Loop until we are certain that the process has been stopped
+    while [ $i -lt $timeout ]; do
+        pgrep -xf $name > /dev/null
+        if [ $? -eq 0 ]; then
+            break;
+        fi
+
+        let i=i+1
+        sleep 1
+        log_if_verbose "$i seconds"
+    done
+
+    pgrep -xf $name > /dev/null
+    return $?
+}
+
+function start
+{
+    $FULLNAME
+}
+
+function stop
+{
+    log_if_verbose "Sending TERM to $NAME"
+    pkill -TERM -xf $FULLNAME
+
+    waitFor $FULLNAME $TIMEOUT
+    retval=$?
+
+    if [ $? -ne 0 ]; then
+        log_if_verbose "Sending KILL to $NAME"
+	pkill -KILL -xf $FULLNAME
+	waitFor $FULLNAME 1
+        retval=$?
+        rm -f /var/run/$NAME.pid
+    fi
+
+    return $retval 
+}
+
+function refresh
+{
+   log_if_verbose "Refresh not implemented."
+   return 1;
+}
+
+case $1 in
+    start) start ;;
+    stop)  stop ;;
+    refresh)  refresh;;
+
+    *) echo "Usage: $0 { start | stop | refresh }" >&2
+       exit $SMF_EXIT_ERR_FATAL
+       ;;
+esac
+
+retval=$?
+
+if [ $? -eq 0 ]; then
+  retval=$SMF_EXIT_OK
+fi;
+
+exit $SMF_EXIT_OK

--- a/sesman/Makefile.am
+++ b/sesman/Makefile.am
@@ -65,3 +65,10 @@ SUBDIRS = \
   sesexec \
   tools \
   chansrv
+
+if SOLARIS
+# must be tab below.  SOLARIS Xorg does not allow logfile parameter.
+install-data-hook:
+	sed -i 's|param=-logfile|;param=-logfile|g' $(DESTDIR)$(sysconfdir)/xrdp/sesman.ini
+	sed -i 's|param=.xorgxrdp.%s.log|;param=.xorgxrdp.%s.log|g' $(DESTDIR)$(sysconfdir)/xrdp/sesman.ini
+endif

--- a/sesman/libsesman/verify_user_pam.c
+++ b/sesman/libsesman/verify_user_pam.c
@@ -503,9 +503,10 @@ auth_end(struct auth_info *auth_info)
             pam_end(auth_info->ph, PAM_SUCCESS);
             auth_info->ph = 0;
         }
+
+        g_free(auth_info);
     }
 
-    g_free(auth_info);
     return 0;
 }
 

--- a/sesman/sesexec/sesexec.c
+++ b/sesman/sesexec/sesexec.c
@@ -222,7 +222,7 @@ set_sigchld_event(int sig)
     }
 
 #ifdef __sun
-/* On solaris we need to re-register for the signal hander. */
+    /* On solaris we need to re-register for the signal hander. */
     g_signal_child_stop(set_sigchld_event);
 #endif
 }

--- a/sesman/sesexec/sesexec.c
+++ b/sesman/sesexec/sesexec.c
@@ -220,6 +220,11 @@ set_sigchld_event(int sig)
     {
         g_set_wait_obj(g_sigchld_event);
     }
+
+#ifdef __sun
+/* On solaris we need to re-register for the signal hander. */
+    g_signal_child_stop(set_sigchld_event);
+#endif
 }
 
 /******************************************************************************/
@@ -241,6 +246,7 @@ sesexec_terminate_main_loop(int status)
 static void
 process_sigchld_event(void)
 {
+    LOG(LOG_LEVEL_TRACE, "process_sigchld_event()");
     struct exit_status e;
     int pid;
 
@@ -249,6 +255,7 @@ process_sigchld_event(void)
     {
         session_process_child_exit(g_session_data, pid, &e);
     }
+    LOG(LOG_LEVEL_TRACE, "process_sigchld_event() returned");
 }
 
 /******************************************************************************/

--- a/sesman/sesexec/session.c
+++ b/sesman/sesexec/session.c
@@ -641,7 +641,7 @@ session_start_wrapped(struct login_info *login_info,
             /* Kill it anyway in case it did start and we just failed to
              * pick up on it */
             g_sigterm(display_pid);
-            g_waitpid(display_pid);
+            g_waitpid(display_pid, 0, 0);
         }
         else
         {
@@ -654,7 +654,7 @@ session_start_wrapped(struct login_info *login_info,
             if (window_manager_pid < 0)
             {
                 g_sigterm(display_pid);
-                g_waitpid(display_pid);
+                g_waitpid(display_pid, 0, 0);
             }
             else
             {

--- a/sesman/sesexec/xwait.c
+++ b/sesman/sesexec/xwait.c
@@ -68,7 +68,7 @@ make_xwait_command(int display, int wait)
         cmd->auto_free = 1;
         g_snprintf(displaystr, sizeof(displaystr), ":%d", display);
         g_snprintf(waitstr, sizeof(waitstr), "%d", wait);
-	
+
         if (!list_add_strdup_multi(cmd, exe, "-d", displaystr, "-w", waitstr, NULL))
         {
             list_delete(cmd);

--- a/sesman/sesexec/xwait.c
+++ b/sesman/sesexec/xwait.c
@@ -56,18 +56,20 @@ log_waitforx_messages(FILE *dp)
  * Contruct the command to run to check the X server
  */
 static struct list *
-make_xwait_command(int display)
+make_xwait_command(int display, int wait)
 {
     const char exe[] = XRDP_LIBEXEC_PATH "/waitforx";
     char displaystr[64];
+    char waitstr[64];
 
     struct list *cmd = list_create();
     if (cmd != NULL)
     {
         cmd->auto_free = 1;
         g_snprintf(displaystr, sizeof(displaystr), ":%d", display);
-
-        if (!list_add_strdup_multi(cmd, exe, "-d", displaystr, NULL))
+        g_snprintf(waitstr, sizeof(waitstr), "%d", wait);
+	
+        if (!list_add_strdup_multi(cmd, exe, "-d", displaystr, "-w", waitstr, NULL))
         {
             list_delete(cmd);
             cmd = NULL;
@@ -86,7 +88,7 @@ wait_for_xserver(uid_t uid,
 {
     enum xwait_status rv = XW_STATUS_MISC_ERROR;
     int fd[2] = {-1, -1};
-    struct list *cmd = make_xwait_command(display);
+    struct list *cmd = make_xwait_command(display, 10);
 
 
     // Construct the command to execute to check the display

--- a/sesman/tools/Makefile.am
+++ b/sesman/tools/Makefile.am
@@ -32,6 +32,10 @@ xrdp_dis_SOURCES = \
 xrdp_dis_LDADD = \
   $(top_builddir)/common/libcommon.la
 
+if SOLARIS
+  xrdp_dis_LDADD += -lsocket
+endif
+
 xrdp_xcon_SOURCES = \
   xcon.c
 
@@ -42,6 +46,10 @@ xrdp_sesrun_LDADD = \
   $(top_builddir)/sesman/libsesman/libsesman.la \
   $(top_builddir)/common/libcommon.la \
   $(top_builddir)/libipm/libipm.la
+
+if SOLARIS
+  xrdp_sesrun_LDADD += -lsocket
+endif
 
 xrdp_sesadmin_LDADD = \
   $(top_builddir)/sesman/libsesman/libsesman.la \

--- a/tools/devel/tcp_proxy/Makefile.am
+++ b/tools/devel/tcp_proxy/Makefile.am
@@ -11,3 +11,7 @@ tcp_proxy_SOURCES = \
 tcp_proxy_LDADD = \
   $(top_builddir)/common/libcommon.la \
   $(DLOPEN_LIBS)
+
+if SOLARIS
+  tcp_proxy_LDADD += -lsocket
+endif

--- a/waitforx/waitforx.c
+++ b/waitforx/waitforx.c
@@ -22,11 +22,11 @@ alarm_handler(int signal_num)
      * Prefix the message with a newline in case another message
      * has been partly output */
 
-    if( signal_num == SIGALRM ) 
+    if ( signal_num == SIGALRM )
     {
-    const char msg[] = "\n<E>Timed out waiting for RandR outputs\n";
-    g_file_write(1, msg, g_strlen(msg));
-    exit(XW_STATUS_TIMED_OUT);
+        const char msg[] = "\n<E>Timed out waiting for RandR outputs\n";
+        g_file_write(1, msg, g_strlen(msg));
+        exit(XW_STATUS_TIMED_OUT);
     }
 }
 
@@ -132,8 +132,8 @@ main(int argc, char **argv)
                 display_name = optarg;
                 break;
             case 'w':
-		wait = atoi(optarg);
-  		break;
+                wait = atoi(optarg);
+                break;
             default: /* '?' */
                 usage(argv[0], status);
         }

--- a/waitforx/waitforx.c
+++ b/waitforx/waitforx.c
@@ -32,7 +32,7 @@ alarm_handler(int signal_num)
 
 /*****************************************************************************/
 static Display *
-open_display(const char *display, const int wait)
+open_display(const char *display, const unsigned int wait)
 {
     Display *dpy = NULL;
     unsigned int n;
@@ -60,7 +60,7 @@ open_display(const char *display, const int wait)
  * @return 0 if/when outputs are available, 1 otherwise
  */
 static int
-wait_for_r_and_r(Display *dpy, int wait)
+wait_for_r_and_r(Display *dpy, unsigned int wait)
 {
     int error_base = 0;
     int event_base = 0;

--- a/waitforx/waitforx.c
+++ b/waitforx/waitforx.c
@@ -21,20 +21,23 @@ alarm_handler(int signal_num)
      *
      * Prefix the message with a newline in case another message
      * has been partly output */
+
+    if( signal_num == SIGALRM ) 
+    {
     const char msg[] = "\n<E>Timed out waiting for RandR outputs\n";
     g_file_write(1, msg, g_strlen(msg));
     exit(XW_STATUS_TIMED_OUT);
+    }
 }
 
 /*****************************************************************************/
 static Display *
-open_display(const char *display)
+open_display(const char *display, const int wait)
 {
     Display *dpy = NULL;
-    unsigned int wait = ATTEMPTS;
     unsigned int n;
 
-    for (n = 1; n <= ATTEMPTS; ++n)
+    for (n = 1; n <= wait; ++n)
     {
         printf("<D>Opening display %s. Attempt %u of %u\n", display, n, wait);
         dpy = XOpenDisplay(display);
@@ -57,12 +60,11 @@ open_display(const char *display)
  * @return 0 if/when outputs are available, 1 otherwise
  */
 static int
-wait_for_r_and_r(Display *dpy)
+wait_for_r_and_r(Display *dpy, int wait)
 {
     int error_base = 0;
     int event_base = 0;
     unsigned int outputs = 0;
-    unsigned int wait = ATTEMPTS;
     unsigned int n;
 
     XRRScreenResources *res = NULL;
@@ -104,7 +106,7 @@ wait_for_r_and_r(Display *dpy)
 static void
 usage(const char *argv0, int status)
 {
-    printf("Usage: %s -d display\n", argv0);
+    printf("Usage: %s -d display [-w waittime]\n", argv0);
     exit(status);
 }
 
@@ -115,19 +117,23 @@ main(int argc, char **argv)
     const char *display_name = NULL;
     int opt;
     int status = XW_STATUS_MISC_ERROR;
+    unsigned int wait = ATTEMPTS;
     Display *dpy = NULL;
 
     /* Disable stdout buffering so any messages are passed immediately
      * to sesman */
     setvbuf(stdout, NULL, _IONBF, 0);
 
-    while ((opt = getopt(argc, argv, "d:")) != -1)
+    while ((opt = getopt(argc, argv, "d:w:")) != -1)
     {
         switch (opt)
         {
             case 'd':
                 display_name = optarg;
                 break;
+            case 'w':
+		wait = atoi(optarg);
+  		break;
             default: /* '?' */
                 usage(argv[0], status);
         }
@@ -140,7 +146,7 @@ main(int argc, char **argv)
 
     g_set_alarm(alarm_handler, ALARM_WAIT);
 
-    dpy = open_display(display_name);
+    dpy = open_display(display_name, wait);
     if (!dpy)
     {
         printf("<E>Unable to open display %s\n", display_name);
@@ -148,7 +154,7 @@ main(int argc, char **argv)
     }
     else
     {
-        if (wait_for_r_and_r(dpy) == 0)
+        if (wait_for_r_and_r(dpy, wait) == 0)
         {
             status = XW_STATUS_OK;
         }

--- a/xrdp/Makefile.am
+++ b/xrdp/Makefile.am
@@ -110,3 +110,4 @@ dist_xrdppkgdata_DATA = \
   sans-18.fv1 \
   cursor0.cur \
   cursor1.cur
+


### PR DESCRIPTION
This will be a combined 2 + 3 for my OS Pull request.  After testing it out, NetBsd requires all of the changes I made for OpenIndiana regarding the SIGINT problem with waitpid, so the actual differences in the changes for the two is minimal.  So for these two it's best to perform the changes in one pull request to avoid a huge overlap and possible breakage.  I wanted to get the initial branch done, then will look at some of the previous comments.  I know of two that I need to address, the formatting issues in the code in some places, will run the script to clean those up, and also change the default pam option back to enabled, and add a --enable-native flag to disable pam.  This will keep the current default behavior.

Common:
- g_sck_get_peer_cred: Added NetBSDs and OpenIndiana's flavor of this.
- Getting strange EINTRs, standard way of handling this is to retry on EINTR. Modified the g_waitpid function to do the automatic retry. This resolved a number of strange errors. This should be a standard way to handle EINTR, so I did not #ifdef it. I tried it on Linux platforms and did not see any issue with it. Also modified a few calls doing a direct waitpid to call the g_waitpid instead.
- Modified alarm registration to also handle SIGINT. Again, believe this should not need to be #ifdef, but could be.
- While testing, added an extra parameter to the new xwait program to allow the wait time to be configurable.

NetBSD:
- g_sleep: NetBSD has a quirk where you can't usleep for more than 1,000,000 microseconds( 1 second ), so created a hybrid sleep, usleep method for netbsd.
- service scripts are the same as for freebsd, added checks for this to install.
- Note I used pkgsrc to install all required libraries. Also note that building against native BSD pam libraries causes undefined symbols, so I built against openpam.

OpenIndiana:
- Have to re-register for SIGCHLD after signal is handled.
- Build flags required -D_XOPEN_SOURCE=600 so posix calls are allowed. Also need this for xorgxrdp.
- Added manifest and method files for SMF for services.
- Note this code should work on Solaris, but I do not have access to any Solaris environments so can't test.
- Commented out line specifying config file when running Xorg, doesn't work on OpenIndiana.
- One issue. I could not get PAM to work on OpenIndiana, I had numerous problems. It looks like enable-pam defaults to yes, and I couldn't find a way to turn it off. So I changed enable-pam to default to no. 

