### PR TITLE
[v0.10] Allow to change config file (sub)directory

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -23,7 +23,7 @@ include_HEADERS = \
   xrdp_sockets.h
 
 AM_CPPFLAGS = \
-  -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
+  -DXRDP_CFG_PATH=\"${sysconfdir}/${sysconfsubdir}\" \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
   -DXRDP_SHARE_PATH=\"${datadir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \

--- a/configure.ac
+++ b/configure.ac
@@ -573,6 +573,12 @@ AC_ARG_WITH([pamconfdir],
                   [], [with_pamconfdir="$sysconfdir/pam.d"])
 AC_SUBST([pamconfdir], [$with_pamconfdir])
 
+AC_ARG_WITH([sysconfsubdir],
+  [AS_HELP_STRING([--with-sysconfsubdir=DIR],
+                  [Use subdirectory for config files (default: xrdp)]))],
+                  [], [with_sysconfsubdir="xrdp"])
+AC_SUBST([sysconfsubdir], [$with_sysconfsubdir])
+
 PKG_INSTALLDIR
 
 AC_CHECK_HEADERS([sys/prctl.h uchar.h])
@@ -660,6 +666,7 @@ echo "  exec_prefix             $exec_prefix"
 echo "  libdir                  $libdir"
 echo "  bindir                  $bindir"
 echo "  sysconfdir              $sysconfdir"
+echo "  sysconfdir+subdir       $sysconfdir/$sysconfsubdir"
 echo "  pamconfdir              $pamconfdir"
 echo "  localstatedir           $localstatedir"
 echo "  runstatedir             $runstatedir"

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -24,6 +24,7 @@ SUBST_VARS = sed \
    -e 's|@sbindir[@]|$(sbindir)|g' \
    -e 's|@localstatedir[@]|$(localstatedir)|g' \
    -e 's|@sysconfdir[@]|$(sysconfdir)|g' \
+   -e 's|@sysconfsubdir[@]|$(sysconfsubdir)|g' \
    -e 's|@socketdir[@]|$(socketdir)|g' \
    -e 's|@xrdpconfdir[@]|$(sysconfdir)/xrdp|g' \
    -e 's|@xrdpdatadir[@]|$(datadir)/xrdp|g' \

--- a/docs/man/sesman.ini.5.in
+++ b/docs/man/sesman.ini.5.in
@@ -440,7 +440,7 @@ All entries in the \fB[SessionVariables]\fR section are set as
 environment variables in the user's session.
 
 .SH "FILES"
-@sysconfdir@/xrdp/sesman.ini
+@sysconfdir@/@sysconfsubdir@/sesman.ini
 
 .SH "SEE ALSO"
 .BR xrdp-sesman (8),

--- a/docs/man/xrdp-chansrv.8.in
+++ b/docs/man/xrdp-chansrv.8.in
@@ -40,7 +40,7 @@ X11 display number. Must be specified.
 
 .SH FILES
 .TP
-.I @sysconfdir@/xrdp/sesman.ini
+.I @sysconfdir@/@sysconfsubdir@/sesman.ini
 Contains some settings for this program.
 .TP
 .I @socketdir@/xrdp_chansrv_socket_*

--- a/docs/man/xrdp-genkeymap.8.in
+++ b/docs/man/xrdp-genkeymap.8.in
@@ -21,7 +21,7 @@ The key map information is stored in the file named \fIoutfile\fP.
 
 .SH "FILES"
 .TP
-.I @sysconfdir@/xrdp/km-XXXXXXXX.ini
+.I @sysconfdir@/@sysconfsubdir@/km-XXXXXXXX.ini
 Files containing the keyboard mapping for language \fIXXXXXXXX\fP, which is a 8 digit hexadecimal number identifying the country and language code.
 .RS 8
 .TP

--- a/docs/man/xrdp-keygen.8.in
+++ b/docs/man/xrdp-keygen.8.in
@@ -15,7 +15,7 @@ xrdp\-keygen \- xrdp RSA key generation utility
 
 .SH DESCRIPTION
 \fBxrdp\-keygen\fP generates the file
-.I @sysconfdir@/xrdp/rsakeys.ini
+.I @sysconfdir@/@sysconfsubdir@/rsakeys.ini
 which contains the RSA key pair used to perform authentication to
 remote clients. The public key is self-signed.
 
@@ -26,14 +26,14 @@ This program takes one of the following options:
 Generate a new key pair.
 The key data is stored in the file named \fIoutfile\fP.
 .br
-If \fBauto\fP is used as \fIoutfile\fP, the default file \fI@sysconfdir@/xrdp/rsakeys.ini\fP gets created if it does not yet exists.
+If \fBauto\fP is used as \fIoutfile\fP, the default file \fI@sysconfdir@/@sysconfsubdir@/rsakeys.ini\fP gets created if it does not yet exists.
 .TP
 .B test
 Generate a test key pair and print information to standard output.
 
 .SH FILES
 .TP
