### PR TITLE
[V0.10] CI: Move to V4 of upload-artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
         if: ${{ matrix.DISTCHECK }}
         run: make distcheck -j $(nproc)
       - name: "Artifact: test-suite.log distcheck"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always() && steps.dist_check.outcome == 'failure'
         with:
           name: test-suite-distcheck-${{ matrix.cc }}-${{ matrix.feature_set }}


### PR DESCRIPTION
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

(cherry picked from commit 110df32016a6f97027a364b95208d11206e6d320)