### PR TITLE
[regression] code to open local display in waitforx is broken by recent libxcb

### DIFF
--- a/common/xrdp_sockets.h
+++ b/common/xrdp_sockets.h
@@ -61,4 +61,10 @@
 #define XRDP_X11RDP_STR       XRDP_SOCKET_PATH "/" XRDP_X11RDP_BASE_STR
 #define XRDP_DISCONNECT_STR   XRDP_SOCKET_PATH "/" XRDP_DISCONNECT_BASE_STR
 
+/* Where X11 stores its Unix Domain Sockets (unlikely to change) */
+#define X11_UNIX_SOCKET_DIRECTORY "/tmp/.X11-unix"
+
+/*  fullpath to an X11 display socket */
+#define X11_UNIX_SOCKET_STR X11_UNIX_SOCKET_DIRECTORY "/X%d"
+
 #endif

--- a/sesman/sesman.c
+++ b/sesman/sesman.c
@@ -925,15 +925,15 @@ main(int argc, char **argv)
     LOG(LOG_LEVEL_INFO,
         "starting xrdp-sesman with pid %d", g_pid);
 
-    /* make sure the /tmp/.X11-unix directory exists */
-    if (!g_directory_exist("/tmp/.X11-unix"))
+    /* make sure the X11_UNIX_SOCKET_DIRECTORY exists */
+    if (!g_directory_exist(X11_UNIX_SOCKET_DIRECTORY))
     {
-        if (!g_create_dir("/tmp/.X11-unix"))
+        if (!g_create_dir(X11_UNIX_SOCKET_DIRECTORY))
         {
             LOG(LOG_LEVEL_ERROR,
-                "sesman.c: error creating dir /tmp/.X11-unix");
+                "sesman.c: error creating dir " X11_UNIX_SOCKET_DIRECTORY);
         }
-        g_chmod_hex("/tmp/.X11-unix", 0x1777);
+        g_chmod_hex(X11_UNIX_SOCKET_DIRECTORY, 0x1777);
     }
 
     if ((error = pre_session_list_init(MAX_PRE_SESSION_ITEMS)) == 0 &&

--- a/sesman/session_list.c
+++ b/sesman/session_list.c
@@ -155,13 +155,13 @@ x_server_running_check_ports(int display)
     int x_running;
     int sck;
 
-    g_sprintf(text, "/tmp/.X11-unix/X%d", display);
+    g_snprintf(text, sizeof(text), X11_UNIX_SOCKET_STR, display);
     x_running = g_file_exist(text);
 
     if (!x_running)
     {
         LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
-        g_sprintf(text, "/tmp/.X%d-lock", display);
+        g_snprintf(text, sizeof(text), "/tmp/.X%d-lock", display);
         x_running = g_file_exist(text);
     }
 
@@ -170,7 +170,7 @@ x_server_running_check_ports(int display)
         LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
         if ((sck = g_tcp_socket()) != -1)
         {
-            g_sprintf(text, "59%2.2d", display);
+            g_snprintf(text, sizeof(text), "59%2.2d", display);
             x_running = g_tcp_bind(sck, text);
             g_tcp_close(sck);
         }
@@ -181,7 +181,7 @@ x_server_running_check_ports(int display)
         LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
         if ((sck = g_tcp_socket()) != -1)
         {
-            g_sprintf(text, "60%2.2d", display);
+            g_snprintf(text, sizeof(text), "60%2.2d", display);
             x_running = g_tcp_bind(sck, text);
             g_tcp_close(sck);
         }
@@ -192,7 +192,7 @@ x_server_running_check_ports(int display)
         LOG(LOG_LEVEL_DEBUG, "Did not find a running X server at %s", text);
         if ((sck = g_tcp_socket()) != -1)
         {
-            g_sprintf(text, "62%2.2d", display);
+            g_snprintf(text, sizeof(text), "62%2.2d", display);
             x_running = g_tcp_bind(sck, text);
             g_tcp_close(sck);
         }

--- a/waitforx/Makefile.am
+++ b/waitforx/Makefile.am
@@ -4,6 +4,7 @@ pkglibexec_PROGRAMS = \
 AM_LDFLAGS = $(X_LIBS) -lX11 -lXrandr
 
 AM_CPPFLAGS = \
+  -DXRDP_SOCKET_ROOT_PATH=\"${socketdir}\" \
   -I$(top_srcdir)/sesman/sesexec \
   -I$(top_srcdir)/common
 


### PR DESCRIPTION
Thanks to @derekschrock for raising this as a comment to #3297 

Commit 80fab03198854268fc2258d7bdea2013e5d109f7 introduced a way to prevent waitforx going to the network when trying to open a display, and hence potentially blocking.

This method turned out to be invalidated by libxcb version 1.16 and 1.17

This change adds an explicit check that the Unix socket for the display in `/tmp/.X11-unix/Xn` is open before trying to connect to display ':n'. This has the same effect.

In the original change I was keen to avoid a dependency on the string `"/tmp/.X11-unix/X%d"` for converting a display number to a unix socket. This was unjustified, as many other utilities assume this string, including ssh:-

```
$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 22.04.5 LTS
Release:	22.04
Codename:	jammy
$  strings $(which ssh) | grep X11-unix
/tmp/.X11-unix/X%u
```