### PR TITLE
Fix misreported cache size

### DIFF
--- a/libxrdp/xrdp_caps.c
+++ b/libxrdp/xrdp_caps.c
@@ -510,7 +510,7 @@ xrdp_caps_process_offscreen_bmpcache(struct xrdp_rdp *self, struct stream *s,
     in_uint16_le(s, i32);
     self->client_info.offscreen_cache_entries = i32;
     LOG(LOG_LEVEL_INFO, "xrdp_process_offscreen_bmpcache: support level %d "
-        "cache size %d MB cache entries %d",
+        "cache size %d bytes cache entries %d",
         self->client_info.offscreen_support_level,
         self->client_info.offscreen_cache_size,
         self->client_info.offscreen_cache_entries);


### PR DESCRIPTION
See [this comment](https://github.com/neutrinolabs/xrdp/discussions/3203#discussioncomment-10352270) for a background.

The TS_OFFSCREEN_CAPABILITYSET in [[MS-RDPBCGR] 2.2.7.1.9](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/412fa921-2faa-4f1b-ab5f-242cdabc04f9) sends us a `offscreenCacheSize` in kilobytes. We're multiplying this by 1024 (to get bytes):-

```c
    self->client_info.offscreen_cache_size = i32 * 1024;
```

We are however, reporting the figure as Megabytes!
