### PR TITLE
GFX: Relegate some logs to LOG_DEVEL

### DIFF
--- a/xrdp/xrdp_egfx.c
+++ b/xrdp/xrdp_egfx.c
@@ -105,7 +105,7 @@ xrdp_egfx_create_surface(struct xrdp_egfx_bulk *bulk, int surface_id,
     int bytes;
     struct stream *s;
 
-    LOG(LOG_LEVEL_TRACE, "xrdp_egfx_create_surface:");
+    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_egfx_create_surface:");
     make_stream(s);
     init_stream(s, 8192);
     /* RDP_SEGMENTED_DATA */
@@ -135,12 +135,12 @@ xrdp_egfx_send_create_surface(struct xrdp_egfx *egfx, int surface_id,
     int error;
     struct stream *s;
 
-    LOG(LOG_LEVEL_TRACE, "xrdp_egfx_send_create_surface:");
+    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_egfx_send_create_surface:");
     s = xrdp_egfx_create_surface(egfx->bulk, surface_id, width, height,
                                  pixel_format);
     error = xrdp_egfx_send_s(egfx, s);
-    LOG(LOG_LEVEL_DEBUG, "xrdp_egfx_send_create_surface: xrdp_egfx_send_s "
-        "error %d", error);
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_egfx_send_create_surface: xrdp_egfx_send_s "
+              "error %d", error);
     free_stream(s);
     return error;
 }
@@ -181,8 +181,8 @@ xrdp_egfx_send_delete_surface(struct xrdp_egfx *egfx, int surface_id)
     LOG(LOG_LEVEL_TRACE, "xrdp_egfx_send_delete_surface:");
     s = xrdp_egfx_delete_surface(egfx->bulk, surface_id);
     error = xrdp_egfx_send_s(egfx, s);
-    LOG(LOG_LEVEL_DEBUG, "xrdp_egfx_send_delete_surface: xrdp_egfx_send_s "
-        "error %d", error);
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_egfx_send_delete_surface: xrdp_egfx_send_s "
+              "error %d", error);
     free_stream(s);
     return error;
 }
@@ -538,16 +538,16 @@ xrdp_egfx_wire_to_surface1(struct xrdp_egfx_bulk *bulk, int surface_id,
         /* RDP8_BULK_ENCODED_DATA */
         out_uint8(s, PACKET_COMPR_TYPE_RDP8); /* header */
         out_uint8a(s, bitmap_data8 + index, segment_size);
-        LOG(LOG_LEVEL_DEBUG, "  segment index %d segment_size %d",
-            segment_count, segment_size);
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "  segment index %d segment_size %d",
+                  segment_count, segment_size);
         index += segment_size;
         segment_count++;
     }
     s_mark_end(s);
     s_pop_layer(s, iso_hdr);
     out_uint16_le(s, segment_count);
-    LOG(LOG_LEVEL_DEBUG, "xrdp_egfx_wire_to_surface1: segment_count %d",
-        segment_count);
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_egfx_wire_to_surface1: segment_count %d",
+              segment_count);
     return s;
 }
 
@@ -561,13 +561,13 @@ xrdp_egfx_send_wire_to_surface1(struct xrdp_egfx *egfx, int surface_id,
     int error;
     struct stream *s;
 
-    LOG(LOG_LEVEL_TRACE, "xrdp_egfx_send_wire_to_surface1:");
+    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_egfx_send_wire_to_surface1:");
     s = xrdp_egfx_wire_to_surface1(egfx->bulk, surface_id, codec_id,
                                    pixel_format, dest_rect,
                                    bitmap_data, bitmap_data_length);
     error = xrdp_egfx_send_s(egfx, s);
-    LOG(LOG_LEVEL_DEBUG, "xrdp_egfx_send_wire_to_surface1: xrdp_egfx_send_s "
-        "error %d", error);
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_egfx_send_wire_to_surface1: xrdp_egfx_send_s "
+              "error %d", error);
     free_stream(s);
     return error;
 }
@@ -586,7 +586,7 @@ xrdp_egfx_wire_to_surface2(struct xrdp_egfx_bulk *bulk, int surface_id,
     struct stream *s;
     char *bitmap_data8;
 
-    LOG(LOG_LEVEL_TRACE, "xrdp_egfx_wire_to_surface2:");
+    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_egfx_wire_to_surface2:");
     make_stream(s);
     bytes = bitmap_data_length + 8192;
     bytes += 5 * (bitmap_data_length / MAX_PART_SIZE);
@@ -623,16 +623,16 @@ xrdp_egfx_wire_to_surface2(struct xrdp_egfx_bulk *bulk, int surface_id,
         /* RDP8_BULK_ENCODED_DATA */
         out_uint8(s, PACKET_COMPR_TYPE_RDP8); /* header */
         out_uint8a(s, bitmap_data8 + index, segment_size);
-        LOG(LOG_LEVEL_DEBUG, "  segment index %d segment_size %d",
-            segment_count, segment_size);
+        LOG_DEVEL(LOG_LEVEL_DEBUG, "  segment index %d segment_size %d",
+                  segment_count, segment_size);
         index += segment_size;
         segment_count++;
     }
     s_mark_end(s);
     s_pop_layer(s, iso_hdr);
     out_uint16_le(s, segment_count);
-    LOG(LOG_LEVEL_DEBUG, "xrdp_egfx_wire_to_surface2: segment_count %d",
-        segment_count);
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_egfx_wire_to_surface2: segment_count %d",
+              segment_count);
     return s;
 }
 
@@ -651,8 +651,8 @@ xrdp_egfx_send_wire_to_surface2(struct xrdp_egfx *egfx, int surface_id,
                                    codec_context_id, pixel_format,
                                    bitmap_data, bitmap_data_length);
     error = xrdp_egfx_send_s(egfx, s);
-    LOG(LOG_LEVEL_DEBUG, "xrdp_egfx_send_wire_to_surface2: xrdp_egfx_send_s "
-        "error %d", error);
+    LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_egfx_send_wire_to_surface2: xrdp_egfx_send_s "
+              "error %d", error);
     free_stream(s);
     return error;
 }


### PR DESCRIPTION
I think these logs are too much for regular use with LOG_LEVEL=DEBUG.