### PR TITLE
Just log Image RemoteFX codec

### DIFF
--- a/libxrdp/xrdp_caps.c
+++ b/libxrdp/xrdp_caps.c
@@ -603,6 +603,12 @@ xrdp_caps_process_codecs(struct xrdp_rdp *self, struct stream *s, int len)
             g_memcpy(self->client_info.h264_prop, s->p, i1);
             self->client_info.h264_prop_len = i1;
         }
+        /* other known codec but not supported yet */
+        else if (g_memcmp(codec_guid, XR_CODEC_GUID_IMAGE_REMOTEFX, 16) == 0)
+        {
+            LOG(LOG_LEVEL_INFO, "xrdp_caps_process_codecs: Image RemoteFX(%s), codec id [%d], properties len [%d]",
+                codec_guid_str, codec_id, codec_properties_length);
+        }
         else
         {
             LOG(LOG_LEVEL_WARNING, "xrdp_caps_process_codecs: unknown(%s), codec id [%d], properties len [%d]",


### PR DESCRIPTION
Just log codec known to xrdp but it is not supported yet.

Backport: v0.9 v0.10

```
[2024-02-15T01:28:25.559+0000] [INFO ] xrdp_caps_process_codecs: NSCodec(CA8D1BB9-000F-154F-589F-AE2D1A87E2D6), codec id [1], properties len [3]
[2024-02-15T01:28:25.560+0000] [WARN ] xrdp_caps_process_codecs: unknown(2744CCD4-9D8A-4E74-803C-0ECBEEA19C54), codec id [5], properties len [49]
```