### PR TITLE
[v0.10] Set different frame capture interval for H.264 and RFX and pass them to xorgxrdp

### DIFF
--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -192,6 +192,11 @@ struct xrdp_client_info
     char variant[16];
     char options[256];
 
+    /* xorgxrdp: frame capture interval (milliseconds) */
+    int rfx_frame_interval;
+    int h264_frame_interval;
+    int normal_frame_interval;
+
     /* ==================================================================== */
     /* Private to xrdp below this line */
     /* ==================================================================== */
@@ -241,11 +246,6 @@ struct xrdp_client_info
 
     int pad1; /* unused; unicode_input_state */
     enum xrdp_capture_code capture_code;
-
-    /* xorgxrdp: frame capture interval (milliseconds) */
-    int rfx_frame_interval;
-    int h264_frame_interval;
-    int normal_frame_interval;
 };
 
 enum xrdp_encoder_flags

--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -241,6 +241,11 @@ struct xrdp_client_info
 
     int pad1; /* unused; unicode_input_state */
     enum xrdp_capture_code capture_code;
+
+    /* xorgxrdp: frame capture interval (milliseconds) */
+    int rfx_frame_interval;
+    int h264_frame_interval;
+    int normal_frame_interval;
 };
 
 enum xrdp_encoder_flags
@@ -260,6 +265,6 @@ enum xrdp_encoder_flags
 
 /* yyyymmdd of last incompatible change to xrdp_client_info */
 /* also used for changes to all the xrdp installed headers */
-#define CLIENT_INFO_CURRENT_VERSION 20240514
+#define CLIENT_INFO_CURRENT_VERSION 20241118
 
 #endif

--- a/common/xrdp_constants.h
+++ b/common/xrdp_constants.h
@@ -87,9 +87,9 @@
 #define MCS_SDIN                       26 /* Send Data Indication */
 
 /* xorgxrdp: frame capture interval (milliseconds) */
-#define RFX_FRAME_INTERVAL             32
-#define H264_FRAME_INTERVAL            16
-#define NORMAL_FRAME_INTERVAL          40
+#define DEFAULT_RFX_FRAME_INTERVAL     32
+#define DEFAULT_H264_FRAME_INTERVAL    16
+#define DEFAULT_NORMAL_FRAME_INTERVAL  40
 
 /******************************************************************************
  *

--- a/common/xrdp_constants.h
+++ b/common/xrdp_constants.h
@@ -86,6 +86,11 @@
 #define MCS_SDRQ                       25 /* Send Data Request */
 #define MCS_SDIN                       26 /* Send Data Indication */
 
+/* xorgxrdp: frame capture interval (milliseconds) */
+#define RFX_FRAME_INTERVAL             32
+#define H264_FRAME_INTERVAL            16
+#define NORMAL_FRAME_INTERVAL          40
+
 /******************************************************************************
  *
  * Constants come from other Microsoft products

--- a/xrdp/xrdp.ini.in
+++ b/xrdp/xrdp.ini.in
@@ -242,6 +242,10 @@ username=ask
 password=ask
 port=-1
 code=20
+; Frame capture interval (milliseconds)
+h264_frame_interval=16
+rfx_frame_interval=32
+normal_frame_interval=40
 
 [Xvnc]
 name=Xvnc

--- a/xup/xup.c
+++ b/xup/xup.c
@@ -170,6 +170,22 @@ lib_mod_connect(struct mod *mod)
         return 1;
     }
 
+
+    // This is a good place to finalise any parameters that need to
+    // be set.
+    if (mod->client_info.h264_frame_interval <= 0)
+    {
+        mod->client_info.h264_frame_interval = H264_FRAME_INTERVAL;
+    }
+    if (mod->client_info.rfx_frame_interval <= 0)
+    {
+        mod->client_info.rfx_frame_interval = RFX_FRAME_INTERVAL;
+    }
+    if (mod->client_info.normal_frame_interval <= 0)
+    {
+        mod->client_info.normal_frame_interval = NORMAL_FRAME_INTERVAL;
+    }
+
     make_stream(s);
     g_sprintf(con_port, "%s", mod->port);
 
@@ -1854,6 +1870,18 @@ lib_mod_set_param(struct mod *mod, const char *name, const char *value)
     else if (g_strcasecmp(name, "port") == 0)
     {
         g_strncpy(mod->port, value, 255);
+    }
+    else if (g_strcasecmp(name, "h264_frame_interval") == 0)
+    {
+        mod->client_info.h264_frame_interval = g_atoi(value);
+    }
+    else if (g_strcasecmp(name, "rfx_frame_interval") == 0)
+    {
+        mod->client_info.rfx_frame_interval = g_atoi(value);
+    }
+    else if (g_strcasecmp(name, "normal_frame_interval") == 0)
+    {
+        mod->client_info.normal_frame_interval = g_atoi(value);
     }
     else if (g_strcasecmp(name, "client_info") == 0)
     {

--- a/xup/xup.c
+++ b/xup/xup.c
@@ -175,15 +175,15 @@ lib_mod_connect(struct mod *mod)
     // be set.
     if (mod->client_info.h264_frame_interval <= 0)
     {
-        mod->client_info.h264_frame_interval = H264_FRAME_INTERVAL;
+        mod->client_info.h264_frame_interval = DEFAULT_H264_FRAME_INTERVAL;
     }
     if (mod->client_info.rfx_frame_interval <= 0)
     {
-        mod->client_info.rfx_frame_interval = RFX_FRAME_INTERVAL;
+        mod->client_info.rfx_frame_interval = DEFAULT_RFX_FRAME_INTERVAL;
     }
     if (mod->client_info.normal_frame_interval <= 0)
     {
-        mod->client_info.normal_frame_interval = NORMAL_FRAME_INTERVAL;
+        mod->client_info.normal_frame_interval = DEFAULT_NORMAL_FRAME_INTERVAL;
     }
 
     make_stream(s);


### PR DESCRIPTION
See [neutrinolabs/xorgxrdp#347](https://github.com/neutrinolabs/xorgxrdp/pull/347) for background.

To include this in the next v0.10 release, making a PR on `v0.10-h264` branch.