### PR TITLE
Wait for capabilities message from Xorg

### DIFF
--- a/xup/xup.c
+++ b/xup/xup.c
@@ -1836,12 +1836,12 @@ lib_mod_process_message(struct mod *mod, struct stream *s)
                     in_uint32_le(s, version);
                     if (version != CLIENT_INFO_CURRENT_VERSION)
                     {
-                        LOG(LOG_LEVEL_ERROR,
-                            "Xorg module has version %d, expected %d",
-                            version, CLIENT_INFO_CURRENT_VERSION);
-                        mod->server_msg(mod,
-                                        "Xorg module has wrong version number",
-                                        0);
+                        char msg[128];
+                        g_snprintf(msg, sizeof(msg),
+                                   "Xorg module has version %d, expected %d",
+                                   version, CLIENT_INFO_CURRENT_VERSION);
+                        LOG(LOG_LEVEL_ERROR, "%s", msg);
+                        mod->server_msg(mod, msg, 0);
                         mod->caps_processing_status = E_CAPS_NOT_OK;
                     }
                     break;

--- a/xup/xup.h
+++ b/xup/xup.h
@@ -21,6 +21,17 @@
 #ifndef XUP_H
 #define XUP_H
 
+/**
+ * Enum for the states used to process a
+ * capabilities message from the Xorg module
+ */
+enum caps_processing_status
+{
+    E_CAPS_NOT_PROCESSED, ///< Capabilities mesage from module not processed
+    E_CAPS_OK,            ///< Capabilities are OK
+    E_CAPS_NOT_OK         ///< Capabilities are not OK
+};
+
 /* include other h files */
 #include "arch.h"
 #include "parse.h"
@@ -202,6 +213,7 @@ struct mod
     char *screen_shmem_pixels;
     struct trans *trans;
     char keycode_set[32];
+    enum caps_processing_status caps_processing_status;
 };
 
 #endif // XUP_H


### PR DESCRIPTION
This is partly mentioned in #1816 

This commit adds a stage into the Xorg connection status to wait for the capabilities message from the Xorg server.

This allows us to move the xorgxrdp version check to xrdp from the X server for better reporting to the user.

This PR needs neutrinolabs/xorgxrdp#332 to function correctly, but can be merged separately.

Currently, if the xrdp and xorgxrdp versions don't match:-
1) The connection terminates immediately.
2) The version mismatch is reported in `~/.xorgxrdp.$D.log` (not `xrdp.log`)
3) The X server aborts.

With both of these PRs:-
1) An error is displayed to the user
2) The version mismatch is reported in `xrdp.log`
3) The X server continues to run.

Screenshot for a version mismatch:-

![image](https://github.com/user-attachments/assets/7a8594cb-a35f-4af2-a948-af10b2919f91)

Corresponding `xrdp.log`:-

```
[2024-08-06T11:32:08.469+0100] [INFO ] [lib_mod_connect(xup.c:269)] lib_mod_connect: connecting via UNIX socket
[2024-08-06T11:32:08.469+0100] [INFO ] [lib_mod_connect(xup.c:304)] lib_mod_connect: connected to Xserver (Xorg) sck 29
[2024-08-06T11:32:08.469+0100] [INFO ] [lib_mod_log_peer(xup.c:79)] lib_mod_log_peer: xrdp_pid=80398 connected to Xorg_pid=80518 Xorg_uid=1001 Xorg_gid=1001 client=[::ffff:172.19.73.10]:32884
[2024-08-06T11:32:08.476+0100] [ERROR] [lib_mod_process_message(xup.c:1839)] Xorg module has version 20240806, expected 20240805
[2024-08-06T11:32:08.479+0100] [ERROR] [xrdp_wm_log_msg(xrdp_wm.c:2434)] xrdp_wm_log_msg: Error connecting to user session
```