### PR TITLE
Address Coverity mutex issues

### DIFF
--- a/common/thread_calls.c
+++ b/common/thread_calls.c
@@ -33,6 +33,7 @@
 #include <semaphore.h>
 #endif
 #include "arch.h"
+#include "log.h"
 #include "thread_calls.h"
 #include "os_calls.h"
 
@@ -136,11 +137,17 @@ tc_mutex_lock(tbus mutex)
 {
 #if defined(_WIN32)
     WaitForSingleObject((HANDLE)mutex, INFINITE);
-    return 0;
 #else
-    pthread_mutex_lock((pthread_mutex_t *)mutex);
-    return 0;
+    if (mutex != 0)
+    {
+        pthread_mutex_lock((pthread_mutex_t *)mutex);
+    }
+    else
+    {
+        LOG(LOG_LEVEL_ERROR, "Attempt made to lock NULL mutex");
+    }
 #endif
+    return 0;
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
Coverity has generated a number of 'Data race condition' and 'Double lock' false positives. A lot of these seem to be caused by the NULL guard in tc_mutex_unlock() not being paired with a NULL guard in tc_mutex_lock(). This PR adds a NULL guard to tc_mutex_lock().

It should be noted, that on Linux at least, passing NULL to tc_mutex_lock() causes a segfault. We clearly aren't doing this at the moment, or we'd know about it. A log message is generated if a NULL call is made, rather than failing silently.