### PR TITLE
[v0.10] Include {xrdp,sesman}.ini.in instead of substituted .ini in tarball

### DIFF
--- a/sesman/Makefile.am
+++ b/sesman/Makefile.am
@@ -27,6 +27,7 @@ xrdp_sesman_SOURCES = \
   scp_process.h \
   sesman.c \
   sesman.h \
+  sesman.ini.in \
   sesexec_control.c \
   sesexec_control.h \
   session_list.c \
@@ -52,7 +53,7 @@ SUFFIXES = .in
 .in:
 	$(subst_verbose)$(SUBST_VARS) $< > $@
 
-dist_sesmansysconf_DATA = \
+nodist_sesmansysconf_DATA = \
   sesman.ini
 
 dist_sesmansysconf_SCRIPTS = \
@@ -64,3 +65,5 @@ SUBDIRS = \
   sesexec \
   tools \
   chansrv
+
+CLEANFILES = $(nodist_sesmansysconf_DATA)

--- a/xrdp/Makefile.am
+++ b/xrdp/Makefile.am
@@ -46,6 +46,7 @@ xrdp_SOURCES = \
   lang.c \
   xrdp.c \
   xrdp.h \
+  xrdp.ini.in \
   xrdp_bitmap.c \
   xrdp_bitmap_load.c \
   xrdp_bitmap_common.c \
@@ -93,8 +94,10 @@ SUFFIXES = .in
 	$(subst_verbose)$(SUBST_VARS) $< > $@
 
 dist_xrdpsysconf_DATA = \
-  xrdp.ini \
   xrdp_keyboard.ini
+
+nodist_xrdpsysconf_DATA = \
+  xrdp.ini
 
 xrdppkgdatadir=$(datadir)/xrdp
 
@@ -110,3 +113,5 @@ dist_xrdppkgdata_DATA = \
   sans-18.fv1 \
   cursor0.cur \
   cursor1.cur
+
+CLEANFILES = $(nodist_xrdpsysconf_DATA)


### PR DESCRIPTION
These config files are intended to be substituted during the build process. The substituted .ini files should not be included in release tarballs.

Fixes:  #3187