### PR TITLE
xrdp.8.in: Fix "SEE ALSO" refs to `xrdp-sesman`, `xrdp-sesrun`

### DIFF
--- a/docs/man/xrdp.8.in
+++ b/docs/man/xrdp.8.in
@@ -70,9 +70,9 @@ Simone Fedele <ilsimo@users.sourceforge.net>
 
 .SH "SEE ALSO"
 .BR xrdp.ini (5),
-.BR sesman (8),
+.BR xrdp\-sesman (8),
 .BR sesman.ini (5),
-.BR sesrun (8)
+.BR xrdp\-sesrun (8)
 
 for more info on \fBxrdp\fR see
 .UR @xrdphomeurl@


### PR DESCRIPTION
`sesman` and `sesrun` got prefixed with `xrdp-` long ago, but the main `xrdp` manpage wasn't updated.