### PR TITLE
Address some Coverity warnings

### DIFF
--- a/common/string_calls.c
+++ b/common/string_calls.c
@@ -444,6 +444,7 @@ g_atoix(const char *str)
         str += 2;
         base = 16;
     }
+    //coverity[OVERRUN:FALSE]
     return strtol(str, NULL, base);
 }
 

--- a/libipm/libipm_recv.c
+++ b/libipm/libipm_recv.c
@@ -135,7 +135,7 @@ libipm_msg_in_check_available(struct trans *trans, int *available)
 enum libipm_status
 libipm_msg_in_wait_available(struct trans *trans)
 {
-    tbus wobj[1];
+    tbus wobj[2]; // trans_get_wait_objs() can return at most 2 elements
     int ocnt = 0;
     enum libipm_status rv = E_LI_SUCCESS;
 

--- a/sesman/sesexec/session.c
+++ b/sesman/sesexec/session.c
@@ -495,9 +495,6 @@ start_x_server(struct login_info *login_info,
                 unknown_session_type = 1;
         }
 
-        g_free(passwd_file);
-        passwd_file = NULL;
-
         if (xserver_params == NULL)
         {
             LOG(LOG_LEVEL_ERROR, "Out of memory allocating X server params");
@@ -520,6 +517,7 @@ start_x_server(struct login_info *login_info,
     }
 
     /* should not get here */
+    g_free(passwd_file);
     list_delete(xserver_params);
     LOG(LOG_LEVEL_ERROR, "A fatal error has occurred attempting "
         "to start the X server on display %u, aborting connection",


### PR DESCRIPTION
This PR addresses the following Coverity issues, which are not publically available:-

| CID | Description | File |
| --- | -------------- | ---- |
| 468106 | Buffer overrun in libipm_msg_in_wait_available() | libipm/libipm_recv.c |
| 468113 | Possible integer overflow in g_get_open_fds() | common/os_calls.c |
| 468121 | Possible integer overflow in g_set_wait_obj() | common/os_calls.c |
| 468142 | Possible string overrun in g_atoix() | common/string_calls.c |
| 468150 | Possible memory leak in start_x_server() | sesman/sesexec/session.c |

# 468106
In summary, `trans_get_wait_objs()` can write a maximum of two values to the array (for TLS connections), and there's only space for one. In practice this can't happen. Simplest fix is to make the buffer big enough for two values.

# 468113
Coverity can't be sure that subtracting the int parameters min and max passed to the function won't result in integer overflow when `max - min` is calculated. Extra checks are added to the parameters and the call to `sysconf(_SC_OPEN_MAX)` to mitigate this. In practice, this won't happen, as this function is only used in testing.

# 468121
Coverity can't be sure that adding the result of a `write()` to an `int` won't cause integer overflow. In practice it won't but a simple extra check should make this clear to Coverity.

# 468142
Coverity is complaining that if "0" (which is two bytes long) is passed to this code as a pointed-to value by `str` :-

```c
    if (*str == '0' && tolower(*(str + 1)) == 'x')
    {
        str += 2;
        base = 16;
    }
```

that `str` could be incremented beyond the end of the string. Coverity is unable to see that the second byte of "0" (i.e. a '\0' character) cannot pass the test `tolower(<byte>) == 'x'`. This is therefor a false-positive, and marked as such.

# 468150
A codepath in this function results in the `passwd_file` not being freed. This is a confirmed defect.

I can't currently run Coverity locally, so these are very much a best-shot at getting these addressed.