### PR TITLE
Update cppcheck and astyle versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,7 +180,7 @@ jobs:
       CC: gcc
       # This is required to use a version of cppcheck other than that
       # supplied with the operating system
-      CPPCHECK_VER: "2.13.0"
+      CPPCHECK_VER: "2.15.0"
       CPPCHECK_REPO: https://github.com/danmar/cppcheck.git
     steps:
       # Set steps.os.outputs.image to the specific OS (e.g. 'ubuntu20')
@@ -209,7 +209,7 @@ jobs:
       CC: gcc
       # This is required to use a version of astyle other than that
       # supplied with the operating system
-      ASTYLE_VER: 3.4.12
+      ASTYLE_VER: 3.4.14
       ASTYLE_REPO: https://gitlab.com/saalen/astyle.git
     steps:
       # Set steps.os.outputs.image to the specific OS (e.g. 'ubuntu20')

--- a/scripts/install_cppcheck.sh
+++ b/scripts/install_cppcheck.sh
@@ -28,11 +28,11 @@ usage()
 call_make()
 {
     # Disable set -e, if active
-    set_entry_opts=`set +o`
+    set_entry_opts=$(set +o)
     set +e
 
     status=1
-    log=`mktemp /tmp/cppcheck-log.XXXXXXXXXX`
+    log=$(mktemp /tmp/cppcheck-log.XXXXXXXXXX)
     if [ -n "$log" ]; then
         make "$@" >"$log" 2>&1
         status=$?
@@ -58,13 +58,15 @@ call_make()
 # ----------------------------------------------------------------------------
 create_z3_version_h()
 {
-    set -- `z3 --version`
-    if [ $# != 3 -o "$1/$2" != Z3/version ]; then
+    # shellcheck disable=SC2046
+    set -- $(z3 --version)
+    if [ $# != 3 ] || [ "$1/$2" != Z3/version ]; then
         echo "** Unexpected output from z3 command '$*'" >&2
         false
     else
-        z3ver=$3 ; # e.g. 4.4.3
-        set -- `echo $z3ver | tr '.' ' '`
+        z3ver="$3" ; # e.g. 4.4.3
+        # shellcheck disable=SC2046
+        set -- $(echo "$z3ver" | tr '.' ' ')
         if [ $# != 3 ]; then
             echo "** Unable to determine Z3 version from '$z3ver'" >&2
             false
@@ -104,7 +106,7 @@ if [ -x "$exe" ]; then
     exit 0
 fi
 
-workdir=`mktemp -d /tmp/cppcheck.XXXXXXXXXX`
+workdir=$(mktemp -d /tmp/cppcheck.XXXXXXXXXX)
 if [ -z "$workdir" ]; then
     echo "** Unable to create temporary working directory" 2>&1
     exit 1
@@ -154,18 +156,19 @@ fi
 
     # Use all available CPUs
     if [ -f /proc/cpuinfo ]; then
-        cpus=`grep ^processor /proc/cpuinfo | wc -l`
+        cpus=$(grep -c ^processor /proc/cpuinfo)
         if [ -n "$cpus" ]; then
             make_args="$make_args -j $cpus"
         fi
     fi
 
     echo "Making cppcheck..."
-    # CFGDIR is needed for cppcheck before 1.86
+    # shellcheck disable=SC2086
     call_make $make_args
 
     echo "Installing cppcheck..."
     mkdir -p "$FILESDIR"
+    # shellcheck disable=SC2086
     call_make install $make_args
 )
 status=$?

--- a/scripts/install_cppcheck.sh
+++ b/scripts/install_cppcheck.sh
@@ -130,12 +130,7 @@ fi
             # CFGDIR is needed for cppcheck before 1.86
             make_args="$make_args CFGDIR=$FILESDIR"
             ;;
-        2.8 | 2.9 | 2.1*)
-            # Cppcheck 2.8 removed the dependency on z3
-            # Cppcheck 2.8 added optional support for utilizing Boost
-            make_args="$make_args CPPFLAGS=-DHAVE_BOOST"
-            ;;
-        2.*)
+        2.0 | 2.1 | 2.2 | 2.3 | 2.4 | 2.4.1 | 2.5 | 2.6 | 2.7)
             make_args="$make_args USE_Z3=yes"
             # Check that the Z3 development files appear to be installed
             # before trying to create z3_version.h. Otherwise we may
@@ -146,6 +141,14 @@ fi
             if [ ! -f /usr/include/z3_version.h ]; then
                 create_z3_version_h
             fi
+            ;;
+        2.8 | 2.9 | 2.10 | 2.11* | 2.12.* | 2.13.* | 2.14.* )
+            # Cppcheck 2.8 removed the dependency on z3
+            # Cppcheck 2.8 added optional support for utilizing Boost
+            make_args="$make_args CPPFLAGS=-DHAVE_BOOST"
+            ;;
+        2.*)
+            # Cppcheck 2.15 doesn't seem to define FILESDIR if CPPFLAGS is set
             ;;
     esac
 

--- a/scripts/run_cppcheck.sh
+++ b/scripts/run_cppcheck.sh
@@ -2,9 +2,11 @@
 
 # Script to run cppcheck
 #
-# Usage: /path/to/run_cppcheck.sh [ -v CPPCHECK_VER] [<extra_opts_and_dirs>]
+# Usage: /path/to/run_cppcheck.sh [-f] [ -v CPPCHECK_VER] [<extra_opts_and_dirs>]
 #
 # - If <extra_opts_and_dirs> is missing, '.' is assumed
