### PR TITLE
Fix evdev keycode problems

### DIFF
--- a/common/ms-rdpbcgr.h
+++ b/common/ms-rdpbcgr.h
@@ -476,6 +476,7 @@
 /* TODO: to be renamed */
 #define KBD_FLAG_RIGHT                 0x0001
 #define KBD_FLAG_EXT                   0x0100 /* KBDFLAGS_EXTENDED */
+#define KBD_FLAG_EXT1                  0x0200 /* KBDFLAGS_EXTENDED1 */
 #define KBD_FLAG_QUIET                 0x1000
 #define KBD_FLAG_DOWN                  0x4000
 #define KBD_FLAG_UP                    0x8000

--- a/libxrdp/xrdp_fastpath.c
+++ b/libxrdp/xrdp_fastpath.c
@@ -184,6 +184,11 @@ xrdp_fastpath_process_EVENT_SCANCODE(struct xrdp_fastpath *self,
         flags |= KBD_FLAG_EXT;
     }
 
+    if ((eventFlags & FASTPATH_INPUT_KBDFLAGS_EXTENDED1))
+    {
+        flags |= KBD_FLAG_EXT1;
+    }
+
     xrdp_fastpath_session_callback(self, RDP_INPUT_SCANCODE,
                                    code, 0, flags, 0);
 

--- a/xup/xup.c
+++ b/xup/xup.c
@@ -311,7 +311,15 @@ lib_mod_event(struct mod *mod, int msg, tbus param1, tbus param2,
         /* xup doesn't need the Unicode character mapping in param1. Send
          * the X11 scancode instead, so xorgxrdp doesn't have to do this
          * work again */
-        param1 = scancode_to_keycode(param3);
+        if ((param4 & KBD_FLAG_EXT) != 0)
+        {
+            // Extended key - set bit 9 of the scancode for the lookup
+            param1 = scancode_to_keycode(param3 | 0x100);
+        }
+        else
+        {
+            param1 = scancode_to_keycode(param3);
+        }
     }
 
     init_stream(s, 8192);


### PR DESCRIPTION
Commit 6257dae74d647a8539e2c9a5e2b31d74ea70fd3f added a way to send an evdev X11 keycode to xorgxrdp. The interface is currently unused, but there are plans to do use it soon - see neutrinolabs/xorgxrdp#303

This PR fixes a couple of problems with the interface which have been uncovered during informal testing.