### PR TITLE
Ask for no videos on the bug form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,6 +8,7 @@ body:
       value: |
         Before submitting a bug, read the [FAQ](https://github.com/neutrinolabs/xrdp/wiki/Tips-and-FAQ).
         **In particular, on systemd-based systems. make sure you are not logged in on the console as the same user you are trying to use for xrdp**
+        Please do not include links to images or videos on external websites. These are not guaranteed to always be available, and could be used to compromise web browsers.
   - type: input
     attributes:
       label: xrdp version

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,9 +6,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        Before submitting a bug, read the [FAQ](https://github.com/neutrinolabs/xrdp/wiki/Tips-and-FAQ).
-        **In particular, on systemd-based systems. make sure you are not logged in on the console as the same user you are trying to use for xrdp**
-        Please do not include links to images or videos on external websites. These are not guaranteed to always be available, and could be used to compromise web browsers.
+        Before submitting a bug, read the [FAQ](https://github.com/neutrinolabs/xrdp/wiki/Tips-and-FAQ). **In particular, on systemd-based systems. make sure you are not logged in on the console as the same user you are trying to use for xrdp**
+        
+        Please do not include links to images or videos on external websites. These are not guaranteed to always be available, and could be used to compromise web browsers. As an exception, if your video is larger than 10MB, you can upload it to https://youtube.com
   - type: input
     attributes:
       label: xrdp version


### PR DESCRIPTION
I'm proposing we ask for no links to external websites for images or videos on the bug report form.

This has bothered me for a while. Not only are these not guaranteed to be available for future readers, but a link to an external website could be used to compromise a developer browser, or find out more information about the developer workstation configuration.

What do people think?

Header on updated bug report form looks like this:-

![image](https://github.com/user-attachments/assets/a2437252-3494-4a8c-9f8f-0be568682e99)


