### PR TITLE
[V0.10] : Bump FreeBSD CI to 14.2 (was 13.4)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@ FreeBSD_task:
       SSL: libressl
   matrix:
     freebsd_instance:
-      image_family: freebsd-13-3
+      image_family: freebsd-14-2
   prepare_script:
     - pkg install -y $SSL git autoconf automake libtool pkgconf opus jpeg-turbo fdk-aac pixman libX11 libXfixes libXrandr nasm fusefs-libs3 check imlib2 freetype2 cmocka
     - git submodule update --init --recursive


### PR DESCRIPTION
FreeBSD 13.3 no longer appears to be available.

@metalefty - I've stuck with 13.x for the `V0.10` branch. Are you happy with that, or would you prefer 14.x? I've moved to 14.x for the `devel` branch.