### PR TITLE
chkpriv: respect $sysconfdir for config files directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ tests/libxrdp/test_libxrdp
 tests/memtest/memtest
 tests/xrdp/test_xrdp
 tools/devel/tcp_proxy/tcp_proxy
+tools/chkpriv/xrdp-chkpriv
+tools/chkpriv/xrdp-droppriv
 *.trs
 waitforx/waitforx
 xrdp/xrdp

--- a/tools/chkpriv/Makefile.am
+++ b/tools/chkpriv/Makefile.am
@@ -17,7 +17,8 @@ xrdp_droppriv_LDADD = \
   $(top_builddir)/common/libcommon.la
 
 SUBST_VARS = sed \
-   -e 's|@pkglibexecdir[@]|$(pkglibexecdir)|g'
+   -e 's|@pkglibexecdir[@]|$(pkglibexecdir)|g' \
+   -e 's|@sysconfdir[@]|$(sysconfdir)|g'
 
 subst_verbose = $(subst_verbose_@AM_V@)
 subst_verbose_ = $(subst_verbose_@AM_DEFAULT_V@)

--- a/tools/chkpriv/xrdp-chkpriv.in
+++ b/tools/chkpriv/xrdp-chkpriv.in
@@ -20,7 +20,7 @@
 # mode
 
 # Change these if they do not match your installation
-CONF_DIR=/etc/xrdp
+CONF_DIR=@sysconfdir@/xrdp
 XRDP_INI="$CONF_DIR"/xrdp.ini
 SESMAN_INI="$CONF_DIR"/sesman.ini
 RSAKEYS_INI="$CONF_DIR"/rsakeys.ini


### PR DESCRIPTION
While here, ignore build artifacts of chkpriv tools.

Follow-up to:   #2974