### PR TITLE
[v0.9] Just log Image RemoteFX codec

### DIFF
--- a/libxrdp/xrdp_caps.c
+++ b/libxrdp/xrdp_caps.c
@@ -591,6 +591,11 @@ xrdp_caps_process_codecs(struct xrdp_rdp *self, struct stream *s, int len)
             g_memcpy(self->client_info.h264_prop, s->p, i1);
             self->client_info.h264_prop_len = i1;
         }
+        else if (g_memcmp(codec_guid, XR_CODEC_GUID_IMAGE_REMOTEFX, 16) == 0)
+        {
+            LOG(LOG_LEVEL_INFO, "xrdp_caps_process_codecs: Image RemoteFX, codec id %d, properties len %d",
+                codec_id, codec_properties_length);
+        }
         else
         {
             LOG(LOG_LEVEL_WARNING, "xrdp_caps_process_codecs: unknown codec id %d", codec_id);


### PR DESCRIPTION
Backport #2946 to v0.9.