### PR TITLE
Support MacOS.

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -3365,14 +3365,16 @@ g_setpgid(int pid, int pgid)
 void
 g_clearenv(void)
 {
+    LOG_DEVEL(LOG_LEVEL_TRACE, "g_clearenv()");
 #if defined(_WIN32)
 #else
-#if defined(BSD)
+#if defined(BSD) || defined(__sun) || defined(__APPLE__)
     environ[0] = 0;
 #else
     environ = 0;
 #endif
 #endif
+    LOG_DEVEL(LOG_LEVEL_TRACE, "--g_clearenv()");
 }
 
 /*****************************************************************************/

--- a/configure.ac
+++ b/configure.ac
@@ -580,6 +580,7 @@ AC_CONFIG_FILES([
   instfiles/pam.d/Makefile
   instfiles/pulse/Makefile
   instfiles/rc.d/Makefile
+  instfiles/launchdaemons/Makefile
   keygen/Makefile
   waitforx/Makefile
   libipm/Makefile

--- a/instfiles/Makefile.am
+++ b/instfiles/Makefile.am
@@ -80,7 +80,9 @@ SUBDIRS += \
 endif
 
 if MACOS
-SUBDIRS += pam.d
+SUBDIRS += \
+  pam.d \
+  launchdaemons
 endif
 
 #

--- a/instfiles/launchdaemons/Makefile.am
+++ b/instfiles/launchdaemons/Makefile.am
@@ -1,0 +1,3 @@
+startscriptdir = /Library/LaunchDaemons
+
+dist_startscript_SCRIPTS = org.xrdp.xrdp.plist org.xrdp.xrdp-sesman.plist

--- a/instfiles/launchdaemons/org.xrdp.xrdp-sesman.plist
+++ b/instfiles/launchdaemons/org.xrdp.xrdp-sesman.plist
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+"http://www.apple.com/DTDs/PropertyList-1.0.dtd" >
+<plist version='1.0'>
+<dict>
+<key>Label</key><string>org.xrdp.xrdp-sesman</string>
+<key>ProgramArguments</key>
+<array>
+	<string>/usr/local/sbin/xrdp-sesman</string>
+	<string>-n</string>
+</array>
+<key>Disabled</key><true/>
+<key>KeepAlive</key><true/>
+</dict>
+</plist>

--- a/instfiles/launchdaemons/org.xrdp.xrdp.plist
+++ b/instfiles/launchdaemons/org.xrdp.xrdp.plist
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+"http://www.apple.com/DTDs/PropertyList-1.0.dtd" >
+<plist version='1.0'>
+<dict>
+<key>Label</key><string>org.xrdp.xrdp</string>
+<key>ProgramArguments</key>
+<array>
+	<string>/usr/local/sbin/xrdp</string>
+	<string>-n</string>
+</array>
+<key>Disabled</key><true/>
+<key>KeepAlive</key><true/>
+</dict>
+</plist>

--- a/instfiles/pam.d/xrdp-sesman.macos
+++ b/instfiles/pam.d/xrdp-sesman.macos
@@ -5,7 +5,7 @@ auth       optional       pam_ntlm.so try_first_pass
 auth       optional       pam_mount.so try_first_pass
 auth       required       pam_opendirectory.so try_first_pass
 account    required       pam_nologin.so
-account    required       pam_sacl.so sacl_service=ssh
+account    required       pam_sacl.so sacl_service=xrdp-sesman
 account    required       pam_opendirectory.so
 password   required       pam_opendirectory.so
 session    required       pam_launchd.so

--- a/xrdp/Makefile.am
+++ b/xrdp/Makefile.am
@@ -110,3 +110,9 @@ dist_xrdppkgdata_DATA = \
   sans-18.fv1 \
   cursor0.cur \
   cursor1.cur
+
+if MACOS
+# must be tab below. Common out Xorg and Xvnc since they don't work on MacOs.
+install-data-hook:
+	sed -i '' '235,249s/^/;/g' $(DESTDIR)$(sysconfdir)/xrdp/xrdp.ini
+endif

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -2605,13 +2605,32 @@ xrdp_mm_connect_sm(struct xrdp_mm *self)
 
                     gw_username = xrdp_mm_get_value(self, "pamusername");
                     gw_password = xrdp_mm_get_value(self, "pampassword");
-                    if (!g_strcmp(gw_username, "same"))
+                    if ( gw_username != NULL )
                     {
-                        gw_username = xrdp_mm_get_value(self, "username");
+                        if (!g_strcmp(gw_username, "same"))
+                        {
+                            gw_username = xrdp_mm_get_value(self, "username");
+                        }
+
+                        if ( !g_strncmp("ask", gw_username, 3))
+                        {
+                            gw_username = self->wm->session->client_info->username;
+                        }
                     }
 
-                    if (gw_password == NULL ||
-                            !g_strcmp(gw_password, "same"))
+                    if (gw_password != NULL )
+                    {
+                        if ( !g_strcmp(gw_password, "same"))
+                        {
+                            gw_password = xrdp_mm_get_value(self, "password");
+                        }
+
+                        if ( !g_strncmp("ask", gw_password, 3))
+                        {
+                            gw_password = self->wm->session->client_info->password;
+                        }
+                    }
+                    else
                     {
                         gw_password = xrdp_mm_get_value(self, "password");
                     }


### PR DESCRIPTION
This is 4 of 4 of my OS changes.  As per comments I'm going to look at removing the daemondo program and see if it will work with manilla plist files.  

MacOS:

Added plist files to run xrdp and xrdp-sesman. Note these rely on a tool available with the macports install, daemondo, which I find is really useful to get traditional services to play nicely with launchd. But of course, user can just modify the installed files to run however they want. All dependent libraries were installed via macports including build tools ( autoconf, automake, etc. )
Added install hook to comment out Xorg and Xvnc blocks automatically, since I believe the only way possible to run on MacOS is through vnc-any.
Made minor enhancement to facilitate how I run it. You have a nice gateway method where you can configure the sesman to act as a gateway for login. However, when I use this with the any-vnc configuration, I could not find a way to configure it because I need the gateway password to be the password the user entered, and the password to be the password for the VNC server. So added the "ask" option for the gateway username and gateway password so they can use the rdp username and password. Running this way, I don't have to rely on VNC with its low security password, and instead can do real authentication. I can also lock down the VNC server to localhost only. My current VNC server of choice is currently OSXvnc-server( now vine server ). I find the performance is quite good.

