### PR TITLE
Remove/replace time calls

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -2045,18 +2045,6 @@ g_obj_wait(tintptr *read_objs, int rcount, tintptr *write_objs, int wcount,
 void
 g_random(char *data, int len)
 {
-#if defined(_WIN32)
-    int index;
-
-    srand(g_time1());
-
-    for (index = 0; index < len; index++)
-    {
-        data[index] = (char)rand(); /* rand returns a number between 0 and
-                                   RAND_MAX */
-    }
-
-#else
     int fd;
 
     memset(data, 0x44, len);
@@ -2075,8 +2063,6 @@ g_random(char *data, int len)
 
         close(fd);
     }
-
-#endif
 }
 
 /*****************************************************************************/
@@ -3776,21 +3762,6 @@ g_check_user_in_group(const char *username, int gid, int *ok)
 #endif
 }
 #endif // HAVE_GETGROUPLIST
-
-/*****************************************************************************/
-/* returns the time since the Epoch (00:00:00 UTC, January 1, 1970),
-   measured in seconds.
-   for windows, returns the number of seconds since the machine was
-   started. */
-int
-g_time1(void)
-{
-#if defined(_WIN32)
-    return GetTickCount() / 1000;
-#else
-    return time(0);
-#endif
-}
 
 /*****************************************************************************/
 /* returns the number of milliseconds since the machine was

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -3764,19 +3764,21 @@ g_check_user_in_group(const char *username, int gid, int *ok)
 #endif // HAVE_GETGROUPLIST
 
 /*****************************************************************************/
-/* returns time in milliseconds, uses gettimeofday
-   does not work in win32 */
-int
-g_time3(void)
+unsigned int
+g_get_elapsed_ms(void)
 {
-#if defined(_WIN32)
-    return 0;
-#else
-    struct timeval tp;
+    unsigned int result = 0;
+    struct timespec tp;
 
-    gettimeofday(&tp, 0);
-    return (tp.tv_sec * 1000) + (tp.tv_usec / 1000);
-#endif
+    if (clock_gettime(CLOCK_MONOTONIC, &tp) == 0)
+    {
+        result = (unsigned int)tp.tv_sec * 1000;
+        // POSIX 1003.1-2004 specifies that tv_nsec is a long (i.e. a
+        // signed type), but can only contain [0..999,999,999]
+        result += tp.tv_nsec / 1000000;
+    }
+
+    return result;
 }
 
 /******************************************************************************/

--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -3764,23 +3764,6 @@ g_check_user_in_group(const char *username, int gid, int *ok)
 #endif // HAVE_GETGROUPLIST
 
 /*****************************************************************************/
-/* returns the number of milliseconds since the machine was
-   started. */
-int
-g_time2(void)
-{
-#if defined(_WIN32)
-    return (int)GetTickCount();
-#else
-    struct tms tm;
-    clock_t num_ticks = 0;
-    g_memset(&tm, 0, sizeof(struct tms));
-    num_ticks = times(&tm);
-    return (int)(num_ticks * 10);
-#endif
-}
-
-/*****************************************************************************/
 /* returns time in milliseconds, uses gettimeofday
    does not work in win32 */
 int

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -393,7 +393,26 @@ int      g_getgroup_info(const char *groupname, int *gid);
  * Primary group of username is also checked
  */
 int      g_check_user_in_group(const char *username, int gid, int *ok);
-int      g_time3(void);
+
+/**
+ * Gets elapsed milliseconds since some arbitrary point in the past
+ *
+ * The returned value is unaffected by leap-seconds or time zone changes.
+ *
+ * @return elaped ms since some arbitrary point
+ *
+ * Calculate the duration of a task by calling this routine before and
+ * after the task, and subtracting the two values.
+ *
+ * The value wraps every so often (every 49.7 days on a 32-bit system),
+ * but as we are using unsigned arithmetic, the difference of any of these
+ * two values can be used to calculate elapsed time, whether-or-not a wrap
+ * occurs during the interval - provided of course the time being measured
+ * is less than the total wrap-around interval.
+ */
+unsigned int
+g_get_elapsed_ms(void);
+
 int      g_save_to_bmp(const char *filename, char *data, int stride_bytes,
                        int width, int height, int depth, int bits_per_pixel);
 void    *g_shmat(int shmid);

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -393,7 +393,6 @@ int      g_getgroup_info(const char *groupname, int *gid);
  * Primary group of username is also checked
  */
 int      g_check_user_in_group(const char *username, int gid, int *ok);
