### PR TITLE
Allow init_stream() to take unsigned size arguments

### DIFF
--- a/common/parse.h
+++ b/common/parse.h
@@ -151,7 +151,7 @@ parser_stream_overflow_check(const struct stream *s, int n, int is_out,
 /******************************************************************************/
 #define init_stream(s, v) do \
     { \
-        if ((v) > (s)->size) \
+        if ((int)(v) > (s)->size) \
         { \
             g_free((s)->data); \
             (s)->data = (char*)g_malloc((v), 0); \


### PR DESCRIPTION
Support using an unsigned argument for the size argument to init_stream(). This argument should not need a cast if passed an unsigned int (e.g.) from the sizeof operator.

The correct fix is probably to move the stream struct to using `unsigned int` or `size_t` rather than `int`. This is somewhat less intrusive for now.