### PR TITLE
Fix possible memory leak

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -2344,6 +2344,7 @@ g_get_open_fds(int min, int max)
                         // Descriptor is open
                         if (!list_add_item(result, i))
                         {
+                            g_free(fds);
                             goto nomem;
                         }
                     }


### PR DESCRIPTION
Memory referenced by ```fds``` was not freed at one exit point.