### PR TITLE
[V0.10] xrdp-droppriv erroneous includes

### DIFF
--- a/tools/chkpriv/xrdp-droppriv.c
+++ b/tools/chkpriv/xrdp-droppriv.c
@@ -23,7 +23,7 @@
 #include "config_ac.h"
 #endif
 
-#include "os_calls.c"
+#include "os_calls.h"
 #include "log.h"
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
xrdp-droppriv.c is erroneously including os_calls.c rather than os_calls.h

This leads to a link failure on Ubuntu 20.04:-

/usr/bin/ld: xrdp-droppriv.o: undefined reference to symbol 'dlclose@@GLIBC_2.2.5'

The error does not happen with later glibc versions, as libdl is included in libc for these versions.

@metalefty - this is needed for v0.10 on older systems. I'll merge as soon as it clears CI