### PR TITLE
waitforx changes

### DIFF
--- a/waitforx/waitforx.c
+++ b/waitforx/waitforx.c
@@ -2,6 +2,7 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <ctype.h>
 #include <sys/signal.h>
 #include <unistd.h>
 
@@ -21,9 +22,46 @@ alarm_handler(int signal_num)
      *
      * Prefix the message with a newline in case another message
      * has been partly output */
-    const char msg[] = "\n<E>Timed out waiting for RandR outputs\n";
+    const char msg[] = "\n<E>Timed out waiting for X display\n";
     g_file_write(1, msg, g_strlen(msg));
     exit(XW_STATUS_TIMED_OUT);
+}
+
+/*****************************************************************************/
+/***
+ * Checks whether display is local.
+ *
+ * Local displays are of the form ':n' or ':n.m' where 'n' and 'm'
+ * are unsigned numbers
+ *
+ * @param display Display string
+ * @return boolean
+ */
+static int
+is_local_display(const char *display)
+{
+    int result = 0;
+    if (display != NULL && *display++ == ':' && isdigit(*display))
+    {
+        do
+        {
+            ++display;
+        }
+        while (isdigit(*display));
+
+        // Skip the optional screen identifier
+        if (*display == '.' && isdigit(*(display + 1)))
+        {
+            do
+            {
+                ++display;
+            }
+            while (isdigit(*display));
+        }
+
+        result = (*display == '\0');
+    }
+    return result;
 }
 
 /*****************************************************************************/
@@ -36,7 +74,7 @@ open_display(const char *display)
 
     for (n = 1; n <= ATTEMPTS; ++n)
     {
-        printf("<D>Opening display %s. Attempt %u of %u\n", display, n, wait);
+        printf("<D>Opening display '%s'. Attempt %u of %u\n", display, n, wait);
         dpy = XOpenDisplay(display);
         if (dpy != NULL)
         {
@@ -112,6 +150,7 @@ usage(const char *argv0, int status)
 int
 main(int argc, char **argv)
 {
+    char unix_display[64]; // Used for local (unix) displays only
     const char *display_name = NULL;
     int opt;
     int status = XW_STATUS_MISC_ERROR;
@@ -139,6 +178,22 @@ main(int argc, char **argv)
     }
 
     g_set_alarm(alarm_handler, ALARM_WAIT);
+
+    if (is_local_display(display_name))
+    {
+        // Don't use the raw display value, as this goes to the
+        // network if the X server port is not yet open. This can
+        // block if the network is configured in an unexpected way,
+        // which leads to use failing to detect the X server starting
+        // up shortly after.
+        //
+        // This code attempts to use a string such as "unix:10" to open
+        // the display. This is undocumented in the X11 man pages but
+        // is implemented in _xcb_open() from libxcb
+        // (which libX11 is now layered on).
+        snprintf(unix_display, sizeof(unix_display), "unix%s", display_name);
+        display_name = unix_display;
+    }
 
     dpy = open_display(display_name);
     if (!dpy)


### PR DESCRIPTION
Two changes to waitforx:-

1) Changed alarm message from "Timed out waiting for RandR outputs" to "Timed out waiting for X display". The former was confusing, and the times where this message was triggered were nothing to do with RandR
2) Don't try to open a display of the form ":n" directory (n >= 0). If the X server hasn't yet opened its local socket, the  `XOpenDisplay()` call can go to the network and possibly block for a long time. Instead, use the (undocumented) "unix:n" display specification, which never goes to the network, and doesn't block.

We've had three reports now of `waitforx` seemingly blocking:-
- #3164 
- #3286 
- #3293 

I've not been able to get to the bottom of any of them satisfactorily, but I got a clue when looking at the last of these.

What I think is happening is this:-
1) `xrdp-sesman` starts `Xorg`
2) `Xorg` takes a while to initialise and open the UNIX socket for the display
3) `waitforx` runs before the socket has opened and tries to open a display of the form ":n". Let's say this is ":10".
4) Because the local socket is unavailable, the code in `XOpenDisplay()` goes to the network to try to connect to TCP port `localhost:6010` for the X server.
5) Network code blocks, either resolving `localhost` or because the user has not unreasonably firewalled off X11 ports.
6) `waitforx` times out.

The fix is to use a display specification of (e.g.) `unix:10` instead of `:10`. This never goes to the network, and so the scenario above is avoided.

**However, the DISPLAY specification 'unix:n' is not documented.**

It's clearly supported in the xcb code in `_xcb_open()`, which libX11 is now layered on:-

https://gitlab.freedesktop.org/xorg/lib/libxcb/-/blob/master/src/xcb_util.c?ref_type=heads#L247

There's evidence of it being supported back in 2007:-
https://gitlab.freedesktop.org/xorg/lib/libxcb/-/commit/09045eaac34973662aaa820a94ca8ed66d9dcb4e

I've tried the notation for both CentOS 7 and Ubuntu 16.04, which are the oldest distros I have available. These both support it.

Are people happy with this notation being used here? Is there a better way to get the same result?