### PR TITLE
Allow a zero timeout for g_obj_wait()

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@ FreeBSD_task:
       SSL: libressl
   matrix:
     freebsd_instance:
-      image_family: freebsd-12-4
+      image_family: freebsd-13-2
   prepare_script:
     - pkg install -y $SSL git autoconf automake libtool pkgconf opus jpeg-turbo fdk-aac pixman libX11 libXfixes libXrandr nasm fusefs-libs check imlib2 freetype2 cmocka
     - git submodule update --init --recursive

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -71,6 +71,6 @@ libcommon_la_SOURCES = \
   $(PIXMAN_SOURCES)
 
 libcommon_la_LIBADD = \
-  -lpthread \
+  -lpthread -lrt \
   $(OPENSSL_LIBS) \
   $(DLOPEN_LIBS)

--- a/common/ms-rdpbcgr.h
+++ b/common/ms-rdpbcgr.h
@@ -52,19 +52,29 @@
 
 /* TS_UD_HEADER: type ((2.2.1.3.1) */
 /* TODO: to be renamed */
-#define SEC_TAG_CLI_INFO               0xc001 /* CS_CORE? */
-#define SEC_TAG_CLI_CRYPT              0xc002 /* CS_SECURITY? */
-#define SEC_TAG_CLI_CHANNELS           0xc003 /* CS_CHANNELS? */
-#define SEC_TAG_CLI_4                  0xc004 /* CS_CLUSTER? */
-#define SEC_TAG_CLI_MONITOR            0xc005 /* CS_MONITOR */
-#define SEC_TAG_CLI_MONITOR_EX         0xc008 /* CS_MONITOR_EX */
+#define SEC_TAG_CLI_INFO       0xc001 /* CS_CORE? */
+#define SEC_TAG_CLI_CRYPT      0xc002 /* CS_SECURITY? */
+#define SEC_TAG_CLI_CHANNELS   0xc003 /* CS_CHANNELS? */
+#define SEC_TAG_CLI_4          0xc004 /* CS_CLUSTER? */
+#define SEC_TAG_CLI_MONITOR    0xc005 /* CS_MONITOR */
+#define SEC_TAG_CLI_MONITOR_EX 0xc008 /* CS_MONITOR_EX */
 
 /* Client Core Data: colorDepth, postBeta2ColorDepth (2.2.1.3.2) */
-#define RNS_UD_COLOR_4BPP              0xCA00
-#define RNS_UD_COLOR_8BPP              0xCA01
-#define RNS_UD_COLOR_16BPP_555         0xCA02
-#define RNS_UD_COLOR_16BPP_565         0xCA03
-#define RNS_UD_COLOR_24BPP             0xCA04
+#define RNS_UD_COLOR_4BPP      0xCA00
+#define RNS_UD_COLOR_8BPP      0xCA01
+#define RNS_UD_COLOR_16BPP_555 0xCA02
+#define RNS_UD_COLOR_16BPP_565 0xCA03
+#define RNS_UD_COLOR_24BPP     0xCA04
+
+/* Client Core Data: supportedColorDepths (2.2.1.3.2) */
+#define RNS_UD_24BPP_SUPPORT 0x0001
+#define RNS_UD_16BPP_SUPPORT 0x0002
+#define RNS_UD_15BPP_SUPPORT 0x0004
+#define RNS_UD_32BPP_SUPPORT 0x0008
+
+/* Client Core Data: earlyCapabilityFlags (2.2.1.3.2) */
+#define RNS_UD_CS_WANT_32BPP_SESSION         0x0002
+#define RNS_UD_CS_SUPPORT_DYNVC_GFX_PROTOCOL 0x0100
 
 /* Client Core Data: connectionType  (2.2.1.3.2) */
 #define CONNECTION_TYPE_MODEM          0x01

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -1979,7 +1979,7 @@ g_obj_wait(tintptr *read_objs, int rcount, tintptr *write_objs, int wcount,
         handles[j++] = (HANDLE)(write_objs[i]);
     }
 
