### PR TITLE
Detect missing drdynvc

### DIFF
--- a/libxrdp/libxrdp.c
+++ b/libxrdp/libxrdp.c
@@ -1408,6 +1408,23 @@ libxrdp_disable_channel(struct xrdp_session *session, int channel_id,
 
 /*****************************************************************************/
 int
+libxrdp_drdynvc_start(struct xrdp_session *session)
+{
+    struct xrdp_rdp *rdp;
+    struct xrdp_sec *sec;
+    struct xrdp_channel *chan;
+
+    LOG_DEVEL(LOG_LEVEL_TRACE, "libxrdp_drdynvc_start:");
+
+    rdp = (struct xrdp_rdp *) (session->rdp);
+    sec = rdp->sec_layer;
+    chan = sec->chan_layer;
+    return xrdp_channel_drdynvc_start(chan);
+}
+
+
+/*****************************************************************************/
+int
 libxrdp_drdynvc_open(struct xrdp_session *session, const char *name,
                      int flags, struct xrdp_drdynvc_procs *procs,
                      int *chan_id)

--- a/libxrdp/libxrdpinc.h
+++ b/libxrdp/libxrdpinc.h
@@ -241,6 +241,8 @@ int
 libxrdp_disable_channel(struct xrdp_session *session, int channel_id,
                         int is_disabled);
 int
+libxrdp_drdynvc_start(struct xrdp_session *session);
+int
 libxrdp_drdynvc_open(struct xrdp_session *session, const char *name,
                      int flags, struct xrdp_drdynvc_procs *procs,
                      int *chan_id);

--- a/libxrdp/xrdp_channel.c
+++ b/libxrdp/xrdp_channel.c
@@ -752,46 +752,53 @@ xrdp_channel_drdynvc_send_capability_request(struct xrdp_channel *self)
 int
 xrdp_channel_drdynvc_start(struct xrdp_channel *self)
 {
-    int index;
-    int count;
-    struct mcs_channel_item *ci;
-    struct mcs_channel_item *dci;
-
-    LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_channel_drdynvc_start: drdynvc_channel_id %d", self->drdynvc_channel_id);
+    int rv = 0;
+    LOG_DEVEL(LOG_LEVEL_INFO,
+              "xrdp_channel_drdynvc_start: drdynvc_channel_id %d",
+              self->drdynvc_channel_id);
     if (self->drdynvc_channel_id != -1)
     {
-        LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_channel_drdynvc_start: already started");
-        return 0;
-    }
-    dci = NULL;
-    count = self->mcs_layer->channel_list->count;
-    for (index = 0; index < count; index++)
-    {
-        ci = (struct mcs_channel_item *)
-             list_get_item(self->mcs_layer->channel_list, index);
-        if (ci != NULL)
-        {
-            if (g_strcasecmp(ci->name, "drdynvc") == 0)
-            {
-                dci = ci;
-            }
-        }
-    }
-    if (dci != NULL)
-    {
-        self->drdynvc_channel_id = (dci->chanid - MCS_GLOBAL_CHANNEL) - 1;
-        LOG_DEVEL(LOG_LEVEL_DEBUG,
-                  "Initializing Dynamic Virtual Channel with channel id %d",
-                  self->drdynvc_channel_id);
-        xrdp_channel_drdynvc_send_capability_request(self);
+        LOG_DEVEL(LOG_LEVEL_INFO,
+                  "xrdp_channel_drdynvc_start: already started");
     }
     else
     {
-        LOG(LOG_LEVEL_WARNING,
-            "Dynamic Virtual Channel named 'drdynvc' not found, "
-            "channel not initialized");
+        int index;
+        int count;
+        struct mcs_channel_item *ci;
+        struct mcs_channel_item *dci;
+        dci = NULL;
+        count = self->mcs_layer->channel_list->count;
+        for (index = 0; index < count; index++)
+        {
+            ci = (struct mcs_channel_item *)
+                 list_get_item(self->mcs_layer->channel_list, index);
+            if (ci != NULL)
+            {
+                if (g_strcasecmp(ci->name, DRDYNVC_SVC_CHANNEL_NAME) == 0)
+                {
+                    dci = ci;
+                    break;
+                }
+            }
+        }
+        if (dci != NULL)
+        {
+            self->drdynvc_channel_id = (dci->chanid - MCS_GLOBAL_CHANNEL) - 1;
+            LOG_DEVEL(LOG_LEVEL_DEBUG, DRDYNVC_SVC_CHANNEL_NAME
+                      "Initializing Dynamic Virtual Channel with channel id %d",
+                      self->drdynvc_channel_id);
+            xrdp_channel_drdynvc_send_capability_request(self);
+        }
+        else
+        {
+            LOG(LOG_LEVEL_WARNING,
+                "Static channel '%s' not found. "
+                "Channel not initialized", DRDYNVC_SVC_CHANNEL_NAME);
+            rv = -1;
+        }
     }
-    return 0;
+    return rv;
 }
 
 /*****************************************************************************/

--- a/libxrdp/xrdp_channel.c
+++ b/libxrdp/xrdp_channel.c
@@ -782,7 +782,19 @@ xrdp_channel_drdynvc_start(struct xrdp_channel *self)
                 }
             }
         }
