### PR TITLE
Replace 'dvorak' keyboard description with 'us(dvorak)'

### DIFF
--- a/xrdp/xrdp_keyboard.ini
+++ b/xrdp/xrdp_keyboard.ini
@@ -86,7 +86,7 @@ rdp_layout_pt=0x00000816
 ; <rdp layout name> = <X11 keyboard layout value>
 [default_layouts_map]
 rdp_layout_us=us
-rdp_layout_us_dvorak=dvorak
+rdp_layout_us_dvorak=us(dvorak)
 rdp_layout_us_dvp=us(dvp)
 rdp_layout_dk=dk
 rdp_layout_de=de
@@ -125,7 +125,7 @@ layouts_map=default_layouts_map
 
 [rdp_layouts_map_mac]
 rdp_layout_us=us
-rdp_layout_us_dvorak=dvorak
+rdp_layout_us_dvorak=us(dvorak)
 rdp_layout_us_dvp=us(dvp)
 rdp_layout_dk=dk
 rdp_layout_de=de


### PR DESCRIPTION
Fixes #3081 

In the words of @iskunk

It is no longer possible to refer to the Dvorak layout as just "dvorak" (as when one would run "setxkbmap dvorak"); one must now use either "us dvorak" or "us(dvorak)"

See https://bugs.debian.org/1063725