-    if (mstimeout < 1)
+    if (mstimeout < 0)
     {
         mstimeout = INFINITE;
     }
@@ -2016,7 +2016,7 @@ g_obj_wait(tintptr *read_objs, int rcount, tintptr *write_objs, int wcount,
     }
     else
     {
-        if (mstimeout < 1)
+        if (mstimeout < 0)
         {
             mstimeout = -1;
         }

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -203,10 +203,13 @@ int      g_delete_wait_obj(tintptr obj);
  * @param rcount Number of elements in read_objs
  * @param write_objs Array of write objects
  * @param rcount Number of elements in write_objs
- * @param mstimeout Timeout in milliseconds. <= 0 means an infinite timeout.
+ * @param mstimeout Timeout in milliseconds. < 0 means an infinite timeout.
  *
  * @return 0 for success. The objects will need to be polled to
  * find out what is readable or writeable.
+ *
+ * An mstimeout of zero will return immediately, although
+ * error conditions may be checked for.
  */
 int      g_obj_wait(tintptr *read_objs, int rcount, tintptr *write_objs,
                     int wcount, int mstimeout);

--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -215,6 +215,14 @@ struct xrdp_client_info
     unsigned int session_physical_height; /* in mm */
 
     int large_pointer_support_flags;
+    int gfx;
+};
+
+enum xrdp_encoder_flags
+{
+    NONE                                   = 0,
+    ENCODE_COMPLETE                        = 1 << 0,
+    GFX_PROGRESSIVE_RFX                    = 1 << 1
 };
 
 /* yyyymmdd of last incompatible change to xrdp_client_info */

--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -222,7 +222,8 @@ enum xrdp_encoder_flags
 {
     NONE                                   = 0,
     ENCODE_COMPLETE                        = 1 << 0,
-    GFX_PROGRESSIVE_RFX                    = 1 << 1
+    GFX_PROGRESSIVE_RFX                    = 1 << 1,
+    GFX_H264                               = 1 << 2
 };
 
 /* yyyymmdd of last incompatible change to xrdp_client_info */

--- a/common/xrdp_constants.h
+++ b/common/xrdp_constants.h
@@ -291,4 +291,50 @@
 #define XR_RDP_SCAN_LSHIFT 42
 #define XR_RDP_SCAN_ALT    56
 
