### PR TITLE
Add new session type SCP_SESSION_TYPE_XVNC_UDS

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -4282,6 +4282,29 @@ g_no_new_privs(void)
 #endif
 }
 
+
+/*****************************************************************************/
+int
+g_fips_mode_enabled(void)
+{
+    int rv = 0;
+#if defined (__linux)
+    char buff[16];
+    int fd = open("/proc/sys/crypto/fips_enabled", O_RDONLY);
+
+    if (fd >= 0)
+    {
+        if (read(fd, buff, sizeof(buff)) > 0)
+        {
+            rv = (buff[0] != '0');
+        }
+
+        close(fd);
+    }
+#endif
+    return rv;
+}
+
 /*****************************************************************************/
 void
 g_qsort(void *base, size_t nitems, size_t size,

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -428,6 +428,14 @@ int      g_tcp4_bind_address(int sck, const char *port, const char *address);
 int      g_tcp6_socket(void);
 int      g_tcp6_bind_address(int sck, const char *port, const char *address);
 int      g_no_new_privs(void);
+/**
+ * Query whether FIPS mode is enabled
+ *
+ * In FIPS mode, some cryptographic algorithms are disabled
+ *
+ * @return 1 -> FIPS mode enabled, 0 -> FIPS mode disabled or unknown
+ */
+int      g_fips_mode_enabled(void);
 void
 g_qsort(void *base, size_t nitems, size_t size,
         int (*compar)(const void *, const void *));
@@ -461,7 +469,7 @@ g_malloc_nofail(size_t size);
 
 /** Allocate memory with error-checking
  *
- * @param Number of elementst to allocate
+ * @param Number of elements to allocate
  * @param size Size of each element
  * @return Allocated memory
  *

--- a/common/trans.c
+++ b/common/trans.c
@@ -22,6 +22,8 @@
 #include <config_ac.h>
 #endif
 
+#include <errno.h>
+
 #include "os_calls.h"
 #include "string_calls.h"
 #include "trans.h"
@@ -750,6 +752,7 @@ trans_connect(struct trans *self, const char *server, const char *port,
     unsigned int start_time = g_get_elapsed_ms();
     int error;
     int ms_before_next_connect;
+    int connect_errno = 0;
 
     /*
      * Function pointers which we use in the main loop to avoid
@@ -792,6 +795,7 @@ trans_connect(struct trans *self, const char *server, const char *port,
 
         if (self->sck < 0)
         {
+            connect_errno = errno;
             error = 1;
             break;
         }
@@ -800,6 +804,7 @@ trans_connect(struct trans *self, const char *server, const char *port,
         g_file_set_cloexec(self->sck, 1);
         g_tcp_set_non_blocking(self->sck);
         error = f_connect(self->sck, server, port);
+        connect_errno = errno;
         if (error == 0)
         {
             /* Connect was immediately successful */
@@ -851,6 +856,8 @@ trans_connect(struct trans *self, const char *server, const char *port,
             g_tcp_close(self->sck);
             self->sck = -1;
         }
+        /* Ensure errno is representative of the last connection attempt */
+        errno = connect_errno;
         self->status = TRANS_STATUS_DOWN;
     }
     else

--- a/common/trans.h
+++ b/common/trans.h
@@ -158,6 +158,9 @@ trans_write_copy_s(struct trans *self, struct stream *out_s);
  *
  * Multiple connection attempts may be made within the timeout period.
  *
+ * If the operation is not successful, errno will have been set by
+ * the last connection attempt.
+ *
  * If the operation is successful, 0 is returned and self->status will
  * be TRANS_STATUS_UP
  */

--- a/docs/man/xrdp.ini.5.in
+++ b/docs/man/xrdp.ini.5.in
@@ -377,7 +377,8 @@ values supported for a particular release of \fBxrdp\fR(8) are documented in
 
 .TP
 \fBcode\fR=\fI<number>\fR|\fI0\fR
-Specifies the session type. The default, \fI0\fR, is Xvnc,
+Specifies the session type. The default, \fI0\fR, is Xvnc over TCP,
+\fI1\fR, is Xvnc over a UNIX domain socket,
 and \fI20\fR is Xorg with xorgxrdp modules.
 
 .TP

