### PR TITLE
GFX tidy-ups

### DIFF
--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -113,26 +113,26 @@ set_keyboard_overrides(struct mod *mod)
 
     if (mod->allow_client_kbd_settings)
     {
-        settings->kbd_type = mod->client_info.keyboard_type;
-        settings->kbd_subtype = mod->client_info.keyboard_subtype;
+        settings->kbd_type = mod->client_info->keyboard_type;
+        settings->kbd_subtype = mod->client_info->keyboard_subtype;
         /* Define the most common number of function keys, 12.
            because we can't get it from client. */
         settings->kbd_fn_keys = 12;
-        settings->kbd_layout = mod->client_info.keylayout;
+        settings->kbd_layout = mod->client_info->keylayout;
 
         /* Exception processing for each RDP Keyboard type */
-        if (mod->client_info.keyboard_type == 0x00)
+        if (mod->client_info->keyboard_type == 0x00)
         {
             /* 0x00000000 : Set on Server */
             LOG(LOG_LEVEL_WARNING, "keyboard_type:[0x%02x] ,Set on Server",
-                mod->client_info.keyboard_type);
+                mod->client_info->keyboard_type);
         }
-        else if (mod->client_info.keyboard_type == 0x04)
+        else if (mod->client_info->keyboard_type == 0x04)
         {
             /* 0x00000004 : IBM enhanced (101- or 102-key) keyboard */
             /* Nothing to do. */
         }