-int      g_time1(void);
 int      g_time2(void);
 int      g_time3(void);
 int      g_save_to_bmp(const char *filename, char *data, int stride_bytes,

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -393,7 +393,6 @@ int      g_getgroup_info(const char *groupname, int *gid);
  * Primary group of username is also checked
  */
 int      g_check_user_in_group(const char *username, int gid, int *ok);
-int      g_time2(void);
 int      g_time3(void);
 int      g_save_to_bmp(const char *filename, char *data, int stride_bytes,
                        int width, int height, int depth, int bits_per_pixel);

--- a/common/trans.c
+++ b/common/trans.c
@@ -696,7 +696,7 @@ local_connect_shim(int fd, const char *server, const char *port)
 /**************************************************************************//**
  * Waits for an asynchronous connect to complete.
  * @param self - Transport object
- * @param start_time Start time of connect (from g_time3())
+ * @param start_time Start time of connect (from g_get_elapsed_ms())
  * @param timeout Total wait timeout
  * @return 0 - connect succeeded, 1 - Connect failed
  *
@@ -704,10 +704,10 @@ local_connect_shim(int fd, const char *server, const char *port)
  * on a regular basis.
  */
 static int
-poll_for_async_connect(struct trans *self, int start_time, int timeout)
+poll_for_async_connect(struct trans *self, unsigned int start_time, int timeout)
 {
     int rv = 1;
-    int ms_remaining = timeout - (g_time3() - start_time);
+    int ms_remaining = timeout - (int)(g_get_elapsed_ms() - start_time);
 
     while (ms_remaining > 0)
     {
@@ -736,7 +736,7 @@ poll_for_async_connect(struct trans *self, int start_time, int timeout)
             break;
         }
 
-        ms_remaining = timeout - (g_time3() - start_time);
+        ms_remaining = timeout - (int)(g_get_elapsed_ms() - start_time);
     }
     return rv;
 }
@@ -747,7 +747,7 @@ int
 trans_connect(struct trans *self, const char *server, const char *port,
               int timeout)
 {
-    int start_time = g_time3();
+    unsigned int start_time = g_get_elapsed_ms();
     int error;
     int ms_before_next_connect;
 
@@ -826,7 +826,7 @@ trans_connect(struct trans *self, const char *server, const char *port,
         }
 
         /* Have we reached the total timeout yet? */
-        int ms_left = timeout - (g_time3() - start_time);
+        int ms_left = timeout - (int)(g_get_elapsed_ms() - start_time);
         if (ms_left <= 0)
         {
             error = 1;

--- a/sesman/chansrv/chansrv.c
+++ b/sesman/chansrv/chansrv.c
@@ -132,7 +132,7 @@ add_timeout(int msoffset, void (*callback)(void *data), void *data)
     tui32 now;
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "add_timeout:");
-    now = g_time3();
+    now = g_get_elapsed_ms();
     tobj = g_new0(struct timeout_obj, 1);
     tobj->mstime = now + msoffset;
     tobj->callback = callback;
@@ -167,7 +167,7 @@ get_timeout(int *timeout)
     tobj = g_timeout_head;
     if (tobj != 0)
     {
-        now = g_time3();
+        now = g_get_elapsed_ms();
         while (tobj != 0)
         {
             LOG_DEVEL(LOG_LEVEL_DEBUG, "  now %u tobj->mstime %u", now, tobj->mstime);
@@ -215,7 +215,7 @@ check_timeout(void)
         while (tobj != 0)
         {
             count++;
-            now = g_time3();
+            now = g_get_elapsed_ms();
             if (now >= tobj->mstime)
             {
                 tobj->callback(tobj->data);

--- a/sesman/chansrv/clipboard_file.c
+++ b/sesman/chansrv/clipboard_file.c
@@ -274,7 +274,7 @@ clipboard_get_file(const char *file, int bytes)
         list_add_item(g_files_list, (tintptr)cfi);
         cfi->size = g_file_get_size(full_fn);
         cfi->flags = CB_FILE_ATTRIBUTE_ARCHIVE;
-        cfi->time = (g_time1() + CB_EPOCH_DIFF) * 10000000LL;
+        cfi->time = (time(NULL) + CB_EPOCH_DIFF) * 10000000LL;
         LOG_DEVEL(LOG_LEVEL_DEBUG, "ok filename [%s] pathname [%s] size [%d]",
                   cfi->filename, cfi->pathname, cfi->size);
         result = 0;

--- a/sesman/chansrv/xcommon.c
+++ b/sesman/chansrv/xcommon.c
@@ -85,15 +85,6 @@ xcommon_fatal_handler(Display *dis)
     return 0;
 }
 
-/*****************************************************************************/
-/* returns time in milliseconds since a point in the past
-   this is a time value similar to what the xserver uses */
-int
-xcommon_get_local_time(void)
-{
-    return g_time3();
-}
-
 /******************************************************************************/
 /* this should be called first */
 int

--- a/sesman/chansrv/xcommon.c
+++ b/sesman/chansrv/xcommon.c
@@ -86,9 +86,7 @@ xcommon_fatal_handler(Display *dis)
 }
 
 /*****************************************************************************/
-/* returns time in milliseconds
-   this is like g_time2 in os_calls, but not milliseconds since machine was
-   up, something else
+/* returns time in milliseconds since a point in the past
    this is a time value similar to what the xserver uses */
 int
 xcommon_get_local_time(void)

--- a/sesman/chansrv/xcommon.h
+++ b/sesman/chansrv/xcommon.h
@@ -29,8 +29,6 @@
 typedef void (*x_server_fatal_cb_type)(void);
 
 int
-xcommon_get_local_time(void);
-int
 xcommon_init(void);
 int
 xcommon_get_wait_objs(tbus *objs, int *count, int *timeout);

--- a/sesman/libsesman/verify_user.c
+++ b/sesman/libsesman/verify_user.c
@@ -225,7 +225,7 @@ auth_check_pwd_chg(const char *user)
     }
 
     /* check if we need a pwd change */
-    now = g_time1();
+    now = time(NULL);
     today = now / SECS_PER_DAY;
 
     if (stp->sp_expire == -1)
@@ -306,7 +306,7 @@ auth_change_pwd(const char *user, const char *newpwd)
         }
 
         stp->sp_pwdp = g_strdup(hash);
-        today = g_time1() / SECS_PER_DAY;
+        today = time(NULL) / SECS_PER_DAY;
         stp->sp_lstchg = today;
         stp->sp_expire = today + stp->sp_max + stp->sp_inact;
         fd = fopen("/etc/shadow", "rw");
@@ -377,7 +377,7 @@ auth_account_disabled(struct spwd *stp)
         return 1;
     }
 
