### PR TITLE
Increase back-stop timeouts for some tests

### DIFF
--- a/tests/common/test_ssl_calls.c
+++ b/tests/common/test_ssl_calls.c
@@ -9,6 +9,11 @@
 
 #include "test_common.h"
 
+/* Time to allow RSA-based test suites to run on older, slower platforms
+ *
+ * These platforms are most often seen on build farms (e.g. Debian CI) */
+#define RSA_BASED_TEST_SUITE_TIMEOUT 60
+
 START_TEST(test_rc4_enc_ok)
 {
     const char *key = "16_byte_key-----";
@@ -369,23 +374,39 @@ Suite *
 make_suite_test_ssl_calls(void)
 {
     Suite *s;
-    TCase *tc_ssl_calls;
+    TCase *tc;
 
     s = suite_create("SSL-Calls");
 
-    tc_ssl_calls = tcase_create("ssl_calls");
-    suite_add_tcase(s, tc_ssl_calls);
-    tcase_add_test(tc_ssl_calls, test_rc4_enc_ok);
-    tcase_add_test(tc_ssl_calls, test_rc4_enc_tv0_ok);
-    tcase_add_test(tc_ssl_calls, test_rc4_enc_tv1_ok);
-    tcase_add_test(tc_ssl_calls, test_rc4_enc_tv2_ok);
-    tcase_add_test(tc_ssl_calls, test_rc4_enc_tv3_ok);
-    tcase_add_test(tc_ssl_calls, test_rc4_enc_tv4_ok);
-    tcase_add_test(tc_ssl_calls, test_sha1_hash_ok);
-    tcase_add_test(tc_ssl_calls, test_md5_hash_ok);
-    tcase_add_test(tc_ssl_calls, test_des3_enc_ok);
-    tcase_add_test(tc_ssl_calls, test_hmac_sha1_dgst_ok);
-    tcase_add_test(tc_ssl_calls, test_gen_key_xrdp1);
+    tc = tcase_create("ssl_calls_rc4");
+    suite_add_tcase(s, tc);
+    tcase_add_test(tc, test_rc4_enc_ok);
+    tcase_add_test(tc, test_rc4_enc_tv0_ok);
+    tcase_add_test(tc, test_rc4_enc_tv1_ok);
+    tcase_add_test(tc, test_rc4_enc_tv2_ok);
+    tcase_add_test(tc, test_rc4_enc_tv3_ok);
+    tcase_add_test(tc, test_rc4_enc_tv4_ok);
+
+    tc = tcase_create("ssl_calls_sha1");
+    suite_add_tcase(s, tc);
+    tcase_add_test(tc, test_sha1_hash_ok);
+
+    tc = tcase_create("ssl_calls_md5");
+    suite_add_tcase(s, tc);
+    tcase_add_test(tc, test_md5_hash_ok);
+
+    tc = tcase_create("ssl_calls_des3");
+    suite_add_tcase(s, tc);
+    tcase_add_test(tc, test_des3_enc_ok);
+
+    tc = tcase_create("ssl_calls_hmac_sha1");
+    suite_add_tcase(s, tc);
+    tcase_add_test(tc, test_hmac_sha1_dgst_ok);
+
+    tc = tcase_create("ssl_calls_rsa_key");
+    suite_add_tcase(s, tc);
+    tcase_set_timeout(tc, RSA_BASED_TEST_SUITE_TIMEOUT);
+    tcase_add_test(tc, test_gen_key_xrdp1);
 
     return s;
 }

--- a/tests/xrdp/test_bitmap_load.c
+++ b/tests/xrdp/test_bitmap_load.c
@@ -45,6 +45,9 @@ static int WHITE = COLOR24RGB(255, 255, 255);
  * be considered close enough to each other */
 #define MAX_SIMILAR_COLOR_DISTANCE 3
 
+/* Time to allow some large bitmap test suites to run on slower platforms */
+#define LARGE_BM_TEST_SUITE_TIMEOUT 10
+
 void setup(void)
 {
 }
@@ -301,37 +304,48 @@ Suite *
 make_suite_test_bitmap_load(void)
 {
     Suite *s;
-    TCase *tc_bitmap_load;
-#ifdef USE_IMLIB2
-    TCase *tc_other_load;
-#endif
+    TCase *tc;
 
     s = suite_create("BitmapLoad");
 
-    tc_bitmap_load = tcase_create("xrdp_bitmap_load");
-    tcase_add_checked_fixture(tc_bitmap_load, setup, teardown);
-    tcase_add_test(tc_bitmap_load, test_bitmap_load__with_invalid_image__fail);
-    tcase_add_test(tc_bitmap_load, test_bitmap_load__4_bit__ok);
-    tcase_add_test(tc_bitmap_load, test_bitmap_load__8_bit__ok);
-    tcase_add_test(tc_bitmap_load, test_bitmap_load__24_bit__ok);
-    tcase_add_test(tc_bitmap_load, test_bitmap_load__max_width_zoom__ok);
-    tcase_add_test(tc_bitmap_load, test_bitmap_load__max_height_zoom__ok);
-    tcase_add_test(tc_bitmap_load, test_bitmap_load__min_zoom__ok);
-    tcase_add_test(tc_bitmap_load, test_bitmap_load__max_width_scale__ok);
-    tcase_add_test(tc_bitmap_load, test_bitmap_load__max_height_scale__ok);
-    tcase_add_test(tc_bitmap_load, test_bitmap_load__min_scale__ok);
-    tcase_add_test(tc_bitmap_load, test_bitmap_load__not_4_pixels_wide_4_bit__ok);
-    tcase_add_test(tc_bitmap_load, test_bitmap_load__not_4_pixels_wide_8_bit__ok);
-    tcase_add_test(tc_bitmap_load, test_bitmap_load__not_4_pixels_wide_24_bit__ok);
+    tc = tcase_create("xrdp_bitmap_load_basic");
+    suite_add_tcase(s, tc);
+    tcase_add_checked_fixture(tc, setup, teardown);
+    tcase_add_test(tc, test_bitmap_load__with_invalid_image__fail);
+    tcase_add_test(tc, test_bitmap_load__4_bit__ok);
+    tcase_add_test(tc, test_bitmap_load__8_bit__ok);
+    tcase_add_test(tc, test_bitmap_load__24_bit__ok);
 
-    suite_add_tcase(s, tc_bitmap_load);
+    tc = tcase_create("xrdp_bitmap_load_zoom");
+    suite_add_tcase(s, tc);
+    tcase_add_checked_fixture(tc, setup, teardown);
+    tcase_set_timeout(tc, LARGE_BM_TEST_SUITE_TIMEOUT);
+    tcase_add_test(tc, test_bitmap_load__max_width_zoom__ok);
+    tcase_add_test(tc, test_bitmap_load__max_height_zoom__ok);
+    tcase_add_test(tc, test_bitmap_load__min_zoom__ok);
+
+    tc = tcase_create("xrdp_bitmap_load_scale");
+    suite_add_tcase(s, tc);
+    tcase_add_checked_fixture(tc, setup, teardown);
+    tcase_set_timeout(tc, LARGE_BM_TEST_SUITE_TIMEOUT);
+    tcase_add_test(tc, test_bitmap_load__max_width_scale__ok);
+    tcase_add_test(tc, test_bitmap_load__max_height_scale__ok);
+    tcase_add_test(tc, test_bitmap_load__min_scale__ok);
+
+    tc = tcase_create("xrdp_bitmap_load_not_mod_4");
+    suite_add_tcase(s, tc);
+    tcase_add_checked_fixture(tc, setup, teardown);
+    tcase_add_test(tc, test_bitmap_load__not_4_pixels_wide_4_bit__ok);
+    tcase_add_test(tc, test_bitmap_load__not_4_pixels_wide_8_bit__ok);
+    tcase_add_test(tc, test_bitmap_load__not_4_pixels_wide_24_bit__ok);
+
 
 #ifdef USE_IMLIB2
-    tc_other_load = tcase_create("xrdp_other_load");
-    tcase_add_checked_fixture(tc_other_load, setup, teardown);
-    tcase_add_test(tc_other_load, test_png_load__blend_ok);
-    tcase_add_test(tc_other_load, test_jpg_load__ok);
-    suite_add_tcase(s, tc_other_load);
+    tc = tcase_create("xrdp_other_load");
+    suite_add_tcase(s, tc);
+    tcase_add_checked_fixture(tc, setup, teardown);
+    tcase_add_test(tc, test_png_load__blend_ok);
+    tcase_add_test(tc, test_jpg_load__ok);
 #endif
 
     return s;


### PR DESCRIPTION
Fixes #2213 #2899

The Debian build farm has a number of older and slower machines which need to run the xrdp test suite.

On these platforms, we occasionally get timeouts where machine load is high. This results in duplicate issues being raised. It is not obvious that the issues are duplicates, which wastes time all round.

This commit splits up some test cases into multiple cases and adds larger timeouts for those cases that are CPU-intensive.