### PR TITLE
Improve portability

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -95,15 +95,10 @@ struct sockaddr_hvs
 #endif
 
 #include "os_calls.h"
+#include "limits.h"
 #include "string_calls.h"
 #include "log.h"
 #include "xrdp_constants.h"
-
-/* for clearenv() */
-#if defined(_WIN32)
-#else
-extern char **environ;
-#endif
 
 #if defined(__linux__)
 #include <linux/unistd.h>
@@ -3446,13 +3441,15 @@ g_setpgid(int pid, int pgid)
 void
 g_clearenv(void)
 {
-#if defined(_WIN32)
-#else
-#if defined(BSD)
+#if defined(HAVE_CLEARENV)
+    clearenv();
+#elif defined(_WIN32)
+#elif defined(BSD)
+    extern char **environ;
     environ[0] = 0;
 #else
+    extern char **environ;
     environ = 0;
-#endif
 #endif
 }
 

--- a/configure.ac
+++ b/configure.ac
@@ -211,7 +211,7 @@ AM_COND_IF([DEVEL_DEBUG],
 AC_SEARCH_LIBS([setusercontext], [util])
 
 # Define HAVE_XXXXX macros for some system functions
-AC_CHECK_FUNCS([setusercontext getgrouplist])
+AC_CHECK_FUNCS([setusercontext getgrouplist clearenv])
 
 # The type used by getgrouplist() is the same type used by getgroups()
 AC_TYPE_GETGROUPS

--- a/sesman/tools/sesrun.c
+++ b/sesman/tools/sesrun.c
@@ -68,8 +68,8 @@
 #   define DEFAULT_BPP 32
 #endif
 
-#ifndef DEFAULT_TYPE
-#   define DEFAULT_TYPE "Xorg"
+#ifndef DEFAULT_SESSION_TYPE
+#   define DEFAULT_SESSION_TYPE "Xorg"
 #endif
 
 /**
@@ -176,7 +176,7 @@ usage(void)
     g_printf("    -g <geometry>         Default:%dx%d\n",
              DEFAULT_WIDTH, DEFAULT_HEIGHT);
     g_printf("    -b <bits-per-pixel>   Default:%d\n", DEFAULT_BPP);
-    g_printf("    -t <type>             Default:%s\n", DEFAULT_TYPE);
+    g_printf("    -t <type>             Default:%s\n", DEFAULT_SESSION_TYPE);
     g_printf("    -D <directory>        Default: $HOME\n"
              "    -S <shell>            Default: Defined window manager\n"
              "    -p <password>         TESTING ONLY - DO NOT USE IN PRODUCTION\n"
@@ -290,7 +290,7 @@ parse_program_args(int argc, char *argv[], struct session_params *sp,
     sp->width = DEFAULT_WIDTH;
     sp->height = DEFAULT_HEIGHT;
     sp->bpp = DEFAULT_BPP;
-    (void)string_to_session_type(DEFAULT_TYPE, &sp->session_type);
+    (void)string_to_session_type(DEFAULT_SESSION_TYPE, &sp->session_type);
 
     sp->directory = "";
     sp->shell = "";


### PR DESCRIPTION
Fixes #2908 

Improves portability
- Use clearenv() if it exists
- Don't rely on <limits.h> being pulled in by <sys/param.h>