### PR TITLE
docs: always include docs/man/xrdp-mkfv1.8.in to dist tarball

### DIFF
--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -1,9 +1,3 @@
-if USE_FREETYPE2
-  MKFV1_MAN = xrdp-mkfv1.8
-else
-  MKFV1_MAN =
-endif
-
 man_MANS = \
   xrdp-dis.1 \
   sesman.ini.5 \
@@ -16,10 +10,13 @@ man_MANS = \
   xrdp-sesadmin.8 \
   xrdp-sesman.8 \
   xrdp-sesrun.8 \
-  xrdp-dumpfv1.8 \
-  $(MKFV1_MAN)
+  xrdp-dumpfv1.8
 
-EXTRA_DIST = $(man_MANS:=.in)
+EXTRA_DIST = xrdp-mkfv1.8.in $(man_MANS:=.in)
+
+if USE_FREETYPE2
+  man_MANS += xrdp-mkfv1.8
+endif
 
 SUBST_VARS = sed \
    -e 's|@PACKAGE_VERSION[@]|$(PACKAGE_VERSION)|g' \


### PR DESCRIPTION
Files included in distribution tarball must always be enumerated, not be enumerated conditionally.

Resolves:   #3149
(cherry picked from commit e83dcc52eb7703da2ae73f4adcca0cffa0e0370d)

----

Forward #3150 to devel.