-        if (dci != NULL)
+        if (dci == NULL)
+        {
+            LOG(LOG_LEVEL_WARNING, "Static channel '%s' not found.",
+                DRDYNVC_SVC_CHANNEL_NAME);
+            rv = -1;
+        }
+        else if (dci->disabled)
+        {
+            LOG(LOG_LEVEL_WARNING, "Static channel '%s' is disabled.",
+                DRDYNVC_SVC_CHANNEL_NAME);
+            rv = -1;
+        }
+        else
         {
             self->drdynvc_channel_id = (dci->chanid - MCS_GLOBAL_CHANNEL) - 1;
             LOG_DEVEL(LOG_LEVEL_DEBUG, DRDYNVC_SVC_CHANNEL_NAME
@@ -790,13 +802,11 @@ xrdp_channel_drdynvc_start(struct xrdp_channel *self)
                       self->drdynvc_channel_id);
             xrdp_channel_drdynvc_send_capability_request(self);
         }
-        else
-        {
-            LOG(LOG_LEVEL_WARNING,
-                "Static channel '%s' not found. "
-                "Channel not initialized", DRDYNVC_SVC_CHANNEL_NAME);
-            rv = -1;
-        }
+    }
+
+    if (rv != 0)
+    {
+        LOG(LOG_LEVEL_WARNING, "Dynamic channels will not be available");
     }
     return rv;
 }

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -1323,7 +1323,6 @@ xrdp_rdp_process_data_font(struct xrdp_rdp *self, struct stream *s)
             self->session->callback(self->session->id, 0x555a, 0, 0,
                                     0, 0);
         }
-        xrdp_channel_drdynvc_start(self->sec_layer->chan_layer);
     }
     else
     {

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -2031,6 +2031,7 @@ callback(intptr_t id, int msg, intptr_t param1, intptr_t param2,
                                     LOWORD(param3), HIWORD(param3));
         case 0x555a:
             // "yeah, up_and_running"
+            libxrdp_drdynvc_start(wm->session);
             xrdp_mm_up_and_running(wm->mm);
             break;
     }


### PR DESCRIPTION
Fixes #2984 

This was slightly more complicated than I'd hoped.

Biggest problem was that the `[Channels]` section in `xrdp.ini` wasn't scanned until `xrdp_wm_init()`, by which time we'd tried to start GFX.

Solution is to scan the `[Channels]` earlier, and disable GFX if for any reason the static channel `drdynvc` can't be started. 'Any reason' here includes the channel being disabled.