### PR TITLE
Add XAuthorityInSystemDir option

### DIFF
--- a/docs/man/sesman.ini.5.in
+++ b/docs/man/sesman.ini.5.in
@@ -252,6 +252,14 @@ to \fI0\fR, unlimited attempts are allowed. If not specified, defaults to
 \fI3\fR.
 
 .TP
+\fBXAuthorityInSystemDir\fR=\fI[no|yes]\fR
+If set to \fByes\fR, xrdp will set XAUTHORITY to be in a system directory
+(currently @socketdir@/\fI<uid>\fR) which is only accessible to the
+logged-in user.
+You may wish to use this if $HOME is NFS-mounted, or you are experiencing
+other applications overwriting the default file.
+
+.TP
 \fBTerminalServerUsers\fR=\fIgroup\fR
 Only the users belonging to the specified group are allowed to login on
 terminal server. If unset or set to an invalid or non\-existent group,

--- a/docs/man/sesman.ini.5.in
+++ b/docs/man/sesman.ini.5.in
@@ -57,7 +57,7 @@ In this instance, the system administrator is responsible for ensuring
 the socket can only be created by a suitably privileged process.
 .PP
 If the parameter does not start with a '/', a name within
-@socketdir@ is used.
+@socketdir@/\fI<uid>\fR is used.
 .RE
 
 .TP

--- a/docs/man/sesman.ini.5.in
+++ b/docs/man/sesman.ini.5.in
@@ -253,9 +253,13 @@ to \fI0\fR, unlimited attempts are allowed. If not specified, defaults to
 
 .TP
 \fBXAuthorityInSystemDir\fR=\fI[no|yes]\fR
-If set to \fByes\fR, xrdp will set XAUTHORITY to be in a system directory
-(currently @socketdir@/\fI<uid>\fR) which is only accessible to the
-logged-in user.
+If set to \fBno\fR (the default), \fBXAUTHORITY\fR will not be set for
+sessions, and the X11 authfile will be $HOME/.Xauthority.
+.br
+If set to \fByes\fR, xrdp will point \fBXAUTHORITY\fR to a file
+in a system directory private to the logged-in user (currently
+@socketdir@/\fI<uid>\fR/Xauthority).
+.br
 You may wish to use this if $HOME is NFS-mounted, or you are experiencing
 other applications overwriting the default file.
 

--- a/sesman/libsesman/sesman_config.c
+++ b/sesman/libsesman/sesman_config.c
@@ -63,6 +63,7 @@
 */
 #define SESMAN_CFG_SECURITY                        "Security"
 #define SESMAN_CFG_SEC_LOGIN_RETRY                 "MaxLoginRetry"
+#define SESMAN_CFG_XAUTH_IN_SYSDIR                 "XAuthorityInSystemDir"
 #define SESMAN_CFG_SEC_ALLOW_ROOT                  "AllowRootLogin"
 #define SESMAN_CFG_SEC_USR_GROUP                   "TerminalServerUsers"
 #define SESMAN_CFG_SEC_ADM_GROUP                   "TerminalServerAdmins"
@@ -307,6 +308,7 @@ config_read_security(int file, struct config_security *sc,
     /* setting defaults */
     sc->allow_root = 0;
     sc->login_retry = 3;
+    sc->xauth_in_sysdir = 0;
     sc->restrict_outbound_clipboard = 0;
     sc->restrict_inbound_clipboard = 0;
     sc->allow_alternate_shell = 1;
@@ -329,6 +331,10 @@ config_read_security(int file, struct config_security *sc,
         else if (0 == g_strcasecmp(buf, SESMAN_CFG_SEC_LOGIN_RETRY))
         {
             sc->login_retry = g_atoi(value);
+        }
+        else if (0 == g_strcasecmp(buf, SESMAN_CFG_XAUTH_IN_SYSDIR))
+        {
+            sc->xauth_in_sysdir = g_text2bool(value);
         }
         else if (0 == g_strcasecmp(buf, SESMAN_CFG_SEC_USR_GROUP))
         {
@@ -672,6 +678,7 @@ config_dump(struct config_sesman *config)
     g_writeln("Security configuration:");
     g_writeln("    AllowRootLogin:            %d", sc->allow_root);
     g_writeln("    MaxLoginRetry:             %d", sc->login_retry);
+    g_writeln("    XAuthorityInSystemDir:     %d", sc->xauth_in_sysdir);
     g_writeln("    AlwaysGroupCheck:          %d", sc->ts_always_group_check);
     g_writeln("    AllowAlternateShell:       %d", sc->allow_alternate_shell);
 #ifdef HAVE_SYS_PRCTL_H

--- a/sesman/libsesman/sesman_config.h
+++ b/sesman/libsesman/sesman_config.h
@@ -69,6 +69,12 @@ struct config_security
      */
     int login_retry;
     /**
+     * @var x_authority_in_system_dir
+     * @brief Move XAUTHORITY to a system directory
+     */
+    int xauth_in_sysdir;
+
+    /**
      * @var ts_users
      * @brief Terminal Server Users group
      */

--- a/sesman/sesexec/env.c
+++ b/sesman/sesexec/env.c
@@ -162,6 +162,12 @@ env_set_user(int uid, char **passwd_file, int display,
             /* pulse source socket */
             g_snprintf(text, sizeof(text), CHANSRV_PORT_IN_BASE_STR, display);
             g_setenv("XRDP_PULSE_SOURCE_SOCKET", text, 1);
+            if (g_cfg->sec.xauth_in_sysdir)
+            {
+                g_snprintf(text, sizeof(text), XRDP_SOCKET_PATH "/Xauthority",
+                           uid);
+                g_setenv("XAUTHORITY", text, 1);
+            }
             if ((env_names != 0) && (env_values != 0) &&
                     (env_names->count == env_values->count))
             {

--- a/sesman/sesman.ini.in
+++ b/sesman/sesman.ini.in
@@ -14,6 +14,7 @@ ReconnectScript=reconnectwm.sh
 [Security]
 AllowRootLogin=true
 MaxLoginRetry=4
+XAuthorityInSystemDir=no
 TerminalServerUsers=tsusers
 TerminalServerAdmins=tsadmins
 ; When AlwaysGroupCheck=false access will be permitted


### PR DESCRIPTION
Fixes #3383 

Add an option to allow XAUTHORITY to be moved away from $HOME.
    
This is modelled on the lightm 'user-authority-in-system-dir' option, and also current GDM default behaviour.

A minor typo in `sesman.ini(5)` related to the port setting is also fixed.