### PR TITLE
Simplify allowed system calls for xrdp

### DIFF
--- a/instfiles/xrdp.service.in
+++ b/instfiles/xrdp.service.in
@@ -10,9 +10,7 @@ EnvironmentFile=-@sysconfdir@/sysconfig/xrdp
 EnvironmentFile=-@sysconfdir@/default/xrdp
 ExecStart=@sbindir@/xrdp $XRDP_OPTIONS --nodaemon
 SystemCallArchitectures=native
-SystemCallFilter=@basic-io @file-system @io-event @ipc @network-io @process
-SystemCallFilter=@signal @system-service ioctl madvise sysinfo uname
-SystemCallErrorNumber=EPERM
+SystemCallFilter=@system-service
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR relates to a [comment](/neutrinolabs/xrdp/commit/ccead296e615b92afc17daf67447876fb3c122e0#r138317995) I made on ccead296e615b92afc17daf67447876fb3c122e0

My original plan was to
- Remove `SystemCallErrorNumber=` as this makes for safer deployments (although it's fine for development).
- Investigate the reasons why we needed to add `@system-service` to `SystemCallFilter=`

The second one of these defeated me. Although I'd encountered the problem myself during GFX development, I was unable to generate it with the current `devel` release on my own test setups. Since we're close to releasing v0.10, I though it too risky to remove this setting now.

However, I did note from the output of `systemd-analyze syscall-filter` (Ubuntu 22.04) that this line can be simplified considerably.

<pre>
$ <b>systemd-analyze syscall-filter</b>
   &lt;snipped&gt;
@system-service
    # General system service operations
    @aio
    <b>@basic-io</b>
    @chown
    @default
    <b>@file-system</b>
    <b>@io-event</b>
    <b>@ipc</b>
    @keyring
    @memlock
    <b>@network-io</b>
    <b>@process</b>
    @resources
    @setuid
    <b>@signal</b>
    @sync
    @timer
    capget
    capset
    copy_file_range
    fadvise64
    fadvise64_64
    flock
    get_mempolicy
    getcpu
    getpriority
    <b>ioctl</b>
    ioprio_get
    kcmp
    <b>madvise</b>
    mremap
    . . .
    setsid
    splice
    <b>sysinfo</b>
    tee
    umask
    <b>uname</b>
    userfaultfd
    vmsplice
</pre>

I also tested the lists on CentOS 8 which contain the same items.