### PR TITLE
[V0.10] chansrv clip fixes

### DIFF
--- a/sesman/chansrv/chansrv_xfs.h
+++ b/sesman/chansrv/chansrv_xfs.h
@@ -29,7 +29,11 @@
 
 #include "arch.h"
 
-#define XFS_MAXFILENAMELEN 255
+/* Maximum length of filename supported (in bytes).
+ * This is a sensible limit to a filename length. It is not used by
+ * this module to allocate long-lived storage, so it can be increased
+ * if necessary */
+#define XFS_MAXFILENAMELEN 1023
 
 /*
  * Incomplete types for the public interface
@@ -37,6 +41,9 @@
 struct xfs_fs;
 struct xfs_dir_handle;
 
+/**
+ * Describe an inode in the XFS filesystem
+ */
 typedef struct xfs_inode
 {
     fuse_ino_t      inum;              /* File serial number.               */
@@ -47,7 +54,7 @@ typedef struct xfs_inode
     time_t          atime;             /* Time of last access.              */
     time_t          mtime;             /* Time of last modification.        */
     time_t          ctime;             /* Time of last status change.       */
-    char            name[XFS_MAXFILENAMELEN + 1]; /* Short name             */
+    char            *name;             /* Short name (dynamically allocated) */
     tui32           generation;        /* Changes if inode is reused        */
     char            is_redirected;     /* file is on redirected device      */
     tui32           device_id;         /* device ID of redirected device    */

--- a/sesman/chansrv/clipboard_file.c
+++ b/sesman/chansrv/clipboard_file.c
@@ -538,10 +538,12 @@ clipboard_send_file_data(int streamId, int lindex,
     make_stream(s);
     init_stream(s, cbRequested + 64);
     size = g_file_read(fd, s->data + 12, cbRequested);
-    if (size < 1)
+    // If we're at end-of-file, 0 is a valid response
+    if (size < 0)
     {
-        LOG_DEVEL(LOG_LEVEL_ERROR, "clipboard_send_file_data: read error, want %d got %d",
-                  cbRequested, size);
+        LOG_DEVEL(LOG_LEVEL_ERROR,
+                  "clipboard_send_file_data: read error, want %d got [%s]",
+                  cbRequested, g_get_strerror());
         free_stream(s);
         g_file_close(fd);
         clipboard_send_filecontents_response_fail(streamId);

--- a/sesman/chansrv/clipboard_file.c
+++ b/sesman/chansrv/clipboard_file.c
@@ -285,37 +285,38 @@ clipboard_get_file(const char *file, int bytes)
 }
 
 /*****************************************************************************/
+/*
+ * Calls clipboard_get_file() for each filename in a list.
+ *
+ * List items are separated by line terminators. Blank items are ignored */
 static int
 clipboard_get_files(const char *files, int bytes)
 {
-    int index;
-    int file_index;
-    char file[512];
+    const char *start = files;
+    const char *end = files + bytes;
+    const char *p;
 
-    file_index = 0;
-    for (index = 0; index < bytes; index++)
+    for (p = start ; p < end ; ++p)
     {
-        if (files[index] == '\n' || files[index] == '\r')
+        if (*p == '\n' || *p == '\r')
         {
-            if (file_index > 0)
+            /* Skip zero-length files (which might be caused by
+             * multiple line terminators */
+            if (p > start)
             {
-                if (clipboard_get_file(file, file_index) == 0)
-                {
-                }
-                file_index = 0;
+                /* Get file. Errors are logged */
+                (void)clipboard_get_file(start, p - start);
             }
-        }
-        else
-        {
-            file[file_index] = files[index];
-            file_index++;
+
+            /* Move the start of filename pointer to either 'end', or
+             * the next character which will either be a filename or
+             * another terminator */
+            start = p + 1;
         }
     }
-    if (file_index > 0)
+    if (end > start)
     {
-        if (clipboard_get_file(file, file_index) == 0)
-        {
-        }
+        (void)clipboard_get_file(start, end - start);
     }
     if (g_files_list->count < 1)
     {

--- a/sesman/chansrv/devredir.c
+++ b/sesman/chansrv/devredir.c
@@ -53,6 +53,7 @@
 #include "log.h"
 #include "chansrv.h"
 #include "chansrv_fuse.h"
+#include "chansrv_xfs.h"
 #include "devredir.h"
 #include "smartcard.h"
 #include "ms-rdpefs.h"
@@ -1249,7 +1250,13 @@ devredir_proc_query_dir_response(IRP *irp,
                 return -1;
             }
 
+            // Size the filename buffer so it's big enough for
+            // storing the file in our filesystem if we need to.
+#ifdef XFS_MAXFILENAMELEN
+            char  filename[XFS_MAXFILENAMELEN + 1];
+#else
             char  filename[256];
+#endif
             tui64 LastAccessTime;
             tui64 LastWriteTime;
             tui64 EndOfFile;


### PR DESCRIPTION
Backport of #3165 / #3173 to V0.10

- Much longer filenames are now supported by the redirector. This is useful when dealing with some character encodings which use 4-byte UTF-8 encoded characters.
- Some hard-coded buffer sizes used for filenames have been removed.
- An issue related to pasting file lists from the clipboard when using the FreeRDP client has been fixed

Special thanks to @tsz8899 for raising the original issue and working with the team on resolving it.