### PR TITLE
GFX: selectable lossy compression levels

### DIFF
--- a/xrdp/xrdp_encoder.c
+++ b/xrdp/xrdp_encoder.c
@@ -37,11 +37,30 @@
 #define OUT_DATA_BYTES_DEFAULT_SIZE (16 * 1024 * 1024)
 
 #ifdef XRDP_RFXCODEC
-/* LH3 LL3, HH3 HL3, HL2 LH2, LH1 HH2, HH1 HL1 todo check this */
-static const unsigned char g_rfx_quantization_values[] =
+/*
+ * LH3 LL3, HH3 HL3, HL2 LH2, LH1 HH2, HH1 HL1
+ * https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdprfx/3e9c8af4-7539-4c9d-95de-14b1558b902c
+ */
+
+/* standard quality */
+static const unsigned char g_rfx_quantization_values_std[] =
 {
     0x66, 0x66, 0x77, 0x87, 0x98,
     0x76, 0x77, 0x88, 0x98, 0x99
+};
+
+/* low quality */
+static const unsigned char g_rfx_quantization_values_lq[] =
+{
+    0x66, 0x66, 0x77, 0x87, 0x98,
+    0xAA, 0xAA, 0xAA, 0xAA, 0xAA /* TODO: tentative value */
+};
+
+/* ultra low quality */
+static const unsigned char g_rfx_quantization_values_ulq[] =
+{
+    0x66, 0x66, 0x77, 0x87, 0x98,
+    0xBB, 0xBB, 0xBB, 0xBB, 0xBB /* TODO: tentative value */
 };
 #endif
 
@@ -137,11 +156,28 @@ xrdp_encoder_create(struct xrdp_mm *mm)
         client_info->capture_code = 4;
         self->process_enc = process_enc_egfx;
         self->gfx = 1;
-        self->quants = (const char *) g_rfx_quantization_values;
         self->num_quants = 2;
         self->quant_idx_y = 0;
         self->quant_idx_u = 1;
         self->quant_idx_v = 1;
+
+        switch (client_info->mcs_connection_type)
+        {
+            case CONNECTION_TYPE_MODEM:
+            case CONNECTION_TYPE_BROADBAND_LOW:
+            case CONNECTION_TYPE_SATELLITE:
+                self->quants = (const char *) g_rfx_quantization_values_ulq;
+                break;
+            case CONNECTION_TYPE_BROADBAND_HIGH:
+            case CONNECTION_TYPE_WAN:
+                self->quants = (const char *) g_rfx_quantization_values_lq;
+                break;
+            case CONNECTION_TYPE_LAN:
+            case CONNECTION_TYPE_AUTODETECT: /* not implemented yet */
+            default:
+                self->quants = (const char *) g_rfx_quantization_values_std;
+
+        }
     }
     else if (client_info->rfx_codec_id != 0)
     {


### PR DESCRIPTION
Reboot of #2539. This feature is also requested by @unstabler and another enterprise user.

Classic RemoteFX [requires connectionType==LAN](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdprfx/516f1a1c-20ec-4ea1-b92a-7995d8a322cf) so we can't use the parameter to adjust compression level. In contrast, GFX can be used whatever value connectionType is set to. Therefore, we can use this parameter to tell the encoder compression level.

This is still a proof of concept so this PR is a draft.


### Ultra Low Quality
![image](https://github.com/neutrinolabs/xrdp/assets/941609/d6c0e3fd-c6c5-4669-8d6e-fbbb8d8edce0)

### Low Quality
![image](https://github.com/neutrinolabs/xrdp/assets/941609/032b8b83-6125-46ea-b103-8f257131c4e5)

### Standard Quality
![image](https://github.com/neutrinolabs/xrdp/assets/941609/58b95e2e-511c-4938-b7e5-31b227067a87)
