### PR TITLE
Allow for empty fields in TS_EXTENDED_INFO_PACKET

### DIFF
--- a/common/ms-rdpbcgr.h
+++ b/common/ms-rdpbcgr.h
@@ -131,6 +131,9 @@
 #define RDP_LOGON_LEAVE_AUDIO          0x2000
 #define RDP_LOGON_RAIL                 0x8000
 
+/* Extended Info Packet: clientAddress (2.2.1.11.1.1.1) */
+#define EXTENDED_INFO_MAX_CLIENT_ADDR_LENGTH 80
+
 /* Extended Info Packet: performanceFlags (2.2.1.11.1.1.1) */
 /* TODO: to be renamed */
 #define RDP5_DISABLE_NOTHING           0x00


### PR DESCRIPTION
Fixes #2853

Tested by @derekschrock 

Some clients appears to be sending cbClientAddress and/or cbClientDir as 0 in the TS_EXTENDED_INFO_PACKET. This appears to be at odds with [MS-RDPBCGR] which requires mandatory terminators for these fields.

This PR addresses this by not parsing the fields we are not currently using. Additionally, a few ints have been made unsigned to simplify length checks for incoming data.