### PR TITLE
Remove duplicate DEBUG output

### DIFF
--- a/xrdp/xrdp_login_wnd.c
+++ b/xrdp/xrdp_login_wnd.c
@@ -1458,8 +1458,6 @@ load_xrdp_config(struct xrdp_config *config, const char *xrdp_ini, int bpp)
     LOG(LOG_LEVEL_DEBUG, "tcp_keepalive:           %d", globals->tcp_keepalive);
     LOG(LOG_LEVEL_DEBUG, "tcp_send_buffer_bytes:   %d", globals->tcp_send_buffer_bytes);
     LOG(LOG_LEVEL_DEBUG, "tcp_recv_buffer_bytes:   %d", globals->tcp_recv_buffer_bytes);
-    LOG(LOG_LEVEL_DEBUG, "new_cursors:             %d", globals->new_cursors);
-    LOG(LOG_LEVEL_DEBUG, "allow_multimon:          %d", globals->allow_multimon);
 
     LOG(LOG_LEVEL_DEBUG, "grey:                    %d", globals->grey);
     LOG(LOG_LEVEL_DEBUG, "black:                   %d", globals->black);


### PR DESCRIPTION
allow_multimon and new_cursors are printed twice.

I left the lines which make most sense with their surroundings, but feel free to switch to the other option.