### PR TITLE
Neutrinordp sidebutton click

### DIFF
--- a/common/xrdp_constants.h
+++ b/common/xrdp_constants.h
@@ -257,6 +257,7 @@
 #define WM_PAINT       3
 #define WM_KEYDOWN     15
 #define WM_KEYUP       16
+#define WM_KEYBRD_SYNC 17
 #define WM_MOUSEMOVE   100
 #define WM_LBUTTONUP   101
 #define WM_LBUTTONDOWN 102
@@ -281,6 +282,7 @@
 #define WM_TOUCH_HSCROLL 141
 
 #define WM_INVALIDATE  200
+#define WM_CHANNEL_DATA 201
 
 #define CB_ITEMCHANGE  300
 

--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -315,7 +315,7 @@ lxrdp_event(struct mod *mod, int msg, long param1, long param2,
 
     switch (msg)
     {
-        case 15: /* key down */
+        case WM_KEYDOWN:
 
             /* Before we handle the first character we synchronize
                capslock and numlock. */
@@ -331,11 +331,11 @@ lxrdp_event(struct mod *mod, int msg, long param1, long param2,
             mod->inst->input->KeyboardEvent(mod->inst->input, param4, param3);
             break;
 
-        case 16: /* key up */
+        case WM_KEYUP:
             mod->inst->input->KeyboardEvent(mod->inst->input, param4, param3);
             break;
 
-        case 17: /* Synchronize */
+        case WM_KEYBRD_SYNC:
             LOG_DEVEL(LOG_LEVEL_DEBUG, "Synchronized event handled : %ld", param1);
             /* In some situations the Synchronize event come to early.
                Therefore we store this information and use it when we
@@ -351,7 +351,7 @@ lxrdp_event(struct mod *mod, int msg, long param1, long param2,
 
             break;
 
-        case 100: /* mouse move */
+        case WM_MOUSEMOVE: /* mouse move */
             LOG_DEVEL(LOG_LEVEL_DEBUG, "mouse move %ld %ld", param1, param2);
             x = param1;
             y = param2;
@@ -359,7 +359,7 @@ lxrdp_event(struct mod *mod, int msg, long param1, long param2,
             mod->inst->input->MouseEvent(mod->inst->input, flags, x, y);
             break;
 
-        case 101: /* left button up */
+        case WM_LBUTTONUP:
             LOG_DEVEL(LOG_LEVEL_DEBUG, "left button up %ld %ld", param1, param2);
             x = param1;
             y = param2;
@@ -367,7 +367,7 @@ lxrdp_event(struct mod *mod, int msg, long param1, long param2,
             mod->inst->input->MouseEvent(mod->inst->input, flags, x, y);
             break;
 
-        case 102: /* left button down */
+        case WM_LBUTTONDOWN:
             LOG_DEVEL(LOG_LEVEL_DEBUG, "left button down %ld %ld", param1, param2);
             x = param1;
             y = param2;
@@ -375,7 +375,7 @@ lxrdp_event(struct mod *mod, int msg, long param1, long param2,
             mod->inst->input->MouseEvent(mod->inst->input, flags, x, y);
             break;
 
-        case 103: /* right button up */
+        case WM_RBUTTONUP:
             LOG_DEVEL(LOG_LEVEL_DEBUG, "right button up %ld %ld", param1, param2);
             x = param1;
             y = param2;
@@ -383,7 +383,7 @@ lxrdp_event(struct mod *mod, int msg, long param1, long param2,
             mod->inst->input->MouseEvent(mod->inst->input, flags, x, y);
             break;
 
-        case 104: /* right button down */
+        case WM_RBUTTONDOWN:
             LOG_DEVEL(LOG_LEVEL_DEBUG, "right button down %ld %ld", param1, param2);
             x = param1;
             y = param2;
@@ -391,7 +391,7 @@ lxrdp_event(struct mod *mod, int msg, long param1, long param2,
             mod->inst->input->MouseEvent(mod->inst->input, flags, x, y);
             break;
 
-        case 105: /* middle button up */
+        case WM_BUTTON3UP: /* middle button up */
             LOG_DEVEL(LOG_LEVEL_DEBUG, "middle button up %ld %ld", param1, param2);
             x = param1;
             y = param2;
@@ -399,7 +399,7 @@ lxrdp_event(struct mod *mod, int msg, long param1, long param2,
             mod->inst->input->MouseEvent(mod->inst->input, flags, x, y);
             break;
 
-        case 106: /* middle button down */
+        case WM_BUTTON3DOWN: /* middle button down */
             LOG_DEVEL(LOG_LEVEL_DEBUG, "middle button down %ld %ld", param1, param2);
             x = param1;
             y = param2;
@@ -407,23 +407,23 @@ lxrdp_event(struct mod *mod, int msg, long param1, long param2,
             mod->inst->input->MouseEvent(mod->inst->input, flags, x, y);
             break;
 
-        case 107: /* wheel up */
+        case WM_BUTTON4UP: /* wheel up */
             flags = PTR_FLAGS_WHEEL | 0x0078;
             mod->inst->input->MouseEvent(mod->inst->input, flags, 0, 0);
             break;
 
-        case 108:
+        case WM_BUTTON4DOWN:
             break;
 
-        case 109: /* wheel down */
+        case WM_BUTTON5UP: /* wheel down */
             flags = PTR_FLAGS_WHEEL | PTR_FLAGS_WHEEL_NEGATIVE | 0x0088;
             mod->inst->input->MouseEvent(mod->inst->input, flags, 0, 0);
             break;
 
-        case 110:
+        case WM_BUTTON5DOWN:
             break;
 
-        case 115: /* extended mouse button8 up */
+        case WM_BUTTON8UP:
             LOG_DEVEL(LOG_LEVEL_DEBUG, "extended mouse button8 up %ld %ld", param1, param2);
             x = param1;
             y = param2;
@@ -431,7 +431,7 @@ lxrdp_event(struct mod *mod, int msg, long param1, long param2,
             mod->inst->input->ExtendedMouseEvent(mod->inst->input, flags, x, y);
             break;
 
-        case 116: /* extended mouse button8 down */
+        case WM_BUTTON8DOWN:
             LOG_DEVEL(LOG_LEVEL_DEBUG, "extended mouse button8 down %ld %ld", param1, param2);
             x = param1;
             y = param2;
@@ -439,7 +439,7 @@ lxrdp_event(struct mod *mod, int msg, long param1, long param2,
             mod->inst->input->ExtendedMouseEvent(mod->inst->input, flags, x, y);
             break;
 
-        case 117: /* extended mouse button9 up */
+        case WM_BUTTON9UP:
             LOG_DEVEL(LOG_LEVEL_DEBUG, "extended mouse button9 up %ld %ld", param1, param2);
             x = param1;
             y = param2;
@@ -447,7 +447,7 @@ lxrdp_event(struct mod *mod, int msg, long param1, long param2,
             mod->inst->input->ExtendedMouseEvent(mod->inst->input, flags, x, y);
             break;
 
-        case 118: /* extended mouse button9 down */
+        case WM_BUTTON9DOWN:
             LOG_DEVEL(LOG_LEVEL_DEBUG, "extended mouse button9 down %ld %ld", param1, param2);
             x = param1;
             y = param2;
@@ -455,7 +455,7 @@ lxrdp_event(struct mod *mod, int msg, long param1, long param2,
             mod->inst->input->ExtendedMouseEvent(mod->inst->input, flags, x, y);
             break;
 
-        case 200:
+        case WM_INVALIDATE:
             LOG_DEVEL(LOG_LEVEL_DEBUG, "Invalidate request sent from client");
             x = (param1 >> 16) & 0xffff;
             y = (param1 >> 0) & 0xffff;
@@ -464,7 +464,7 @@ lxrdp_event(struct mod *mod, int msg, long param1, long param2,
             mod->inst->SendInvalidate(mod->inst, -1, x, y, cx, cy);
             break;
 
-        case 0x5555:
+        case WM_CHANNEL_DATA:
             chanid = LOWORD(param1);
             flags = HIWORD(param1);
             size = (int)param2;

--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -423,6 +423,38 @@ lxrdp_event(struct mod *mod, int msg, long param1, long param2,
         case 110:
             break;
 
+        case 115: /* extended mouse button8 up */
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "extended mouse button8 up %ld %ld", param1, param2);
+            x = param1;
+            y = param2;
+            flags = PTR_XFLAGS_BUTTON1;
+            mod->inst->input->ExtendedMouseEvent(mod->inst->input, flags, x, y);
+            break;
+
+        case 116: /* extended mouse button8 down */
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "extended mouse button8 down %ld %ld", param1, param2);
+            x = param1;
+            y = param2;
+            flags = PTR_XFLAGS_BUTTON1 | PTR_XFLAGS_DOWN;
+            mod->inst->input->ExtendedMouseEvent(mod->inst->input, flags, x, y);
+            break;
+
+        case 117: /* extended mouse button9 up */
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "extended mouse button9 up %ld %ld", param1, param2);
+            x = param1;
+            y = param2;
+            flags = PTR_XFLAGS_BUTTON2;
+            mod->inst->input->ExtendedMouseEvent(mod->inst->input, flags, x, y);
+            break;
+
+        case 118: /* extended mouse button9 down */
+            LOG_DEVEL(LOG_LEVEL_DEBUG, "extended mouse button9 down %ld %ld", param1, param2);
+            x = param1;
+            y = param2;
+            flags = PTR_XFLAGS_BUTTON2 | PTR_XFLAGS_DOWN;
+            mod->inst->input->ExtendedMouseEvent(mod->inst->input, flags, x, y);
+            break;
+
         case 200:
             LOG_DEVEL(LOG_LEVEL_DEBUG, "Invalidate request sent from client");
             x = (param1 >> 16) & 0xffff;

--- a/vnc/vnc.c
+++ b/vnc/vnc.c
@@ -486,7 +486,7 @@ lib_mod_event(struct vnc *v, int msg, long param1, long param2,
     error = 0;
     make_stream(s);
 
-    if (msg == 0x5555) /* channel data */
+    if (msg == WM_CHANNEL_DATA)
     {
         chanid = LOWORD(param1);
         flags = HIWORD(param1);

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -557,8 +557,8 @@ xrdp_mm_setup_mod2(struct xrdp_mm *self)
         {
             if (self->mod->mod_event != 0)
             {
-                self->mod->mod_event(self->mod, 17, key_flags, device_flags,
-                                     key_flags, device_flags);
+                self->mod->mod_event(self->mod, WM_KEYBRD_SYNC, key_flags,
+                                     device_flags, key_flags, device_flags);
             }
         }
     }

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -1636,8 +1636,8 @@ xrdp_wm_key_sync(struct xrdp_wm *self, int device_flags, int key_flags)
     {
         if (self->mm->mod->mod_event != 0)
         {
-            self->mm->mod->mod_event(self->mm->mod, 17, key_flags, device_flags,
-                                     key_flags, device_flags);
+            self->mm->mod->mod_event(self->mm->mod, WM_KEYBRD_SYNC, key_flags,
+                                     device_flags, key_flags, device_flags);
         }
     }
 
@@ -1946,8 +1946,8 @@ xrdp_wm_process_channel_data(struct xrdp_wm *self,
         {
             if (self->mm->mod->mod_event != 0)
             {
-                rv = self->mm->mod->mod_event(self->mm->mod, 0x5555, param1, param2,
-                                              param3, param4);
+                rv = self->mm->mod->mod_event(self->mm->mod, WM_CHANNEL_DATA,
+                                              param1, param2, param3, param4);
             }
         }
     }


### PR DESCRIPTION
Forward port of #2860 to devel

As well as @naruhito's cherry-picked commit, I've added a further commit removing the magic numbers from the module interface.

There's an actual value change here - the magic number 0x5555 (now `WM_MODULE_DATA`) has been replaced with the value 201. However, 0x5555 is still used by libxrdp to callback into xrdp with the actual module channel data. I've left that change for another day as it's more complex.