### PR TITLE
Fix possible memory leak

### DIFF
--- a/xrdp/xrdp_egfx.c
+++ b/xrdp/xrdp_egfx.c
@@ -827,12 +827,16 @@ xrdp_egfx_process_capsadvertise(struct xrdp_egfx *egfx, struct stream *s)
     {
         if (!s_check_rem(s, 8))
         {
+            g_free(versions);
+            g_free(flagss);
             return 1;
         }
         in_uint32_le(s, version);
         in_uint32_le(s, capsDataLength);
         if (!s_check_rem(s, capsDataLength))
         {
+            g_free(versions);
+            g_free(flagss);
             return 1;
         }
         holdp = s->p;


### PR DESCRIPTION
First, I considered a single cleanup block at the end of the function with ```ret = 1; goto cleanup;``` instead of ```return 1```.
However, I decided to keep it simple because the function is relatively small and there are only two cases of returning without freeing memory.
