### PR TITLE
Fix more coverity warnings

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -1457,6 +1457,16 @@ g_sck_recv_fd_set(int sck, void *ptr, unsigned int len,
     if ((rv = recvmsg(sck, &msg, 0)) > 0)
     {
         struct cmsghdr *cmsg;
+
+        // Coverity: msg is 'tainted', so check msg.control and
+        // msg.msg_controllen are sane (i.e. recvmsg() hasn't done
+        // something odd)
+        msg.msg_control = control_un.control;
+        if (msg.msg_controllen > sizeof(control_un.control))
+        {
+            msg.msg_controllen = sizeof(control_un.control);
+        }
+
         if ((msg.msg_flags & MSG_CTRUNC) != 0)
         {
             LOG(LOG_LEVEL_WARNING, "Ancillary data on recvmsg() was truncated");

--- a/sesman/chansrv/audin.c
+++ b/sesman/chansrv/audin.c
@@ -103,7 +103,6 @@ audin_wave_format_tag_to_str(int tag)
         (tag == WAVE_FORMAT_ADPCM)      ? "WAVE_FORMAT_ADPCM" :
         (tag == WAVE_FORMAT_ALAW)       ? "WAVE_FORMAT_ALAW" :
         (tag == WAVE_FORMAT_MULAW)      ? "WAVE_FORMAT_MULAW" :
-        (tag == WAVE_FORMAT_MULAW)      ? "WAVE_FORMAT_MULAW" :
         (tag == WAVE_FORMAT_MPEGLAYER3) ? "WAVE_FORMAT_MPEGLAYER3" :
         (tag == WAVE_FORMAT_OPUS)       ? "WAVE_FORMAT_OPUS" :
         (tag == WAVE_FORMAT_AAC)        ? "WAVE_FORMAT_AAC" :

--- a/sesman/sesman.c
+++ b/sesman/sesman.c
@@ -933,7 +933,12 @@ main(int argc, char **argv)
             LOG(LOG_LEVEL_ERROR,
                 "sesman.c: error creating dir " X11_UNIX_SOCKET_DIRECTORY);
         }
-        g_chmod_hex(X11_UNIX_SOCKET_DIRECTORY, 0x1777);
+        if (g_chmod_hex(X11_UNIX_SOCKET_DIRECTORY, 0x1777) != 0)
+        {
+            LOG(LOG_LEVEL_ERROR,
+                "sesman.c: can't set permissions on "
+                X11_UNIX_SOCKET_DIRECTORY "[%s]", g_get_strerror());
+        }
     }
 
     if ((error = pre_session_list_init(MAX_PRE_SESSION_ITEMS)) == 0 &&

--- a/xrdp/xrdp_encoder.c
+++ b/xrdp/xrdp_encoder.c
@@ -390,7 +390,7 @@ xrdp_encoder_delete(struct xrdp_encoder *self)
     }
     /* tell worker thread to shut down */
     g_set_wait_obj(self->xrdp_encoder_term_request);
-    g_obj_wait(&self->xrdp_encoder_term_done, 1, NULL, 0, 5000);
+    (void)g_obj_wait(&self->xrdp_encoder_term_done, 1, NULL, 0, 5000);
     if (!g_is_wait_obj_set(self->xrdp_encoder_term_done))
     {
         LOG(LOG_LEVEL_WARNING, "Encoder failed to shut down cleanly");

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -1560,7 +1560,11 @@ xrdp_mm_update_module_frame_ack(struct xrdp_mm *self)
             LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_mm_update_module_ack: "
                       "frame_id_server %d", encoder->frame_id_server);
             encoder->frame_id_server_sent = encoder->frame_id_server;
-            self->mod->mod_frame_ack(self->mod, 0, encoder->frame_id_server);
+            if (self->mod != NULL)
+            {
+                self->mod->mod_frame_ack(self->mod, 0,
+                                         encoder->frame_id_server);
+            }
         }
     }
     return 0;
@@ -3737,7 +3741,7 @@ xrdp_mm_process_enc_done(struct xrdp_mm *self)
                     self->encoder->frame_id_server = enc_done->frame_id;
                     xrdp_mm_update_module_frame_ack(self);
                 }
-                else
+                else if (self->mod != NULL)
                 {
                     self->mod->mod_frame_ack(self->mod, 0,
                                              enc_done->frame_id);

--- a/xrdp/xrdp_painter.c
+++ b/xrdp/xrdp_painter.c
@@ -250,6 +250,7 @@ wm_painter_set_target(struct xrdp_painter *self)
 int
 xrdp_painter_begin_update(struct xrdp_painter *self)
 {
+    int rv;
     LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_painter_begin_update:");
     if (self == 0)
     {
@@ -263,9 +264,9 @@ xrdp_painter_begin_update(struct xrdp_painter *self)
         return 0;
     }
 
-    libxrdp_orders_init(self->session);
+    rv = libxrdp_orders_init(self->session);
     wm_painter_set_target(self);
-    return 0;
+    return rv;
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
Follows on from #3426 

These are all minor:-

|CID |Description |
|---|------|
|475385 | Result of `g_chmod_hex()` not checked |
|468102 | Possibility of `self->mod` being accessed when NULL |
|468103 | Result of `g_obj_wait()` ignored when other calls to it aren't |
|468108 | Repeated line in conditional (dead code) |
|468112 | Result of `libxrdp_orders_init()` ignored when other calls to it aren't | 
|468117 | Variables derived from 'tainted' values used in loop control |

475385 was reported as a new fault following the last merge of #3439 to devel. The merge had nothing to do with the area in question, so I don't understand why this is being reported now.
