### PR TITLE
[V0.10] pam: debian: Explicitly include pam_limits for xrdp sessions

### DIFF
--- a/instfiles/pam.d/xrdp-sesman.debian
+++ b/instfiles/pam.d/xrdp-sesman.debian
@@ -9,6 +9,8 @@ auth     required  pam_env.so readenv=1 envfile=/etc/default/locale
 
 @include common-password
 
+# Ensure resource limits are applied
+session    required     pam_limits.so
 @include common-session
 -session optional  pam_gnome_keyring.so auto_start
 -session optional  pam_kwallet5.so auto_start


### PR DESCRIPTION
This is required, as on Debian, pam_limits is not automatically included for common sessions, and only for "login" sessions and session managers. So, xrdp has to include it explicitly to make limits take effect.

See https://wiki.debian.org/Limits for details.

Backport of #3343

(cherry picked from commit f581d8ead7b1454864b9ff2e90a2f5e178acbf07)