### PR TITLE
startwm.sh POSIX rewrite with better error handling.

### DIFF
--- a/sesman/startwm.sh
+++ b/sesman/startwm.sh
@@ -23,23 +23,32 @@
 #         END IF
 #     END IF
 # END IF
-pre_start()
-{
-  if [ -r /etc/profile ]; then
-    . /etc/profile
-  fi
-  if [ -r ~/.bash_profile ]; then
-    . ~/.bash_profile
-  else
-    if [ -r ~/.bash_login ]; then
-      . ~/.bash_login
-    else
-      if [ -r ~/.profile ]; then
-        . ~/.profile
-      fi
+
+error_exit() {
+    echo "Error: $1" >&2
+    exit 1
+}
+
+log() {
+    echo "[$(date +'%Y-%m-%d %H:%M:%S')] $1" >&2
+}
+
+source_if_exists() {
+    if [ -r "$1" ]; then
+        . "$1" || error_exit "Failed to source $1"
     fi
-  fi
-  return 0
+}
+
+
+pre_start() {
+    source_if_exists /etc/profile
+    if [ -r "$HOME/.bash_profile" ]; then
+        source_if_exists "$HOME/.bash_profile"
+    elif [ -r "$HOME/.bash_login" ]; then
+        source_if_exists "$HOME/.bash_login"
+    else
+        source_if_exists "$HOME/.profile"
+    fi
 }
 
 # When logging out from the interactive shell, the execution sequence is:
@@ -47,100 +56,69 @@ pre_start()
 # IF ~/.bash_logout exists THEN
 #     execute ~/.bash_logout
 # END IF
-post_start()
-{
-  if [ -r ~/.bash_logout ]; then
-    . ~/.bash_logout
-  fi
-  return 0
+post_start() {
+    source_if_exists "$HOME/.bash_logout"
 }
 
-get_xdg_session_startupcmd()
-{
+
   # If DESKTOP_SESSION is set and valid then the STARTUP command will be taken from there
   # GDM exports environment variables XDG_CURRENT_DESKTOP and XDG_SESSION_DESKTOP.
   # This follows it.
-  if [ -n "$1" ] && [ -d /usr/share/xsessions ] \
-    && [ -f "/usr/share/xsessions/$1.desktop" ]; then
-    STARTUP=$(grep ^Exec= "/usr/share/xsessions/$1.desktop")
-    STARTUP=${STARTUP#Exec=*}
-    XDG_CURRENT_DESKTOP=$(grep ^DesktopNames= "/usr/share/xsessions/$1.desktop")
-    XDG_CURRENT_DESKTOP=${XDG_CURRENT_DESKTOP#DesktopNames=*}
-    XDG_CURRENT_DESKTOP=${XDG_CURRENT_DESKTOP//;/:}
-    export XDG_CURRENT_DESKTOP
-    export XDG_SESSION_DESKTOP="$DESKTOP_SESSION"
-  fi
+  
+get_xdg_session_startupcmd() {
+    if [ -n "$1" ] && [ -d /usr/share/xsessions ] && [ -f "/usr/share/xsessions/$1.desktop" ]; then
+        STARTUP=$(grep '^Exec=' "/usr/share/xsessions/$1.desktop" | cut -d= -f2-)
+        XDG_CURRENT_DESKTOP=$(grep '^DesktopNames=' "/usr/share/xsessions/$1.desktop" | cut -d= -f2- | tr ';' ':')
+        export XDG_CURRENT_DESKTOP
+        export XDG_SESSION_DESKTOP="$DESKTOP_SESSION"
+    fi
 }
 
 #start the window manager
-wm_start()
-{
-  if [ -r /etc/default/locale ]; then
-    . /etc/default/locale
-    export LANG LANGUAGE
-  fi
-
-  # debian
-  if [ -r /etc/X11/Xsession ]; then
-    pre_start
-
-    # if you want to start preferred desktop environment,
-    # add following line,
-    #  [ -n "$XRDP_SESSION" ] && export DESKTOP_SESSION=<your preferred desktop>
-    # in either of following file.
-    # 1. ~/.profile
-    # 2. create a file (any_filename.sh is OK) in /etc/profile.d
-    # <your preferred desktop> shall be one of "ls -1 /usr/share/xsessions/|cut -d. -f1"
-    # e.g.  [ -n "$XRDP_SESSION" ] && export DESKTOP_SESSION=ubuntu
-
-    # STARTUP is the default startup command.
-    # if $1 is empty and STARTUP was not set
-    # /etc/X11/Xsession.d/50x11-common_determine-startup will fallback to
-    # x-session-manager
-    if [ -z "$STARTUP" ] && [ -n "$DESKTOP_SESSION" ]; then
-      get_xdg_session_startupcmd "$DESKTOP_SESSION"
+wm_start() {
+    if [ -r /etc/default/locale ]; then
+        . /etc/default/locale || error_exit "Failed to source /etc/default/locale"
+        export LANG LANGUAGE
     fi
 
-    . /etc/X11/Xsession
-    post_start
-    exit 0
-  fi
-
-  # alpine
-  # Don't use /etc/X11/xinit/Xsession - it doesn't work
-  if [ -f /etc/alpine-release ]; then
-    if [ -f /etc/X11/xinit/xinitrc ]; then
+    if [ -r /etc/X11/Xsession ]; then
         pre_start
-        /etc/X11/xinit/xinitrc
+        if [ -z "${STARTUP:-}" ] && [ -n "${DESKTOP_SESSION:-}" ]; then
+            get_xdg_session_startupcmd "$DESKTOP_SESSION"
+        fi
+        . /etc/X11/Xsession || error_exit "Failed to source /etc/X11/Xsession"
         post_start
-    else
-        echo "** xinit package isn't installed" >&2
-        exit 1
+        exit 0
     fi
-  fi
 
-  # el
-  if [ -r /etc/X11/xinit/Xsession ]; then
+    if [ -f /etc/alpine-release ]; then
+        if [ -f /etc/X11/xinit/xinitrc ]; then
+            pre_start
+            /etc/X11/xinit/xinitrc || error_exit "Failed to execute /etc/X11/xinit/xinitrc"
+            post_start
+        else
+            error_exit "xinit package isn't installed"
+        fi
+    fi
+
+    if [ -r /etc/X11/xinit/Xsession ]; then
+        pre_start
+        . /etc/X11/xinit/Xsession || error_exit "Failed to source /etc/X11/xinit/Xsession"
+        post_start
+        exit 0
+    fi
+
+    if [ -r /etc/X11/xdm/Xsession ]; then
+        . /etc/X11/xdm/Xsession || error_exit "Failed to source /etc/X11/xdm/Xsession"
+        exit 0
+    elif [ -r /usr/etc/X11/xdm/Xsession ]; then
+        . /usr/etc/X11/xdm/Xsession || error_exit "Failed to source /usr/etc/X11/xdm/Xsession"
+        exit 0
+    fi
+
     pre_start
-    . /etc/X11/xinit/Xsession
+    xterm || error_exit "Failed to start xterm"
     post_start
-    exit 0
-  fi
-
-  # suse
-  if [ -r /etc/X11/xdm/Xsession ]; then
-    # since the following script run a user login shell,
-    # do not execute the pseudo login shell scripts
-    . /etc/X11/xdm/Xsession
-    exit 0
-  elif [ -r /usr/etc/X11/xdm/Xsession ]; then
-    . /usr/etc/X11/xdm/Xsession
-    exit 0
-  fi
-
-  pre_start
-  xterm
-  post_start
 }
 
 #. /etc/environment
@@ -157,6 +135,6 @@ wm_start()
 # includes
 # auth       required     pam_env.so readenv=1
 
+log "Starting window manager"
 wm_start
-
-exit 1
+error_exit "Window manager exited unexpectedly"


### PR DESCRIPTION
I was having trouble getting this to work on Gentoo using the boilerplate install, so I rewrote some scripts in hope of gaining functionality.

I cleaned this script up, I went for POSIX compatibility above all else - so we use `/bin/sh` and then use sh conventions. These are universal. 

Next, I added an error_exit function that will provide actual details if it fails (this was my primary motivation). Using `set -e` and `set -u` treats unset variables as errors so instead of the script and program starting, we find out what needs to change.

I have tested this on Gentoo, Arch, and Fedora. All seem to work fine.