### PR TITLE
Mention how to copy & paste in fenced code blocks more clearly

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -20,7 +20,7 @@ body:
       description: Copy & paste the result of `xrdp --version`. DO NOT remove `~~~` but paste the result between two `~~~`.
       value: |
         ~~~
-        PASTE HERE
+        Paste the result between `~~~`.  Please DO NOT remove `~~~`!
         ~~~
   - type: input
     attributes:


### PR DESCRIPTION
Sometimes reporters remove `~~~` despite it is described not to remove just above. For example, #3033.