### PR TITLE
Fix min/max monitor placing issue

### DIFF
--- a/xrdp/xrdp_egfx.h
+++ b/xrdp/xrdp_egfx.h
@@ -222,6 +222,10 @@ xrdp_egfx_send_wire_to_surface2(struct xrdp_egfx *egfx, int surface_id,
                                 int codec_id, int codec_context_id,
                                 int pixel_format,
                                 void *bitmap_data, int bitmap_data_length);
+/*
+ * NB: mi below must be such that the (top,left) co-ordinate of
+ * the primary monitor is (0.0)
+ */
 struct stream *
 xrdp_egfx_reset_graphics(struct xrdp_egfx_bulk *bulk, int width, int height,
                          int monitor_count, struct monitor_info *mi);

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -1444,7 +1444,7 @@ xrdp_mm_egfx_caps_advertise(void *user, int caps_count,
         error = xrdp_egfx_send_reset_graphics(self->egfx,
                                               screen->width, screen->height,
                                               self->wm->client_info->display_sizes.monitorCount,
-                                              self->wm->client_info->display_sizes.minfo_wm);
+                                              self->wm->client_info->display_sizes.minfo);
         LOG(LOG_LEVEL_INFO, "xrdp_mm_egfx_caps_advertise: xrdp_egfx_send_reset_graphics "
             "error %d monitorCount %d",
             error, self->wm->client_info->display_sizes.monitorCount);


### PR DESCRIPTION
Fixes #3075 

When a multi-monitor session has the top-left vertex of the primary monitor at a desktop location other than (0,0), minimising and maximising the session results in the (0,0) co-ordinate of the entire desktop being placed at the top-left of the primary monitor.

The implementation seems to be at odds with [MS-RDPEGFX] 2.2.2.14 which suggests the monitorDefArray of the RDPGFX_RESET_GRAPHICS_PDU should be the same as that in the Monitor Layout PDU ([MS-RDPBCGR] 2.2.12.1)