### PR TITLE
Fix more coverity warnings

### DIFF
--- a/common/string_calls.c
+++ b/common/string_calls.c
@@ -1191,7 +1191,7 @@ utf8_get_next_char(const char **utf8str_ref, unsigned int *len_ref)
     /*
      * Macro used to parse a continuation character
      * @param cp Character Pointer (incremented on success)
-     * @param end One character past end of input string
+     * @param end One character past end of input string, or NULL
      * @param value The value we're constructing
      * @param finish_label Where to go in the event of an error */
 #define PARSE_CONTINUATION_CHARACTER(cp, end, value, finish_label) \
@@ -1210,7 +1210,7 @@ utf8_get_next_char(const char **utf8str_ref, unsigned int *len_ref)
 
     /* Easier to work with unsigned chars and no indirection */
     const unsigned char *cp = (const unsigned char *)*utf8str_ref;
-    const unsigned char *end = (len_ref != NULL) ? cp + *len_ref : cp + 6;
+    const unsigned char *end = (len_ref != NULL) ? cp + *len_ref : NULL;
 
     if (cp == end)
     {

--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -1790,6 +1790,10 @@ lfreerdp_synchronize(rdpContext *context)
 static boolean
 lfreerdp_pre_connect(freerdp *instance)
 {
+#define MAX_FREERDP_CHANNELS \
+    (sizeof(instance->settings->channels) / \
+     sizeof(instance->settings->channels[0]))
+
     struct mod *mod;
     int index;
     int error;
@@ -1797,7 +1801,7 @@ lfreerdp_pre_connect(freerdp *instance)
     int target_chan;
     int ch_flags;
     char ch_name[256];
-    const char *ch_names[MAX_STATIC_CHANNELS];
+    const char *ch_names[MAX_FREERDP_CHANNELS];
     char *dst_ch_name;
 
     LOG_DEVEL(LOG_LEVEL_INFO, "lfreerdp_pre_connect:");
@@ -1828,7 +1832,7 @@ lfreerdp_pre_connect(freerdp *instance)
                 LOG(LOG_LEVEL_INFO, "Channel '%s' not passed to module",
                     ch_name);
             }
-            else if (target_chan < MAX_STATIC_CHANNELS)
+            else if (target_chan < MAX_FREERDP_CHANNELS)
             {
                 dst_ch_name = instance->settings->channels[target_chan].name;
                 ch_names[target_chan] = dst_ch_name;

--- a/neutrinordp/xrdp-neutrinordp.h
+++ b/neutrinordp/xrdp-neutrinordp.h
@@ -231,7 +231,7 @@ struct mod
     struct bitmap_item bitmap_cache[4][4096];
     struct brush_item brush_cache[64];
     struct pointer_item pointer_cache[32];
-    char pamusername[255];
+    char pamusername[256];
 
     int allow_client_experiencesettings;
     int perf_settings_override_mask; /* Performance bits overridden in ini file */

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -1273,7 +1273,7 @@ xrdp_wm_clear_popup(struct xrdp_wm *self)
     //struct xrdp_bitmap* b;
 
     //b = 0;
-    if (self->popup_wnd != 0)
+    if (self->popup_wnd != NULL)
     {
         //b = self->popup_wnd->popped_from;
         i = list_index_of(self->screen->child_list, (long)self->popup_wnd);
@@ -1282,6 +1282,7 @@ xrdp_wm_clear_popup(struct xrdp_wm *self)
                  self->popup_wnd->width, self->popup_wnd->height);
         xrdp_bitmap_invalidate(self->screen, &rect);
         xrdp_bitmap_delete(self->popup_wnd);
+        self->popup_wnd = NULL;
     }
 
     //xrdp_wm_set_focused(self, b->parent);


### PR DESCRIPTION
This PR fixes the remainder of the high-impact Coverity warnings, plus a couple from the neutrinolabs directory which are not included in the automatic scan.

See #3394 for the precursor to this PR

|CID | Description | File |
|---| ------------| ----|
|468125 | Out-of-bounds reference parsing "OK" string in xrdp_wm_show_log() | xrdp_wm.c |
|468132 | Out-of-bounds reference parsing "OK" string in xrdp_wm_help_clicked() | xrdp_login_wnd.c |
| 468146 | Potential double-free of popup_wnd in xrdp_wm_key() | xrdp_wm.c |
| 468153 | Resource leak in scard_function_list_readers_return() | smartcard_pcsc.c|
| - | Access past end of neutrinolabs mod->pamusername in lxrdp_set_param() | xrdp-neutrinordp.c |
| - | Channels array overflow in freerdp->settings->channels in lfreerdp_pre_connect() | xrdp-neutrinordp.c |

## 468125 / 468132
These are both caused by an assumption made in utf8_get_next_char() that the character pointer can be advanced by 6 bytes for a credible end-stop for parsing. This isn't true for a short string such as (e.g.) "OK"

The fix is not to add 6 to the character pointer to get an end-stop, but just to assign NULL to the end-stop. The parsing logic for this function only needs an end-stop when parsing a short multi-byte character.

## 468146
This is caused by not assigning NULL to `self->popup_wnd` after it is freed. If this is done, a double-free is not possible.

## 468153
This code is currently unused. A memory leak on an error-return from a function is addressed to keep Coverity happy

## (neutrinordp)
The neutrinordp module is not currently scanned by the automated Coverity check, but this can be done manually.

These are two simple array overflows.