### PR TITLE
Bump Cirrus CI to 14.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@ FreeBSD_task:
       SSL: libressl
   matrix:
     freebsd_instance:
-      image_family: freebsd-13-3
+      image_family: freebsd-14-2
   prepare_script:
     - pkg install -y $SSL git autoconf automake libtool pkgconf opus jpeg-turbo fdk-aac pixman libX11 libXfixes libXrandr libxkbfile nasm fusefs-libs3 check imlib2 freetype2 cmocka ibus
     - git submodule update --init --recursive


### PR DESCRIPTION
FreeBSD 13.3 no longer appears to be available.