### PR TITLE
Remove the wait for the ibus daemon to start

### DIFF
--- a/sesman/chansrv/input_ibus.c
+++ b/sesman/chansrv/input_ibus.c
@@ -220,8 +220,21 @@ xrdp_input_unicode_init(void)
         return 0;
     }
 
-    /* Wait becasue ibus daemon may not be ready in first login. Do we have a flag to avoid busy waiting? */
-    sleep(3);
+    /* Wait because the ibus daemon may not be ready on first login */
+    const char *addr = ibus_get_address();
+    unsigned int cnt = 0;
+    while (!addr && cnt < 10)
+    {
+        usleep(500 * 1000); // half a second
+        addr = ibus_get_address();
+        ++cnt;
+    }
+    if (!addr)
+    {
+        LOG(LOG_LEVEL_ERROR,
+            "xrdp_ibus_init: Timed out waiting for iBus daemon");
+        return 1;
+    }
 
     LOG(LOG_LEVEL_INFO, "xrdp_ibus_init: Initializing the iBus engine");
     ibus_init();

--- a/sesman/chansrv/input_ibus.c
+++ b/sesman/chansrv/input_ibus.c
@@ -155,8 +155,6 @@ xrdp_input_main_loop(void *in_val)
     factory = ibus_factory_new(ibus_bus_get_connection(bus));
     g_object_ref_sink(factory);
     g_signal_connect(factory, "create-engine", G_CALLBACK(xrdp_input_ibus_create_engine), NULL);
-    g_signal_connect(factory, "enable", G_CALLBACK(xrdp_input_ibus_engine_enable), NULL);
-    g_signal_connect(factory, "disable", G_CALLBACK(xrdp_input_ibus_engine_disable), NULL);
 
     ibus_factory_add_engine(factory, "XrdpIme", IBUS_TYPE_ENGINE);
 


### PR DESCRIPTION
Fixes #3080 and tested by @seflerZ 

The initial implementation of Uinicode input via IBus used a startup delay of 3 seconds to wait for the daemon to be ready before connecting to it.

This commit introduces a poll-wait loop which can remove the delay entirely if the daemon is up when chansrv starts the interface.