### PR TITLE
CI: add a job with address sanitizer enabled

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,16 @@ jobs:
             unittests: true
             DISTCHECK: true
 
+          - CC: clang
+            feature_set: max
+            arch: amd64
+            os: ubuntu-latest
+            unittests: true
+            DISTCHECK: false
+            name_extra: and AddressSanitized
+            CFLAGS: "-fsanitize=address -ggdb"
+            LDFLAGS: "-fsanitize=address"
+
           # Maximal debug 64-bit arch builds
           # Check we can also do a static build without
           # installing .a files
@@ -80,6 +90,8 @@ jobs:
             unittests: true
             DISTCHECK: false
             name_extra: for 32-bit arch (legacy OS)
+            CFLAGS: "-m32"
+            LDFLAGS: "-m32"
 
           - CC: g++
             feature_set: max
@@ -88,6 +100,8 @@ jobs:
             unittests: false
             DISTCHECK: false
             name_extra: for 32-bit arch (legacy OS)
+            CFLAGS: "-m32"
+            LDFLAGS: "-m32"
 
           - CC: clang
             feature_set: max
@@ -96,11 +110,15 @@ jobs:
             unittests: true
             DISTCHECK: false
             name_extra: for 32-bit arch (legacy OS)
+            CFLAGS: "-m32"
+            LDFLAGS: "-m32"
 
     name: ${{ matrix.feature_set }} features with ${{ matrix.CC }} ${{ matrix.name_extra }}
     runs-on: ${{ matrix.os }}
     env:
       CC: ${{ matrix.CC }}
+      CFLAGS: ${{ matrix.CFLAGS }}
+      LDFLAGS: ${{ matrix.LDFLAGS }}
 
       # HACK (2020-11-16): github actions doesn't support YAML anchors/aliases to
       # avoid repeating long config values. So instead the config values are defined
@@ -121,8 +139,6 @@ jobs:
                   --host=i686-linux --enable-tests"
 
       PKG_CONFIG_PATH_i386: "/usr/lib/i386-linux-gnu/pkgconfig"
-      CFLAGS_i386: "-m32"
-      LDFLAGS_i386: "-m32"
     steps:
       - name: "Define feature and arch dependent environment variables"
         # Note: any "variable=value" written to the $GITHUB_ENV file will be
@@ -131,8 +147,6 @@ jobs:
         run: |
           echo "CONF_FLAGS=$CONF_FLAGS_${{ matrix.arch }}_${{ matrix.feature_set }} ${{ matrix.CONF_FLAGS_EXTRA }}" >> $GITHUB_ENV
           echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH_${{ matrix.arch }}" >> $GITHUB_ENV
-          echo "CFLAGS=$CFLAGS_${{ matrix.arch }}" >> $GITHUB_ENV
-          echo "LDFLAGS=$LDFLAGS_${{ matrix.arch }}" >> $GITHUB_ENV
       - uses: actions/checkout@v4
       - name: "Install Dependencies"
         # See https://github.com/actions/runner-images/issues/7192
@@ -147,7 +161,7 @@ jobs:
         run: make -j $(nproc)
       - name: unittests
         if: ${{ matrix.unittests }}
