### PR TITLE
Set up alternative definitions for some window messages

### DIFF
--- a/neutrinordp/xrdp-color.c
+++ b/neutrinordp/xrdp-color.c
@@ -22,6 +22,10 @@
 #endif
 
 #include "xrdp-neutrinordp.h"
+#include "defines.h"
+#include "log.h"
+#include "os_calls.h"
+#include "string_calls.h"
 
 char *
 convert_bitmap(int in_bpp, int out_bpp, char *bmpdata,

--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -17,6 +17,17 @@
  * limitations under the License.
  */
 
+#include <freerdp/freerdp.h>
+#include <freerdp/codec/bitmap.h>
+
+// FreeRDP defines some macros that we have different values for.
+// To catch this we need to include the freerdp includes before our
+// local ones (see gcc bug #16358)
+#undef WM_LBUTTONUP
+#undef WM_LBUTTONDOWN
+#undef WM_RBUTTONUP
+#undef WM_RBUTTONDOWN
+
 #if defined(HAVE_CONFIG_H)
 #include <config_ac.h>
 #endif
@@ -26,8 +37,8 @@
 #include "xrdp_rail.h"
 #include "trans.h"
 #include "log.h"
+#include "os_calls.h"
 #include "string_calls.h"
-#include <freerdp/settings.h>
 
 #if defined(VERSION_STRUCT_RDP_FREERDP)
 #if VERSION_STRUCT_RDP_FREERDP > 1

--- a/neutrinordp/xrdp-neutrinordp.h
+++ b/neutrinordp/xrdp-neutrinordp.h
@@ -20,22 +20,15 @@
 #ifndef XRDP_NEUTRINORDP_H
 #define XRDP_NEUTRINORDP_H
 
-/* include other h files */
 #include "arch.h"
-#include "parse.h"
-#include "os_calls.h"
-#include "defines.h"
-#include "xrdp_rail.h"
-#include "xrdp_client_info.h"
 #include "xrdp_constants.h"
+#include "xrdp_client_info.h"
 
-/* this is the freerdp main header */
-#include <freerdp/freerdp.h>
-#include <freerdp/rail.h>
-#include <freerdp/rail/rail.h>
-#include <freerdp/codec/bitmap.h>
-//#include <freerdp/utils/memory.h>
-//#include "/home/jay/git/jsorg71/staging/include/freerdp/freerdp.h"
+/* Incomplete type definitions, referenced below */
+struct rail_window_state_order;
+struct rail_notify_state_order;
+struct rail_monitored_desktop_order;
+struct rail_icon_info;
 
 struct bitmap_item
 {


### PR DESCRIPTION
This fixes a regression introduced by #2864

FreeRDP silently redefines WM_LBUTTONUP, WM_LBUTTONDOWN, WM_RBUTTONUP and WM_RBUTTONDOWN. Consequently on my neutrinordp build at least, the right and left buttons don't work.

This is the least disruptive change. Renaming the defines totally will break xorgxrdp.

This probably needs backporting to v0.9 - I'll test that tomorrow.