### PR TITLE
[v0.9] Backport touchpad intertial scrolling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ xrdp/xrdp
 xrdp/xrdp.ini
 xrdp_configure_options.h
 xrdpapi/xrdp-xrdpapi-simple
+.vscode/*

--- a/common/xrdp_constants.h
+++ b/common/xrdp_constants.h
@@ -232,6 +232,12 @@
 #define BUTTON_STATE_UP   0
 #define BUTTON_STATE_DOWN 1
 
+/* touch gestures */
+#define TOUCH_TWO_FINGERS_DOWN 0
+#define TOUCH_TWO_FINGERS_UP 1
+#define TOUCH_TWO_FINGERS_LEFT 2
+#define TOUCH_TWO_FINGERS_RIGHT 3
+
 /* messages */
 #define WM_PAINT       3
 #define WM_KEYDOWN     15
@@ -255,6 +261,10 @@
 #define WM_BUTTON8DOWN 116
 #define WM_BUTTON9UP   117
 #define WM_BUTTON9DOWN 118
+
+#define WM_TOUCH_VSCROLL 140
+#define WM_TOUCH_HSCROLL 141
+
 #define WM_INVALIDATE  200
 
 #define CB_ITEMCHANGE  300

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -119,6 +119,8 @@ xrdp_wm_get_vis_region(struct xrdp_wm *self, struct xrdp_bitmap *bitmap,
 int
 xrdp_wm_mouse_move(struct xrdp_wm *self, int x, int y);
 int
+xrdp_wm_mouse_touch(struct xrdp_wm *self, int gesture, int param);
+int
 xrdp_wm_mouse_click(struct xrdp_wm *self, int x, int y, int but, int down);
 int
 xrdp_wm_key(struct xrdp_wm *self, int device_flags, int scan_code);


### PR DESCRIPTION
Resolves: https://github.com/neutrinolabs/xorgxrdp/issues/265

v0.9 had only a workaround for too fast scroll issue by environment variable `XRDP_XORG_TOUCHPAD_SCROLL_HACK=yes` however the hack is not working on some environments. I think we can backport inertial scrolling as a fundamental solution now.