+// Since we're not guaranteed to have pixman, copy these directives.
+#define XRDP_PIXMAN_TYPE_ARGB   2
+#define XRDP_PIXMAN_TYPE_ABGR   3
+#define XRDP_PIXMAN_FORMAT(bpp,type,a,r,g,b)    (((bpp) << 24) |  \
+        ((type) << 16) | \
+        ((a) << 12) |    \
+        ((r) << 8) |     \
+        ((g) << 4) |     \
+        ((b)))
+
+#define XRDP_a8b8g8r8 \
+    XRDP_PIXMAN_FORMAT(32, XRDP_PIXMAN_TYPE_ABGR, 8, 8, 8, 8)
+
+#define XRDP_a8r8g8b8 \
+    XRDP_PIXMAN_FORMAT(32, XRDP_PIXMAN_TYPE_ARGB, 8, 8, 8, 8)
+
+#define XRDP_r5g6b5 \
+    XRDP_PIXMAN_FORMAT(16, XRDP_PIXMAN_TYPE_ARGB, 0, 5, 6, 5)
+
+#define XRDP_a1r5g5b5 \
+    XRDP_PIXMAN_FORMAT(16, XRDP_PIXMAN_TYPE_ARGB, 1, 5, 5, 5)
+
+#define XRDP_r3g3b2 \
+    XRDP_PIXMAN_FORMAT(8, XRDP_PIXMAN_TYPE_ARGB, 0, 3, 3, 2)
+
+// The last used constant in pixman is 63, so use 64+
+#define XRDP_nv12 \
+    XRDP_PIXMAN_FORMAT(12, 64, 0, 0, 0, 0)
+
+#define XRDP_i420 \
+    XRDP_PIXMAN_FORMAT(12, 65, 0, 0, 0, 0)
+
+#define XRDP_nv12_709fr \
+    XRDP_PIXMAN_FORMAT(12, 66, 0, 0, 0, 0)
+
+#define XRDP_yuv444_709fr \
+    XRDP_PIXMAN_FORMAT(32, 67, 0, 0, 0, 0)
+
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpegfx/8131c1bc-1af8-4907-a05a-f72f4581160f
+#define XRDP_yuv444_v1_stream_709fr \
+    XRDP_PIXMAN_FORMAT(32, 68, 0, 0, 0, 0)
+
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpegfx/781406c3-5e24-4f2b-b6ff-42b76bf64f6d
+#define XRDP_yuv444_v2_stream_709fr \
+    XRDP_PIXMAN_FORMAT(32, 69, 0, 0, 0, 0)
+
 #endif

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -2114,10 +2114,14 @@ xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec *self, struct stream *s)
     in_uint16_le(s, supportedColorDepths);
     LOG_DEVEL(LOG_LEVEL_TRACE, "Received [MS-RDPBCGR] TS_UD_CS_CORE "
               "<Optional Field> supportedColorDepths %s",
-              supportedColorDepths == 0x0001 ? "RNS_UD_24BPP_SUPPORT" :
-              supportedColorDepths == 0x0002 ? "RNS_UD_16BPP_SUPPORT" :
-              supportedColorDepths == 0x0004 ? "RNS_UD_15BPP_SUPPORT" :
-              supportedColorDepths == 0x0008 ? "RNS_UD_32BPP_SUPPORT" :
+              supportedColorDepths == RNS_UD_24BPP_SUPPORT
+              ? "RNS_UD_24BPP_SUPPORT" :
+              supportedColorDepths == RNS_UD_16BPP_SUPPORT
+              ? "RNS_UD_16BPP_SUPPORT" :
+              supportedColorDepths == RNS_UD_15BPP_SUPPORT
+              ? "RNS_UD_15BPP_SUPPORT" :
+              supportedColorDepths == RNS_UD_32BPP_SUPPORT
+              ? "RNS_UD_32BPP_SUPPORT" :
               "unknown");
 
     if (!s_check_rem(s, 2))
@@ -2129,11 +2133,20 @@ xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec *self, struct stream *s)
     LOG_DEVEL(LOG_LEVEL_TRACE, "Received [MS-RDPBCGR] TS_UD_CS_CORE "
               "<Optional Field> earlyCapabilityFlags 0x%4.4x",
               earlyCapabilityFlags);
-    if ((earlyCapabilityFlags & 0x0002) && (supportedColorDepths & 0x0008))
+    if ((earlyCapabilityFlags & RNS_UD_CS_WANT_32BPP_SESSION)
+            && (supportedColorDepths & RNS_UD_32BPP_SUPPORT))
     {
         client_info->bpp = 32;
     }
