### PR TITLE
Fall back to IPv4 if IPv6 capable but don't have an IPv6 address set

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -378,6 +378,7 @@ g_tcp_socket(void)
     {
         switch (errno)
         {
+            case EPROTONOSUPPORT: /* if IPv6 is supported, but don't have an IPv6 address */
             case EAFNOSUPPORT: /* if IPv6 not supported, retry IPv4 */
                 LOG(LOG_LEVEL_INFO, "IPv6 not supported, falling back to IPv4");
                 rv = (int)socket(AF_INET, SOCK_STREAM, 0);


### PR DESCRIPTION
When xrdp is built with IPv6 support it will only fall back to IPv4 if IPv6 is not supported (EAFNOSUPPORT).  However, if the system is IPv6 capable but doesn't have an IPv6 address set (at least inside a FreeBSD jail) EPROTONOSUPPORT is returned from socket().


Failing case without path from xrdp.log:

```
...
[20240225-21:37:41] [INFO ] address [0.0.0.0] port [3389] mode 1
[20240225-21:37:41] [INFO ] listening to port 3389 on 0.0.0.0
[20240225-21:37:41] [ERROR] g_tcp_socket: Protocol not supported
[20240225-21:37:41] [ERROR] trans_listen_address failed
[20240225-21:37:41] [CORE ] Failed to start xrdp daemon, possibly address already in use.
...
```

With the patch and xrdp.log:

```
...
[2024-02-25T22:50:36.418+0000] [INFO ] [xrdp_listen_process_startup_params(xrdp_listen.c:679)] address [0.0.0.0] port [3389] mode 1
[2024-02-25T22:50:36.418+0000] [INFO ] [xrdp_listen_process_startup_params(xrdp_listen.c:688)] listening to port 3389 on 0.0.0.0
[2024-02-25T22:50:36.419+0000] [INFO ] [g_tcp_socket(os_calls.c:383)] IPv6 not supported, falling back to IPv4
[2024-02-25T22:50:36.419+0000] [INFO ] [xrdp_listen_process_startup_params(xrdp_listen.c:674)] xrdp_listen_pp done
[2024-02-25T22:50:38.481+0000] [INFO ] [main(xrdp.c:555)] starting xrdp with pid 89144
[2024-02-25T22:50:38.482+0000] [INFO ] [xrdp_listen_process_startup_params(xrdp_listen.c:679)] address [0.0.0.0] port [3389] mode 1
[2024-02-25T22:50:38.482+0000] [INFO ] [xrdp_listen_process_startup_params(xrdp_listen.c:688)] listening to port 3389 on 0.0.0.0
[2024-02-25T22:50:38.482+0000] [INFO ] [g_tcp_socket(os_calls.c:383)] IPv6 not supported, falling back to IPv4
[2024-02-25T22:50:38.483+0000] [INFO ] [xrdp_listen_process_startup_params(xrdp_listen.c:674)] xrdp_listen_pp done
...
```

Then from xrdp-sesman.log:
```
...
[2024-02-25T22:50:48.255+0000] [INFO ] [g_tcp_socket(os_calls.c:383)] IPv6 not supported, falling back to IPv4
[2024-02-25T22:50:48.259+0000] [DEBUG] [g_sck_close(os_calls.c:756)] Closed socket 15 (0.0.0.0:5910)
[2024-02-25T22:50:48.263+0000] [DEBUG] [x_server_running_check_ports(session_list.c:181)] Did not find a running X server at 5910
[2024-02-25T22:50:48.267+0000] [INFO ] [g_tcp_socket(os_calls.c:383)] IPv6 not supported, falling back to IPv4
[2024-02-25T22:50:48.271+0000] [DEBUG] [g_sck_close(os_calls.c:756)] Closed socket 15 (0.0.0.0:6010)
[2024-02-25T22:50:48.274+0000] [DEBUG] [x_server_running_check_ports(session_list.c:192)] Did not find a running X server at 6010
[2024-02-25T22:50:48.277+0000] [INFO ] [g_tcp_socket(os_calls.c:383)] IPv6 not supported, falling back to IPv4
[2024-02-25T22:50:48.281+0000] [DEBUG] [g_sck_close(os_calls.c:756)] Closed socket 15 (0.0.0.0:6210)
[2024-02-25T22:50:48.282+0000] [DEBUG] [g_sck_close(os_calls.c:756)] Closed socket 13 (AF_UNIX)
[2024-02-25T22:50:48.283+0000] [DEBUG] [wait_for_xserver(xwait.c:134)] Waiting for X server to start on display :10
...
```

Closing the xrdp connection and reconnecting to the same session continues to work.