### PR TITLE
Fix problems detected by -fsanitize=address

### DIFF
--- a/common/list.c
+++ b/common/list.c
@@ -345,7 +345,14 @@ int
 split_string_append_fragment(const char **start, const char *end,
                              struct list *list)
 {
-    const unsigned int len = end - *start;
+    unsigned int len = end - *start;
+    // Check for an unexpected terminator in the string
+    const char *term = (const char *)memchr(*start, '\0', len);
+    if (term != NULL)
+    {
+        end = term;
+        len = end - *start;
+    }
     char *copy = (char *)malloc(len + 1);
     if (copy == NULL)
     {

--- a/tests/common/test_os_calls_signals.c
+++ b/tests/common/test_os_calls_signals.c
@@ -111,7 +111,7 @@ START_TEST(test_g_signal_child_stop_1)
         // Before raising the signal, change directory to a non-writeable
         // one to avoid generating a corefile.
         g_set_current_dir("/");
-        raise(SIGSEGV);
+        raise(SIGUSR2);
     }
     ck_assert_int_ne(pid, 0);
     g_obj_wait(&g_wobj1, 1, NULL, 0, 2000);
@@ -120,7 +120,7 @@ START_TEST(test_g_signal_child_stop_1)
     e = g_waitpid_status(pid);
 
     ck_assert_int_eq(e.reason, E_PXR_SIGNAL);
-    ck_assert_int_eq(e.val, SIGSEGV);
+    ck_assert_int_eq(e.val, SIGUSR2);
 
     // Clean up
     g_signal_child_stop(NULL);

--- a/tests/xrdp/test_xrdp_egfx.c
+++ b/tests/xrdp/test_xrdp_egfx.c
@@ -54,6 +54,7 @@ START_TEST(test_xrdp_egfx_send_create_surface__happy_path)
     in_uint8(s, descriptor);
     ck_assert_int_eq(0xE0, descriptor);
 
+    free_stream(s);
     g_free(bulk);
 }
 END_TEST


### PR DESCRIPTION
This PR fixes some problems in the test suite found with `-fsanitize=address`

For some context, see #3057