-        else if (mod->client_info.keyboard_type == 0x07)
+        else if (mod->client_info->keyboard_type == 0x07)
         {
             /* 0x00000007 : Japanese keyboard */
             /* Nothing to do. */
@@ -281,7 +281,7 @@ lxrdp_connect(struct mod *mod)
         LOG(LOG_LEVEL_ERROR, "NeutrinoRDP proxy connection: status [Failed],"
             " RDP client [%s], RDP server [%s:%d], RDP server username [%s],"
             " xrdp pamusername [%s], xrdp process id [%d]",
-            mod->client_info.client_description,
+            mod->client_info->client_description,
             mod->inst->settings->hostname,
             mod->inst->settings->port,
             mod->inst->settings->username,
@@ -294,7 +294,7 @@ lxrdp_connect(struct mod *mod)
         LOG(LOG_LEVEL_INFO, "NeutrinoRDP proxy connection: status [Success],"
             " RDP client [%s], RDP server [%s:%d], RDP server username [%s],"
             " xrdp pamusername [%s], xrdp process id [%d]",
-            mod->client_info.client_description,
+            mod->client_info->client_description,
             mod->inst->settings->hostname,
             mod->inst->settings->port,
             mod->inst->settings->username,
@@ -574,7 +574,7 @@ lxrdp_end(struct mod *mod)
     LOG(LOG_LEVEL_INFO, "NeutrinoRDP proxy connection: status [Disconnect],"
         " RDP client [%s], RDP server [%s:%d], RDP server username [%s],"
         " xrdp pamusername [%s], xrdp process id [%d]",
-        mod->client_info.client_description,
+        mod->client_info->client_description,
         mod->inst->settings->hostname,
         mod->inst->settings->port,
         mod->inst->settings->username,
@@ -636,7 +636,7 @@ lxrdp_set_param(struct mod *mod, const char *name, const char *value)
     }
     else if (g_strcmp(name, "client_info") == 0)
     {
-        g_memcpy(&(mod->client_info), value, sizeof(mod->client_info));
+        mod->client_info = (struct xrdp_client_info *)value;
         /* This is a Struct and cannot be printed in next else*/
         LOG_DEVEL(LOG_LEVEL_DEBUG, "Client_info struct ignored");
     }
@@ -1906,15 +1906,15 @@ lfreerdp_pre_connect(freerdp *instance)
     instance->settings->password = g_strdup(mod->password);
     instance->settings->domain = g_strdup(mod->domain);
 
-    if (mod->client_info.rail_enable && (mod->client_info.rail_support_level > 0))
+    if (mod->client_info->rail_enable && (mod->client_info->rail_support_level > 0))
     {
         LOG_DEVEL(LOG_LEVEL_INFO, "Railsupport !!!!!!!!!!!!!!!!!!");
         instance->settings->remote_app = 1;
         instance->settings->rail_langbar_supported = 1;
         instance->settings->workarea = 1;
         instance->settings->performance_flags = PERF_DISABLE_WALLPAPER | PERF_DISABLE_FULLWINDOWDRAG;
-        instance->settings->num_icon_caches = mod->client_info.wnd_num_icon_caches;
-        instance->settings->num_icon_cache_entries = mod->client_info.wnd_num_icon_cache_entries;
+        instance->settings->num_icon_caches = mod->client_info->wnd_num_icon_caches;
+        instance->settings->num_icon_cache_entries = mod->client_info->wnd_num_icon_cache_entries;
 
 
     }
@@ -1930,14 +1930,14 @@ lfreerdp_pre_connect(freerdp *instance)
     /* Allow users or administrators to configure the mstsc experience settings. #1903 */
 
     if ((mod->allow_client_experiencesettings == 1) &&
-            (mod->client_info.mcs_connection_type == CONNECTION_TYPE_AUTODETECT))
+            (mod->client_info->mcs_connection_type == CONNECTION_TYPE_AUTODETECT))
     {
         /* auto-detect not yet supported - use default performance settings */
     }
     else if (mod->allow_client_experiencesettings == 1)
     {
         instance->settings->performance_flags =
-            (mod->client_info.rdp5_performanceflags &
+            (mod->client_info->rdp5_performanceflags &
              /* Mask to avoid accepting invalid flags. */
              (PERF_DISABLE_WALLPAPER |
               PERF_DISABLE_FULLWINDOWDRAG |
@@ -1951,11 +1951,11 @@ lfreerdp_pre_connect(freerdp *instance)
         LOG(LOG_LEVEL_DEBUG, "RDP client experience settings, "
             "rdp5_performance_flags:[0x%08x], "
             "masked performance_flags:[0x%08x]",
-            mod->client_info.rdp5_performanceflags,
+            mod->client_info->rdp5_performanceflags,
             instance->settings->performance_flags);
 
-        if (mod->client_info.rail_enable &&
-                (mod->client_info.rail_support_level > 0))
+        if (mod->client_info->rail_enable &&
+                (mod->client_info->rail_support_level > 0))
         {
             instance->settings->performance_flags |= (PERF_DISABLE_WALLPAPER |
                     PERF_DISABLE_FULLWINDOWDRAG);
@@ -1986,7 +1986,7 @@ lfreerdp_pre_connect(freerdp *instance)
 
     // Multi Monitor Settings
     const struct display_size_description *display_sizes =
-            &mod->client_info.display_sizes;
+            &mod->client_info->display_sizes;
     instance->settings->num_monitors = display_sizes->monitorCount;
 
     for (index = 0; index < display_sizes->monitorCount; index++)

--- a/neutrinordp/xrdp-neutrinordp.h
+++ b/neutrinordp/xrdp-neutrinordp.h
@@ -217,7 +217,7 @@ struct mod
     int bool_keyBoardSynced ; /* Numlock can be out of sync, we hold state here to resolve */
     int keyBoardLockInfo ; /* Holds initial numlock capslock state */
 
-    struct xrdp_client_info client_info;
+    struct xrdp_client_info *client_info;
 
     struct rdp_freerdp *inst;
     struct bitmap_item bitmap_cache[4][4096];

--- a/neutrinordp/xrdp-neutrinordp.h
+++ b/neutrinordp/xrdp-neutrinordp.h
@@ -184,6 +184,8 @@ struct mod
                             int srcx, int srcy, int mskx, int msky,
                             int dstx, int dsty, int width, int height,
                             int dstformat);
+    // Module must call this before server_paint_rects / server_paint_rects_ex
+    int (*server_start_encoder)(struct mod *v);
     int (*server_paint_rects)(struct mod *v,
                               int num_drects, short *drects,
                               int num_crects, short *crects,
@@ -191,7 +193,7 @@ struct mod
                               int flags, int frame_id);
     int (*server_session_info)(struct mod *v, const char *data,
                                int data_bytes);
-    tintptr server_dumby[100 - 46]; /* align, 100 minus the number of server
+    tintptr server_dumby[100 - 47]; /* align, 100 minus the number of server
                                        functions above */
     /* common */
     tintptr handle; /* pointer to self as long */

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -535,6 +535,8 @@ server_composite(struct xrdp_mod *mod, int srcidx, int srcformat, int srcwidth,
                  int srcx, int srcy, int mskx, int msky,
                  int dstx, int dsty, int width, int height, int dstformat);
 int
+server_start_encoder(struct xrdp_mod *mod);
+int
 server_paint_rects(struct xrdp_mod *mod, int num_drects, short *drects,
                    int num_crects, short *crects,
                    char *data, int width, int height,

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -474,6 +474,7 @@ struct display_control_monitor_layout_data
     /// This flag is set if the state machine needs to
     /// shutdown/startup EGFX
     int using_egfx;
+    int restart_encoder;
 };
 
 int

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -1674,6 +1674,7 @@ process_display_control_monitor_layout_data(struct xrdp_wm *wm)
             // Disable the encoder until the resize is complete.
             if (mm->encoder != NULL)
             {
+                description->restart_encoder = 1;
                 xrdp_encoder_delete(mm->encoder);
                 mm->encoder = NULL;
             }
@@ -1833,7 +1834,7 @@ process_display_control_monitor_layout_data(struct xrdp_wm *wm)
             advance_resize_state_machine(mm, WMRZ_ENCODER_CREATE);
             break;
         case WMRZ_ENCODER_CREATE:
-            if (mm->encoder == NULL)
+            if (description->restart_encoder)
             {
                 mm->encoder = xrdp_encoder_create(mm);
             }

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -1370,13 +1370,7 @@ xrdp_mm_egfx_caps_advertise(void *user, int caps_count,
         self->encoder = xrdp_encoder_create(self);
         xrdp_mm_egfx_invalidate_all(self);
 
-        if (self->resize_data != NULL
-                && self->resize_data->state == WMRZ_EGFX_INITALIZING)
-        {
-            advance_resize_state_machine(self, WMRZ_EGFX_INITIALIZED);
-        }
         LOG(LOG_LEVEL_INFO, "xrdp_mm_egfx_caps_advertise: egfx created.");
-        xrdp_wm_set_login_state(self->wm, WMLS_RESET);
     }
     else
     {
@@ -1388,10 +1382,21 @@ xrdp_mm_egfx_caps_advertise(void *user, int caps_count,
         lrect.right = screen->width;
         lrect.bottom = screen->height;
         self->wm->client_info->gfx = 0;
+        self->egfx_flags = XRDP_EGFX_NONE;
         xrdp_encoder_delete(self->encoder);
         self->encoder = xrdp_encoder_create(self);
         xrdp_bitmap_invalidate(screen, &lrect);
     }
+
+    if (self->resize_data != NULL
+            && self->resize_data->state == WMRZ_EGFX_INITALIZING)
+    {
+        advance_resize_state_machine(self, WMRZ_EGFX_INITIALIZED);
+    }
+
+    // Now the virtual channel is up (or can't be started), kick the
+    // window manager state machine into life.
+    xrdp_wm_set_login_state(self->wm, WMLS_RESET);
     g_free(ver_flags);
     return 0;
 }

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -1376,11 +1376,7 @@ xrdp_mm_egfx_caps_advertise(void *user, int caps_count,
             advance_resize_state_machine(self, WMRZ_EGFX_INITIALIZED);
         }
         LOG(LOG_LEVEL_INFO, "xrdp_mm_egfx_caps_advertise: egfx created.");
-        if (self->gfx_delay_autologin)
-        {
-            self->gfx_delay_autologin = 0;
-            xrdp_wm_set_login_state(self->wm, WMLS_START_CONNECT);
-        }
+        xrdp_wm_set_login_state(self->wm, WMLS_RESET);
     }
     else
     {

--- a/xrdp/xrdp_process.c
+++ b/xrdp/xrdp_process.c
@@ -79,10 +79,15 @@ xrdp_process_loop(struct xrdp_process *self, struct stream *s)
         {
             LOG_DEVEL(LOG_LEVEL_TRACE, "calling xrdp_wm_init and creating wm");
             self->wm = xrdp_wm_create(self, self->session->client_info);
-            /* at this point the wm(window manager) is created and
-               wm::login_state is WMLS_RESET and wm::login_state_event is set
-               so xrdp_wm_init should be called by xrdp_wm_check_wait_objs
-               */
+            /* at this point the wm(window manager) is created. One of
+             * the following is true:-
+             * 1) (non-GFX) wm::login_state is WMLS_RESET and
+             *     wm::login_state_event is set so xrdp_wm_init should
+             *     be called by xrdp_wm_check_wait_objs
+             * 2) (GFX) We're waiting for the EGFX virtual channel to
+             *     come up. wm::login_state_event is clear, and gets set
+             *     when the EGFX virtual channel comes up
+             */
         }
     }
 

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -165,6 +165,7 @@ struct xrdp_mod
                             int srcx, int srcy, int mskx, int msky,
                             int dstx, int dsty, int width, int height,
                             int dstformat);
+    int (*server_start_encoder)(struct xrdp_mod *v);
     int (*server_paint_rects)(struct xrdp_mod *v,
                               int num_drects, short *drects,
                               int num_crects, short *crects,
@@ -182,7 +183,7 @@ struct xrdp_mod
                                  int width, int height,
                                  int flags, int frame_id,
                                  void *shmem_ptr, int shmem_bytes);
-    tintptr server_dumby[100 - 48]; /* align, 100 minus the number of server
+    tintptr server_dumby[100 - 49]; /* align, 100 minus the number of server
                                      functions above */
     /* common */
     tintptr handle; /* pointer to self as int */

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -432,7 +432,6 @@ struct xrdp_mm
     struct xrdp_egfx *egfx;
     int egfx_up;
     enum xrdp_egfx_flags egfx_flags;
-    int gfx_delay_autologin;
     /* Resize on-the-fly control */
     struct display_control_monitor_layout_data *resize_data;
     struct list *resize_queue;

--- a/xup/xup.c
+++ b/xup/xup.c
@@ -77,7 +77,7 @@ lib_mod_log_peer(struct mod *mod)
             "to Xorg_pid=%d Xorg_uid=%d Xorg_gid=%d "
             "client=%s",
             my_pid, pid, uid, gid,
-            mod->client_info.client_description);
+            mod->client_info->client_description);
     }
     else
     {
@@ -1642,8 +1642,8 @@ lib_send_client_info(struct mod *mod)
     init_stream(s, 8192);
     s_push_layer(s, iso_hdr, 4);
     out_uint16_le(s, 104);
-    g_memcpy(s->p, &(mod->client_info), sizeof(mod->client_info));
-    s->p += sizeof(mod->client_info);
+    g_memcpy(s->p, mod->client_info, sizeof(*mod->client_info));
+    s->p += sizeof(*mod->client_info);
     s_mark_end(s);
     len = (int)(s->end - s->data);
     s_pop_layer(s, iso_hdr);
@@ -1806,7 +1806,7 @@ lib_mod_set_param(struct mod *mod, const char *name, const char *value)
     }
     else if (g_strcasecmp(name, "client_info") == 0)
     {
-        g_memcpy(&(mod->client_info), value, sizeof(mod->client_info));
+        mod->client_info = (struct xrdp_client_info *)value;
     }
 
     return 0;

--- a/xup/xup.c
+++ b/xup/xup.c
@@ -221,6 +221,11 @@ lib_mod_connect(struct mod *mod)
 
     if (error == 0)
     {
+        error = mod->server_start_encoder(mod);
+    }
+
+    if (error == 0)
+    {
         error = send_server_version_message(mod, s);
     }
 

--- a/xup/xup.h
+++ b/xup/xup.h
@@ -150,6 +150,8 @@ struct mod
                             int mskformat, int mskwidth, int mskrepeat, int op,
                             int srcx, int srcy, int mskx, int msky,
                             int dstx, int dsty, int width, int height, int dstformat);
