### PR TITLE
[V0.10] Add support for 16-bit layout fallback for xorgxrdp

### DIFF
--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -364,6 +364,26 @@ xrdp_load_keyboard_layout(struct xrdp_client_info *client_info)
                 break;
             }
         }
+        if (rdp_layout[0] == '\0' && (client_info->keylayout & ~0xffff) != 0)
+        {
+            // We failed to match the layout, but we may be able
+            // to match on the lower 16-bits
+            int alt_layout = client_info->keylayout & 0xffff;
+            for (index = 0; index < items->count; index++)
+            {
+                item = (char *)list_get_item(items, index);
+                value = (char *)list_get_item(values, index);
+                int rdp_layout_id = g_htoi(value);
+                if (rdp_layout_id == alt_layout)
+                {
+                    g_strncpy(rdp_layout, item, 255);
+                    LOG(LOG_LEVEL_INFO,
+                        "Failed to match layout %08X, but matched %04X to %s",
+                        client_info->keylayout, alt_layout, rdp_layout);
+                    break;
+                }
+            }
+        }
         list_clear(items);
         list_clear(values);
         file_read_section(fd, section_layouts_map, items, values);


### PR DESCRIPTION
Keyboard layout values from the client such as 00010416 (Brazil ABNT2) may not have a matching entry in xrdp_keyboard.ini. For these clients, we map a US keyboard as a fallback.

Before falling back to US, we should first try to match on the lower 16-bits of the layout, which in this case is 0416 (ABNT). This is more likely to result in something usable.

We already implement this functionality for the keyboard files used by the login screen and VNC back-end.

(cherry picked from commit c8f5888e632ec284a1882884c7c30e4b55c1e85d)