-    today = g_time1() / SECS_PER_DAY;
+    today = time(NULL) / SECS_PER_DAY;
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "last   %ld", stp->sp_lstchg);
     LOG_DEVEL(LOG_LEVEL_DEBUG, "min    %ld", stp->sp_min);

--- a/sesman/sesexec/login_info.c
+++ b/sesman/sesexec/login_info.c
@@ -57,8 +57,8 @@ log_authfail_message(const char *username, const char *ip_addr)
     {
         ip_addr = "unknown";
     }
-    LOG(LOG_LEVEL_INFO, "AUTHFAIL: user=%s ip=%s time=%d",
-        username, ip_addr, g_time1());
+    LOG(LOG_LEVEL_INFO, "AUTHFAIL: user=%s ip=%s time=%ld",
+        username, ip_addr, (long)time(NULL));
 }
 
 /******************************************************************************/

--- a/sesman/sesexec/session.c
+++ b/sesman/sesexec/session.c
@@ -674,7 +674,7 @@ session_start_wrapped(struct login_info *login_info,
                 sd->win_mgr = window_manager_pid;
                 sd->x_server = display_pid;
                 sd->chansrv = chansrv_pid;
-                sd->start_time = g_time1();
+                sd->start_time = time(NULL);
                 status = E_SCP_SCREATE_OK;
             }
         }
@@ -860,7 +860,7 @@ session_process_child_exit(struct session_data *sd,
     }
     else if (pid == sd->win_mgr)
     {
-        int wm_wait_time = g_time1() - sd->start_time;
+        int wm_wait_time = time(NULL) - sd->start_time;
 
         if (e->reason == E_PXR_STATUS_CODE && e->val == 0)
         {

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -489,8 +489,8 @@ struct display_control_monitor_layout_data
 {
     struct display_size_description description;
     enum display_resize_state state;
-    int last_state_update_timestamp;
-    int start_time;
+    unsigned int last_state_update_timestamp;
+    unsigned int start_time;
     /// This flag is set if the state machine needs to
     /// shutdown/startup EGFX
     int using_egfx;

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -589,7 +589,7 @@ struct xrdp_wm
     struct xrdp_tconfig_gfx *gfx_config;
 
     struct xrdp_region *screen_dirty_region;
-    int last_screen_draw_time;
+    unsigned int last_screen_draw_time;
 };
 
 /* rdp process */


### PR DESCRIPTION
**Edit:** No longer draft.

This does not need to be back-ported to v0.10. It's mostly a tidy-up looking to the future.

This PR removes `g_time1()` and `g_time2()` and replaces `g_time3()` with the more descriptively named `g_get_elapsed_ms()`

Each function is addressed in a separate commit in this PR.

`g_time1()` is not year 2038 compliant on systems with 32-bit integers. It can be trivially replaced with `time()` which is a standard C library function, so that is done here.

`g_time2()` is no longer used.

`g_time3()` is a little more complex:-
- The `gettimeofday()` call it uses is obsoleted in POSIX.1-2008. Here we use `clock_gettime(CLOCK_MONOTONIC, )`
- To comply with the C standard on integer overflow, the function needs to return an unsigned integer type. Expressions (or sub-expressions) used to calculate elapsed time must also used unsigned arithmetic.