### PR TITLE
Add a '-y' switch to apt-get upgrade

### DIFF
--- a/scripts/install_xrdp_build_dependencies_with_apt.sh
+++ b/scripts/install_xrdp_build_dependencies_with_apt.sh
@@ -107,7 +107,7 @@ in
                 ;;
         esac
         apt-get update
-        apt-get upgrade
+        apt-get -y upgrade
         ;;
 
     i386)


### PR DESCRIPTION
Minor fix suggested by @Zeor-Xain [here](https://github.com/neutrinolabs/xrdp/pull/3447#issuecomment-2744339069)