+# - If '-f' is specified, the exhaustive check level is used. This can take
+#   an hour or two.
 # - If -v CPPCHECK_VER is specified, that version of cppcheck is run from
 #   ~/cppcheck.local (whether or not it's there!). Use install_cppcheck.sh
 #   to install a new version.
@@ -14,11 +16,50 @@
 # CPPCHECK       : Override the default cppcheck command ('cppcheck').
 #                  Ignored if -v is specified
 # CPPCHECK_FLAGS : Override the default cppcheck flags
+# CPPCHECK_QUICK : If non-zero, disables the exhaustive check level.
+#                  Useful when developing
+
+# ----------------------------------------------------------------------------
+# C P P C H E C K   V E R S I O N   S T R
+#
+# Get the cppcheck version, and then convert to AABBCC for comparisons
+# where AA is the major version, BB is the minor version and CC is the
+# revision
+# For example, cppcheck version 2.13.0 produces 021300
+# ----------------------------------------------------------------------------
+CppcheckVerCompareStr()
+{
+    # shellcheck disable=SC2046
+    set -- $($CPPCHECK --version 2>/dev/null)
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            [0123456789]*) break;;
+            *) shift
+        esac
+    done
+
+    if [ $# -eq 0 ]; then
+        echo 000000 ; # Something has gone wrong
+    else
+        case "$1" in
+            *.*.*) echo "$1" | awk -F.  '{printf "%02d%02d%02d",$1,$2,$3 }' ;;
+            *.*)   echo "$1" | awk -F.  '{printf "%02d%02d00",$1,$2 }' ;;
+            *)     printf '%02d0000\n' "$1"
+        esac
+    fi
+}
 
 INSTALL_ROOT=~/cppcheck.local
 
-# Figure out CPPCHECK setting, if any. Currently '-v' must be the first
-# argument on the command line.
+# Exhaustive test?
+if [ "$1" = "-f" ]; then
+    check_level=exhaustive
+    shift
+else
+    check_level=normal
+fi
+
+# Figure out CPPCHECK setting, if any.
 case "$1" in
     -v) # Version is separate parameter
         if [ $# -ge 2 ]; then
@@ -45,15 +86,30 @@ if [ -z "$CPPCHECK_FLAGS" ]; then
     CPPCHECK_FLAGS="--quiet --force --std=c11 --std=c++11 --inline-suppr \
                     --enable=warning --error-exitcode=1 -i third_party \
                     --suppress=uninitMemberVar:ulalaca/ulalaca.cpp \
-                    --suppress=shiftTooManyBits:libxrdp/xrdp_mppc_enc.c \
-                    -I . -I common"
+                    --suppress=shiftTooManyBits:libxrdp/xrdp_mppc_enc.c"
+
+    # Check for flags added in later versions
+    CPPCHECK_COMPARE_VERSION=$(CppcheckVerCompareStr)
+    if [ "$CPPCHECK_COMPARE_VERSION" -ge 021100 ]; then
+        if [ "$check_level" = "normal" ]; then
+            # Disable warnings related to the check level
+            CPPCHECK_FLAGS="$CPPCHECK_FLAGS \
+                --suppress=normalCheckLevelMaxBranches"
+        fi
+        CPPCHECK_FLAGS="$CPPCHECK_FLAGS --check-level=$check_level"
+    else
+        # This is echoed later
+        check_level="Default (option not supported)"
+    fi
+
+    CPPCHECK_FLAGS="$CPPCHECK_FLAGS -I . -I common"
 fi
 CPPCHECK_FLAGS="$CPPCHECK_FLAGS -D__cppcheck__"
 
 # Any options/directories specified?
 if [ $# -eq 0 ]; then
     if [ -f /proc/cpuinfo ]; then
-        cpus=$(grep '^processor' /proc/cpuinfo | wc -l)
+        cpus=$(grep -c '^processor' /proc/cpuinfo)
     else
         cpus=2
     fi
@@ -63,5 +119,8 @@ fi
 # Display the cppcheck version and command for debugging
 "$CPPCHECK" --version && {
     echo "Command: $CPPCHECK $CPPCHECK_FLAGS" "$@"
+    echo "Check level: $check_level"
+
+    # shellcheck disable=SC2086
     "$CPPCHECK" $CPPCHECK_FLAGS "$@"
 }


### PR DESCRIPTION
Bumped astyle and cppcheck to latest versions.

There's an issue with cppcheck which I'd appreciate a comment on. Version 2.13.0 was taking around 20 minutes or so to run. With 2.14.0, I get warnings like this with the same sources:-

```
common/base64.c:0:0: information: Limiting analysis of branches. Use --check-level=exhaustive to analyze all branches. [normalCheckLevelMaxBranches]

^
common/file.c:0:0: information: Limiting analysis of branches. Use --check-level=exhaustive to analyze all branches. [normalCheckLevelMaxBranches]

^
common/list.c:0:0: information: Limiting analysis of branches. Use --check-level=exhaustive to analyze all branches. [normalCheckLevelMaxBranches]

^
common/log.c:0:0: information: Limiting analysis of branches. Use --check-level=exhaustive to analyze all branches. [normalCheckLevelMaxBranches]
...
```

If I use `--check-level=exhaustive` with 2.14.0, I get check times of around an hour:-

https://github.com/matt335672/xrdp/actions/runs/8781923998/job/24094941025

However, if I just disable the warnings and go with `--check-level=normal`, I'm getting run times of about 4 minutes, 30 seconds:-

https://github.com/matt335672/xrdp/actions/runs/8782777220/job/24097568007

Neither option seems as good to me, but I've gone for the shorter one. A longer run can still be requested manually.

Any thoughts appreciated.