### PR TITLE
Remove unnecessary '-lrt' from common lib link

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -71,6 +71,6 @@ libcommon_la_SOURCES = \
   $(PIXMAN_SOURCES)
 
 libcommon_la_LIBADD = \
-  -lpthread -lrt \
+  -lpthread \
   $(OPENSSL_LIBS) \
   $(DLOPEN_LIBS)


### PR DESCRIPTION
The '-lrt' added to the Makefile for the common library appears to be unnecessary.

- On modern Linuxes, this library has been merged with libc, and the supplied library is empty.
- On older ones (e.g. Devuan 4), the library contains routines we do not use in xrdp (although we use 'shm_open()' in xorgxrdp).
- On FreeBSD 14 the library contains only mq_*  and timer_* routines which, again, are not required.

@Nexarian - what do you think? You added this in afa70e464a6f9550ac0f64527a94df1935bedf9b