### PR TITLE
Fix a systemd dependency ("network-online.target")

### DIFF
--- a/instfiles/xrdp.service.in
+++ b/instfiles/xrdp.service.in
@@ -2,7 +2,7 @@
 Description=xrdp daemon
 Documentation=man:xrdp(8) man:xrdp.ini(5)
 Requires=xrdp-sesman.service
-After=network.target xrdp-sesman.service
+After=network-online.target xrdp-sesman.service
 
 [Service]
 Type=exec


### PR DESCRIPTION
Hi, this PR fixes a problem that the "xrdp.service" fail to auto-start when instructed to listen on a specific interface

- By changing the "network.target" systemd dependency to "network-online.target"
- The "network-online.target", in short, means at least one network interface has finished IP level setup.
- The previously used "network.target" is vague and does not provide such guarantee (ref: man systemd.special(7)).
- Which often cause "xrdp.service" fail to auto-start when the service is configured to listen on a specific interface (e.g. in xrdp.ini, "port=tcp://192.168.0.1:3389"). Because the interface may have not finish setting up its IP, when "xrdp.service" starts.