### PR TITLE
Fix 32-bit CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,9 +134,9 @@ jobs:
                   --enable-painter --enable-pixman --enable-utmp
                   --with-imlib2 --with-freetype2 --enable-tests --with-x264
                   --enable-openh264"
-      CONF_FLAGS_i386_max: "--enable-ibus --enable-ipv6 --enable-jpeg
+      CONF_FLAGS_i386_max: "--enable-ipv6 --enable-jpeg
                   --enable-mp3lame --enable-opus --enable-rfxcodec
-                  --enable-painter --disable-pixman --with-imlib2
+                  --enable-painter --disable-pixman
                   --with-freetype2 --host=i686-linux --enable-tests"
 
       PKG_CONFIG_PATH_i386: "/usr/lib/i386-linux-gnu/pkgconfig"

--- a/scripts/install_xrdp_build_dependencies_with_apt.sh
+++ b/scripts/install_xrdp_build_dependencies_with_apt.sh
@@ -116,15 +116,15 @@ in
         # build support tool.
         # - Ubuntu 18.04 -> 20.04
         #       Removed fdk-aac-dev:i386 and libfuse-dev:i386
+        # - Ubuntu 24.04.1
+        #       Removed libibus-1.0-dev:i386 and libimlib2-dev:i386
         PACKAGES="$PACKAGES \
             g++-multilib \
             gcc-multilib \
             $LIBFREETYPE_DEV:i386 \
             libgl1-mesa-dev:i386 \
             libglu1-mesa-dev:i386 \
-            libibus-1.0-dev:i386 \
             libjpeg-dev:i386 \
-            libimlib2-dev:i386 \
             libmp3lame-dev:i386 \
             libopus-dev:i386 \
             libpam0g-dev:i386 \


### PR DESCRIPTION
Removing libibus-1.0-dev:i386 and libimlib2-dev:i386 from the 32-bit build fixes this error:-

```
The following packages have unmet dependencies:
 shim-signed : Depends: grub-efi-amd64-signed (>= 1.191~) but it is not going to be installed or
                        grub-efi-arm64-signed (>= 1.191~) but it is not installable or
                        base-files (< 12.3)
               Depends: grub-efi-amd64-signed (>= 1.187.2~) but it is not going to be installed or
                        grub-efi-arm64-signed (>= 1.187.2~) but it is not installable
E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.
```
This is somewhat difficult to comprehend, as the following packages are installed:-

| Package | Version |
| ---- | ---- |
|base-files | 13ubuntu10.1 |
|grub-efi-amd64-signed | 1.202+2.12-1ubuntu7 |
|shim-signed | 1.58+15.8-0ubuntu1 |

Info from runner-
- Operating System
  - Ubuntu
  - 24.04.1
  - LTS
- Runner Image
  - Image: ubuntu-24.04
  - Version: 20250105.1.0
  - Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20250105.1/images/ubuntu/Ubuntu2404-Readme.md
  - Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250105.1

The 32-bit builds are of decreasing utility, but I suspect that if they're working on 24.04 now, we can probably hang on to them for a little longer.

I'm going to merge this now, to fix the CI.