### PR TITLE
Add sesman.ini FuseMountNameColonCharReplacement option

### DIFF
--- a/docs/man/sesman.ini.5.in
+++ b/docs/man/sesman.ini.5.in
@@ -381,6 +381,15 @@ drive. To fix this, consult the docs for your chosen desktop.
 .RE
 
 .TP
+\fBFuseMountNameColonCharReplacement\fR=\fIstring\fR
+Character to replace colon in redirected drive mount point names.
+If not specified no colon will not be replaced.
+If empty then colon will be replaced by null character.
+If longer than one character, only first character used.
+Only last colon replaced.
+.RE
+
+.TP
 \fBFuseDirectIO\fR=\fI[false|true]\fR
 Defaults to \fIfalse\fR. Set to \fItrue\fR to disable page caching in
 FUSE when opening files on a redirected drive. Direct I/O can impact

--- a/sesman/chansrv/chansrv_config.c
+++ b/sesman/chansrv/chansrv_config.c
@@ -40,6 +40,7 @@
 #define DEFAULT_RESTRICT_INBOUND_CLIPBOARD  0
 #define DEFAULT_ENABLE_FUSE_MOUNT           1
 #define DEFAULT_FUSE_MOUNT_NAME             "xrdp-client"
+#define DEFAULT_FUSE_MOUNT_NAME_COLON_CHAR_REPLACEMENT ':'
 #define DEFAULT_FUSE_DIRECT_IO              0
 #define DEFAULT_FILE_UMASK                  077
 #define DEFAULT_USE_NAUTILUS3_FLIST_FORMAT  0
@@ -220,6 +221,25 @@ read_config_chansrv(log_func_t logmsg,
                 break;
             }
         }
+        else if (g_strcasecmp(name, "FuseMountNameColonCharReplacement") == 0)
+        {
+            size_t vallen = g_strlen(value);
+            if (vallen < 1)
+            {
+                cfg->fuse_mount_name_colon_char_replacement = '\0';
+            }
+            else
+            {
+                if (vallen > 1)
+                {
+                    logmsg(LOG_LEVEL_WARNING, "FuseMountNameColonCharReplacement "
+                           "must be 1 character length, now it is '%s'."
+                           "Only first char will be used!",
+                           value);
+                }
+                cfg->fuse_mount_name_colon_char_replacement = value[0];
+            }
+        }
         else if (g_strcasecmp(name, "FuseDirectIO") == 0)
         {
             cfg->fuse_direct_io = g_text2bool(value);
@@ -315,6 +335,7 @@ new_config(void)
         cfg->restrict_outbound_clipboard = DEFAULT_RESTRICT_OUTBOUND_CLIPBOARD;
         cfg->restrict_inbound_clipboard = DEFAULT_RESTRICT_INBOUND_CLIPBOARD;
         cfg->fuse_mount_name = fuse_mount_name;
+        cfg->fuse_mount_name_colon_char_replacement = DEFAULT_FUSE_MOUNT_NAME_COLON_CHAR_REPLACEMENT;
         cfg->fuse_direct_io = DEFAULT_FUSE_DIRECT_IO;
         cfg->file_umask = DEFAULT_FILE_UMASK;
         cfg->use_nautilus3_flist_format = DEFAULT_USE_NAUTILUS3_FLIST_FORMAT;
@@ -419,6 +440,7 @@ config_dump(struct config_chansrv *config)
     g_writeln("    EnableFuseMount            %s",
               g_bool2text(config->enable_fuse_mount));
     g_writeln("    FuseMountName:             %s", config->fuse_mount_name);
+    g_writeln("    FuseMountNameColonCharReplacement:             %c", config->fuse_mount_name_colon_char_replacement);
     g_writeln("    FuseDirectIO:              %s",
               g_bool2text(config->fuse_direct_io));
     g_writeln("    FileMask:                  0%o", config->file_umask);

--- a/sesman/chansrv/chansrv_config.h
+++ b/sesman/chansrv/chansrv_config.h
@@ -39,6 +39,8 @@ struct config_chansrv
 
     /** * FuseMountName from sesman.ini */
     char *fuse_mount_name;
+    /** * FuseMountNameColonCharReplacement from sesman.ini */
+    char fuse_mount_name_colon_char_replacement;
     /** FileUmask from sesman.ini */
     mode_t file_umask;
 

--- a/sesman/sesman.ini.in
+++ b/sesman/sesman.ini.in
@@ -168,6 +168,7 @@ param=96
 #FuseMountName=/run/user/%u/thinclient_drives
 #FuseMountName=/media/thinclient_drives/%U/thinclient_drives
 FuseMountName=thinclient_drives
+#FuseMountNameColonCharReplacement=
 ; this value allows only the user to access their own mapped drives.
 ; Make this more permissive (e.g. 022) if required.
 FileUmask=077


### PR DESCRIPTION
The colon(`:`) in file paths is not supported on all OSes, on others need quoting/escaping, not all software treat colons in paths adequately.
The patch modifies default behaviour by stripping colon from redirected drive mount points(which emerges from windows clients with shared drive connected), but provides config option to customize the replacement(including reverting to "good old" colons in drive names).