### PR TITLE
[V0.10] Fix misreported cache size

### DIFF
--- a/libxrdp/xrdp_caps.c
+++ b/libxrdp/xrdp_caps.c
@@ -489,7 +489,7 @@ xrdp_caps_process_offscreen_bmpcache(struct xrdp_rdp *self, struct stream *s,
     in_uint16_le(s, i32);
     self->client_info.offscreen_cache_entries = i32;
     LOG(LOG_LEVEL_INFO, "xrdp_process_offscreen_bmpcache: support level %d "
-        "cache size %d MB cache entries %d",
+        "cache size %d bytes cache entries %d",
         self->client_info.offscreen_support_level,
         self->client_info.offscreen_cache_size,
         self->client_info.offscreen_cache_entries);


### PR DESCRIPTION
Printed offscreen bitmap cache size is in bytes, not MB.

(cherry picked from commit 3bfa59472e6cf4fad159c9a03875b79795d48193)