### PR TITLE
Fix session list processing

### DIFF
--- a/sesman/session_list.c
+++ b/sesman/session_list.c
@@ -209,9 +209,12 @@ x_server_running_check_ports(int display)
 /******************************************************************************/
 /* Helper function for get_sorted_display_list():qsort() */
 static int
-icmp(const void *i1, const void *i2)
+icmp(const void *v1, const void *v2)
 {
-    return *(const unsigned int *)i2 - *(const unsigned int *)i1;
+    // Pointers point to unsigned ints
+    unsigned int i1 = *(unsigned int *)v1;
+    unsigned int i2 = *(unsigned int *)v2;
+    return (i1 < i2) ? -1 : (i1 > i2) ? 1 : 0;
 }
 
 /******************************************************************************/


### PR DESCRIPTION
Fixes #3095 

The get_sorted_session_displays() is broken in that it doesn't produce a sorted list of displays.

The problem is the `qsort` comparison function which has 2 errors in 4 lines:-
1) The test is the wrong way round (i.e. arg1 < arg2 produces a positive result instead of negative)
2) Subtracting two unsigned ints in C will never return < 0

The broken function has been masked by other display checks which mean that it is only visible in a few situations:-
1) Starting two sessions very closely to each other may allocate the same display to both sessions.
2) If `/tmp` is namespaced, the other display checks do not work, and more than two sessions cannot be started - see #3095 