### PR TITLE
pam: debian: Explicitly include pam_limits for xrdp sessions

### DIFF
--- a/instfiles/pam.d/xrdp-sesman.debian
+++ b/instfiles/pam.d/xrdp-sesman.debian
@@ -9,6 +9,8 @@ auth     required  pam_env.so readenv=1 envfile=/etc/default/locale
 
 @include common-password
 
+# Ensure resource limits are applied
+session    required     pam_limits.so
 # Set the loginuid process attribute.
 session    required     pam_loginuid.so
 # Update wtmp/lastlog


### PR DESCRIPTION
Hello!
This change makes xrdp-sesman PAM explicitly request pam_limits in its Debian configuration.
This is needed, as on Debian, pam_limits is not automatically included for common sessions, and only for "login" sessions and session managers. So, xrdp has to include it explicitly to make limits take effect.
Without the change, limits might be set very low, which can yield a lot of really odd problems especially when running scientific software (we found out that things like MATLAB takes 15min to launch, and some Python code outright refuses to work. Especially for the MATLAB issue, the cause was fairly difficult to find).

This apparently has been a problem for a while, a web search yielded posts like https://florent.clairambault.fr/xrdp-and-the-ulimits-nofile-issue/ - but the solution given there isn't ideal, as it will alter the limits of system daemons as well, which may not be intended.

I think fixing this in xrdp is the better approach, and also way easier. We have been running with this configuration change for a year without any issues so far.

See https://wiki.debian.org/Limits for details on limits on Debian.
Thank you for considering the patch! :-)