### PR TITLE
Add markdown asking user to read the FAQ before submitting a bug

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,6 +3,11 @@ description: Report errors or unexpected behavior
 labels:
   - "bug"
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Before submitting a bug, read the [FAQ](https://github.com/neutrinolabs/xrdp/wiki/Tips-and-FAQ).
+        **In particular, on systemd-based systems. make sure you are not logged in on the console as the same user you are trying to use for xrdp**
   - type: input
     attributes:
       label: xrdp version


### PR DESCRIPTION
Small change to the bug reporting form asking users to read the FAQ before submitting.

Is this in the right place?