-
+    if (earlyCapabilityFlags & RNS_UD_CS_SUPPORT_DYNVC_GFX_PROTOCOL)
+    {
+        LOG(LOG_LEVEL_INFO, "client supports gfx protocol");
+        self->rdp_layer->client_info.gfx = 1;
+    }
+    else
+    {
+        LOG_DEVEL(LOG_LEVEL_INFO, "client DOES NOT support gfx");
+    }
     if (!s_check_rem(s, 64))
     {
         return 0;

--- a/sesman/chansrv/chansrv.c
+++ b/sesman/chansrv/chansrv.c
@@ -1787,7 +1787,7 @@ main(int argc, char **argv)
         waiters[1] = g_exec_event;
         waiters[2] = g_sigchld_event;
 
-        if (g_obj_wait(waiters, 3, 0, 0, 0) != 0)
+        if (g_obj_wait(waiters, 3, 0, 0, -1) != 0)
         {
             LOG_DEVEL(LOG_LEVEL_ERROR, "main: error, g_obj_wait failed");
             break;
@@ -1814,7 +1814,7 @@ main(int argc, char **argv)
     while (g_thread_done_event > 0 && !g_is_wait_obj_set(g_thread_done_event))
     {
         /* wait for thread to exit */
-        if (g_obj_wait(&g_thread_done_event, 1, 0, 0, 0) != 0)
+        if (g_obj_wait(&g_thread_done_event, 1, 0, 0, -1) != 0)
         {
             LOG_DEVEL(LOG_LEVEL_ERROR, "main: error, g_obj_wait failed");
             break;

--- a/sesman/sesexec/sesexec.c
+++ b/sesman/sesexec/sesexec.c
@@ -283,7 +283,7 @@ sesexec_main_loop(void)
             continue;
         }
 
-        if (g_obj_wait(robjs, robjs_count, NULL, 0, 0) != 0)
+        if (g_obj_wait(robjs, robjs_count, NULL, 0, -1) != 0)
         {
             /* should not get here */
             LOG(LOG_LEVEL_WARNING, "sesexec_main_loop: "

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -543,7 +543,8 @@ server_set_pointer_large(struct xrdp_mod *mod, int x, int y,
                          char *data, char *mask, int bpp,
                          int width, int height);
 int
-server_paint_rects_ex(struct xrdp_mod *mod, int num_drects, short *drects,
+server_paint_rects_ex(struct xrdp_mod *mod,
+                      int num_drects, short *drects,
                       int num_crects, short *crects,
                       char *data, int left, int top,
                       int width, int height,

--- a/xrdp/xrdp_encoder.h
+++ b/xrdp/xrdp_encoder.h
@@ -3,6 +3,7 @@
 #define _XRDP_ENCODER_H
 
 #include "arch.h"
+#include "xrdp_client_info.h"
 struct fifo;
 
 struct xrdp_enc_data;
@@ -27,6 +28,13 @@ struct xrdp_encoder
     int frame_id_server; /* last frame id received from Xorg */
     int frame_id_server_sent;
     int frames_in_flight;
+    int gfx;
+    int gfx_ack_off;
+    const char *quants;
+    int num_quants;
+    int quant_idx_y;
+    int quant_idx_u;
+    int quant_idx_v;
 };
 
 /* used when scheduling tasks in xrdp_encoder.c */
@@ -63,6 +71,7 @@ struct xrdp_enc_data_done
     int y;
     int cx;
     int cy;
+    enum xrdp_encoder_flags flags;
 };
 
 typedef struct xrdp_enc_data_done XRDP_ENC_DATA_DONE;

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -79,7 +79,13 @@ xrdp_mm_create(struct xrdp_wm *owner)
               self->wm->client_info->rfx_codec_id,
               self->wm->client_info->h264_codec_id);
 
-    self->encoder = xrdp_encoder_create(self);
+    if ((self->wm->client_info->gfx == 0) &&
+            ((self->wm->client_info->h264_codec_id != 0) ||
+             (self->wm->client_info->jpeg_codec_id != 0) ||
+             (self->wm->client_info->rfx_codec_id != 0)))
+    {
+        self->encoder = xrdp_encoder_create(self);
+    }
 
     return self;
 }

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -374,6 +374,13 @@ enum display_resize_state
      "unknown" \
     )
 
+enum xrdp_egfx_flags
+{
+    XRDP_EGFX_NONE = 0,
+    XRDP_EGFX_H264 = 1,
+    XRDP_EGFX_RFX_PRO = 2
+};
+
 struct xrdp_mm
 {
     struct xrdp_wm *wm; /* owner */
@@ -410,7 +417,8 @@ struct xrdp_mm
     int dynamic_monitor_chanid;
     struct xrdp_egfx *egfx;
     int egfx_up;
-
+    int egfx_flags;
+    int gfx_delay_autologin;
     /* Resize on-the-fly control */
     struct display_control_monitor_layout_data *resize_data;
     struct list *resize_queue;

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -28,6 +28,7 @@
 #include "xrdp_constants.h"
 #include "fifo.h"
 #include "guid.h"
+#include "xrdp_client_info.h"
 
 #define MAX_NR_CHANNELS 16
 #define MAX_CHANNEL_NAME 16
@@ -343,7 +344,9 @@ enum display_resize_state
     WMRZ_EGFX_CONN_CLOSED,
     WRMZ_EGFX_DELETE,
     WMRZ_SERVER_MONITOR_RESIZE,
-    WMRZ_SERVER_VERSION_MESSAGE,
+    WMRZ_SERVER_VERSION_MESSAGE_START,
+    WMRZ_SERVER_MONITOR_MESSAGE_PROCESSING,
+    WMRZ_SERVER_MONITOR_MESSAGE_PROCESSED,
     WMRZ_XRDP_CORE_RESIZE,
     WMRZ_EGFX_INITIALIZE,
     WMRZ_EGFX_INITALIZING,
@@ -362,7 +365,12 @@ enum display_resize_state
      (status) == WMRZ_EGFX_CONN_CLOSED ? "WMRZ_EGFX_CONN_CLOSED" : \
      (status) == WRMZ_EGFX_DELETE ? "WMRZ_EGFX_DELETE" : \
      (status) == WMRZ_SERVER_MONITOR_RESIZE ? "WMRZ_SERVER_MONITOR_RESIZE" : \
-     (status) == WMRZ_SERVER_VERSION_MESSAGE ? "WMRZ_SERVER_VERSION_MESSAGE" : \
+     (status) == WMRZ_SERVER_VERSION_MESSAGE_START ? \
+     "WMRZ_SERVER_VERSION_MESSAGE_START" : \
+     (status) == WMRZ_SERVER_MONITOR_MESSAGE_PROCESSING ? \
+     "WMRZ_SERVER_MONITOR_MESSAGE_PROCESSING" : \
+     (status) == WMRZ_SERVER_MONITOR_MESSAGE_PROCESSED ? \
+     "WMRZ_SERVER_MONITOR_MESSAGE_PROCESSED" : \
      (status) == WMRZ_XRDP_CORE_RESIZE ? "WMRZ_XRDP_CORE_RESIZE" : \
      (status) == WMRZ_EGFX_INITIALIZE ? "WMRZ_EGFX_INITIALIZE" : \
      (status) == WMRZ_EGFX_INITALIZING ? "WMRZ_EGFX_INITALIZING" : \
@@ -417,7 +425,7 @@ struct xrdp_mm
     int dynamic_monitor_chanid;
     struct xrdp_egfx *egfx;
     int egfx_up;
-    int egfx_flags;
+    enum xrdp_egfx_flags egfx_flags;
     int gfx_delay_autologin;
     /* Resize on-the-fly control */
     struct display_control_monitor_layout_data *resize_data;

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -767,10 +767,19 @@ xrdp_wm_init(struct xrdp_wm *self)
                     list_add_strdup(self->mm->login_values, r);
                 }
 
-                /*
-                 * Skip the login box and go straight to the connection phase
-                 */
-                xrdp_wm_set_login_state(self, WMLS_START_CONNECT);
+                if (self->session->client_info->gfx && !self->mm->egfx_up)
+                {
+                    /* gfx session but have not recieved caps advertise yet,
+                       set flag so we will connect to backend later */
+                    self->mm->gfx_delay_autologin = 1;
+                }
+                else
+                {
+                    /*
+                    * Skip the login box and go straight to the connection phase
+                    */
+                    xrdp_wm_set_login_state(self, WMLS_START_CONNECT);
+                }
             }
             else
             {

--- a/xup/xup.c
+++ b/xup/xup.c
@@ -1174,47 +1174,33 @@ process_server_paint_rect_shmem_ex(struct mod *amod, struct stream *s)
     in_uint16_le(s, height);
 
     bmpdata = 0;
-    if (flags == 0) /* screen */
+    if (amod->screen_shmem_id_mapped == 0)
     {
-        /* Do we need to map (or remap) the memory
-         * area shared with the X server ? */
-        if (amod->screen_shmem_id_mapped == 0 ||
-                amod->screen_shmem_id != shmem_id)
+        amod->screen_shmem_id = shmem_id;
+        amod->screen_shmem_pixels = (char *) g_shmat(amod->screen_shmem_id);
+        if (amod->screen_shmem_pixels == (void *) -1)
         {
-            if (amod->screen_shmem_id_mapped != 0)
-            {
-                g_shmdt(amod->screen_shmem_pixels);
-            }
-            amod->screen_shmem_pixels = (char *) g_shmat(shmem_id);
-            if (amod->screen_shmem_pixels == (void *) -1)
-            {
-                /* failed */
-                if (amod->screen_shmem_id_mapped == 0)
-                {
-                    LOG(LOG_LEVEL_ERROR,
-                        "Can't attach to shared memory id %d [%s]",
-                        shmem_id, g_get_strerror());
-                }
-                else
-                {
-                    LOG(LOG_LEVEL_ERROR,
-                        "Can't attach to shared memory id %d from id %d [%s]",
-                        shmem_id, amod->screen_shmem_id, g_get_strerror());
-                }
-                amod->screen_shmem_id = 0;
-                amod->screen_shmem_pixels = 0;
-                amod->screen_shmem_id_mapped = 0;
-            }
-            else
-            {
-                amod->screen_shmem_id = shmem_id;
-                amod->screen_shmem_id_mapped = 1;
-            }
+            /* failed */
+            amod->screen_shmem_id = 0;
+            amod->screen_shmem_pixels = 0;
+            amod->screen_shmem_id_mapped = 0;
         }
-
-        if (amod->screen_shmem_pixels != 0)
+        else
         {
-            bmpdata = amod->screen_shmem_pixels + shmem_offset;
+            amod->screen_shmem_id_mapped = 1;
+        }
+    }
+    else if (amod->screen_shmem_id != shmem_id)
+    {
+        amod->screen_shmem_id = shmem_id;
+        g_shmdt(amod->screen_shmem_pixels);
+        amod->screen_shmem_pixels = (char *) g_shmat(amod->screen_shmem_id);
+        if (amod->screen_shmem_pixels == (void *) -1)
+        {
+            /* failed */
+            amod->screen_shmem_id = 0;
+            amod->screen_shmem_pixels = 0;
+            amod->screen_shmem_id_mapped = 0;
         }
     }
     else
@@ -1225,7 +1211,10 @@ process_server_paint_rect_shmem_ex(struct mod *amod, struct stream *s)
                   flags, frame_id, shmem_id, shmem_offset,
                   width, height);
     }
