### PR TITLE
Add ability to skip login window / auto login

### DIFF
--- a/docs/man/xrdp.ini.5.in
+++ b/docs/man/xrdp.ini.5.in
@@ -34,6 +34,11 @@ with be used to select the section. If no domain name is supplied, the
 first suitable section will be used for automatic login.
 
 .TP
+\fBskiploginwindow\fP=\fI[true|false]\fP
+If set to \fB1\fP, \fBtrue\fP, \fByes\fP or  \fBon\fP it will skip the login window and uses the session specified in autorun or the first one in the \fBxrdp.ini\fR. It is required that all login-related fields are set, and no field in the is set to \fIask\fR in the session.
+If not specified, defaults to \fBfalse\fP.
+
+.TP
 \fBbitmap_cache\fR=\fI[true|false]\fR
 If set to \fB1\fR, \fBtrue\fR or \fByes\fR this option enables bitmap caching in \fBxrdp\fR(8).
 

--- a/xrdp/xrdp.ini.in
+++ b/xrdp/xrdp.ini.in
@@ -74,6 +74,7 @@ ssl_protocols=TLSv1.2, TLSv1.3
 ; If empty and no domain name is given, the first suitable section in
 ; this file will be used.
 autorun=
+#skiploginwindow=true
 
 allow_channels=true
 allow_multimon=true

--- a/xrdp/xrdp_login_wnd.c
+++ b/xrdp/xrdp_login_wnd.c
@@ -1264,6 +1264,11 @@ load_xrdp_config(struct xrdp_config *config, const char *xrdp_ini, int bpp)
             g_strncpy(globals->autorun, v, 255);
         }
 
+        else if (g_strncmp(n, "skiploginwindow", 64) == 0)
+        {
+            globals->skiploginwindow = g_text2bool(v);
+        }
+
         else if (g_strncmp(n, "hidelogwindow", 64) == 0)
         {
             globals->hidelogwindow = g_text2bool(v);
@@ -1472,6 +1477,7 @@ load_xrdp_config(struct xrdp_config *config, const char *xrdp_ini, int bpp)
     LOG(LOG_LEVEL_DEBUG, "background:              %d", globals->background);
 
     LOG(LOG_LEVEL_DEBUG, "autorun:                 %s", globals->autorun);
+    LOG(LOG_LEVEL_DEBUG, "skiploginwindow:         %d", globals->skiploginwindow);
     LOG(LOG_LEVEL_DEBUG, "hidelogwindow:           %d", globals->hidelogwindow);
     LOG(LOG_LEVEL_DEBUG, "require_credentials:     %d", globals->require_credentials);
     LOG(LOG_LEVEL_DEBUG, "bulk_compression:        %d", globals->bulk_compression);

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -527,6 +527,7 @@ struct xrdp_wm
     struct xrdp_mm *mm;
     struct xrdp_font *default_font;
     struct xrdp_keymap keymap;
+    int skip_login_window;
     int hide_log_window;
     int fatal_error_in_log_window;
     struct xrdp_bitmap *target_surface; /* either screen or os surface */
@@ -756,6 +757,7 @@ struct xrdp_cfg_globals
     int  tcp_send_buffer_bytes;
     int  tcp_recv_buffer_bytes;
     char autorun[256];
+    int  skiploginwindow;
     int  hidelogwindow;
     int  require_credentials;
     int  bulk_compression;

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -489,6 +489,11 @@ xrdp_wm_load_static_colors_plus(struct xrdp_wm *self, char *autorun_name)
                             g_strncpy(autorun_name, val, 255);
                         }
                     }
+                    else if (g_strcasecmp(val, "skiploginwindow") == 0)
+                    {
+                        val = (char *)list_get_item(values, index);
+                        self->skip_login_window = g_text2bool(val);
+                    }
                     else if (g_strcasecmp(val, "hidelogwindow") == 0)
                     {
                         val = (char *)list_get_item(values, index);
@@ -636,7 +641,7 @@ xrdp_wm_init(struct xrdp_wm *self)
     xrdp_wm_load_static_pointers(self);
     self->screen->bg_color = self->xrdp_config->cfg_globals.ls_top_window_bg_color;
 
-    if (self->session->client_info->rdp_autologin)
+    if (self->session->client_info->rdp_autologin || self->skip_login_window)
     {
         /*
          * NOTE: this should eventually be accessed from self->xrdp_config


### PR DESCRIPTION
I wanted to add the ability to not have to click the OK button if there is only a single session and the username/password is already set in xrdp.ini. This is my concept of how this could be achieved.

Currently, it is possible to set the username and password in xrdp.ini. However, automatic login only functions when the client sends credentials. Even if the client's credentials are incorrect, the session logs in based on the credentials in the .ini file. With the skiploginwindow=True variable, this behavior can now be achieved without the need to send false credentials to trigger the if-condition.

Currently, if skiploginwindow=True and the credentials in the .ini are wrong, the error-log-window loops without showing the login window. So implementing this as a session variable would be a good way to prevent this, if the auto login fails you will see the login window. This could be done by using the skiploginwindow config variable to set rdp_autologin to 1 when creating the session, but I have not found a good place for this logic yet.