### PR TITLE
[V0.10] Allow a path to be specified for the chansrv log file

### DIFF
--- a/docs/man/sesman.ini.5.in
+++ b/docs/man/sesman.ini.5.in
@@ -98,7 +98,33 @@ stdout. Use for debugging only\fR
 
 It is ignored in the [ChansrvLogging] section
 since the channel server creates one log file per display and instead uses the
-following log file naming convention \fIxrdp-chansrv.${DISPLAY}.log\fR
+following log file naming convention \fIxrdp-chansrv.${DISPLAY}.log\fR. For
+details of the chansrv log file location, see \fBLogFilePath\fR.
+
+.TP
+\fBLogFilePath\fR=\fIstring\fR
+Directory for storing the chansrv log file. This setting only applies to
+chansrv. The sesman log file is always created in \fI@localstatedir@/log\fR.
+
+Created if it doesn't exist.
+If first character is not a '/', this is relative to $HOME, where
+chansrv is normally started.
+
+.RS
+The following substitutions are made in this string:-
+    %U - Username
+    %u - Numeric UID
+    %% - Percent character
+
+This is most useful if you are using NFS-mounted home directories, and
+wish to move the chansrv log file to the local disk.
+
+If this parameter isn't specified, the log file is stored in one of
+the following locations :-
+    -   $CHANSRV_LOG_PATH
+    -   $XDG_DATA_HOME/xrdp
+    -   $HOME/.local/share/xrdp
+.RE
 
 .TP
 \fBLogLevel\fR=\fIlevel\fR
@@ -408,28 +434,6 @@ If not specified, defaults to \fI2\fR.
 Sets the duration(msec). Sound data is not send to client during \fInumber\fR
 millisecond(s) after close message is sent, when AAC/MP3 is selected.
 If set to 0, all the data is sent. If not specified, defaults to \fI1000\fR.
-
-.TP
-\fBLogFilePath\fR=\fIstring\fR
-Directory for storing the chansrv log file
-Created if it doesn't exist.
-If first character is not a '/', this is relative to $HOME.
-.P
-.RS
-The following substitutions are made in this string:-
-    %U - Username
-    %u - Numeric UID
-    %% - Percent character
-.P
-This is most useful if you are using NFS-mounted home directories, and
-wish to move the chansrv log file to the local disk.
-
-If this isn't specified, the log file is stored in one of the following
-locations :-
-    -   $CHANSRV_LOG_PATH
-    -   $XDG_DATA_HOME/xrdp
-    -   $HOME/.local/share/xrdp
-.RE
 
 .SH "SESSIONS VARIABLES"
 All entries in the \fB[SessionVariables]\fR section are set as

--- a/docs/man/sesman.ini.5.in
+++ b/docs/man/sesman.ini.5.in
@@ -409,6 +409,28 @@ Sets the duration(msec). Sound data is not send to client during \fInumber\fR
 millisecond(s) after close message is sent, when AAC/MP3 is selected.
 If set to 0, all the data is sent. If not specified, defaults to \fI1000\fR.
 
+.TP
+\fBLogFilePath\fR=\fIstring\fR
+Directory for storing the chansrv log file
+Created if it doesn't exist.
+If first character is not a '/', this is relative to $HOME.
+.P
+.RS
+The following substitutions are made in this string:-
+    %U - Username
+    %u - Numeric UID
+    %% - Percent character
+.P
+This is most useful if you are using NFS-mounted home directories, and
+wish to move the chansrv log file to the local disk.
+
+If this isn't specified, the log file is stored in one of the following
+locations :-
+    -   $CHANSRV_LOG_PATH
+    -   $XDG_DATA_HOME/xrdp
+    -   $HOME/.local/share/xrdp
+.RE
+
 .SH "SESSIONS VARIABLES"
 All entries in the \fB[SessionVariables]\fR section are set as
 environment variables in the user's session.

--- a/sesman/chansrv/chansrv.c
+++ b/sesman/chansrv/chansrv.c
@@ -1595,20 +1595,32 @@ get_log_path(char *path, int bytes)
     int rv;
 
     rv = 1;
