### PR TITLE
[v0.9] Disable touch events on Xvnc Session

### DIFF
--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -55,7 +55,6 @@ xrdp_mm_chansrv_connect(struct xrdp_mm *self, const char *ip, const char *port);
 static void
 xrdp_mm_connect_sm(struct xrdp_mm *self);
 
-
 /*****************************************************************************/
 struct xrdp_mm *
 xrdp_mm_create(struct xrdp_wm *owner)

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -32,6 +32,14 @@
 #define MAX_NR_CHANNELS 16
 #define MAX_CHANNEL_NAME 16
 
+/* Code values used in 'xrdp_mm->code=' settings */
+#define XVNC_SESSION_CODE 0
+#define XRDP_SESSION_CODE 10
+#define XORG_SESSION_CODE 20
+
+/* To check whether touch events has been implemented on session type 'mm' */
+#define XRDP_MM_IMPLEMENTS_TOUCH(mm) ((mm)->code != XVNC_SESSION_CODE)
+
 struct source_info;
 
 /* lib */

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -34,7 +34,6 @@
 
 /* Code values used in 'xrdp_mm->code=' settings */
 #define XVNC_SESSION_CODE 0
-#define XRDP_SESSION_CODE 10
 #define XORG_SESSION_CODE 20
 
 /* To check whether touch events has been implemented on session type 'mm' */

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -29,8 +29,6 @@
 #include "log.h"
 #include "string_calls.h"
 
-
-
 /*****************************************************************************/
 struct xrdp_wm *
 xrdp_wm_create(struct xrdp_process *owner,
@@ -1806,7 +1804,7 @@ xrdp_wm_process_input_mouse(struct xrdp_wm *self, int device_flags,
              * The negative number is represented by complement.
              */
             delta = (device_flags & WheelRotationMask) | ~WheelRotationMask;
-            if (delta != 0)
+            if (delta != 0 && XRDP_MM_IMPLEMENTS_TOUCH(self->mm))
             {
                 // Use nature scrolling, up direction is negative.
                 xrdp_wm_mouse_touch(self, TOUCH_TWO_FINGERS_UP, delta);
@@ -1819,7 +1817,7 @@ xrdp_wm_process_input_mouse(struct xrdp_wm *self, int device_flags,
         else
         {
             delta = device_flags & WheelRotationMask;
-            if (delta != 0)
+            if (delta != 0 && XRDP_MM_IMPLEMENTS_TOUCH(self->mm))
             {
                 xrdp_wm_mouse_touch(self, TOUCH_TWO_FINGERS_DOWN, delta);
             }
@@ -1852,7 +1850,7 @@ xrdp_wm_process_input_mouse(struct xrdp_wm *self, int device_flags,
              * The negative number is represented by complement.
              */
             delta = (device_flags & WheelRotationMask) | ~WheelRotationMask;
-            if (delta != 0)
+            if (delta != 0 && XRDP_MM_IMPLEMENTS_TOUCH(self->mm))
             {
                 // Use nature scrolling, right direction is negative.
                 xrdp_wm_mouse_touch(self, TOUCH_TWO_FINGERS_RIGHT, delta);
@@ -1865,7 +1863,7 @@ xrdp_wm_process_input_mouse(struct xrdp_wm *self, int device_flags,
         else
         {
             delta = device_flags & WheelRotationMask;
-            if (delta != 0)
+            if (delta != 0 && XRDP_MM_IMPLEMENTS_TOUCH(self->mm))
             {
                 xrdp_wm_mouse_touch(self, TOUCH_TWO_FINGERS_LEFT, delta);
             }


### PR DESCRIPTION
My bad, forgot to backport this to v0.9.

Fixes: #2993.