### PR TITLE
Don't generate a corefile when generating SIGSEGV

### DIFF
--- a/tests/common/test_os_calls_signals.c
+++ b/tests/common/test_os_calls_signals.c
@@ -108,6 +108,9 @@ START_TEST(test_g_signal_child_stop_1)
     pid = g_fork();
     if (pid == 0)
     {
+        // Before raising the signal, change directory to a non-writeable
+        // one to avoid generating a corefile.
+        g_set_current_dir("/");
         raise(SIGSEGV);
     }
     ck_assert_int_ne(pid, 0);


### PR DESCRIPTION
Fixes #2986 

One of the tests uses a child process which generates SIGSEGV. On FreeBSD this generates a corefile by default which breaks the 'make distcheck' process.