### PR TITLE
Fix coverity warning concerning unchecked return

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -4294,7 +4294,8 @@ g_fips_mode_enabled(void)
 
     if (fd >= 0)
     {
-        if (read(fd, buff, sizeof(buff)) > 0)
+        ssize_t res = read(fd, buff, sizeof(buff));
+        if (res > 0 && (size_t)res < sizeof(buff))
         {
             rv = (buff[0] != '0');
         }


### PR DESCRIPTION
Follow on from #3452 

Coverity insists the return value from read() is unchecked. This seems to not be true to me, but adding a complete sanity check seems to fix it.