### PR TITLE
Update xrdp-neutrinordp.c to support side button (forward/back) click

### DIFF
--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -425,6 +425,38 @@ lxrdp_event(struct mod *mod, int msg, long param1, long param2,
         case 110:
             break;
 
+        case 115: /* extended mouse button8 up */
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "extended mouse button8 up %ld %ld", param1, param2);
+            x = param1;
+            y = param2;
+            flags = PTR_XFLAGS_BUTTON1;
+            mod->inst->input->ExtendedMouseEvent(mod->inst->input, flags, x, y);
+            break;
+
+        case 116: /* extended mouse button8 down */
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "extended mouse button8 down %ld %ld", param1, param2);
+            x = param1;
+            y = param2;
+            flags = PTR_XFLAGS_BUTTON1 | PTR_XFLAGS_DOWN;
+            mod->inst->input->ExtendedMouseEvent(mod->inst->input, flags, x, y);
+            break;
+
+        case 117: /* extended mouse button9 up */
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "extended mouse button9 up %ld %ld", param1, param2);
+            x = param1;
+            y = param2;
+            flags = PTR_XFLAGS_BUTTON2;
+            mod->inst->input->ExtendedMouseEvent(mod->inst->input, flags, x, y);
+            break;
+
+        case 118: /* extended mouse button9 down */
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "extended mouse button9 down %ld %ld", param1, param2);
+            x = param1;
+            y = param2;
+            flags = PTR_XFLAGS_BUTTON2 | PTR_XFLAGS_DOWN;
+            mod->inst->input->ExtendedMouseEvent(mod->inst->input, flags, x, y);
+            break;
+
         case 200:
             LOG_DEVEL(LOG_LEVEL_DEBUG, "Invalidate request sent from client");
             x = (param1 >> 16) & 0xffff;


### PR DESCRIPTION
Hello, thank you for the [NeutrinoRDP proxy module](https://github.com/neutrinolabs/xrdp/wiki/NeutrinoRDP-proxy-module-for-xrdp) feature of xrdp.

While using the feature, we found that so-called forward/back button won't work, and in this PR, we would like you to consider merging this patch to solve the issue. @matt335672

![forard-back](https://github.com/neutrinolabs/xrdp/assets/263047/8ed77ab8-8382-49ef-ad36-8e21f651580e)

[What are the buttons on the side of my mouse called?](https://www.quora.com/What-are-the-buttons-on-the-side-of-my-mouse-called)