--- a/docs/man/xrdp.ini.5.in
+++ b/docs/man/xrdp.ini.5.in
@@ -377,10 +377,10 @@ values supported for a particular release of \fBxrdp\fR(8) are documented in
 
 .TP
 \fBcode\fR=\fI<number>\fR|\fI0\fR
-Specifies the session type. The default, \fI0\fR, is Xvnc over TCP,
-\fI1\fR, is Xvnc over a UNIX domain socket,
+Specifies the session type. \fI0\fR is Xvnc over TCP,
+\fI1\fR is Xvnc over a UNIX domain socket,
 and \fI20\fR is Xorg with xorgxrdp modules.
-
+The default is \fI0\fR on non-FIPS systems, and \fI1\fR on FIPS systems.
 .TP
 \fBchansrvport\fR=\fBDISPLAY(\fR\fIn\fR\fB)\fR|\fBDISPLAY(\fR\fIn,u\fR\fB)\fR||\fI/path/to/domain-socket\fR
 Asks xrdp to connect to a manually started \fBxrdp-chansrv\fR instance.

--- a/libipm/scp_application_types.h
+++ b/libipm/scp_application_types.h
@@ -34,11 +34,13 @@
 enum scp_session_type
 {
     SCP_SESSION_TYPE_XVNC = 0,  ///< Session used Xvnc
+    SCP_SESSION_TYPE_XVNC_UDS,  ///< Session used Xvnc with UDS connection
     SCP_SESSION_TYPE_XORG  ///< Session used Xorg + xorgxrdp
 };
 
 #define SCP_SESSION_TYPE_TO_STR(t) \
     ((t) == SCP_SESSION_TYPE_XVNC ? "Xvnc" : \
+     (t) == SCP_SESSION_TYPE_XVNC_UDS ? "Xvnc-UDS" : \
      (t) == SCP_SESSION_TYPE_XORG ? "Xorg" : \
      "unknown" \
     )

--- a/sesman/sesexec/env.c
+++ b/sesman/sesexec/env.c
@@ -53,6 +53,15 @@ env_check_password_file(const char *filename, const char *passwd)
     void *des;
     void *sha1;
 
+    /*
+     * If we're in FIPS mode, do not write the GUID to disk after it's
+     * been encrypted with an insecure algorithm.
+     */
+    if (g_fips_mode_enabled())
+    {
+        LOG(LOG_LEVEL_ERROR, "Can't create VNC password file in FIPS mode");
+        return 1;
+    }
     /* create password hash from password */
     passwd_bytes = g_strlen(passwd);
     sha1 = ssl_sha1_info_create();

--- a/sesman/sesexec/session.c
+++ b/sesman/sesexec/session.c
@@ -388,10 +388,21 @@ prepare_xorg_xserver_params(const struct session_parameters *s,
 }
 
 /******************************************************************************/
