### PR TITLE
Remove tcutils channel from xrdp.ini

### DIFF
--- a/xrdp/xrdp.ini.in
+++ b/xrdp/xrdp.ini.in
@@ -219,7 +219,6 @@ drdynvc=true
 cliprdr=true
 rail=true
 xrdpvr=true
-tcutils=true
 
 ; for debugging xrdp, in section xrdp1, change port=-1 to this:
 #port=/tmp/.xrdp/xrdp_display_10


### PR DESCRIPTION
According to #1943 tcutils was removed, so update the channel section to match.