-.I @sysconfdir@/xrdp/rsakeys.ini
+.I @sysconfdir@/@sysconfsubdir@/rsakeys.ini
 RSA public and private key pair used to identify this XRDP server.
 
 .SH SEE ALSO

--- a/docs/man/xrdp-sesman.8.in
+++ b/docs/man/xrdp-sesman.8.in
@@ -50,7 +50,7 @@ to be used primarily for testing or for unusual configurations.
 .P
 .RS
 If you use this option, be aware that you will have to have a
-\fB@sysconfdir@/xrdp/sesman.ini\fR in place too, as a few elements of
+\fB@sysconfdir@/@sysconfsubdir@/sesman.ini\fR in place too, as a few elements of
 the system (notably \fBxrdp(8)\fR and \fBxrdp\-chansrv(8)\fR) will want
 to read it.
 .RE
@@ -64,7 +64,7 @@ not running \fBxrdp\-sesman\fR as a daemon.
 .br
 @bindir@/xrdp\-sesrun
 .br
-@sysconfdir@/xrdp/sesman.ini
+@sysconfdir@/sysconfsubdir@/sesman.ini
 .br
 @localstatedir@/log/xrdp\-sesman.log
 .br

--- a/docs/man/xrdp-sesrun.8.in
+++ b/docs/man/xrdp-sesrun.8.in
@@ -90,7 +90,7 @@ first. The \fBgnome\-terminal\fR utility probably won't work here.
 .br
 @bindir@/xrdp\-sesrun
 .br
-@sysconfdir@/xrdp/sesman.ini
+@sysconfdir@/@sysconfsubdir@/sesman.ini
 
 .SH "AUTHORS"
 Jay Sorg <jsorg71@users.sourceforge.net>

--- a/docs/man/xrdp.8.in
+++ b/docs/man/xrdp.8.in
@@ -57,7 +57,7 @@ to be used primarily for testing or for unusual configurations.
 .SH "FILES"
 @sbindir@/xrdp
 .br
-@sysconfdir@/xrdp/xrdp.ini
+@sysconfdir@/@sysconfsubdir@/xrdp.ini
 .br
 @localstatedir@/log/xrdp.log
 .br

--- a/docs/man/xrdp.ini.5.in
+++ b/docs/man/xrdp.ini.5.in
@@ -50,7 +50,7 @@ If set to \fB1\fR, \fBtrue\fR or \fByes\fR this option enables compression of bu
 .TP
 \fBkey_file\fP=\fI/path/to/private_key\fP
 Set location of TLS certificate and private key. They must be written in PEM format.
-If not specified, defaults to \fB@sysconfdir@/xrdp/cert.pem\fP, \fB@sysconfdir@/xrdp/key.pem\fP.
+If not specified, defaults to \fB@sysconfdir@/@sysconfsubdir@/cert.pem\fP, \fB@sysconfdir@/@sysconfsubdir@/key.pem\fP.
 
 This parameter is effective only if \fBsecurity_layer\fP is set to \fBtls\fP or \fBnegotiate\fP.
 
@@ -435,7 +435,7 @@ password={base64}cGFzc3dvcmQhCg==
 .fi
 
 .SH "FILES"
-@sysconfdir@/xrdp/xrdp.ini
+@sysconfdir@/@sysconfsubdir@/xrdp.ini
 
 .SH "SEE ALSO"
 .BR xrdp (8),

--- a/genkeymap/Makefile.am
+++ b/genkeymap/Makefile.am
@@ -2,6 +2,9 @@ EXTRA_DIST = \
   dump-keymaps.sh \
   readme.txt
 
+AM_CPPFLAGS = \
+  -DXRDP_CFG_PATH=\"${sysconfdir}/${sysconfsubdir}\"
+
 AM_CFLAGS = $(X_CFLAGS)
 
 bin_PROGRAMS = \

--- a/genkeymap/genkeymap.c
+++ b/genkeymap/genkeymap.c
@@ -78,7 +78,8 @@ int main(int argc, char **argv)
     if (argc != 2)
     {
         fprintf(stderr, "Usage: %s out_filename\n", programname);
-        fprintf(stderr, "Example: %s /etc/xrdp/km-00000409.ini\n", programname);
+        fprintf(stderr, "Example: %s ", programname);
+        fprintf(stderr, XRDP_CFG_PATH "/km-00000409.ini\n");
         return 1;
     }
 

