### PR TITLE
add option to enable FUSE direct i/o on file open

### DIFF
--- a/docs/man/sesman.ini.5.in
+++ b/docs/man/sesman.ini.5.in
@@ -355,6 +355,12 @@ drive. To fix this, consult the docs for your chosen desktop.
 .RE
 
 .TP
+\fBFuseDirectIO\fR=\fI[false|true]\fR
+Defaults to \fIfalse\fR. Set to \fItrue\fR to disable page caching in
+FUSE when opening files on a redirected drive. Direct I/O can impact
+the performance of file operations.
+
+.TP
 \fBFileUmask\fR=\fImode\fR
 Additional umask to apply to files in the \fBFuseMountName\fR directory.
 The default value of 077 prevents other users on the system from reading

--- a/sesman/chansrv/chansrv_config.c
+++ b/sesman/chansrv/chansrv_config.c
@@ -40,6 +40,7 @@
 #define DEFAULT_RESTRICT_INBOUND_CLIPBOARD  0
 #define DEFAULT_ENABLE_FUSE_MOUNT           1
 #define DEFAULT_FUSE_MOUNT_NAME             "xrdp-client"
+#define DEFAULT_FUSE_DIRECT_IO              0
 #define DEFAULT_FILE_UMASK                  077
 #define DEFAULT_USE_NAUTILUS3_FLIST_FORMAT  0
 #define DEFAULT_NUM_SILENT_FRAMES_AAC       4
@@ -163,6 +164,10 @@ read_config_chansrv(log_func_t logmsg,
                 break;
             }
         }
+        else if (g_strcasecmp(name, "FuseDirectIO") == 0)
+        {
+            cfg->fuse_direct_io = g_text2bool(value);
+        }
         else if (g_strcasecmp(name, "FileUmask") == 0)
         {
             cfg->file_umask = strtol(value, NULL, 0);
@@ -212,6 +217,7 @@ new_config(void)
         cfg->restrict_outbound_clipboard = DEFAULT_RESTRICT_OUTBOUND_CLIPBOARD;
         cfg->restrict_inbound_clipboard = DEFAULT_RESTRICT_INBOUND_CLIPBOARD;
         cfg->fuse_mount_name = fuse_mount_name;
+        cfg->fuse_direct_io = DEFAULT_FUSE_DIRECT_IO;
         cfg->file_umask = DEFAULT_FILE_UMASK;
         cfg->use_nautilus3_flist_format = DEFAULT_USE_NAUTILUS3_FLIST_FORMAT;
         cfg->num_silent_frames_aac = DEFAULT_NUM_SILENT_FRAMES_AAC;
@@ -300,6 +306,8 @@ config_dump(struct config_chansrv *config)
     g_writeln("    EnableFuseMount            %s",
               g_bool2text(config->enable_fuse_mount));
     g_writeln("    FuseMountName:             %s", config->fuse_mount_name);
+    g_writeln("    FuseDirectIO:              %s",
+              g_bool2text(config->fuse_direct_io));
     g_writeln("    FileMask:                  0%o", config->file_umask);
     g_writeln("    Nautilus 3 Flist Format:   %s",
               g_bool2text(config->use_nautilus3_flist_format));

--- a/sesman/chansrv/chansrv_config.h
+++ b/sesman/chansrv/chansrv_config.h
@@ -26,6 +26,9 @@ struct config_chansrv
     /** Whether the FUSE mount is enabled or not */
     int enable_fuse_mount;
 
+    /** Whether to use direct I/O to FUSE filesystems */
+    int fuse_direct_io;
+
     /** RestrictOutboundClipboard setting from sesman.ini */
     int restrict_outbound_clipboard;
     /** RestrictInboundClipboard setting from sesman.ini */

--- a/sesman/chansrv/chansrv_fuse.c
+++ b/sesman/chansrv/chansrv_fuse.c
@@ -2200,6 +2200,10 @@ static void xfuse_cb_open(fuse_req_t req, fuse_ino_t ino,
             fip->fi = *fi;
             fip->inum = ino;
 
+            if (g_cfg->fuse_direct_io) {
+                fip->fi.direct_io = 1;
+            }
+
             /* we want path minus 'root node of the share' */
             cptr = filename_on_device(full_path);
 

--- a/sesman/chansrv/chansrv_fuse.c
+++ b/sesman/chansrv/chansrv_fuse.c
@@ -2200,7 +2200,8 @@ static void xfuse_cb_open(fuse_req_t req, fuse_ino_t ino,
             fip->fi = *fi;
             fip->inum = ino;
 
-            if (g_cfg->fuse_direct_io) {
+            if (g_cfg->fuse_direct_io)
+            {
                 fip->fi.direct_io = 1;
             }
 

--- a/sesman/sesman.ini.in
+++ b/sesman/sesman.ini.in
@@ -173,6 +173,10 @@ FuseMountName=thinclient_drives
 FileUmask=077
 ; Can be used to disable FUSE functionality - see sesman.ini(5)
 #EnableFuseMount=false
+; Can be used to enable direct I/O to FUSE open file calls. This is useful
+; when open file handles need to immediately see changes made on the client
+; side. There is a performance hit, so use with caution.
+#FuseDirectIO=true
 ; Uncomment this line only if you are using GNOME 3 versions 3.29.92
 ; and up, and you wish to cut-paste files between Nautilus and Windows. Do
 ; not use this setting for GNOME 4, or other file managers


### PR DESCRIPTION
This patch adds the option to disable file page caching in FUSE. If a program running on the server is accessing a file on a redirected drive, it may not see changes made from the client side with an existing file descriptor.

https://libfuse.github.io/doxygen/structfuse__config.html#ae335bab50dfddef49b0ed81671066fa8