### PR TITLE
Remove hard-coded version from scripts/run_astyle.sh

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,6 +213,6 @@ jobs:
       - run: sudo scripts/install_astyle_dependencies_with_apt.sh
       - run: scripts/install_astyle.sh $ASTYLE_REPO $ASTYLE_VER
       - name: Format code with astyle
-        run: scripts/run_astyle.sh
+        run: scripts/run_astyle.sh -v $ASTYLE_VER
       - name: Check code formatting
         run: git diff --exit-code

--- a/scripts/run_astyle.sh
+++ b/scripts/run_astyle.sh
@@ -2,12 +2,15 @@
 
 # Script to run astyle on the code
 #
-# Usage: /path/to/run_astyle.sh
+# Usage: /path/to/run_astyle.sh [ -v ASTYLE_VER]
 #
+# - If -v ASTYLE_VER is specified, that version of astyle is run from
+#   ~/astyle.local (whether or not it's there!). Use install_astyle.sh
+#   to install a new version.
+
 # Note: the script must be run from the root directory of the xrdp repository
 
 INSTALL_ROOT=~/astyle.local
-ASTYLE_FROM_XRDP=$INSTALL_ROOT/3.4.12/usr/bin/astyle
 MIN_ASTYLE_VER="3.1"
 
 # ----------------------------------------------------------------------------
@@ -15,53 +18,66 @@ MIN_ASTYLE_VER="3.1"
 # ----------------------------------------------------------------------------
 usage()
 {
-    echo "** Usage: $0"
-    echo "   e.g. $0"
+    echo "** Usage: $0 [ -v version]"
+    echo "   e.g. $0 -v 3.4.12"
 } >&2
 
 # ----------------------------------------------------------------------------
 # M A I N
 # ----------------------------------------------------------------------------
+# Figure out ASTYLE setting, if any. Currently '-v' must be the first
+# argument on the command line.
+case "$1" in
+    -v) # Version is separate parameter
+        if [ $# -ge 2 ]; then
+            ASTYLE="$INSTALL_ROOT/$2/usr/bin/astyle"
+            shift 2
+        else
+            echo "** ignoring '-v' with no arg" >&2
+            shift 1
+        fi
+        ;;
+    -v*) # Version is in same parameter
+        # ${parameter#word} is not supported by classic Bourne shell,
+        # but it is on bash, dash, etc. If it doesn't work on your shell,
+        # don't use this form!
+        ASTYLE="$INSTALL_ROOT/${1#-v}/usr/bin/astyle"
+        shift 1
+esac
+
+if [ -z "$ASTYLE" ]; then
+    ASTYLE=astyle
+fi
+
 if [ $# -ne 0 ]; then
     usage
     exit 1
 fi
 
-# check if the built-in astyle meets the minimum requrements
-ASTYLE_FROM_OS_VER_OUTPUT=`astyle --version | grep "Artistic Style Version" | cut -d' ' -f4`
 
-ASTYLE=""
-ERROR_MESSAGE=""
-if [ ! -z "$ASTYLE_FROM_OS_VER_OUTPUT" ]; then
-    # astyle is installed, so check if it's version meets the minimum requirements
-    LOWEST_VERSION=`echo -e "$MIN_ASTYLE_VER\n$ASTYLE_FROM_OS_VER_OUTPUT" | sort -V | head -n1`
-    if [ "$MIN_ASTYLE_VER" = "$LOWEST_VERSION" ]; then
-        ASTYLE=astyle
-    else
+# check if the selected astyle meets the minimum requrements
+ASTYLE_VER_OUTPUT=`$ASTYLE --version 2>/dev/null | grep "Artistic Style Version" | cut -d' ' -f4`
+
+if [ ! -z "$ASTYLE_VER_OUTPUT" ]; then
+    # Check the version meets the minimum requirements
+    LOWEST_VERSION=`{ echo "$MIN_ASTYLE_VER" ; echo "$ASTYLE_VER_OUTPUT"; } | sort -V | head -n1`
+    if [ "$MIN_ASTYLE_VER" != "$LOWEST_VERSION" ]; then
         ERROR_MESSAGE="The version of astyle installed does not meet the minimum version requirement: >= $MIN_ASTYLE_VER "
     fi
-else
+elif [ "$ASTYLE" = astyle ]; then
     ERROR_MESSAGE="astyle is not installed on the system path"
-fi
-
-if [ -z "$ASTYLE" ]; then
-    # astyle from the os is invlid, fallback to the xrdp version if it is installed
-    if [ -x "$ASTYLE_FROM_XRDP" ]; then
-        ASTYLE="$ASTYLE_FROM_XRDP"
-        ERROR_MESSAGE=""
-    else
-        ERROR_MESSAGE="${ERROR_MESSAGE}\nastyle $MIN_ASTYLE_VER is not installed at the expected path: $ASTYLE_FROM_XRDP"
-    fi
+else
+    ERROR_MESSAGE="Can't find $ASTYLE"
 fi
 
 if [ ! -z "$ERROR_MESSAGE" ]; then
-    echo "$ERROR_MESSAGE"
+    echo "$ERROR_MESSAGE" >&2
     exit 1
 fi
 
 if [ ! -f "astyle_config.as" ]; then
-    echo "$0 must be run from the root xrdp repository directory which "
-    echo "contains the 'astyle_config.as' file."
+    echo "$0 must be run from the root xrdp repository directory which " >&2
+    echo "contains the 'astyle_config.as' file." >&2
     exit 2
 fi
 
@@ -72,3 +88,5 @@ ASTYLE_FLAGS="--options=astyle_config.as --exclude=third_party ./\*.c ./\*.h"
     echo "Command: $ASTYLE $ASTYLE_FLAGS"
     "$ASTYLE" $ASTYLE_FLAGS
 }
+
+exit $?


### PR DESCRIPTION
This script now works the same way as cppcheck. The version to be used is specified once in the github CI action.

One subtlety I found is that `echo -e` isn't a recognised option in dash. I've replaced this line:-

```sh
LOWEST_VERSION=`echo -e "$MIN_ASTYLE_VER\n$ASTYLE_FROM_OS_VER_OUTPUT" | sort -V | head -n1`
```

with this one:-

```sh
LOWEST_VERSION=`{ echo "$MIN_ASTYLE_VER" ; echo "$ASTYLE_VER_OUTPUT"; } | sort -V | head -n1`
```