### PR TITLE
Address more Coverity warnings

### DIFF
--- a/sesman/chansrv/chansrv_xfs.c
+++ b/sesman/chansrv/chansrv_xfs.c
@@ -283,7 +283,9 @@ xfs_create_xfs_fs(mode_t umask, uid_t uid, gid_t gid)
                 (xino1 = g_new0(XFS_INODE_ALL, 1)) == NULL ||
                 (xino2 = g_new0(XFS_INODE_ALL, 1)) == NULL ||
                 (xino1_name = strdup(".")) == NULL ||
-                (xino2_name = strdup(".delete-pending")) == NULL)
+                (xino2_name = strdup(".delete-pending")) == NULL ||
+                // This keeps Coverity happy (see below)
+                xfs->free_count < 3)
         {
             free(xino1);
             free(xino2);

--- a/sesman/chansrv/rail.c
+++ b/sesman/chansrv/rail.c
@@ -1362,7 +1362,7 @@ rail_create_window(Window window_id, Window owner_id)
     char *title_bytes = 0;
     int title_size = 0;
     XWindowAttributes attributes;
-    int style;
+    tui32 style;
     int ext_style;
     int num_window_rects = 1;
     int num_visibility_rects = 1;

--- a/tools/devel/tcp_proxy/main.c
+++ b/tools/devel/tcp_proxy/main.c
@@ -275,7 +275,7 @@ main_loop(char *local_port, char *remote_ip, char *remote_port, int hexdump)
                             g_tcp_socket_ok(con_sck);
                         }
                     }
-                    else if (i < 1)
+                    else if (i < 1 || i > (count - sent))
                     {
                         error = 1;
                     }

--- a/vnc/vnc.c
+++ b/vnc/vnc.c
@@ -2141,7 +2141,7 @@ lib_mod_set_param(struct vnc *v, const char *name, const char *value)
     }
     else if (g_strcasecmp(name, "disabled_encodings_mask") == 0)
     {
-        v->enabled_encodings_mask = ~g_atoi(value);
+        v->enabled_encodings_mask = (unsigned int)~g_atoi(value);
     }
     else if (g_strcasecmp(name, "client_info") == 0)
     {


### PR DESCRIPTION
These are all pretty minor:-

|CID | Comment |
|---|-------|
|468119 | Add extra check to convince Coverity `xfs->free_count` >= 3 |
| 468140 | Unsigned type needed for `style` in `rail_create_window()` to handle 0x80000000 (`RAIL_STYLE_TOOLTIP`) |
| 468157 | Unsigned cast needed to handle ~ operator applied to 0 |
| 468110/468131 | Part of the test TCP proxy. File descriptors cannot be 0 if unused. Fixing this exposed another warning which was addressed by checking the return value of `g_tcp_send()` more closely |