-    log_path = g_getenv("CHANSRV_LOG_PATH");
-    if (log_path == 0)
+    if (g_cfg->log_file_path != NULL && g_cfg->log_file_path[0] != '\0')
     {
-        log_path = g_getenv("XDG_DATA_HOME");
-        if (log_path != 0)
+        char uidstr[64];
+        char username[64];
+        const struct info_string_tag map[] =
         {
-            g_snprintf(path, bytes, "%s%s", log_path, "/xrdp");
-            if (g_directory_exist(path) || (g_mkdir(path) == 0))
-            {
-                rv = 0;
-            }
+            {'u', uidstr},
+            {'U', username},
+            INFO_STRING_END_OF_LIST
+        };
+
+        int uid = g_getuid();
+        g_snprintf(uidstr, sizeof(uidstr), "%d", uid);
+        if (g_getlogin(username, sizeof(username)) != 0)
+        {
+            /* Fall back to UID */
+            g_strncpy(username, uidstr, sizeof(username) - 1);
+        }
+
+        (void)g_format_info_string(path, bytes, g_cfg->log_file_path, map);
+        if (g_directory_exist(path) || (g_mkdir(path) == 0))
+        {
+            rv = 0;
         }
     }
-    else
+    else if ((log_path = g_getenv("CHANSRV_LOG_PATH")) != 0)
     {
         g_snprintf(path, bytes, "%s", log_path);
         if (g_directory_exist(path) || (g_mkdir(path) == 0))
@@ -1616,6 +1628,16 @@ get_log_path(char *path, int bytes)
             rv = 0;
         }
     }
+    else if ((log_path = g_getenv("XDG_DATA_HOME")) != 0)
+    {
+        g_snprintf(path, bytes, "%s%s", log_path, "/xrdp");
+        if (g_directory_exist(path) || (g_mkdir(path) == 0))
+        {
+            rv = 0;
+        }
+    }
+
+    // Always fall back to the home directory
     if (rv != 0)
     {
         log_path = g_getenv("HOME");
@@ -1731,14 +1753,6 @@ main(int argc, char **argv)
     g_init("xrdp-chansrv"); /* os_calls */
     g_memset(g_drdynvcs, 0, sizeof(g_drdynvcs));
 
-    log_path[255] = 0;
-    if (get_log_path(log_path, 255) != 0)
-    {
-        g_writeln("error reading CHANSRV_LOG_PATH and HOME environment variable");
-        main_cleanup();
-        return 1;
-    }
-
     display_text = g_getenv("DISPLAY");
     if (display_text == NULL)
     {
@@ -1764,6 +1778,13 @@ main(int argc, char **argv)
         return 1;
     }
     config_dump(g_cfg);
+
+    if (get_log_path(log_path, sizeof(log_path)) != 0)
+    {
+        g_writeln("error reading CHANSRV_LOG_PATH and HOME environment variable");
+        main_cleanup();
+        return 1;
+    }
 
     pid = g_getpid();
 

--- a/sesman/chansrv/chansrv_config.c
+++ b/sesman/chansrv/chansrv_config.c
@@ -244,7 +244,35 @@ read_config_chansrv(log_func_t logmsg,
         {
             cfg->msec_do_not_send = strtoul(value, NULL, 0);
         }
-        else if (g_strcasecmp(name, "LogFilePath") == 0)
+    }
+
+    return error;
+}
+
+/***************************************************************************//**
+ * Reads the config values we need from the [ChansrvLogging] section
+ *
+ * @param logmsg Function to use to log messages
+ * @param names List of definitions in the section
+ * @params values List of corresponding values for the names
+ * @params cfg Pointer to structure we're filling in
+ *
+ * @return 0 for success
+ */
+static int
+read_config_chansrv_logging(log_func_t logmsg,
+                            struct list *names, struct list *values,
+                            struct config_chansrv *cfg)
+{
+    int error = 0;
+    int index;
+
+    for (index = 0; index < names->count; ++index)
+    {
+        const char *name = (const char *)list_get_item(names, index);
+        const char *value = (const char *)list_get_item(values, index);
+
+        if (g_strcasecmp(name, "LogFilePath") == 0)
         {
             g_free(cfg->log_file_path);
             cfg->log_file_path = g_strdup(value);
@@ -344,6 +372,12 @@ config_read(int use_logger, const char *sesman_ini)
                 error = read_config_chansrv(logmsg, names, values, cfg);
             }
 
+            if (!error &&
+                    file_read_section(fd, "ChansrvLogging", names, values) == 0)
+            {
+                error = read_config_chansrv_logging(logmsg, names, values, cfg);
+            }
+
             list_delete(names);
             list_delete(values);
         }
@@ -391,7 +425,7 @@ config_dump(struct config_chansrv *config)
     g_writeln("    Nautilus 3 Flist Format:   %s",
               g_bool2text(config->use_nautilus3_flist_format));
     g_writeln("    LogFilePath            :   %s",
-              (config->log_file_path) ? config->log_file_path : "<default>");
+              (config->log_file_path[0]) ? config->log_file_path : "<default>");
 }
 
 /******************************************************************************/