+/**
+ * Prepare a list of parameters for the Xvnc X server
+ * @param s Session parameters
+ * @params authfile XAUTHORITY file
+ * @params passwd_file VNC password file, or NULL
+ * @params port UDS port to connect to, or NULL
+ * @return parameters list
+ *
+ * One of passwd_file and port must be set
+ */
 static struct list *
 prepare_xvnc_xserver_params(const struct session_parameters *s,
                             const char *authfile,
-                            const char *passwd_file)
+                            const char *passwd_file,
+                            const char *port)
 {
     char screen[32] = {0}; /* display number */
     char geometry[32] = {0};
@@ -420,8 +431,34 @@ prepare_xvnc_xserver_params(const struct session_parameters *s,
                               "-auth", authfile,
                               "-geometry", geometry,
                               "-depth", depth,
-                              "-rfbauth", passwd_file,
                               NULL);
+
+        if (passwd_file != NULL)
+        {
+            /* RFB authorization */
+            list_add_strdup_multi(params,
+                                  "-rfbauth", passwd_file,
+                                  NULL);
+        }
+        else if (port != NULL)
+        {
+            /* UDS connection. Authorization is handled by standard socket
+             * permissions, so we do not need to authorize within the
+             * VNC protocol exchange as well */
+            char sock_mode[16];
+
+            /* Convert a standard permissions mask into decimal
+             * for the -rfbunixmode switch argument
+             */
+            g_snprintf(sock_mode, sizeof(sock_mode),
+                       "%d", 0660); /* rw-rw---- */
+
+            list_add_strdup_multi(params,
+                                  "-rfbunixpath", port,
+                                  "-rfbunixmode", sock_mode,
+                                  "-SecurityTypes", "None",
+                                  NULL);
+        }
 
         /* additional parameters from sesman.ini file */
         //config_read_xserver_params(SCP_SESSION_TYPE_XVNC,
@@ -482,13 +519,22 @@ start_x_server(struct login_info *login_info,
     {
         switch (s->type)
         {
+                char port[256];
+
             case SCP_SESSION_TYPE_XORG:
                 xserver_params = prepare_xorg_xserver_params(s, authfile);
                 break;
 
             case SCP_SESSION_TYPE_XVNC:
                 xserver_params = prepare_xvnc_xserver_params(s, authfile,
-                                 passwd_file);
+                                 passwd_file, NULL);
+                break;
+
+            case SCP_SESSION_TYPE_XVNC_UDS:
+                g_snprintf(port, sizeof(port), XRDP_X11RDP_STR,
+                           login_info->uid, s->display);
+                xserver_params = prepare_xvnc_xserver_params(s, authfile,
+                                 NULL, port);
                 break;
 
             default:

--- a/sesman/tools/sesrun.c
+++ b/sesman/tools/sesrun.c
@@ -83,6 +83,7 @@ static struct
 } type_map[] =
 {
     { "Xvnc", SCP_SESSION_TYPE_XVNC},
+    { "Xvnc-UDS", SCP_SESSION_TYPE_XVNC_UDS},
     { "Xorg", SCP_SESSION_TYPE_XORG},
     { NULL, (enum scp_session_type) - 1}
 };

--- a/vnc/vnc.c
+++ b/vnc/vnc.c
@@ -1732,71 +1732,78 @@ lib_mod_connect(struct vnc *v)
 
     error = trans_connect(v->trans, v->ip, con_port, 3000);
 
+    if (error != 0)
+    {
+        g_snprintf(text, sizeof(text), "Error connecting to VNC server [%s]",
+                   g_get_strerror());
+        v->server_msg(v, text, 0);
+        free_stream(s);
+        free_stream(pixel_format);
+        return 1;
+    }
+
+    v->server_msg(v, "VNC tcp connected", 0);
+    /* protocol version */
+    init_stream(s, 8192);
+    error = trans_force_read_s(v->trans, s, 12);
     if (error == 0)
     {
-        v->server_msg(v, "VNC tcp connected", 0);
-        /* protocol version */
-        init_stream(s, 8192);
-        error = trans_force_read_s(v->trans, s, 12);
-        if (error == 0)
-        {
-            s->p = s->data;
-            out_uint8a(s, "RFB 003.003\n", 12);
-            s_mark_end(s);
-            error = trans_force_write_s(v->trans, s);
-        }
+        s->p = s->data;
+        out_uint8a(s, "RFB 003.003\n", 12);
+        s_mark_end(s);
+        error = trans_force_write_s(v->trans, s);
+    }
 
-        /* sec type */
-        if (error == 0)
+    /* sec type */
+    if (error == 0)
+    {
+        init_stream(s, 8192);
+        error = trans_force_read_s(v->trans, s, 4);
+    }
+
+    if (error == 0)
+    {
+        in_uint32_be(s, i);
+        g_sprintf(text, "VNC security level is %d (1 = none, 2 = standard)", i);
+        v->server_msg(v, text, 0);
+
+        if (i == 1) /* none */
+        {
+            check_sec_result = 0;
+        }
+        else if (i == 2) /* dec the password and the server random */
         {
             init_stream(s, 8192);
-            error = trans_force_read_s(v->trans, s, 4);
-        }
+            error = trans_force_read_s(v->trans, s, 16);
 
-        if (error == 0)
-        {
-            in_uint32_be(s, i);
-            g_sprintf(text, "VNC security level is %d (1 = none, 2 = standard)", i);
-            v->server_msg(v, text, 0);
-
-            if (i == 1) /* none */
-            {
-                check_sec_result = 0;
-            }
-            else if (i == 2) /* dec the password and the server random */
+            if (error == 0)
             {
                 init_stream(s, 8192);
-                error = trans_force_read_s(v->trans, s, 16);
-
-                if (error == 0)
+                if (guid_is_set(&v->guid))
                 {
-                    init_stream(s, 8192);
-                    if (guid_is_set(&v->guid))
-                    {
-                        char guid_str[GUID_STR_SIZE];
-                        guid_to_str(&v->guid, guid_str);
-                        rfbHashEncryptBytes(s->data, guid_str);
-                    }
-                    else
-                    {
-                        rfbEncryptBytes(s->data, v->password);
-                    }
-                    s->p += 16;
-                    s_mark_end(s);
-                    error = trans_force_write_s(v->trans, s);
-                    check_sec_result = 1; // not needed
+                    char guid_str[GUID_STR_SIZE];
+                    guid_to_str(&v->guid, guid_str);
+                    rfbHashEncryptBytes(s->data, guid_str);
                 }
+                else
+                {
+                    rfbEncryptBytes(s->data, v->password);
+                }
+                s->p += 16;
+                s_mark_end(s);
+                error = trans_force_write_s(v->trans, s);
+                check_sec_result = 1; // not needed
             }
-            else if (i == 0)
-            {
-                LOG(LOG_LEVEL_ERROR, "VNC Server will disconnect");
-                error = 1;
-            }
-            else
-            {
-                LOG(LOG_LEVEL_ERROR, "VNC unsupported security level %d", i);
-                error = 1;
-            }
+        }
+        else if (i == 0)
+        {
+            LOG(LOG_LEVEL_ERROR, "VNC Server will disconnect");
+            error = 1;
+        }
+        else
+        {
+            LOG(LOG_LEVEL_ERROR, "VNC unsupported security level %d", i);
+            error = 1;
         }
     }
 

--- a/vnc/vnc.c
+++ b/vnc/vnc.c
@@ -1659,6 +1659,9 @@ lib_mod_connect(struct vnc *v)
     int error;
     int i;
     int check_sec_result;
+    int socket_mode;
+
+    g_snprintf(con_port, sizeof(con_port), "%s", v->port);
 
     v->server_msg(v, "VNC started connecting", 0);
     check_sec_result = 1;
@@ -1678,17 +1681,26 @@ lib_mod_connect(struct vnc *v)
             return 1;
     }
 
-    if (g_strcmp(v->ip, "") == 0)
+    /* Assume a TCP-port based connection (i.e. not a UDS connection)
+     * if the port is not an absolute path */
+    if (con_port[0] == '/')
     {
-        v->server_msg(v, "VNC error - no ip set", 0);
-        return 1;
+        socket_mode = TRANS_MODE_UNIX;
+    }
+    else
+    {
+        socket_mode = TRANS_MODE_TCP;
+        if (g_strcmp(v->ip, "") == 0)
+        {
+            v->server_msg(v, "VNC error - no IP set for TCP connection", 0);
+            return 1;
+        }
     }
 
     make_stream(s);
-    g_sprintf(con_port, "%s", v->port);
     make_stream(pixel_format);
 
-    v->trans = trans_create(TRANS_MODE_TCP, 8 * 8192, 8192);
+    v->trans = trans_create(socket_mode, 8 * 8192, 8192);
     if (v->trans == 0)
     {
         v->server_msg(v, "VNC error: trans_create() failed", 0);
@@ -1705,7 +1717,14 @@ lib_mod_connect(struct vnc *v)
         g_sleep(v->delay_ms);
     }
 
-    g_sprintf(text, "VNC connecting to %s %s", v->ip, con_port);
+    if (socket_mode == TRANS_MODE_TCP)
+    {
+        g_sprintf(text, "VNC connecting to TCP %s %s", v->ip, con_port);
+    }
+    else
+    {
+        g_sprintf(text, "VNC connecting to local socket %s", con_port);
+    }
     v->server_msg(v, text, 0);
 
     v->trans->si = v->si;

--- a/xrdp/xrdp.ini.in
+++ b/xrdp/xrdp.ini.in
@@ -260,11 +260,13 @@ lib=libvnc.@lib_extension@
 username=ask
 password=ask
 ip=127.0.0.1
+; port is -1 (sesman controlled), numeric (TCP connection) or an
+; absolute path (UDS connection).
 port=-1
-; For Xvnc, the 'code' parameter can be used to switch the connection
-; protocol:-
-; 0 - Use a TCP connection (default)
-; 1 - Use a Unix Domain Sockets (UDS) connection.
+; For sesman-controlled Xvnc, the 'code' parameter can be used to switch
+; the connection protocol:-
+; 0 - Use a TCP connection
+; 1 - Use a Unix Domain Sockets (UDS) connection
 ;     UDS connections are not supported by older VNC servers, but are
 ;     supported by TigerVNC. If you select this option, comment out
 ;     (or remove) the 'ip=' setting.
@@ -272,8 +274,10 @@ port=-1
 ; UDS connections are recommended, if your X server supports them. They are
 ; more secure, and untroubled by firewalls.
 ;
-; On FIPS-based systems, UDS MUST be used, as the classic algorithm used for
+; On FIPS-based systems, TCP CANNOT be used, as the classic algorithm used for
 ; VNC password files is no longer considered secure by FIPS
+;
+; The default value is 0 on non-FIPS systems, and 1 on FIPS-based systems.
 #code=0
 #xserverbpp=24
 #delay_ms=2000

--- a/xrdp/xrdp.ini.in
+++ b/xrdp/xrdp.ini.in
@@ -261,6 +261,20 @@ username=ask
 password=ask
 ip=127.0.0.1
 port=-1
+; For Xvnc, the 'code' parameter can be used to switch the connection
+; protocol:-
+; 0 - Use a TCP connection (default)
+; 1 - Use a Unix Domain Sockets (UDS) connection.
+;     UDS connections are not supported by older VNC servers, but are
+;     supported by TigerVNC. If you select this option, comment out
+;     (or remove) the 'ip=' setting.
+;
+; UDS connections are recommended, if your X server supports them. They are
+; more secure, and untroubled by firewalls.
+;
+; On FIPS-based systems, UDS MUST be used, as the classic algorithm used for
+; VNC password files is no longer considered secure by FIPS
+#code=0
 #xserverbpp=24
 #delay_ms=2000
 ; Disable requested encodings to support buggy VNC servers

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -3239,13 +3239,30 @@ xrdp_mm_user_session_connect(struct xrdp_mm *self)
 void
 xrdp_mm_connect(struct xrdp_mm *self)
 {
+    const char *p;
     const char *port = xrdp_mm_get_value(self, "port");
     const char *gw_username = xrdp_mm_get_value(self, "pamusername");
 
     /* make sure we start in correct state */
     cleanup_states(self);
 
-    self->code = xrdp_mm_get_value_int(self, "code", 0);
+    /*
+     * Standard VNC sessions cannot be supported in FIPS mode, so
+     * don't default to this session type */
+    if ((p = xrdp_mm_get_value(self, "code")) != NULL)
+    {
+        self->code = g_atoi(p);
+    }
+    else if (g_fips_mode_enabled())
+    {
+        LOG(LOG_LEVEL_INFO, "FIPS: defaulting to a VNC session over UDS");
+        self->code = XVNC_UDS_SESSION_CODE;
+    }
+    else
+    {
+        LOG(LOG_LEVEL_INFO, "non-FIPS: defaulting to a VNC session over TCP");
+        self->code = XVNC_SESSION_CODE;
+    }
 
     /* Look at our module parameters to decide if we need to connect
      * to sesman or not */

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -283,6 +283,10 @@ xrdp_mm_create_session(struct xrdp_mm *self)
             type = SCP_SESSION_TYPE_XVNC;
             break;
 
+        case XVNC_UDS_SESSION_CODE:
+            type = SCP_SESSION_TYPE_XVNC_UDS;
+            break;
+
         case  XORG_SESSION_CODE:
             type = SCP_SESSION_TYPE_XORG;
             break;
@@ -509,7 +513,8 @@ xrdp_mm_setup_mod2(struct xrdp_mm *self)
             {
                 g_snprintf(text, sizeof(text), "%d", 5900 + self->display);
             }
-            else if (self->code == XORG_SESSION_CODE)
+            else if (self->code == XORG_SESSION_CODE ||
+                     self->code == XVNC_UDS_SESSION_CODE)
             {
                 g_snprintf(text, sizeof(text), XRDP_X11RDP_STR,
                            self->uid, self->display);
@@ -3250,11 +3255,11 @@ xrdp_mm_connect(struct xrdp_mm *self)
         self->use_sesman = 1;
         /* Connecting to a remote sesman is no longer supported. For purely
          * local session types, this setting could be removed.
-         * The 'ip' value is still used for Xvnc sessions, to find the TCP
-         * address that the X server is listening on */
+         * The 'ip' value is still used for non-UDS Xvnc sessions, to find
+         * the TCP address that the X server is listening on */
         if (xrdp_mm_get_value(self, "ip") != NULL)
         {
-            if (self->code == XORG_SESSION_CODE)
+            if (self->code != XVNC_SESSION_CODE)
             {
                 xrdp_wm_log_msg(self->wm,
                                 LOG_LEVEL_WARNING,

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -37,10 +37,13 @@
 
 /* Code values used in 'xrdp_mm->code=' settings */
 #define XVNC_SESSION_CODE 0
+#define XVNC_UDS_SESSION_CODE 1
 #define XORG_SESSION_CODE 20
 
 /* To check whether touch events has been implemented on session type 'mm' */
-#define XRDP_MM_IMPLEMENTS_TOUCH(mm) ((mm)->code != XVNC_SESSION_CODE)
+#define XRDP_MM_IMPLEMENTS_TOUCH(mm) \
+    (((mm)->code != XVNC_SESSION_CODE) && \
+     ((mm)->code != XVNC_UDS_SESSION_CODE))
 
 struct source_info;
 struct list16;

--- a/xup/xup.c
+++ b/xup/xup.c
@@ -324,7 +324,8 @@ lib_mod_connect(struct mod *mod)
     }
     else
     {
-        mod->server_msg(mod, "connection problem, giving up", 0);
+        LOG(LOG_LEVEL_ERROR, "Error connecting to X server [%s]",
+            g_get_strerror());
     }
 
     if (error == 0)


### PR DESCRIPTION
Fixes #2518 

~~Currently draft, as more testing required.~~

This PR adds the following
1) support for VNC servers which can be contacted by a VNC viewer over a Unix Domain Socket (UDS).
2) A new sesman session type, which is a VNC session using a UDS connection. This session type requires the Xvnc server to support the `-rfbunixpath`, `-rfbunixmode` and `-SecurityTypes` parameters. Currently known supported X servers are TigerVNC and TurboVNC.
3) FIPS detection and support (see below)

When sesman creates a VNC-over-UDS session, the same UDS socket name is used as would be used for an Xorg session. The socket protections are the same, in that the socket can only be accessed by the authenticated user and the xrdp daemon user.

## FIPS support
This PR provides a way for xrdp to support FIPS_based deployments using VNC - the classic VNC password algorithm is not supported by FIPS. This is primarily a problem with RHEL and derivatives with FIPS mode enabled, as these default to VNC as the xrdp backend.

FIPS-based systems are detected at run-time. The following changes are made:-
1) The default session type is changed from VNC-over-TCP to VNC-over-UDS.
2) The DES3-based encryption algorithm used by the VNC-over-TCP session is explicitly disabled to prevent authentication material protected by DES3 being written to disk. This should not be allowed if FIPS is enabled.

I've tested this on AlmaLinux 9.5 with FIPS mode enabled. If there's anyone out there willing to test this as well, I'd be grateful. I can build and sign test RPMs for anyone who can take me up on this offer.

@metalefty - this could be back-ported to v0.10.x fairly easily. For devel, I'm wondering if we should make VNC-over-UDS the default session type when a VNC backend is chosen.