--- a/instfiles/Makefile.am
+++ b/instfiles/Makefile.am
@@ -13,6 +13,7 @@ CLEANFILES= \
 SUBST_VARS = sed \
    -e 's|@sbindir[@]|$(sbindir)|g' \
    -e 's|@sysconfdir[@]|$(sysconfdir)|g' \
+   -e 's|@sysconfsubdir[@]|$(sysconfsubdir)|g' \
    -e 's|@localstatedir[@]|$(localstatedir)|g'
 
 subst_verbose = $(subst_verbose_@AM_V@)
@@ -26,7 +27,7 @@ SUFFIXES = .in
 #
 # files for all platforms
 #
-startscriptdir=$(sysconfdir)/xrdp
+startscriptdir=$(sysconfdir)/$(sysconfsubdir)
 
 dist_startscript_DATA = \
   km-00000405.ini \

--- a/instfiles/pulse/Makefile.am
+++ b/instfiles/pulse/Makefile.am
@@ -1,2 +1,2 @@
-pulsedir = $(sysconfdir)/xrdp/pulse
+pulsedir = $(sysconfdir)/$(sysconfsubdir)/pulse
 dist_pulse_DATA = default.pa

--- a/keygen/Makefile.am
+++ b/keygen/Makefile.am
@@ -1,7 +1,7 @@
 EXTRA_DIST = openssl.conf
 
 AM_CPPFLAGS = \
-  -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
+  -DXRDP_CFG_PATH=\"${sysconfdir}/${sysconfsubdir}\" \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
   -DXRDP_SHARE_PATH=\"${datadir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \
@@ -15,7 +15,7 @@ xrdp_keygen_SOURCES = keygen.c
 xrdp_keygen_LDADD = \
   $(top_builddir)/common/libcommon.la
 
-xrdpsysconfdir = $(sysconfdir)/xrdp
+xrdpsysconfdir = $(sysconfdir)/$(sysconfsubdir)
 
 install-data-hook:
 	umask 077 && \

--- a/keygen/keygen.c
+++ b/keygen/keygen.c
@@ -463,7 +463,7 @@ key_gen(const char *path_and_file_name)
 static int
 key_gen_auto(void)
 {
-    return key_gen("/etc/xrdp/rsakeys.ini");
+    return key_gen(XRDP_CFG_PATH "/rsakeys.ini");
 }
 
 /*****************************************************************************/

--- a/libxrdp/Makefile.am
+++ b/libxrdp/Makefile.am
@@ -2,7 +2,7 @@ EXTRA_DIST = \
   xrdp_surface.c
 
 AM_CPPFLAGS = \
-  -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
+  -DXRDP_CFG_PATH=\"${sysconfdir}/${sysconfsubdir}\" \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
   -DXRDP_SHARE_PATH=\"${datadir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \

--- a/mc/Makefile.am
+++ b/mc/Makefile.am
@@ -1,5 +1,5 @@
 AM_CPPFLAGS = \
-  -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
+  -DXRDP_CFG_PATH=\"${sysconfdir}/${sysconfsubdir}\" \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
   -DXRDP_SHARE_PATH=\"${datadir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \

--- a/neutrinordp/Makefile.am
+++ b/neutrinordp/Makefile.am
@@ -1,5 +1,5 @@
 AM_CPPFLAGS = \
-  -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
+  -DXRDP_CFG_PATH=\"${sysconfdir}/${sysconfsubdir}\" \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
   -DXRDP_SHARE_PATH=\"${datadir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \

--- a/sesman/Makefile.am
+++ b/sesman/Makefile.am
@@ -2,7 +2,7 @@ EXTRA_DIST = \
   Doxyfile
 
 AM_CPPFLAGS = \
-  -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
+  -DXRDP_CFG_PATH=\"${sysconfdir}/${sysconfsubdir}\" \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
   -DXRDP_LIBEXEC_PATH=\"${libexecdir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \
@@ -40,7 +40,7 @@ xrdp_sesman_LDADD = \
   $(top_builddir)/libipm/libipm.la \
   $(top_builddir)/common/libcommon.la
 
-sesmansysconfdir=$(sysconfdir)/xrdp
+sesmansysconfdir=$(sysconfdir)/$(sysconfsubdir)
 
 SUBST_VARS = sed \
    -e 's|@sesmansysconfdir[@]|$(sesmansysconfdir)|g'

--- a/sesman/chansrv/Makefile.am
+++ b/sesman/chansrv/Makefile.am
@@ -4,7 +4,7 @@ EXTRA_DIST = \
   wave-format-server.txt
 
 AM_CPPFLAGS = \
-  -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
+  -DXRDP_CFG_PATH=\"${sysconfdir}/${sysconfsubdir}\" \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
   -DXRDP_SHARE_PATH=\"${datadir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \

