### PR TITLE
Suppress some logs when no errors

### DIFF
--- a/xrdp/xrdp_egfx.c
+++ b/xrdp/xrdp_egfx.c
@@ -392,8 +392,11 @@ xrdp_egfx_send_frame_start(struct xrdp_egfx *egfx, int frame_id, int timestamp)
     LOG(LOG_LEVEL_TRACE, "xrdp_egfx_send_frame_start:");
     s = xrdp_egfx_frame_start(egfx->bulk, frame_id, timestamp);
     error = xrdp_egfx_send_s(egfx, s);
-    LOG(LOG_LEVEL_DEBUG, "xrdp_egfx_send_frame_start: xrdp_egfx_send_s "
-        "error %d", error);
+    if (error != 0)
+    {
+        LOG(LOG_LEVEL_DEBUG, "xrdp_egfx_send_frame_start: xrdp_egfx_send_s "
+            "error %d", error);
+    }
     free_stream(s);
     return error;
 }
@@ -434,8 +437,11 @@ xrdp_egfx_send_frame_end(struct xrdp_egfx *egfx, int frame_id)
     LOG(LOG_LEVEL_TRACE, "xrdp_egfx_send_frame_end:");
     s = xrdp_egfx_frame_end(egfx->bulk, frame_id);
     error = xrdp_egfx_send_s(egfx, s);
-    LOG(LOG_LEVEL_DEBUG, "xrdp_egfx_send_frame_end: xrdp_egfx_send_s "
-        "error %d", error);
+    if (error != 0)
+    {
+        LOG(LOG_LEVEL_DEBUG, "xrdp_egfx_send_frame_end: xrdp_egfx_send_s "
+            "error %d", error);
+    }
     free_stream(s);
     return error;
 }


### PR DESCRIPTION
This outputs per-frame logs when using VNC backend and on login screen.

Backport to v0.10.