### PR TITLE
Add support for strlcpy()

### DIFF
--- a/common/string_calls.c
+++ b/common/string_calls.c
@@ -15,6 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
+ * The strlcpy implementation is taken from OpenBSD and reformatted. The
+ * original has the following notice attached:-
+ * |
+ * |   Copyright (c) 1998, 2015 Todd C. Miller <millert@openbsd.org>
+ * |
+ * |   Permission to use, copy, modify, and distribute this software for any
+ * |   purpose with or without fee is hereby granted, provided that the above
+ * |   copyright notice and this permission notice appear in all copies.
+ * |
+ * |   THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * |   WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * |   MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * |   ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * |   WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * |   ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * |   OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.*
+ *
  * generic string handling calls
  */
 
@@ -447,6 +464,42 @@ g_atoix(const char *str)
     //coverity[OVERRUN:FALSE]
     return strtol(str, NULL, base);
 }
+
+/*****************************************************************************/
+#if !defined(HAVE_STRLCPY)
+size_t strlcpy(char *dst, const char *src, size_t dsize)
+{
+    const char *osrc = src;
+    size_t nleft = dsize;
+
+    /* Copy as many bytes as will fit. */
+    if (nleft != 0)
+    {
+        while (--nleft != 0)
+        {
+            if ((*dst++ = *src++) == '\0')
+            {
+                break;
+            }
+        }
+    }
+
+    /* Not enough room in dst, add NUL and traverse rest of src. */
+    if (nleft == 0)
+    {
+        if (dsize != 0)
+        {
+            *dst = '\0';        /* NUL-terminate dst */
+        }
+        while (*src++)
+        {
+            ;
+        }
+    }
+
+    return (src - osrc - 1);      /* count does not include NUL */
+}
+#endif
 
 /*****************************************************************************/
 int

--- a/common/string_calls.h
+++ b/common/string_calls.h
@@ -296,6 +296,11 @@ int      g_strcasecmp(const char *c1, const char *c2);
 int      g_strncasecmp(const char *c1, const char *c2, int len);
 int      g_atoi(const char *str);
 
+/* Non-standard but useful functions */
+#if !defined(HAVE_STRLCPY)
+size_t   strlcpy(char *dst, const char *src, size_t dsize);
+#endif
+
 /**
  * Extends g_atoi(), Converts decimal and hexadecimal number String to integer
  *

--- a/configure.ac
+++ b/configure.ac
@@ -238,7 +238,7 @@ AM_COND_IF([DEVEL_DEBUG],
 AC_SEARCH_LIBS([setusercontext], [util])
 
 # Define HAVE_XXXXX macros for some system functions
-AC_CHECK_FUNCS([setusercontext getgrouplist clearenv])
+AC_CHECK_FUNCS([setusercontext getgrouplist clearenv strlcpy])
 
 # The type used by getgrouplist() is the same type used by getgroups()
 AC_TYPE_GETGROUPS


### PR DESCRIPTION
Too many places in xrdp use strncpy() to copy strings to fixed-length buffers, when this is not the correct function to use.

This PR makes sure strlcpy() from the BSDs is available as a saner alternative. This function is available by default on Linux and FreeBSD.

At the moment I don't intend for this to be back-ported to v0.10.x, but as it's a standalone function this can be done in the future if necessary.

**Edit:** On Linux this function was only added for glibc 2.38 (2024-07-31). When building on Ubuntu 24.04 and later, the glibc version of the function is used. When building on 22.04, the fallback function is used. The function is available in libbsd on the older platform, but the implementation is virtually identical:-

https://gitlab.freedesktop.org/libbsd/libbsd/-/blob/main/src/strlcpy.c

*This function is somewhat controversial* - here are some discussions about it:-

https://lwn.net/Articles/507319/
https://lwn.net/Articles/612244/
https://lwn.net/Articles/905777/

My own opinion is that given the style xrdp is written in `strlcpy()` is a better choice than `g_strncpy()` for most calls.

Given the controversy, comments would be very welcome on this!