### PR TITLE
[V0.10] update cppcheck version to v2.16.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,7 +165,7 @@ jobs:
       CC: gcc
       # This is required to use a version of cppcheck other than that
       # supplied with the operating system
-      CPPCHECK_VER: "2.15.0"
+      CPPCHECK_VER: "2.16.0"
       CPPCHECK_REPO: https://github.com/danmar/cppcheck.git
     steps:
       # Set steps.os.outputs.image to the specific OS (e.g. 'ubuntu20')

--- a/common/ssl_calls.c
+++ b/common/ssl_calls.c
@@ -1104,15 +1104,12 @@ ssl_tls_accept(struct ssl_tls *self, long ssl_protocols,
         return 1;
     }
     DH_free(dh); // ok to free, copied into ctx by SSL_CTX_set_tmp_dh()
-#else
-    if (!SSL_CTX_set_dh_auto(self->ctx, 1))
-    {
-        LOG(LOG_LEVEL_ERROR, "TLS DHE auto failed to be enabled");
-        dump_ssl_error_stack(self);
-        return 1;
-    }
 #endif
-#if defined(SSL_CTX_set_ecdh_auto)
+
+#if (OPENSSL_VERSION_NUMBER >= 0x10000020L) && \
+    OPENSSL_VERSION_NUMBER < (0x10100000L)
+    // SSL_CTX_set_ecdh_auto() added in OpenSSL 1.0.2 and
+    // removed for OpenSSL 1.1.0
     if (!SSL_CTX_set_ecdh_auto(self->ctx, 1))
     {
         LOG(LOG_LEVEL_WARNING, "TLS ecdh auto failed to be enabled");


### PR DESCRIPTION
Backport of #3291 

Bumps the cppcheck version from 2.15.0 to 2.16.0

There is also a small change to common/ssl_calls.c.

Initially, this version of cppcheck threw a syntax error on this code:-

```c
#if defined(SSL_CTX_set_ecdh_auto)
    if (!SSL_CTX_set_ecdh_auto(self->ctx, 1))
    {
        LOG(LOG_LEVEL_WARNING, "TLS ecdh auto failed to be enabled");
    }
#endif
```

The reason is that cppcheck tries a pass with SSL_CTX_set_ecdh_auto set to 1, which (of course) fails.

The macro was introduced for OpenSSL 1.0.2 (see https://github.com/openssl/openssl/blob/OpenSSL_1_0_2/CHANGES) and disabled for OpenSSL 1.1.0 (see https://github.com/openssl/openssl/blob/OpenSSL_1_1_0/CHANGES). Versions of OpenSSL after 1.1.0 have a compatibility macro which does nothing if the second parameter is non-zero (i.e.):-

```c
#  define SSL_CTX_set_ecdh_auto(dummy, onoff)      ((onoff) != 0)
```

Solution for the cppcheck issue is to replace the test for the SSL_CTX_set_ecdh_auto macro with explicit version tests.

Another problem with the code was that the macro was being called twice for OpenSSL 3.x. This regression was introduced during the OpenSSL 3.x migration (https://github.com/neutrinolabs/xrdp/commit/6cebade78e15ac5fdb5c807220291ef19ed41a5b). As previously explained there is no need to call this macro for this version of OpenSSL.