-        run: make check -j $(nproc)
+        run: make check -j $(nproc) || (cat tests/*/test-suite.log && exit 1)
       - name: distcheck
         id: dist_check
         if: ${{ matrix.DISTCHECK }}


### PR DESCRIPTION
this enables additional job which runs unittests with address sanitizer

I think the most interesting thing found

```
2024-05-04T22:10:46.1544435Z ==59390==ERROR: AddressSanitizer: global-buffer-overflow on address 0x55b0c8c8a7cb at pc 0x55b0c8c1ed97 bp 0x7ffdb5f65bb0 sp 0x7ffdb5f65380
2024-05-04T22:10:46.1545346Z READ of size 1000 at 0x55b0c8c8a7cb thread T0
2024-05-04T22:10:46.1546236Z     #0 0x55b0c8c1ed96 in __asan_memcpy (/home/runner/work/xrdp/xrdp/tests/common/.libs/test_common+0xc9d96) (BuildId: 9f39a5cdc888caba15ef79957b3f1e399b300649)
2024-05-04T22:10:46.1547615Z     #1 0x7f4d874bff8a in split_string_append_fragment /home/runner/work/xrdp/xrdp/common/list.c:355:5
2024-05-04T22:10:46.1548568Z     #2 0x55b0c8c5d112 in test_list__append_fragment_fn /home/runner/work/xrdp/xrdp/tests/common/test_list_calls.c:162:20
2024-05-04T22:10:46.1549742Z     #3 0x55b0c8c75a88 in srunner_run_tagged (/home/runner/work/xrdp/xrdp/tests/common/.libs/test_common+0x120a88) (BuildId: 9f39a5cdc888caba15ef79957b3f1e399b300649)
2024-05-04T22:10:46.1550808Z     #4 0x55b0c8c5aa80 in main /home/runner/work/xrdp/xrdp/tests/common/test_common_main.c:73:5
2024-05-04T22:10:46.1551781Z     #5 0x7f4d87029d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 962015aa9d133c6cbcfb31ec300596d7f44d3348)
2024-05-04T22:10:46.1552842Z     #6 0x7f4d87029e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 962015aa9d133c6cbcfb31ec300596d7f44d3348)
2024-05-04T22:10:46.1553990Z     #7 0x55b0c8b9cc24 in _start (/home/runner/work/xrdp/xrdp/tests/common/.libs/test_common+0x47c24) (BuildId: 9f39a5cdc888caba15ef79957b3f1e399b300649)
2024-05-04T22:10:46.1554681Z 
2024-05-04T22:10:46.1558649Z 0x55b0c8c8a7cb is located 21 bytes to the left of global variable '<string literal>' defined in 'test_list_calls.c:159:5' (0x55b0c8c8a7e0) of size 18
2024-05-04T22:10:46.1559605Z   '<string literal>' is ascii string 'fragment_ret == 1'
2024-05-04T22:10:46.1560588Z 0x55b0c8c8a7cb is located 0 bytes to the right of global variable '<string literal>' defined in 'test_list_calls.c:155:31' (0x55b0c8c8a7c0) of size 11
2024-05-04T22:10:46.1561432Z   '<string literal>' is ascii string 'split this'
2024-05-04T22:10:46.1562602Z SUMMARY: AddressSanitizer: global-buffer-overflow (/home/runner/work/xrdp/xrdp/tests/common/.libs/test_common+0xc9d96) (BuildId: 9f39a5cdc888caba15ef79957b3f1e399b300649) in __asan_memcpy
2024-05-04T22:10:46.1563615Z Shadow bytes around the buggy address:
2024-05-04T22:10:46.1564040Z   0x0ab6991894a0: f9 f9 f9 f9 00 01 f9 f9 00 00 00 06 f9 f9 f9 f9
2024-05-04T22:10:46.1564529Z   0x0ab6991894b0: 02 f9 f9 f9 02 f9 f9 f9 02 f9 f9 f9 02 f9 f9 f9
2024-05-04T22:10:46.1565009Z   0x0ab6991894c0: 02 f9 f9 f9 02 f9 f9 f9 02 f9 f9 f9 02 f9 f9 f9
2024-05-04T22:10:46.1565474Z   0x0ab6991894d0: 00 00 01 f9 f9 f9 f9 f9 00 03 f9 f9 03 f9 f9 f9
2024-05-04T22:10:46.1565928Z   0x0ab6991894e0: 00 00 00 07 f9 f9 f9 f9 00 00 01 f9 f9 f9 f9 f9
2024-05-04T22:10:46.1566384Z =>0x0ab6991894f0: 00 00 00 03 f9 f9 f9 f9 00[03]f9 f9 00 00 02 f9
2024-05-04T22:10:46.1566855Z   0x0ab699189500: f9 f9 f9 f9 00 05 f9 f9 06 f9 f9 f9 02 f9 f9 f9
2024-05-04T22:10:46.1567616Z   0x0ab699189510: 01 f9 f9 f9 07 f9 f9 f9 00 00 00 00 00 00 00 00
2024-05-04T22:10:46.1568074Z   0x0ab699189520: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
2024-05-04T22:10:46.1568529Z   0x0ab699189530: 07 f9 f9 f9 f9 f9 f9 f9 00 00 00 00 00 00 02 f9
2024-05-04T22:10:46.1568983Z   0x0ab699189540: f9 f9 f9 f9 00 00 00 00 05 f9 f9 f9 f9 f9 f9 f9
2024-05-04T22:10:46.1569514Z Shadow byte legend (one shadow byte represents 8 application bytes):
2024-05-04T22:10:46.1569957Z   Addressable:           00
2024-05-04T22:10:46.1570269Z   Partially addressable: 01 02 03 04 05 06 07 
2024-05-04T22:10:46.1570625Z   Heap left redzone:       fa
2024-05-04T22:10:46.1571207Z   Freed heap region:       fd
2024-05-04T22:10:46.1571494Z   Stack left redzone:      f1
2024-05-04T22:10:46.1571774Z   Stack mid redzone:       f2
2024-05-04T22:10:46.1572046Z   Stack right redzone:     f3
2024-05-04T22:10:46.1572316Z   Stack after return:      f5
2024-05-04T22:10:46.1572594Z   Stack use after scope:   f8
2024-05-04T22:10:46.1572872Z   Global redzone:          f9
2024-05-04T22:10:46.1573136Z   Global init order:       f6
2024-05-04T22:10:46.1573407Z   Poisoned by user:        f7
2024-05-04T22:10:46.1573676Z   Container overflow:      fc
2024-05-04T22:10:46.1574092Z   Array cookie:            ac
2024-05-04T22:10:46.1574366Z   Intra object redzone:    bb
2024-05-04T22:10:46.1574629Z   ASan internal:           fe
2024-05-04T22:10:46.1574906Z   Left alloca redzone:     ca
2024-05-04T22:10:46.1575180Z   Right alloca redzone:    cb
```