### PR TITLE
[v0.9] remove ss clipboard code

### DIFF
--- a/sesman/chansrv/clipboard_common.h
+++ b/sesman/chansrv/clipboard_common.h
@@ -52,8 +52,6 @@ struct clip_c2s /* client to server, pasting from mstsc to linux app */
     int xrdp_clip_type; /* XRDP_CB_TEXT, XRDP_CB_BITMAP, XRDP_CB_FILE, ... */
     int converted;
     int in_request; /* a data request has been sent to client */
-    int doing_response_ss; /* doing response short circuit */
-    Time clip_time;
 };
 
 struct clip_file_desc /* CLIPRDR_FILEDESCRIPTOR */


### PR DESCRIPTION
Backport of #2810 

When significant amounts of data is coming from the client in a fragmented CLIPRDR_DATA_RESPONSE PDU, this code provides a way to start copying it to a requesting client before it is all read.

The only advantage of this code is to provide a slight speedup before a paste is visible on the server.

There are significant problems with this code. Notably, it is very difficult to parse Unicode text coming through this route. Each UTF-16 character can occupy up to 4 bytes, and a fragmentation boundary could occur at any point within a UTF-16 character.