### PR TITLE
Fix github runner version for v0.10 at 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,21 +20,21 @@ jobs:
           - CC: gcc
             feature_set: min
             arch: amd64
-            os: ubuntu-latest
+            os: ubuntu-22.04
             unittests: false
             DISTCHECK: false
 
           - CC: g++
             feature_set: min
             arch: amd64
-            os: ubuntu-latest
+            os: ubuntu-22.04
             unittests: false
             DISTCHECK: false
 
           - CC: clang
             feature_set: min
             arch: amd64
-            os: ubuntu-latest
+            os: ubuntu-22.04
             unittests: false
             DISTCHECK: false
 
@@ -42,21 +42,21 @@ jobs:
           - CC: gcc
             feature_set: max
             arch: amd64
-            os: ubuntu-latest
+            os: ubuntu-22.04
             unittests: true
             DISTCHECK: true
 
           - CC: g++
             feature_set: max
             arch: amd64
-            os: ubuntu-latest
+            os: ubuntu-22.04
             unittests: false
             DISTCHECK: false
 
           - CC: clang
             feature_set: max
             arch: amd64
-            os: ubuntu-latest
+            os: ubuntu-22.04
             unittests: true
             DISTCHECK: true
 
@@ -66,7 +66,7 @@ jobs:
           - CC: gcc
             feature_set: max
             arch: amd64
-            os: ubuntu-latest
+            os: ubuntu-22.04
             unittests: true
             DISTCHECK: false
             name_extra: and DEBUG
@@ -76,7 +76,7 @@ jobs:
           - CC: gcc
             feature_set: max
             arch: i386
-            os: ubuntu-latest
+            os: ubuntu-22.04
             unittests: true
             DISTCHECK: false
             name_extra: for 32-bit arch (legacy OS)
@@ -84,7 +84,7 @@ jobs:
           - CC: g++
             feature_set: max
             arch: i386
-            os: ubuntu-latest
+            os: ubuntu-22.04
             unittests: false
             DISTCHECK: false
             name_extra: for 32-bit arch (legacy OS)
@@ -92,7 +92,7 @@ jobs:
           - CC: clang
             feature_set: max
             arch: i386
-            os: ubuntu-latest
+            os: ubuntu-22.04
             unittests: true
             DISTCHECK: false
             name_extra: for 32-bit arch (legacy OS)
@@ -160,7 +160,7 @@ jobs:
 
   cppcheck:
     name: cppcheck
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       CC: gcc
       # This is required to use a version of cppcheck other than that
@@ -189,7 +189,7 @@ jobs:
 
   code_formatting_check:
     name: code formatting check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       CC: gcc
       # This is required to use a version of astyle other than that


### PR DESCRIPTION
At the time of writing, the github runner for ubuntu-latest is 22.04, but this will change to 24.04 later in the year.

This change has not yet been announced, but the change from ubuntu 20.04 to 22.04 happened [around November '22](https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/) so it's reasonable to assume the change to 24.04 will happen round about November '24.

We've already made sure that `devel` will run on 24.04 in #3206. This necessitated a small change to both the libpainter (neutrinolabs/libpainter#23) and librfxcodec (neutrinolabs/librfxcodec#72) submodules. The change to `devel` means that `devel` can carry on using `ubuntu-latest`, and we (hopefully) won't notice.

For the V0.10 branch, I believe we have three choices to keep CI running after November '24:-
1) Make a v0.10.x branch for each submodule, based at their current v0.10 location and make the necessary changes to the branches.
2) Update the v0.10.x branch to use the latest versions of the submodules
3) Fix v0.10.x at Ubuntu CI version 22.04.

My personal preference is for 1) or 3). @akarl10 has suggested 3), and in the absence of any other suggestions I'm happy to go with that.


