### PR TITLE
Bump CI version of FreeBSD to 13.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@ FreeBSD_task:
       SSL: libressl
   matrix:
     freebsd_instance:
-      image_family: freebsd-12-4
+      image_family: freebsd-13-2
   prepare_script:
     - pkg install -y $SSL git autoconf automake libtool pkgconf opus jpeg-turbo fdk-aac pixman libX11 libXfixes libXrandr nasm fusefs-libs check imlib2 freetype2 cmocka
     - git submodule update --init --recursive


### PR DESCRIPTION
The Cirrus CI version of FreeBSD 12.4 no longer appears to be available (see #2888)

This may be a temporary failure. However, since FreeBSD 14.0 is now out FreeBSD 12.4 is no longer supported. We ought to move up to FreeBSD 13.