+    // Module must call this before server_paint_rects / server_paint_rects_ex
+    int (*server_start_encoder)(struct mod *v);
     int (*server_paint_rects)(struct mod *v,
                               int num_drects, short *drects,
                               int num_crects, short *crects,
@@ -167,7 +169,7 @@ struct mod
                                  int width, int height,
                                  int flags, int frame_id,
                                  void *shmem_ptr, int shmem_bytes);
-    tintptr server_dumby[100 - 48]; /* align, 100 minus the number of server
+    tintptr server_dumby[100 - 49]; /* align, 100 minus the number of server
                                      functions above */
     /* common */
     tintptr handle; /* pointer to self as long */

--- a/xup/xup.h
+++ b/xup/xup.h
@@ -184,7 +184,7 @@ struct mod
     char ip[256];
     char port[256];
     int shift_state;
-    struct xrdp_client_info client_info;
+    struct xrdp_client_info *client_info;
     int screen_shmem_id;
     int screen_shmem_id_mapped; /* boolean */
     char *screen_shmem_pixels;


### PR DESCRIPTION
A number of tidy-ups to the GFX code:-

**Edit 2024-1-25 : NeutrinoRDP is now working with GFX. Comment updated**

## Fixes
- Don't enable GFX if the client doesn't support 32 bpp.

  mstsc.exe sets 'GFX available' in the early capability flags for bpp < 32, but when you try to use it, mstsc.exe fails.
- Add error checking to the `xrdp_mm_egfx_send_planar_bitmap()` codepaths

  Without this, you can end up with xrdp processes which don't exit when the client exits.
- Improved codec logging when creating an encoder thread.
- Fixed behaviour if a GFX codec cannot be chosen.

## Changes
- If using GFX, always wait for the egfx virtual channel to come up before starting the Window Manager state machine.

  This keeps the codepath for autologin the same as the non-autologin case, and makes sure the channel is up before we draw anything.
- Only start the encoder thread for xorgxrdp as other session types don't need it.

  This is a fairly significant change and encompasses 4 commits in this PR.

- Update NeutrinoRDP to not pass the "drdynvc" virtual channel through to the target.

   Dynamic virtual channels for neutrinordp have not been working since v0.9.9. This doesn't fix that, but it does prevent a target which attempts to use drdynvc from blowing up GFX.

## What's working
- GFX/RFX/no-codec session types tested with mstsc.exe and xorg and xvnc backends
- neutrinordp

## What's not working
- neutrinordp mouse buttons. This appears to be a regression in devel, so not related to GFX.
