### PR TITLE
GFX: Fix disconnect on resize of busy windows

### DIFF
--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -4150,11 +4150,13 @@ server_egfx_cmd(struct xrdp_mod *mod,
     mm = wm->mm;
     if (mm->encoder == NULL)
     {
+        // This can happen when we are in the resize state machine, if
+        // there are messages queued up by the X server
         if (data != NULL)
         {
             g_munmap(data, data_bytes);
         }
-        return 1;
+        return 0;
     }
     enc = g_new0(struct xrdp_enc_data, 1);
     if (enc == NULL)


### PR DESCRIPTION
When a resize is underway on a busy X server, it is possible for a queued EGFX cmd (order #62) to be processed after the decoder has been deleted. This causes a client disconnect with no useful error message.