### PR TITLE
[V0.10] Fix potential name buffer overflows in redirector

### DIFF
--- a/sesman/chansrv/chansrv_fuse.c
+++ b/sesman/chansrv/chansrv_fuse.c
@@ -202,7 +202,7 @@ struct state_lookup
 {
     fuse_req_t        req;        /* Original FUSE request from lookup  */
     fuse_ino_t        pinum;      /* inum of parent directory           */
-    char              name[XFS_MAXFILENAMELEN];
+    char              name[XFS_MAXFILENAMELEN + 1];
     /* Name to look up                    */
     fuse_ino_t        existing_inum;
     /* inum of an existing entry          */
@@ -241,7 +241,7 @@ struct state_create
     fuse_req_t        req;        /* Original FUSE request from lookup  */
     struct fuse_file_info fi;     /* File info struct passed to open    */
     fuse_ino_t        pinum;      /* inum of parent directory           */
-    char              name[XFS_MAXFILENAMELEN];
+    char              name[XFS_MAXFILENAMELEN + 1];
     /* Name of file in parent directory   */
     mode_t            mode;       /* Mode of file to create             */
 };
@@ -280,7 +280,7 @@ struct state_rename
     fuse_req_t        req;        /* Original FUSE request from lookup  */
     fuse_ino_t        pinum;      /* inum of parent of file             */
     fuse_ino_t        new_pinum;  /* inum of new parent of file         */
-    char              name[XFS_MAXFILENAMELEN];
+    char              name[XFS_MAXFILENAMELEN + 1];
     /* New name of file in new parent dir */
 };
 


### PR DESCRIPTION
The state buffers used by the following structs in chansrv_fuse.c are one byte too small for filenames of length XFS_MAXFILENAMELEN:-
- struct state_lookup
- struct state_create
- struct state_rename

In practice, there is no runtime danger, as XFS_MAXFILENAMELEN is 255, and these buffers will be followed by non-byte aligned data. Nevertheless this should be fixed to prevent problems if the value is changed.

(cherry picked from commit c9e84dc16ced157fed9cb0f7d3bcc19782fb8551)