--- a/sesman/chansrv/chansrv_config.h
+++ b/sesman/chansrv/chansrv_config.h
@@ -51,7 +51,7 @@ struct config_chansrv
     /** Do net send sound data afer SNDC_CLOSE is sent. unit is millisecond, setting from sesman.ini */
     unsigned int msec_do_not_send;
 
-    /** LogFilePath from sesman.ini */
+    /** LogFilePath from sesman.ini ([ChansrvLogging]) */
     char *log_file_path;
 };
 

--- a/sesman/chansrv/chansrv_config.h
+++ b/sesman/chansrv/chansrv_config.h
@@ -50,6 +50,9 @@ struct config_chansrv
     unsigned int num_silent_frames_mp3;
     /** Do net send sound data afer SNDC_CLOSE is sent. unit is millisecond, setting from sesman.ini */
     unsigned int msec_do_not_send;
+
+    /** LogFilePath from sesman.ini */
+    char *log_file_path;
 };
 
 

--- a/sesman/sesman.ini.in
+++ b/sesman/sesman.ini.in
@@ -191,6 +191,11 @@ FileUmask=077
 #SoundNumSilentFramesAAC=4
 #SoundNumSilentFramesMP3=2
 #SoundMsecDoNotSend=1000
+; Log file path
+; Set this to move the log file away from its default location. You may want
+; to do this for (e.g.) NFS-mounted home directories
+; See sesman.ini(5) for the format of this parameter
+#LogFilePath=/run/user/%u/xrdp
 
 [ChansrvLogging]
 ; Note: one log file is created per display and the LogFile config value

--- a/sesman/sesman.ini.in
+++ b/sesman/sesman.ini.in
@@ -191,11 +191,6 @@ FileUmask=077
 #SoundNumSilentFramesAAC=4
 #SoundNumSilentFramesMP3=2
 #SoundMsecDoNotSend=1000
-; Log file path
-; Set this to move the log file away from its default location. You may want
-; to do this for (e.g.) NFS-mounted home directories
-; See sesman.ini(5) for the format of this parameter
-#LogFilePath=/run/user/%u/xrdp
 
 [ChansrvLogging]
 ; Note: one log file is created per display and the LogFile config value
@@ -209,6 +204,11 @@ EnableSyslog=true
 #EnableConsole=false
 #ConsoleLevel=INFO
 #EnableProcessId=false
+; Log file path
+; Set this to move the log file away from its default location. You may want
+; to do this for (e.g.) NFS-mounted home directories
+; See sesman.ini(5) for the format of this parameter
+#LogFilePath=/run/user/%u/xrdp
 
 [ChansrvLoggingPerLogger]
 ; Note: per logger configuration is only used if xrdp is built with


### PR DESCRIPTION
Fixes #3337 

A parameter `LogFilePath` is added to the `[ChansrvLogging]` section in sesman.ini. Manpage excerpt:-

```
       LogFilePath=string
              Directory  for  storing  the chansrv log file. This setting only
              applies to chansrv. The sesman log file  is  always  created  in
              /var/log.

              Created  if  it doesn't exist.  If first character is not a '/',
              this is relative to $HOME, where chansrv is normally started.

              The following substitutions are made in this string:-
                  %U - Username
                  %u - Numeric UID
                  %% - Percent character

              This is most useful if you are using NFS-mounted  home  directo‐
              ries, and wish to move the chansrv log file to the local disk.

              If this parameter isn't specified, the log file is stored in one
              of the following locations :-
                  -   $CHANSRV_LOG_PATH
                  -   $XDG_DATA_HOME/xrdp
                  -   $HOME/.local/share/xrdp
```