-
+    if (amod->screen_shmem_pixels != 0)
+    {
+        bmpdata = amod->screen_shmem_pixels + shmem_offset;
+    }
     if (bmpdata != 0)
     {
         rv = amod->server_paint_rects(amod, num_drects, ldrects,
@@ -1237,9 +1226,6 @@ process_server_paint_rect_shmem_ex(struct mod *amod, struct stream *s)
     {
         rv = 1;
     }
-
-    //LOG_DEVEL(LOG_LEVEL_TRACE, "frame_id %d", frame_id);
-    //send_paint_rect_ex_ack(amod, flags, frame_id);
 
     g_free(lcrects);
     g_free(ldrects);
@@ -1680,73 +1666,70 @@ lib_mod_process_message(struct mod *mod, struct stream *s)
     char *phold;
 
     LOG_DEVEL(LOG_LEVEL_TRACE, "lib_mod_process_message:");
+    in_uint16_le(s, type);
+    in_uint16_le(s, num_orders);
+    in_uint32_le(s, len);
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "lib_mod_process_message: type %d", type);
+
     rv = 0;
-    if (rv == 0)
+    if (type == 1) /* original order list */
     {
-        in_uint16_le(s, type);
-        in_uint16_le(s, num_orders);
-        in_uint32_le(s, len);
-        LOG_DEVEL(LOG_LEVEL_TRACE, "lib_mod_process_message: type %d", type);
-
-        if (type == 1) /* original order list */
+        for (index = 0; index < num_orders; index++)
         {
-            for (index = 0; index < num_orders; index++)
-            {
-                in_uint16_le(s, type);
-                rv = lib_mod_process_orders(mod, type, s);
+            in_uint16_le(s, type);
+            rv = lib_mod_process_orders(mod, type, s);
 
-                if (rv != 0)
-                {
+            if (rv != 0)
+            {
+                break;
+            }
+        }
+    }
+    else if (type == 2) /* caps */
+    {
+        LOG_DEVEL(LOG_LEVEL_TRACE,
+                  "lib_mod_process_message: type 2 len %d", len);
+        for (index = 0; index < num_orders; index++)
+        {
+            phold = s->p;
+            in_uint16_le(s, type);
+            in_uint16_le(s, len);
+
+            switch (type)
+            {
+                default:
+                    LOG_DEVEL(LOG_LEVEL_TRACE,
+                              "lib_mod_process_message: unknown"
+                              " cap type %d len %d",
+                              type, len);
                     break;
-                }
             }
+            s->p = phold + len;
         }
-        else if (type == 2) /* caps */
+        lib_send_client_info(mod);
+    }
+    else if (type == 3) /* order list with len after type */
+    {
+        LOG_DEVEL(LOG_LEVEL_INFO,
+                  "lib_mod_process_message: type 3 len %d", len);
+        for (index = 0; index < num_orders; index++)
         {
-            LOG_DEVEL(LOG_LEVEL_TRACE,
-                      "lib_mod_process_message: type 2 len %d", len);
-            for (index = 0; index < num_orders; index++)
+            phold = s->p;
+            in_uint16_le(s, type);
+            in_uint16_le(s, len);
+            rv = lib_mod_process_orders(mod, type, s);
+
+            if (rv != 0)
             {
-                phold = s->p;
-                in_uint16_le(s, type);
-                in_uint16_le(s, len);
-
-                switch (type)
-                {
-                    default:
-                        LOG_DEVEL(LOG_LEVEL_TRACE,
-                                  "lib_mod_process_message: unknown"
-                                  " cap type %d len %d",
-                                  type, len);
-                        break;
-                }
-
-                s->p = phold + len;
+                break;
             }
 
-            lib_send_client_info(mod);
+            s->p = phold + len;
         }
-        else if (type == 3) /* order list with len after type */
-        {
-            for (index = 0; index < num_orders; index++)
-            {
-                phold = s->p;
-                in_uint16_le(s, type);
-                in_uint16_le(s, len);
-                rv = lib_mod_process_orders(mod, type, s);
-
-                if (rv != 0)
-                {
-                    break;
-                }
-
-                s->p = phold + len;
-            }
-        }
-        else
-        {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "unknown type %d", type);
-        }
+    }
+    else
+    {
+        LOG_DEVEL(LOG_LEVEL_TRACE, "unknown type %d", type);
     }
 
     return rv;


### PR DESCRIPTION
At the moment, timeouts of -1 or 0 for g_obj_wait() both mean 'no timeout', i.e. wait forever. This commit changes a timeout of 0 to mean 'return immediately'. This is more consistent with poll() and WaitForMultipleObjects(), and can be used by the new encoder logic.

There are a very few places on xrdp where a timeout of 0 is currently specified to mean 'wait forever'. These are replaced with values of -1.