--- a/sesman/libsesman/Makefile.am
+++ b/sesman/libsesman/Makefile.am
@@ -3,7 +3,7 @@
 
 AM_CPPFLAGS = \
   -DXRDP_PAMCONF_PATH=\"${pamconfdir}\" \
-  -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
+  -DXRDP_CFG_PATH=\"${sysconfdir}/${sysconfsubdir}\" \
   -DXRDP_SOCKET_ROOT_PATH=\"${socketdir}\" \
   -I$(top_srcdir)/libipm \
   -I$(top_srcdir)/common

--- a/sesman/sesexec/Makefile.am
+++ b/sesman/sesexec/Makefile.am
@@ -1,5 +1,5 @@
 AM_CPPFLAGS = \
-  -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
+  -DXRDP_CFG_PATH=\"${sysconfdir}/${sysconfsubdir}\" \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
   -DXRDP_LIBEXEC_PATH=\"${libexecdir}/xrdp\" \
   -DXRDP_SOCKET_ROOT_PATH=\"${socketdir}\" \

--- a/sesman/tools/Makefile.am
+++ b/sesman/tools/Makefile.am
@@ -1,5 +1,5 @@
 AM_CPPFLAGS = \
-  -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
+  -DXRDP_CFG_PATH=\"${sysconfdir}/${sysconfsubdir}\" \
   -DXRDP_SOCKET_ROOT_PATH=\"${socketdir}\" \
   -I$(top_srcdir)/sesman/libsesman \
   -I$(top_srcdir)/common \

--- a/tools/chkpriv/Makefile.am
+++ b/tools/chkpriv/Makefile.am
@@ -20,7 +20,8 @@ xrdp_droppriv_LDADD = \
 
 SUBST_VARS = sed \
    -e 's|@pkglibexecdir[@]|$(pkglibexecdir)|g' \
-   -e 's|@sysconfdir[@]|$(sysconfdir)|g'
+   -e 's|@sysconfdir[@]|$(sysconfdir)|g' \
+   -e 's|@sysconfsubdir[@]|$(sysconfsubdir)|g'
 
 subst_verbose = $(subst_verbose_@AM_V@)
 subst_verbose_ = $(subst_verbose_@AM_DEFAULT_V@)

--- a/tools/chkpriv/xrdp-chkpriv.in
+++ b/tools/chkpriv/xrdp-chkpriv.in
@@ -20,7 +20,7 @@
 # mode
 
 # Change these if they do not match your installation
-CONF_DIR=@sysconfdir@/xrdp
+CONF_DIR=@sysconfdir@/@sysconfsubdir@
 XRDP_INI="$CONF_DIR"/xrdp.ini
 SESMAN_INI="$CONF_DIR"/sesman.ini
 RSAKEYS_INI="$CONF_DIR"/rsakeys.ini

--- a/vnc/Makefile.am
+++ b/vnc/Makefile.am
@@ -1,5 +1,5 @@
 AM_CPPFLAGS = \
-  -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
+  -DXRDP_CFG_PATH=\"${sysconfdir}/${sysconfsubdir}\" \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
   -DXRDP_SHARE_PATH=\"${datadir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \

--- a/xrdp/Makefile.am
+++ b/xrdp/Makefile.am
@@ -4,7 +4,7 @@ EXTRA_DIST = \
   xrdpwin.c
 
 AM_CPPFLAGS = \
-  -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
+  -DXRDP_CFG_PATH=\"${sysconfdir}/${sysconfsubdir}\" \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
   -DXRDP_SHARE_PATH=\"${datadir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \
@@ -92,7 +92,7 @@ xrdp_LDADD = \
   $(IMLIB2_LIBS) \
   $(XRDP_EXTRA_LIBS)
 
-xrdpsysconfdir=$(sysconfdir)/xrdp
+xrdpsysconfdir=$(sysconfdir)/$(sysconfsubdir)
 
 if MACOS
 lib_extension = dylib

--- a/xup/Makefile.am
+++ b/xup/Makefile.am
@@ -1,5 +1,5 @@
 AM_CPPFLAGS = \
-  -DXRDP_CFG_PATH=\"${sysconfdir}/xrdp\" \
+  -DXRDP_CFG_PATH=\"${sysconfdir}/${sysconfsubdir}\" \
   -DXRDP_SBIN_PATH=\"${sbindir}\" \
   -DXRDP_SHARE_PATH=\"${datadir}/xrdp\" \
   -DXRDP_PID_PATH=\"${localstatedir}/run\" \


### PR DESCRIPTION
This allows the `xrdp` part of the path `/etc/xrdp` where config files are placed to be customizable. This change is useful when trying the stable version and the devel version alternately.

(cherry picked from commit 75736f4853773a391cf18a24e4eebfc41d0053a1)

Backport of #3368.