### PR TITLE
Refactor struct xrdp_client_info

### DIFF
--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -18,7 +18,6 @@
  * xrdp / xserver info / caps
  */
 
-#include "xrdp_constants.h"
 #include "ms-rdpbcgr.h"
 
 #if !defined(XRDP_CLIENT_INFO_H)
@@ -50,14 +49,6 @@ struct monitor_info
     unsigned int is_primary;
 };
 
-/* xrdp keyboard overrids */
-struct xrdp_keyboard_overrides
-{
-    int type;
-    int subtype;
-    int layout;
-};
-
 struct display_size_description
 {
     unsigned int monitorCount; /* 2.2.2.2 DISPLAYCONTROL_MONITOR_LAYOUT_PDU: number of monitors detected (max = 16) */
@@ -65,13 +56,6 @@ struct display_size_description
     struct monitor_info minfo_wm[CLIENT_MONITOR_DATA_MAXIMUM_MONITORS]; /* client monitor data, non-negative values */
     unsigned int session_width;
     unsigned int session_height;
-};
-
-enum client_resize_mode
-{
-    CRMODE_NONE,
-    CRMODE_SINGLE_SCREEN,
-    CRMODE_MULTI_SCREEN
 };
 
 enum xrdp_capture_code
@@ -85,115 +69,29 @@ enum xrdp_capture_code
 };
 
 /**
- * Type describing Unicode input state
- */
-enum unicode_input_state
-{
-    UIS_UNSUPPORTED = 0, ///< Client does not support Unicode
-    UIS_SUPPORTED,       ///< Client supports Unicode, but it's not active
-    UIS_ACTIVE           ///< Unicode input is active
-};
-/**
  * Information about the xrdp client
  *
  * @note This structure is shared with xorgxrdp. If you change anything
- *       above the 'private to xrdp below this line' comment, you MUST
- *       bump the CLIENT_INFO_CURRENT_VERSION number so that the mismatch
- *       can be detected.
+ *       in this structure, you MUST bump the CLIENT_INFO_CURRENT_VERSION
+ *       number so that the mismatch can be detected.
  */
 struct xrdp_client_info
 {
     int size; /* bytes for this structure */
     int version; /* Should be CLIENT_INFO_CURRENT_VERSION */
     int bpp;
-    /* bitmap cache info */
-    int cache1_entries;
-    int cache1_size;
-    int cache2_entries;
-    int cache2_size;
-    int cache3_entries;
-    int cache3_size;
-    int bitmap_cache_persist_enable; /* 0 or 2 */
-    int bitmap_cache_version; /* ored 1 = original version, 2 = v2, 4 = v3 */
-    /* pointer info */
-    int pointer_cache_entries;
-    /* other */
-    int use_bitmap_comp;
-    int use_bitmap_cache;
-    int op1; /* use smaller bitmap header, non cache */
-    int op2; /* use smaller bitmap header in bitmap cache */
-    int desktop_cache;
-    int use_compact_packets; /* rdp5 smaller packets */
-    char hostname[32];
-    int build;
-    int keylayout;
-    char username[INFO_CLIENT_MAX_CB_LEN];
-    char password[INFO_CLIENT_MAX_CB_LEN];
-    char domain[INFO_CLIENT_MAX_CB_LEN];
-    char program[INFO_CLIENT_MAX_CB_LEN];
-    char directory[INFO_CLIENT_MAX_CB_LEN];
-    int rdp_compression;
-    int rdp_autologin;
-    int crypt_level; /* 1, 2, 3 = low, medium, high */
-    int channels_allowed; /* 0 = no channels 1 = channels */
-    int sound_code; /* 1 = leave sound at server */
-    int is_mce;
-    int rdp5_performanceflags;
-    int brush_cache_code; /* 0 = no cache 1 = 8x8 standard cache
-                           2 = arbitrary dimensions */
-
-    int max_bpp;
     int jpeg; /* non standard bitmap cache v2 cap */
     int offscreen_support_level;
     int offscreen_cache_size;
     int offscreen_cache_entries;
-    int rfx;
 
-    /* CAPSETTYPE_RAIL */
-    int rail_support_level;
-    /* CAPSETTYPE_WINDOW */
-    int wnd_support_level;
-    int wnd_num_icon_caches;
-    int wnd_num_icon_cache_entries;
-    /* codecs */
-    int rfx_codec_id;
-    int rfx_prop_len;
-    char rfx_prop[64];
-    int ns_codec_id;
-    int ns_prop_len;
-    char ns_prop[64];
-    int jpeg_codec_id;
-    int jpeg_prop_len;
-    char jpeg_prop[64];
-    int v3_codec_id;
-    int rfx_min_pixel;
     char orders[32];
     int order_flags_ex;
-    int use_bulk_comp;
     int pointer_flags; /* 0 color, 1 new, 2 no new */
-    int use_fast_path;
-    int require_credentials; /* when true, credentials *must* be passed on cmd line */
-
-    int security_layer; /* 0 = rdp, 1 = tls , 2 = hybrid */
-    int multimon; /* 0 = deny , 1 = allow */
     struct display_size_description display_sizes;
 
-    int keyboard_type;
-    int keyboard_subtype;
-
-    int png_codec_id;
-    int png_prop_len;
-    char png_prop[64];
-    int vendor_flags[4];
-    int mcs_connection_type;
-    int mcs_early_capability_flags;
-
-    int max_fastpath_frag_bytes;
-    int pad0; /* unused */
+    enum xrdp_capture_code capture_code;
     int capture_format;
-
-    char certificate[1024];
-    char key_file[1024];
 
     /* X11 keyboard layout - inferred from keyboard type/subtype */
     char model[16];
@@ -211,55 +109,7 @@ struct xrdp_client_info
     int h264_frame_interval;
     int normal_frame_interval;
 
-    /* ==================================================================== */
-    /* Private to xrdp below this line */
-    /* ==================================================================== */
-
-    /* codec */
-    int h264_codec_id;
-    int h264_prop_len;
-    char h264_prop[64];
-
-    int use_frame_acks;
-    int max_unacknowledged_frame_count;
-
-    long ssl_protocols;
-    char *tls_ciphers;
-
-    char client_ip[MAX_PEER_ADDRSTRLEN];
-    char client_description[MAX_PEER_DESCSTRLEN];
-
-    int client_os_major;
-    int client_os_minor;
-
-    int no_orders_supported;
-    int use_cache_glyph_v2;
-    int rail_enable;
-    // Mask of reasons why output may be suppressed
-    // (see enum suppress_output_reason)
-    unsigned int suppress_output_mask;
-
-    int enable_token_login;
-    char domain_user_separator[16];
-
-    /* xrdp.override_* values */
-    struct xrdp_keyboard_overrides xrdp_keyboard_overrides;
-
-    /* These values are optionally send over as part of TS_UD_CS_CORE.
-     * They can be used as a fallback for a single monitor session
-     * if physical sizes are not available in the monitor-specific
-     * data */
-    unsigned int session_physical_width; /* in mm */
-    unsigned int session_physical_height; /* in mm */
-
     int large_pointer_support_flags;
-    int gfx;
-
-    // Can we resize the desktop by using a Deactivation-Reactivation Sequence?
-    enum client_resize_mode client_resize_mode;
-
-    enum unicode_input_state unicode_input_support;
-    enum xrdp_capture_code capture_code;
 };
 
 enum xrdp_encoder_flags
@@ -271,14 +121,8 @@ enum xrdp_encoder_flags
     KEY_FRAME_REQUESTED                    = 1 << 3
 };
 
-/*
- * Return true if output is suppressed for a particular reason
- */
-#define OUTPUT_SUPPRESSED_FOR_REASON(ci,reason) \
-    (((ci)->suppress_output_mask & (unsigned int)reason) != 0)
-
 /* yyyymmdd of last incompatible change to xrdp_client_info */
 /* also used for changes to all the xrdp installed headers */
-#define CLIENT_INFO_CURRENT_VERSION 20241118
+#define CLIENT_INFO_CURRENT_VERSION 20250403
 
 #endif

--- a/common/xrdp_client_info_all.h
+++ b/common/xrdp_client_info_all.h
@@ -1,0 +1,193 @@
+/**
+ * xrdp: A Remote Desktop Protocol server.
+ *
+ * Copyright (C) Jay Sorg 2004-2014
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * xrdp / xserver info / caps
+ */
+
+#include "xrdp_client_info.h"
+#include "xrdp_constants.h"
+
+#if !defined(XRDP_CLIENT_INFO_ALL_H)
+#define XRDP_CLIENT_INFO_ALL_H
+
+/* xrdp keyboard overrides */
+struct xrdp_keyboard_overrides
+{
+    int type;
+    int subtype;
+    int layout;
+};
+
+enum client_resize_mode
+{
+    CRMODE_NONE,
+    CRMODE_SINGLE_SCREEN,
+    CRMODE_MULTI_SCREEN
+};
+
+/**
+ * Type describing Unicode input state
+ */
+enum unicode_input_state
+{
+    UIS_UNSUPPORTED = 0, ///< Client does not support Unicode
+    UIS_SUPPORTED,       ///< Client supports Unicode, but it's not active
+    UIS_ACTIVE           ///< Unicode input is active
+};
+/**
+ * Information about the xrdp client
+ *
+ * @note This structure is shared with xorgxrdp. If you change anything
+ *       above the 'private to xrdp below this line' comment, you MUST
+ *       bump the CLIENT_INFO_CURRENT_VERSION number so that the mismatch
+ *       can be detected.
+ */
+struct xrdp_client_info_all
+{
+    struct xrdp_client_info pub; // Information shared with xorgxrdp
+
+    /* bitmap cache info */
+    int cache1_entries;
+    int cache1_size;
+    int cache2_entries;
+    int cache2_size;
+    int cache3_entries;
+    int cache3_size;
+    int bitmap_cache_persist_enable; /* 0 or 2 */
+    int bitmap_cache_version; /* ored 1 = original version, 2 = v2, 4 = v3 */
+    /* pointer info */
+    int pointer_cache_entries;
+    /* other */
+    int use_bitmap_comp;
+    int use_bitmap_cache;
+    int op1; /* use smaller bitmap header, non cache */
+    int op2; /* use smaller bitmap header in bitmap cache */
+    int desktop_cache;
+    int use_compact_packets; /* rdp5 smaller packets */
+    char hostname[32];
+    int build;
+    int keylayout;
+    char username[INFO_CLIENT_MAX_CB_LEN];
+    char password[INFO_CLIENT_MAX_CB_LEN];
+    char domain[INFO_CLIENT_MAX_CB_LEN];
+    char program[INFO_CLIENT_MAX_CB_LEN];
+    char directory[INFO_CLIENT_MAX_CB_LEN];
+    int rdp_compression;
+    int rdp_autologin;
+    int crypt_level; /* 1, 2, 3 = low, medium, high */
+    int channels_allowed; /* 0 = no channels 1 = channels */
+    int sound_code; /* 1 = leave sound at server */
+    int is_mce;
+    int rdp5_performanceflags;
+    int brush_cache_code; /* 0 = no cache 1 = 8x8 standard cache
+                           2 = arbitrary dimensions */
+
+    int max_bpp;
+    int rfx;
+
+    /* CAPSETTYPE_RAIL */
+    int rail_support_level;
+    /* CAPSETTYPE_WINDOW */
+    int wnd_support_level;
+    int wnd_num_icon_caches;
+    int wnd_num_icon_cache_entries;
+    /* codecs */
+    int rfx_codec_id;
+    int rfx_prop_len;
+    char rfx_prop[64];
+    int ns_codec_id;
+    int ns_prop_len;
+    char ns_prop[64];
+    int jpeg_codec_id;
+    int jpeg_prop_len;
+    char jpeg_prop[64];
+    int v3_codec_id;
+    int rfx_min_pixel;
+    int use_bulk_comp;
+    int use_fast_path;
+    int require_credentials; /* when true, credentials *must* be passed on cmd line */
+
+    int security_layer; /* 0 = rdp, 1 = tls , 2 = hybrid */
+    int multimon; /* 0 = deny , 1 = allow */
+
+    int keyboard_type;
+    int keyboard_subtype;
+
+    int png_codec_id;
+    int png_prop_len;
+    char png_prop[64];
+    int vendor_flags[4];
+    int mcs_connection_type;
+    int mcs_early_capability_flags;
+
+    int max_fastpath_frag_bytes;
+
+    char certificate[1024];
+    char key_file[1024];
+
+    /* codec */
+    int h264_codec_id;
+    int h264_prop_len;
+    char h264_prop[64];
+
+    int use_frame_acks;
+    int max_unacknowledged_frame_count;
+
+    long ssl_protocols;
+    char *tls_ciphers;
+
+    char client_ip[MAX_PEER_ADDRSTRLEN];
+    char client_description[MAX_PEER_DESCSTRLEN];
+
+    int client_os_major;
+    int client_os_minor;
+
+    int no_orders_supported;
+    int use_cache_glyph_v2;
+    int rail_enable;
+    // Mask of reasons why output may be suppressed
+    // (see enum suppress_output_reason)
+    unsigned int suppress_output_mask;
+
+    int enable_token_login;
+    char domain_user_separator[16];
+
+    /* xrdp.override_* values */
+    struct xrdp_keyboard_overrides xrdp_keyboard_overrides;
+
+    /* These values are optionally send over as part of TS_UD_CS_CORE.
+     * They can be used as a fallback for a single monitor session
+     * if physical sizes are not available in the monitor-specific
+     * data */
+    unsigned int session_physical_width; /* in mm */
+    unsigned int session_physical_height; /* in mm */
+
+    int gfx;
+
+    // Can we resize the desktop by using a Deactivation-Reactivation Sequence?
+    enum client_resize_mode client_resize_mode;
+
+    enum unicode_input_state unicode_input_support;
+};
+
+/*
+ * Return true if output is suppressed for a particular reason
+ */
+#define OUTPUT_SUPPRESSED_FOR_REASON(ci,reason) \
+    (((ci)->suppress_output_mask & (unsigned int)reason) != 0)
+
+#endif

--- a/libxrdp/libxrdp.c
+++ b/libxrdp/libxrdp.c
@@ -291,7 +291,7 @@ libxrdp_send_palette(struct xrdp_session *session, int *palette)
     int color = 0;
     struct stream *s = (struct stream *)NULL;
 
-    if (session->client_info->bpp > 8)
+    if (session->client_info->pub.bpp > 8)
     {
         return 0;
     }
@@ -750,7 +750,7 @@ libxrdp_send_pointer(struct xrdp_session *session, int cache_idx,
         height = 32;
     }
     /* error check */
-    if ((session->client_info->pointer_flags & 1) == 0)
+    if ((session->client_info->pub.pointer_flags & 1) == 0)
     {
         if (bpp != 24)
         {
@@ -781,7 +781,7 @@ libxrdp_send_pointer(struct xrdp_session *session, int cache_idx,
             return 1;
         }
 
-        if ((session->client_info->pointer_flags & 1) != 0)
+        if ((session->client_info->pub.pointer_flags & 1) != 0)
         {
             out_uint16_le(s, bpp); /* TS_FP_POINTERATTRIBUTE -> newPointerUpdateData.xorBpp */
         }
@@ -790,7 +790,7 @@ libxrdp_send_pointer(struct xrdp_session *session, int cache_idx,
     {
         LOG_DEVEL(LOG_LEVEL_DEBUG, "libxrdp_send_pointer: slowpath");
         xrdp_rdp_init_data((struct xrdp_rdp *)session->rdp, s);
-        if ((session->client_info->pointer_flags & 1) == 0)
+        if ((session->client_info->pub.pointer_flags & 1) == 0)
         {
             out_uint16_le(s, RDP_POINTER_COLOR);
             out_uint16_le(s, 0); /* pad */
@@ -869,7 +869,7 @@ libxrdp_send_pointer(struct xrdp_session *session, int cache_idx,
     s_mark_end(s);
     if (session->client_info->use_fast_path & 1) /* fastpath output supported */
     {
-        if ((session->client_info->pointer_flags & 1) == 0)
+        if ((session->client_info->pub.pointer_flags & 1) == 0)
         {
             LOG_DEVEL(LOG_LEVEL_TRACE, "Sending [MS-RDPBCGR] TS_FP_COLORPOINTERATTRIBUTE "
                       "cachedPointerUpdateData = { cacheIndex %d, "
@@ -907,7 +907,7 @@ libxrdp_send_pointer(struct xrdp_session *session, int cache_idx,
     }
     else
     {
-        if ((session->client_info->pointer_flags & 1) == 0)
+        if ((session->client_info->pub.pointer_flags & 1) == 0)
         {
             LOG_DEVEL(LOG_LEVEL_TRACE, "Sending [MS-RDPBCGR] TS_COLORPOINTERATTRIBUTE "
                       "cacheIndex %d, "

--- a/libxrdp/libxrdp.h
+++ b/libxrdp/libxrdp.h
@@ -32,7 +32,7 @@
 #include "log.h"
 #include "file.h"
 #include "libxrdpinc.h"
-#include "xrdp_client_info.h"
+#include "xrdp_client_info_all.h"
 #include "log.h"
 
 
@@ -165,7 +165,7 @@ struct xrdp_rdp
     struct xrdp_sec *sec_layer;
     int share_id;
     int mcs_channel;
-    struct xrdp_client_info client_info;
+    struct xrdp_client_info_all client_info;
     struct xrdp_mppc_enc *mppc_enc;
     void *rfx_enc;
 };

--- a/libxrdp/libxrdpinc.h
+++ b/libxrdp/libxrdpinc.h
@@ -72,7 +72,7 @@ struct xrdp_session
     int check_for_app_input;
     void *rdp;
     void *orders;
-    struct xrdp_client_info *client_info;
+    struct xrdp_client_info_all *client_info;
     int up_and_running;
     int (*is_term)(void);
     int in_process_data; /* inc / dec libxrdp_process_data calls */

--- a/libxrdp/xrdp_caps.c
+++ b/libxrdp/xrdp_caps.c
@@ -59,7 +59,7 @@ xrdp_caps_send_monitorlayout(struct xrdp_rdp *self)
         return 1;
     }
 
-    description = &self->client_info.display_sizes;
+    description = &self->client_info.pub.display_sizes;
 
     out_uint32_le(s, description->monitorCount); /* monitorCount (4 bytes) */
 
@@ -186,7 +186,7 @@ xrdp_caps_process_order(struct xrdp_rdp *self, struct stream *s,
     in_uint8s(s, 2); /* Number of fonts */
     in_uint16_le(s, cap_flags); /* Capability flags */
     in_uint8a(s, order_caps, 32); /* Orders supported */
-    g_memcpy(self->client_info.orders, order_caps, 32);
+    g_memcpy(self->client_info.pub.orders, order_caps, 32);
 
     LOG_DEVEL(LOG_LEVEL_TRACE, "TS_ORDER_CAPABILITYSET: terminalDescriptor (ignored as per protocol spec)");
     LOG_DEVEL(LOG_LEVEL_TRACE, "TS_ORDER_CAPABILITYSET: desktopSaveXGranularity (ignored as per protocol spec)");
@@ -230,7 +230,7 @@ xrdp_caps_process_order(struct xrdp_rdp *self, struct stream *s,
 
     if (cap_flags & 0x80) /* ORDER_FLAGS_EXTRA_SUPPORT */
     {
-        self->client_info.order_flags_ex = ex_flags;
+        self->client_info.pub.order_flags_ex = ex_flags;
         if (ex_flags & XR_ORDERFLAGS_EX_CACHE_BITMAP_REV3_SUPPORT)
         {
             LOG_DEVEL(LOG_LEVEL_INFO, "Client Capability: bitmap cache v3 supported");
@@ -315,7 +315,7 @@ xrdp_caps_process_bmpcache2(struct xrdp_rdp *self, struct stream *s,
         return 1;
     }
     self->client_info.bitmap_cache_version |= 2;
-    Bpp = (self->client_info.bpp + 7) / 8;
+    Bpp = (self->client_info.pub.bpp + 7) / 8;
     in_uint16_le(s, i); /* cache flags */
     self->client_info.bitmap_cache_persist_enable = i;
     in_uint8s(s, 2); /* number of caches in set, 3 */
@@ -379,9 +379,9 @@ xrdp_caps_process_pointer(struct xrdp_rdp *self, struct stream *s,
         LOG(LOG_LEVEL_ERROR, "xrdp_caps_process_pointer: error");
         return 1;
     }
-    no_new_cursor = self->client_info.pointer_flags & 2;
+    no_new_cursor = self->client_info.pub.pointer_flags & 2;
     in_uint16_le(s, colorPointerFlag);
-    self->client_info.pointer_flags = colorPointerFlag;
+    self->client_info.pub.pointer_flags = colorPointerFlag;
     in_uint16_le(s, i);
     i = MIN(i, 32);
     self->client_info.pointer_cache_entries = i;
@@ -402,7 +402,7 @@ xrdp_caps_process_pointer(struct xrdp_rdp *self, struct stream *s,
     {
         LOG(LOG_LEVEL_INFO, "xrdp_caps_process_pointer: new(color) cursor is "
             "disabled by config");
-        self->client_info.pointer_flags = 0;
+        self->client_info.pub.pointer_flags = 0;
     }
     return 0;
 }
@@ -504,16 +504,16 @@ xrdp_caps_process_offscreen_bmpcache(struct xrdp_rdp *self, struct stream *s,
         return 1;
     }
     in_uint32_le(s, i32);
-    self->client_info.offscreen_support_level = i32;
+    self->client_info.pub.offscreen_support_level = i32;
     in_uint16_le(s, i32);
-    self->client_info.offscreen_cache_size = i32 * 1024;
+    self->client_info.pub.offscreen_cache_size = i32 * 1024;
     in_uint16_le(s, i32);
-    self->client_info.offscreen_cache_entries = i32;
+    self->client_info.pub.offscreen_cache_entries = i32;
     LOG(LOG_LEVEL_INFO, "xrdp_process_offscreen_bmpcache: support level %d "
         "cache size %d bytes cache entries %d",
-        self->client_info.offscreen_support_level,
-        self->client_info.offscreen_cache_size,
-        self->client_info.offscreen_cache_entries);
+        self->client_info.pub.offscreen_support_level,
+        self->client_info.pub.offscreen_cache_size,
+        self->client_info.pub.offscreen_cache_entries);
     return 0;
 }
 
@@ -704,7 +704,7 @@ xrdp_caps_process_largepointer(struct xrdp_rdp *self, struct stream *s,
     int largePointerSupportFlags;
 
     in_uint16_le(s, largePointerSupportFlags);
-    self->client_info.large_pointer_support_flags = largePointerSupportFlags;
+    self->client_info.pub.large_pointer_support_flags = largePointerSupportFlags;
     return 0;
 }
 
@@ -955,52 +955,52 @@ xrdp_caps_process_confirm_active(struct xrdp_rdp *self, struct stream *s)
     }
 
     if (self->client_info.no_orders_supported &&
-            (self->client_info.offscreen_support_level != 0))
+            (self->client_info.pub.offscreen_support_level != 0))
     {
         LOG(LOG_LEVEL_WARNING, "Client Capability: not enough orders "
             "supported by client, client wants off screen bitmap but "
             "offscreen bitmaps disabled");
-        self->client_info.offscreen_support_level = 0;
-        self->client_info.offscreen_cache_size = 0;
-        self->client_info.offscreen_cache_entries = 0;
+        self->client_info.pub.offscreen_support_level = 0;
+        self->client_info.pub.offscreen_cache_size = 0;
+        self->client_info.pub.offscreen_cache_entries = 0;
     }
 
     if (self->client_info.use_fast_path)
     {
-        if ((self->client_info.large_pointer_support_flags & LARGE_POINTER_FLAG_96x96) &&
+        if ((self->client_info.pub.large_pointer_support_flags & LARGE_POINTER_FLAG_96x96) &&
                 (self->client_info.max_fastpath_frag_bytes < 38055))
         {
             LOG(LOG_LEVEL_WARNING, "Client Capability: client requested "
                 "LARGE_POINTER_FLAG_96x96 but max_fastpath_frag_bytes(%d) is less then "
                 "the required size of 38055, 96x96 large cursor support disabled",
                 self->client_info.max_fastpath_frag_bytes);
-            self->client_info.large_pointer_support_flags &= ~LARGE_POINTER_FLAG_96x96;
+            self->client_info.pub.large_pointer_support_flags &= ~LARGE_POINTER_FLAG_96x96;
         }
-        if ((self->client_info.large_pointer_support_flags & LARGE_POINTER_FLAG_384x384) &&
+        if ((self->client_info.pub.large_pointer_support_flags & LARGE_POINTER_FLAG_384x384) &&
                 (self->client_info.max_fastpath_frag_bytes < 608299))
         {
             LOG(LOG_LEVEL_WARNING, "Client Capability: client requested "
                 "LARGE_POINTER_FLAG_384x384 but max_fastpath_frag_bytes(%d) is less then "
                 "the required size of 608299, 384x384 large cursor support disabled",
                 self->client_info.max_fastpath_frag_bytes);
-            self->client_info.large_pointer_support_flags &= ~LARGE_POINTER_FLAG_384x384;
+            self->client_info.pub.large_pointer_support_flags &= ~LARGE_POINTER_FLAG_384x384;
         }
     }
     else
     {
-        if (self->client_info.large_pointer_support_flags != 0)
+        if (self->client_info.pub.large_pointer_support_flags != 0)
         {
             LOG(LOG_LEVEL_WARNING, "Client Capability: client requested "
                 "large pointers but use_fast_path is false, "
                 "all large cursor support disabled");
-            self->client_info.large_pointer_support_flags = 0;
+            self->client_info.pub.large_pointer_support_flags = 0;
         }
     }
-    if (self->client_info.large_pointer_support_flags & LARGE_POINTER_FLAG_96x96)
+    if (self->client_info.pub.large_pointer_support_flags & LARGE_POINTER_FLAG_96x96)
     {
         LOG(LOG_LEVEL_INFO, "Client Capability: LARGE_POINTER_FLAG_96x96 supported");
     }
-    if (self->client_info.large_pointer_support_flags & LARGE_POINTER_FLAG_384x384)
+    if (self->client_info.pub.large_pointer_support_flags & LARGE_POINTER_FLAG_384x384)
     {
         LOG(LOG_LEVEL_INFO, "Client Capability: LARGE_POINTER_FLAG_384x384 supported");
     }
@@ -1034,8 +1034,8 @@ unsigned int calculate_multifragmentupdate_len(const struct xrdp_rdp *self)
 {
     unsigned int result = MAX_MULTIFRAGMENTUPDATE_SIZE;
 
-    unsigned int x_tiles = (self->client_info.display_sizes.session_width + 63) / 64;
-    unsigned int y_tiles = (self->client_info.display_sizes.session_height + 63) / 64;
+    unsigned int x_tiles = (self->client_info.pub.display_sizes.session_width + 63) / 64;
+    unsigned int y_tiles = (self->client_info.pub.display_sizes.session_height + 63) / 64;
 
     /* Check for overflow on calculation if bad parameters are supplied */
     if ((x_tiles * y_tiles  + 1) < (UINT_MAX / 16384))
@@ -1126,12 +1126,12 @@ xrdp_caps_send_demand_active(struct xrdp_rdp *self)
     caps_count++;
     out_uint16_le(s, CAPSTYPE_BITMAP);
     out_uint16_le(s, CAPSTYPE_BITMAP_LEN);
-    out_uint16_le(s, self->client_info.bpp); /* Preferred BPP */
+    out_uint16_le(s, self->client_info.pub.bpp); /* Preferred BPP */
     out_uint16_le(s, 1); /* Receive 1 BPP */
     out_uint16_le(s, 1); /* Receive 4 BPP */
     out_uint16_le(s, 1); /* Receive 8 BPP */
-    out_uint16_le(s, self->client_info.display_sizes.session_width); /* width */
-    out_uint16_le(s, self->client_info.display_sizes.session_height); /* height */
+    out_uint16_le(s, self->client_info.pub.display_sizes.session_width); /* width */
+    out_uint16_le(s, self->client_info.pub.display_sizes.session_height); /* height */
     out_uint16_le(s, 0); /* Pad */
     out_uint16_le(s, 1); /* Allow resize */
     out_uint16_le(s, 1); /* bitmap compression */
@@ -1402,7 +1402,7 @@ xrdp_caps_send_demand_active(struct xrdp_rdp *self)
     int early_cap_flags = self->client_info.mcs_early_capability_flags;
 
     if ((early_cap_flags & RNS_UD_CS_SUPPORT_MONITOR_LAYOUT_PDU) != 0 &&
-            self->client_info.display_sizes.monitorCount > 0 &&
+            self->client_info.pub.display_sizes.monitorCount > 0 &&
             self->client_info.multimon == 1)
     {
         LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_send_demand_active: sending monitor layout pdu");

--- a/libxrdp/xrdp_iso.c
+++ b/libxrdp/xrdp_iso.c
@@ -110,7 +110,7 @@ xrdp_iso_negotiate_security(struct xrdp_iso *self)
     const char *configured_str = "";
 
     int rv = 0;
-    struct xrdp_client_info *client_info = &(self->mcs_layer->sec_layer->rdp_layer->client_info);
+    struct xrdp_client_info_all *client_info = &(self->mcs_layer->sec_layer->rdp_layer->client_info);
 
     /* Can we do TLS/SSL? (basic check) */
     int ssl_capable = g_file_readable(client_info->certificate) &&

--- a/libxrdp/xrdp_orders.c
+++ b/libxrdp/xrdp_orders.c
@@ -227,7 +227,7 @@ xrdp_orders_check(struct xrdp_orders *self, int max_size)
 {
     int size;
     int max_order_size;
-    struct xrdp_client_info *ci;
+    struct xrdp_client_info_all *ci;
 
     ci = &(self->rdp_layer->client_info);
     max_order_size = MAX_ORDERS_SIZE(ci);
@@ -2242,7 +2242,7 @@ xrdp_orders_send_raw_bitmap(struct xrdp_orders *self,
     int pixel = 0;
     int e = 0;
     int max_order_size;
-    struct xrdp_client_info *ci;
+    struct xrdp_client_info_all *ci;
 
     if (width > 64)
     {
@@ -2368,7 +2368,7 @@ xrdp_orders_send_bitmap(struct xrdp_orders *self,
     struct stream *temp_s = NULL;
     char *p = NULL;
     int max_order_size;
-    struct xrdp_client_info *ci;
+    struct xrdp_client_info_all *ci;
 
     if (width > 64)
     {
@@ -2668,7 +2668,7 @@ xrdp_orders_send_raw_bitmap2(struct xrdp_orders *self,
     int pixel = 0;
     int e = 0;
     int max_order_size;
-    struct xrdp_client_info *ci;
+    struct xrdp_client_info_all *ci;
 
     if (width > 64)
     {
@@ -2796,7 +2796,7 @@ xrdp_orders_send_bitmap2(struct xrdp_orders *self,
     struct stream *temp_s = NULL;
     char *p = NULL;
     int max_order_size;
-    struct xrdp_client_info *ci;
+    struct xrdp_client_info_all *ci;
 
     if (width > 64)
     {
@@ -2974,7 +2974,7 @@ xrdp_orders_send_bitmap3(struct xrdp_orders *self,
                          int width, int height, int bpp, char *data,
                          int cache_id, int cache_idx, int hints)
 {
-    struct xrdp_client_info *ci;
+    struct xrdp_client_info_all *ci;
 #if defined(XRDP_JPEG) || defined(XRDP_NEUTRINORDP)
     int bufsize;
     struct stream *xr_s; /* xrdp stream */

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -39,7 +39,8 @@
 
 /*****************************************************************************/
 static int
-xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
+xrdp_rdp_read_config(const char *xrdp_ini,
+                     struct xrdp_client_info_all *client_info)
 {
     int index = 0;
     struct list *items = (struct list *)NULL;
@@ -135,7 +136,7 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
         }
         else if (g_strcasecmp(item, "new_cursors") == 0)
         {
-            client_info->pointer_flags = g_text2bool(value) == 0 ? 2 : 0;
+            client_info->pub.pointer_flags = g_text2bool(value) == 0 ? 2 : 0;
         }
         else if (g_strcasecmp(item, "require_credentials") == 0)
         {
@@ -389,8 +390,8 @@ xrdp_rdp_create(struct xrdp_session *session, struct trans *trans)
     self->rfx_enc = rfx_context_new();
     rfx_context_set_cpu_opt(self->rfx_enc, xrdp_rdp_detect_cpu());
 #endif
-    self->client_info.size = sizeof(self->client_info);
-    self->client_info.version = CLIENT_INFO_CURRENT_VERSION;
+    self->client_info.pub.size = sizeof(self->client_info.pub);
+    self->client_info.pub.version = CLIENT_INFO_CURRENT_VERSION;
     LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_rdp_create");
     return self;
 }
@@ -1314,8 +1315,8 @@ xrdp_rdp_process_data_font(struct xrdp_rdp *self, struct stream *s)
          * sequence [MS-RDPBCGR] 1.3.1.3 */
         xrdp_rdp_suppress_output(self, 0, XSO_REASON_DEACTIVATE_REACTIVATE,
                                  0, 0,
-                                 self->client_info.display_sizes.session_width,
-                                 self->client_info.display_sizes.session_height);
+                                 self->client_info.pub.display_sizes.session_width,
+                                 self->client_info.pub.display_sizes.session_height);
 
         if (self->session->callback != 0)
         {

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -1490,7 +1490,7 @@ xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec *self, struct stream *s)
     int earlyCapabilityFlags;
 
     UNUSED_VAR(version);
-    struct xrdp_client_info *client_info = &self->rdp_layer->client_info;
+    struct xrdp_client_info_all *client_info = &self->rdp_layer->client_info;
     /* Clear physical sizes. These are optional and may not be read later */
     client_info->session_physical_width = 0;
     client_info->session_physical_height = 0;
@@ -1502,16 +1502,16 @@ xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec *self, struct stream *s)
         return 1;
     }
     in_uint32_le(s, version);
-    in_uint16_le(s, client_info->display_sizes.session_width);
-    in_uint16_le(s, client_info->display_sizes.session_height);
+    in_uint16_le(s, client_info->pub.display_sizes.session_width);
+    in_uint16_le(s, client_info->pub.display_sizes.session_height);
     in_uint16_le(s, colorDepth);
     switch (colorDepth)
     {
         case RNS_UD_COLOR_4BPP:
-            client_info->bpp = 4;
+            client_info->pub.bpp = 4;
             break;
         case RNS_UD_COLOR_8BPP:
-            client_info->bpp = 8;
+            client_info->pub.bpp = 8;
             break;
     }
     in_uint8s(s, 2); /* SASSequence */
@@ -1541,8 +1541,8 @@ xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec *self, struct stream *s)
               "keyboardSubType 0x%8.8x, keyboardFunctionKey (ignored), "
               "imeFileName (ignored)",
               version,
-              client_info->display_sizes.session_width,
-              client_info->display_sizes.session_height,
+              client_info->pub.display_sizes.session_width,
+              client_info->pub.display_sizes.session_height,
               (colorDepth == RNS_UD_COLOR_4BPP ? "RNS_UD_COLOR_4BPP" :
                colorDepth == RNS_UD_COLOR_8BPP ? "RNS_UD_COLOR_8BPP" :
                "unknown"),
@@ -1570,19 +1570,19 @@ xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec *self, struct stream *s)
     switch (postBeta2ColorDepth)
     {
         case RNS_UD_COLOR_4BPP:
-            client_info->bpp = 4;
+            client_info->pub.bpp = 4;
             break;
         case RNS_UD_COLOR_8BPP :
-            client_info->bpp = 8;
+            client_info->pub.bpp = 8;
             break;
         case RNS_UD_COLOR_16BPP_555:
-            client_info->bpp = 15;
+            client_info->pub.bpp = 15;
             break;
         case RNS_UD_COLOR_16BPP_565:
-            client_info->bpp = 16;
+            client_info->pub.bpp = 16;
             break;
         case RNS_UD_COLOR_24BPP:
-            client_info->bpp = 24;
+            client_info->pub.bpp = 24;
             break;
     }
     if (!s_check_rem(s, 2))
@@ -1614,7 +1614,7 @@ xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec *self, struct stream *s)
               highColorDepth == 0x0010 ? "HIGH_COLOR_16BPP" :
               highColorDepth == 0x0018 ? "HIGH_COLOR_24BPP" :
               "unknown");
-    client_info->bpp = highColorDepth;
+    client_info->pub.bpp = highColorDepth;
 
     if (!s_check_rem(s, 2))
     {
@@ -1645,12 +1645,12 @@ xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec *self, struct stream *s)
     if ((earlyCapabilityFlags & RNS_UD_CS_WANT_32BPP_SESSION)
             && (supportedColorDepths & RNS_UD_32BPP_SUPPORT))
     {
-        client_info->bpp = 32;
+        client_info->pub.bpp = 32;
     }
 #ifdef XRDP_RFXCODEC
     if (earlyCapabilityFlags & RNS_UD_CS_SUPPORT_DYNVC_GFX_PROTOCOL)
     {
-        if (client_info->bpp < 32)
+        if (client_info->pub.bpp < 32)
         {
             LOG(LOG_LEVEL_WARNING,
                 "client requested gfx protocol with insufficient color depth");
@@ -1885,7 +1885,7 @@ xrdp_sec_process_mcs_data_channels(struct xrdp_sec *self, struct stream *s)
 {
     int num_channels;
     int index;
-    struct xrdp_client_info *client_info;
+    struct xrdp_client_info_all *client_info;
     struct mcs_channel_item *channel_item;
     int next_mcs_channel_id;
 
@@ -1968,7 +1968,7 @@ xrdp_sec_process_mcs_data_monitors(struct xrdp_sec *self, struct stream *s)
 {
     int flags;
     int error = 0;
-    struct xrdp_client_info *client_info = &(self->rdp_layer->client_info);
+    struct xrdp_client_info_all *client_info = &(self->rdp_layer->client_info);
 
     LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_process_mcs_data_monitors:");
 
@@ -2005,17 +2005,17 @@ xrdp_sec_process_mcs_data_monitors(struct xrdp_sec *self, struct stream *s)
     error = libxrdp_process_monitor_stream(s, description, 0);
     if (error == 0)
     {
-        client_info->display_sizes.monitorCount = description->monitorCount;
+        client_info->pub.display_sizes.monitorCount = description->monitorCount;
 
         LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_process_mcs_data_monitors:"
                   " Received [MS-RDPBCGR] TS_UD_CS_MONITOR"
                   " flags 0x%8.8x, monitorCount %d",
                   flags, description->monitorCount);
 
-        client_info->display_sizes.session_width = description->session_width;
-        client_info->display_sizes.session_height = description->session_height;
-        g_memcpy(client_info->display_sizes.minfo, description->minfo, sizeof(struct monitor_info) * CLIENT_MONITOR_DATA_MAXIMUM_MONITORS);
-        g_memcpy(client_info->display_sizes.minfo_wm, description->minfo_wm, sizeof(struct monitor_info) * CLIENT_MONITOR_DATA_MAXIMUM_MONITORS);
+        client_info->pub.display_sizes.session_width = description->session_width;
+        client_info->pub.display_sizes.session_height = description->session_height;
+        g_memcpy(client_info->pub.display_sizes.minfo, description->minfo, sizeof(struct monitor_info) * CLIENT_MONITOR_DATA_MAXIMUM_MONITORS);
+        g_memcpy(client_info->pub.display_sizes.minfo_wm, description->minfo_wm, sizeof(struct monitor_info) * CLIENT_MONITOR_DATA_MAXIMUM_MONITORS);
     }
 
     g_free(description);
@@ -2030,7 +2030,7 @@ static int
 xrdp_sec_process_mcs_data_monitors_ex(struct xrdp_sec *self, struct stream *s)
 {
     int flags;
-    struct xrdp_client_info *client_info = &(self->rdp_layer->client_info);
+    struct xrdp_client_info_all *client_info = &(self->rdp_layer->client_info);
 
     LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_process_mcs_data_monitors_ex:");
 
@@ -2059,7 +2059,7 @@ xrdp_sec_process_mcs_data_monitors_ex(struct xrdp_sec *self, struct stream *s)
         return SEC_PROCESS_MONITORS_ERR;
     }
 
-    return libxrdp_process_monitor_ex_stream(s, &client_info->display_sizes);
+    return libxrdp_process_monitor_ex_stream(s, &client_info->pub.display_sizes);
 }
 
 /*****************************************************************************/
@@ -2073,7 +2073,7 @@ xrdp_sec_process_mcs_data(struct xrdp_sec *self)
     char *hold_p = (char *)NULL;
     int tag = 0;
     int size = 0;
-    struct xrdp_client_info *client_info = &self->rdp_layer->client_info;
+    struct xrdp_client_info_all *client_info = &self->rdp_layer->client_info;
 
     s = &(self->client_mcs_data);
     /* set p to beginning */
@@ -2169,15 +2169,15 @@ xrdp_sec_process_mcs_data(struct xrdp_sec *self)
 
     if (client_info->max_bpp > 0)
     {
-        if (client_info->bpp > client_info->max_bpp)
+        if (client_info->pub.bpp > client_info->max_bpp)
         {
             LOG(LOG_LEVEL_WARNING, "Client requested %d bpp color depth, "
                 "but the server configuration is limited to %d bpp. "
                 "Downgrading the color depth to %d bits-per-pixel.",
-                client_info->bpp,
+                client_info->pub.bpp,
                 client_info->max_bpp,
                 client_info->max_bpp);
-            client_info->bpp = client_info->max_bpp;
+            client_info->pub.bpp = client_info->max_bpp;
         }
     }
 

--- a/mc/mc.h
+++ b/mc/mc.h
@@ -30,7 +30,7 @@
 #define CURRENT_MOD_VER 3
 
 struct source_info;
-struct xrdp_client_info;
+struct xrdp_client_info_all;
 
 /* Defined in xrdp_client_info.h */
 struct monitor_info;
@@ -100,7 +100,7 @@ struct mod
     int (*server_bell_trigger)(struct mod *v);
     int (*server_chansrv_in_use)(struct mod *v);
     void (*server_init_xkb_layout)(struct mod *v,
-                                   struct xrdp_client_info *client_info);
+                                   struct xrdp_client_info_all *client_info);
     tintptr server_dumby[100 - 29]; /* align, 100 minus the number of server
                                      functions above */
     /* common */

--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -1994,7 +1994,7 @@ lfreerdp_pre_connect(freerdp *instance)
 
     // Multi Monitor Settings
     const struct display_size_description *display_sizes =
-            &mod->client_info.display_sizes;
+            &mod->client_info.pub.display_sizes;
     instance->settings->num_monitors = display_sizes->monitorCount;
 
     for (index = 0; index < display_sizes->monitorCount; index++)

--- a/neutrinordp/xrdp-neutrinordp.h
+++ b/neutrinordp/xrdp-neutrinordp.h
@@ -22,7 +22,7 @@
 
 #include "arch.h"
 #include "xrdp_constants.h"
-#include "xrdp_client_info.h"
+#include "xrdp_client_info_all.h"
 
 /* Incomplete type definitions, referenced below */
 struct rail_window_state_order;
@@ -144,7 +144,7 @@ struct mod
     int (*server_bell_trigger)(struct mod *v);
     int (*server_chansrv_in_use)(struct mod *v);
     void (*server_init_xkb_layout)(struct mod *v,
-                                   struct xrdp_client_info *client_info);
+                                   struct xrdp_client_info_all *client_info);
     /* off screen bitmaps */
     int (*server_create_os_surface)(struct mod *v, int rdpindex,
                                     int width, int height);
@@ -225,7 +225,7 @@ struct mod
     int bool_keyBoardSynced ; /* Numlock can be out of sync, we hold state here to resolve */
     int keyBoardLockInfo ; /* Holds initial numlock capslock state */
 
-    struct xrdp_client_info client_info;
+    struct xrdp_client_info_all client_info;
 
     struct rdp_freerdp *inst;
     struct bitmap_item bitmap_cache[4][4096];

--- a/tests/libxrdp/test_xrdp_sec_process_mcs_data_monitors.c
+++ b/tests/libxrdp/test_xrdp_sec_process_mcs_data_monitors.c
@@ -69,7 +69,7 @@ END_TEST
 
 START_TEST(test_xrdp_sec_process_mcs_data_monitors__with_single_monitor_happy_path)
 {
-    struct xrdp_client_info *client_info = &(rdp_layer->client_info);
+    struct xrdp_client_info_all *client_info = &(rdp_layer->client_info);
     struct stream *s = (struct stream *)NULL;
     make_stream(s);
     init_stream(s, 28);
@@ -92,25 +92,25 @@ START_TEST(test_xrdp_sec_process_mcs_data_monitors__with_single_monitor_happy_pa
     int error = xrdp_sec_process_mcs_data_monitors(sec_layer, s);
     ck_assert_int_eq(error, 0);
 
-    ck_assert_int_eq(client_info->display_sizes.monitorCount, 1);
+    ck_assert_int_eq(client_info->pub.display_sizes.monitorCount, 1);
 
     // Verify normal monitor
-    ck_assert_int_eq(client_info->display_sizes.minfo[0].left, 0);
-    ck_assert_int_eq(client_info->display_sizes.minfo[0].top, 0);
-    ck_assert_int_eq(client_info->display_sizes.minfo[0].right, 3840);
-    ck_assert_int_eq(client_info->display_sizes.minfo[0].bottom, 2160);
-    ck_assert_int_eq(client_info->display_sizes.minfo[0].is_primary, 1);
+    ck_assert_int_eq(client_info->pub.display_sizes.minfo[0].left, 0);
+    ck_assert_int_eq(client_info->pub.display_sizes.minfo[0].top, 0);
+    ck_assert_int_eq(client_info->pub.display_sizes.minfo[0].right, 3840);
+    ck_assert_int_eq(client_info->pub.display_sizes.minfo[0].bottom, 2160);
+    ck_assert_int_eq(client_info->pub.display_sizes.minfo[0].is_primary, 1);
 
     // Verify normalized monitor
-    ck_assert_int_eq(client_info->display_sizes.minfo_wm[0].left, 0);
-    ck_assert_int_eq(client_info->display_sizes.minfo_wm[0].top, 0);
-    ck_assert_int_eq(client_info->display_sizes.minfo_wm[0].right, 3840);
-    ck_assert_int_eq(client_info->display_sizes.minfo_wm[0].bottom, 2160);
-    ck_assert_int_eq(client_info->display_sizes.minfo_wm[0].is_primary, 1);
+    ck_assert_int_eq(client_info->pub.display_sizes.minfo_wm[0].left, 0);
+    ck_assert_int_eq(client_info->pub.display_sizes.minfo_wm[0].top, 0);
+    ck_assert_int_eq(client_info->pub.display_sizes.minfo_wm[0].right, 3840);
+    ck_assert_int_eq(client_info->pub.display_sizes.minfo_wm[0].bottom, 2160);
+    ck_assert_int_eq(client_info->pub.display_sizes.minfo_wm[0].is_primary, 1);
 
     // Verify geometry (+1 greater than )
-    ck_assert_int_eq(client_info->display_sizes.session_width, 3841);
-    ck_assert_int_eq(client_info->display_sizes.session_height, 2161);
+    ck_assert_int_eq(client_info->pub.display_sizes.session_width, 3841);
+    ck_assert_int_eq(client_info->pub.display_sizes.session_height, 2161);
 
     free_stream(s);
 }
@@ -118,7 +118,7 @@ END_TEST
 
 START_TEST(test_xrdp_sec_process_mcs_data_monitors__when_no_primary_monitor_is_specified_one_is_selected)
 {
-    struct xrdp_client_info *client_info = &(rdp_layer->client_info);
+    struct xrdp_client_info_all *client_info = &(rdp_layer->client_info);
     struct stream *s = (struct stream *)NULL;
     make_stream(s);
     init_stream(s, 28);
@@ -141,25 +141,25 @@ START_TEST(test_xrdp_sec_process_mcs_data_monitors__when_no_primary_monitor_is_s
     int error = xrdp_sec_process_mcs_data_monitors(sec_layer, s);
     ck_assert_int_eq(error, 0);
 
-    ck_assert_int_eq(client_info->display_sizes.monitorCount, 1);
+    ck_assert_int_eq(client_info->pub.display_sizes.monitorCount, 1);
 
     // Verify normal monitor
-    ck_assert_int_eq(client_info->display_sizes.minfo[0].left, 0);
-    ck_assert_int_eq(client_info->display_sizes.minfo[0].top, 0);
-    ck_assert_int_eq(client_info->display_sizes.minfo[0].right, 3840);
-    ck_assert_int_eq(client_info->display_sizes.minfo[0].bottom, 2160);
-    ck_assert_int_eq(client_info->display_sizes.minfo[0].is_primary, 1);
+    ck_assert_int_eq(client_info->pub.display_sizes.minfo[0].left, 0);
+    ck_assert_int_eq(client_info->pub.display_sizes.minfo[0].top, 0);
+    ck_assert_int_eq(client_info->pub.display_sizes.minfo[0].right, 3840);
+    ck_assert_int_eq(client_info->pub.display_sizes.minfo[0].bottom, 2160);
+    ck_assert_int_eq(client_info->pub.display_sizes.minfo[0].is_primary, 1);
 
     // Verify normalized monitor
-    ck_assert_int_eq(client_info->display_sizes.minfo_wm[0].left, 0);
-    ck_assert_int_eq(client_info->display_sizes.minfo_wm[0].top, 0);
-    ck_assert_int_eq(client_info->display_sizes.minfo_wm[0].right, 3840);
-    ck_assert_int_eq(client_info->display_sizes.minfo_wm[0].bottom, 2160);
-    ck_assert_int_eq(client_info->display_sizes.minfo_wm[0].is_primary, 1);
+    ck_assert_int_eq(client_info->pub.display_sizes.minfo_wm[0].left, 0);
+    ck_assert_int_eq(client_info->pub.display_sizes.minfo_wm[0].top, 0);
+    ck_assert_int_eq(client_info->pub.display_sizes.minfo_wm[0].right, 3840);
+    ck_assert_int_eq(client_info->pub.display_sizes.minfo_wm[0].bottom, 2160);
+    ck_assert_int_eq(client_info->pub.display_sizes.minfo_wm[0].is_primary, 1);
 
     // Verify geometry (+1 greater than )
-    ck_assert_int_eq(client_info->display_sizes.session_width, 3841);
-    ck_assert_int_eq(client_info->display_sizes.session_height, 2161);
+    ck_assert_int_eq(client_info->pub.display_sizes.session_width, 3841);
+    ck_assert_int_eq(client_info->pub.display_sizes.session_height, 2161);
 
     free_stream(s);
 }

--- a/vnc/vnc.c
+++ b/vnc/vnc.c
@@ -41,7 +41,7 @@
 #include "trans.h"
 #include "ssl_calls.h"
 #include "string_calls.h"
-#include "xrdp_client_info.h"
+#include "xrdp_client_info_all.h"
 
 /* elements in above list */
 #define EDS_STATUS_MSG_COUNT \
@@ -2484,8 +2484,8 @@ lib_mod_set_param(struct vnc *v, const char *name, const char *value)
     }
     else if (g_strcasecmp(name, "client_info") == 0)
     {
-        const struct xrdp_client_info *client_info =
-            (const struct xrdp_client_info *) value;
+        const struct xrdp_client_info_all *client_info =
+            (const struct xrdp_client_info_all *) value;
 
         v->multimon_configured = client_info->multimon;
 
@@ -2493,10 +2493,10 @@ lib_mod_set_param(struct vnc *v, const char *name, const char *value)
          * Use minfo_wm, as this is normalised for a top-left of (0,0)
          * as required by RFC6143 */
         init_client_layout(v,
-                           client_info->display_sizes.session_width,
-                           client_info->display_sizes.session_height,
-                           client_info->display_sizes.monitorCount,
-                           client_info->display_sizes.minfo_wm);
+                           client_info->pub.display_sizes.session_width,
+                           client_info->pub.display_sizes.session_height,
+                           client_info->pub.display_sizes.monitorCount,
+                           client_info->pub.display_sizes.minfo_wm);
         log_screen_layout(LOG_LEVEL_DEBUG, "client_info", &v->client_layout);
     }
 

--- a/vnc/vnc.h
+++ b/vnc/vnc.h
@@ -69,7 +69,7 @@ enum vnc_resize_support_status
 };
 
 struct source_info;
-struct xrdp_client_info;
+struct xrdp_client_info_all;
 
 /* Defined in vnc_clip.c */
 struct vnc_clipboard_data;
@@ -153,7 +153,7 @@ struct vnc
     int (*server_bell_trigger)(struct vnc *v);
     int (*server_chansrv_in_use)(struct vnc *v);
     void (*server_init_xkb_layout)(struct vnc *v,
-                                   struct xrdp_client_info *client_info);
+                                   struct xrdp_client_info_all *client_info);
     tintptr server_dumby[100 - 29]; /* align, 100 minus the number of server
                                      functions above */
     /* common */

--- a/xrdp/lang.c
+++ b/xrdp/lang.c
@@ -528,7 +528,7 @@ lookup_keylayout(int keylayout,
 }
 /*****************************************************************************/
 void
-xrdp_init_xkb_layout(struct xrdp_client_info *client_info)
+xrdp_init_xkb_layout(struct xrdp_client_info_all *client_info)
 {
     int fd;
     int index = 0;
@@ -570,13 +570,14 @@ xrdp_init_xkb_layout(struct xrdp_client_info *client_info)
     }
     /* infer model/variant */
     /* TODO specify different X11 keyboard models/variants */
-    client_info->model[0] = '\0';
-    client_info->variant[0] = '\0';
-    strlcpy(client_info->layout, "us", sizeof(client_info->layout));
+    client_info->pub.model[0] = '\0';
+    client_info->pub.variant[0] = '\0';
+    strlcpy(client_info->pub.layout, "us", sizeof(client_info->pub.layout));
     if (client_info->keyboard_subtype == 3)
     {
         /* macintosh keyboard */
-        strlcpy(client_info->variant, "mac", sizeof(client_info->variant));
+        strlcpy(client_info->pub.variant, "mac",
+                sizeof(client_info->pub.variant));
     }
     else if (client_info->keyboard_subtype == 0)
     {
@@ -660,24 +661,24 @@ xrdp_init_xkb_layout(struct xrdp_client_info *client_info)
                     {
                         if (section_found != -1 && section_found == index)
                         {
-                            strlcpy(client_info->model, value,
-                                    sizeof(client_info->model));
+                            strlcpy(client_info->pub.model, value,
+                                    sizeof(client_info->pub.model));
                         }
                     }
                     else if (g_strcasecmp(item, "variant") == 0)
                     {
                         if (section_found != -1 && section_found == index)
                         {
-                            strlcpy(client_info->variant, value,
-                                    sizeof(client_info->variant));
+                            strlcpy(client_info->pub.variant, value,
+                                    sizeof(client_info->pub.variant));
                         }
                     }
                     else if (g_strcasecmp(item, "options") == 0)
                     {
                         if (section_found != -1 && section_found == index)
                         {
-                            strlcpy(client_info->options, value,
-                                    sizeof(client_info->options));
+                            strlcpy(client_info->pub.options, value,
+                                    sizeof(client_info->pub.options));
                         }
                     }
                     else
@@ -760,8 +761,8 @@ xrdp_init_xkb_layout(struct xrdp_client_info *client_info)
                 value = (const char *)list_get_item(values, index);
                 if (g_strcasecmp(item, rdp_layout) == 0)
                 {
-                    strlcpy(client_info->layout, value,
-                            sizeof(client_info->layout));
+                    strlcpy(client_info->pub.layout, value,
+                            sizeof(client_info->pub.layout));
                     break;
                 }
             }
@@ -771,8 +772,9 @@ xrdp_init_xkb_layout(struct xrdp_client_info *client_info)
         list_delete(values);
 
         LOG(LOG_LEVEL_INFO, "xrdp_init_xkb_layout: model [%s] variant [%s] "
-            "layout [%s] options [%s]", client_info->model,
-            client_info->variant, client_info->layout, client_info->options);
+            "layout [%s] options [%s]", client_info->pub.model,
+            client_info->pub.variant, client_info->pub.layout,
+            client_info->pub.options);
         g_file_close(fd);
     }
     else
@@ -782,20 +784,20 @@ xrdp_init_xkb_layout(struct xrdp_client_info *client_info)
     }
 
     // Initialise the rules and a few keycodes for xorgxrdp
-    strlcpy(client_info->xkb_rules, scancode_get_xkb_rules(),
-            sizeof(client_info->xkb_rules));
+    strlcpy(client_info->pub.xkb_rules, scancode_get_xkb_rules(),
+            sizeof(client_info->pub.xkb_rules));
     if (keylayout_supports_caps_lock(client_info->keylayout))
     {
-        client_info->x11_keycode_caps_lock =
+        client_info->pub.x11_keycode_caps_lock =
             scancode_to_x11_keycode(SCANCODE_CAPS_KEY);
     }
     else
     {
         LOG(LOG_LEVEL_INFO, "xrdp_init_xkb_layout: caps lock is not supported");
-        client_info->x11_keycode_caps_lock = 0;
+        client_info->pub.x11_keycode_caps_lock = 0;
     }
-    client_info->x11_keycode_num_lock =
+    client_info->pub.x11_keycode_num_lock =
         scancode_to_x11_keycode(SCANCODE_NUMLOCK_KEY);
-    client_info->x11_keycode_scroll_lock =
+    client_info->pub.x11_keycode_scroll_lock =
         scancode_to_x11_keycode(SCANCODE_SCROLL_KEY);
 }

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -35,7 +35,7 @@
 #include "ssl_calls.h"
 #include "thread_calls.h"
 #include "file.h"
-#include "xrdp_client_info.h"
+#include "xrdp_client_info_all.h"
 #include "log.h"
 
 #if defined(XRDP_X264) || defined(XRDP_OPENH264) || defined(XRDP_NVENC)
@@ -88,12 +88,12 @@ g_process_waiting_function(void);
 /* xrdp_cache.c */
 struct xrdp_cache *
 xrdp_cache_create(struct xrdp_wm *owner, struct xrdp_session *session,
-                  struct xrdp_client_info *client_info);
+                  struct xrdp_client_info_all *client_info);
 void
 xrdp_cache_delete(struct xrdp_cache *self);
 int
 xrdp_cache_reset(struct xrdp_cache *self,
-                 struct xrdp_client_info *client_info);
+                 struct xrdp_client_info_all *client_info);
 int
 xrdp_cache_add_bitmap(struct xrdp_cache *self, struct xrdp_bitmap *bitmap,
                       int hints);
@@ -123,7 +123,7 @@ xrdp_cache_get_os_bitmap(struct xrdp_cache *self, int rdpindex);
 /* xrdp_wm.c */
 struct xrdp_wm *
 xrdp_wm_create(struct xrdp_process *owner,
-               struct xrdp_client_info *client_info);
+               struct xrdp_client_info_all *client_info);
 void
 xrdp_wm_delete(struct xrdp_wm *self);
 int
@@ -458,7 +458,7 @@ km_load_file(const char *filename, struct xrdp_keymap *keymap);
  * @param client_info Client info struct to initialise
  */
 void
-xrdp_init_xkb_layout(struct xrdp_client_info *client_info);
+xrdp_init_xkb_layout(struct xrdp_client_info_all *client_info);
 
 /* xrdp_login_wnd.c */
 /**
@@ -543,7 +543,7 @@ int
 server_chansrv_in_use(struct xrdp_mod *mod);
 void
 server_init_xkb_layout(struct xrdp_mod *mod,
-                       struct xrdp_client_info *client_info);
+                       struct xrdp_client_info_all *client_info);
 int
 server_fill_rect(struct xrdp_mod *mod, int x, int y, int cx, int cy);
 int

--- a/xrdp/xrdp_cache.c
+++ b/xrdp/xrdp_cache.c
@@ -84,7 +84,7 @@ xrdp_cache_reset_crc(struct xrdp_cache *self)
 struct xrdp_cache *
 xrdp_cache_create(struct xrdp_wm *owner,
                   struct xrdp_session *session,
-                  struct xrdp_client_info *client_info)
+                  struct xrdp_client_info_all *client_info)
 {
     struct xrdp_cache *self;
 
@@ -178,7 +178,7 @@ xrdp_cache_delete(struct xrdp_cache *self)
 /*****************************************************************************/
 int
 xrdp_cache_reset(struct xrdp_cache *self,
-                 struct xrdp_client_info *client_info)
+                 struct xrdp_client_info_all *client_info)
 {
     struct xrdp_wm *wm;
     struct xrdp_session *session;

--- a/xrdp/xrdp_encoder.c
+++ b/xrdp/xrdp_encoder.c
@@ -189,7 +189,7 @@ xrdp_encoder_create(struct xrdp_mm *mm)
     LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_encoder_create:");
 
     struct xrdp_encoder *self;
-    struct xrdp_client_info *client_info;
+    struct xrdp_client_info_all *client_info;
     char buf[1024];
     int pid;
 
@@ -203,7 +203,7 @@ xrdp_encoder_create(struct xrdp_mm *mm)
             return 0;
         }
     }
-    if (client_info->bpp < 24)
+    if (client_info->pub.bpp < 24)
     {
         return 0;
     }
@@ -221,8 +221,8 @@ xrdp_encoder_create(struct xrdp_mm *mm)
         self->codec_id = client_info->jpeg_codec_id;
         self->in_codec_mode = 1;
         self->codec_quality = client_info->jpeg_prop[0];
-        client_info->capture_code = CC_SIMPLE;
-        client_info->capture_format = XRDP_a8b8g8r8;
+        client_info->pub.capture_code = CC_SIMPLE;
+        client_info->pub.capture_format = XRDP_a8b8g8r8;
         self->process_enc = process_enc_jpg;
     }
 #if defined(XRDP_X264) || defined(XRDP_OPENH264)
@@ -231,8 +231,8 @@ xrdp_encoder_create(struct xrdp_mm *mm)
         LOG(LOG_LEVEL_INFO,
             "xrdp_encoder_create: starting h264 codec session gfx");
         self->in_codec_mode = 1;
-        client_info->capture_code = CC_GFX_A2;
-        client_info->capture_format = XRDP_nv12_709fr;
+        client_info->pub.capture_code = CC_GFX_A2;
+        client_info->pub.capture_format = XRDP_nv12_709fr;
         self->gfx = 1;
     }
     else if (mm->libh264_loaded && client_info->h264_codec_id != 0)
@@ -240,8 +240,8 @@ xrdp_encoder_create(struct xrdp_mm *mm)
         LOG(LOG_LEVEL_INFO, "xrdp_encoder_create: starting h264 codec session");
         self->codec_id = client_info->h264_codec_id;
         self->in_codec_mode = 1;
-        client_info->capture_code = CC_SUF_A2;
-        client_info->capture_format = XRDP_nv12;
+        client_info->pub.capture_code = CC_SUF_A2;
+        client_info->pub.capture_format = XRDP_nv12;
         self->process_enc = process_enc_h264;
     }
 #endif
@@ -251,7 +251,7 @@ xrdp_encoder_create(struct xrdp_mm *mm)
         LOG(LOG_LEVEL_INFO,
             "xrdp_encoder_create: starting gfx rfx pro codec session");
         self->in_codec_mode = 1;
-        client_info->capture_code = CC_GFX_PRO;
+        client_info->pub.capture_code = CC_GFX_PRO;
         self->gfx = 1;
         self->num_quants = 2;
         self->quant_idx_y = 0;
@@ -281,7 +281,7 @@ xrdp_encoder_create(struct xrdp_mm *mm)
         LOG(LOG_LEVEL_INFO, "xrdp_encoder_create: starting rfx codec session");
         self->codec_id = client_info->rfx_codec_id;
         self->in_codec_mode = 1;
-        client_info->capture_code = CC_SUF_RFX;
+        client_info->pub.capture_code = CC_SUF_RFX;
         self->process_enc = process_enc_rfx;
         self->codec_handle_rfx = rfxcodec_encode_create(mm->wm->screen->width,
                                  mm->wm->screen->height,

--- a/xrdp/xrdp_login_wnd.c
+++ b/xrdp/xrdp_login_wnd.c
@@ -674,7 +674,7 @@ xrdp_login_wnd_get_monitor_dpi(struct xrdp_wm *self)
 {
     unsigned int result = 0;
     const struct display_size_description *display_sizes =
-            &self->client_info->display_sizes;
+            &self->client_info->pub.display_sizes;
     unsigned int height_pixels = 0;
     unsigned int height_mm = 0;
 
@@ -797,16 +797,16 @@ xrdp_login_wnd_create(struct xrdp_wm *self)
     }
 
     /* multimon scenario, draw login window on primary monitor */
-    if (self->client_info->display_sizes.monitorCount > 1)
+    if (self->client_info->pub.display_sizes.monitorCount > 1)
     {
-        for (index = 0; index < self->client_info->display_sizes.monitorCount; index++)
+        for (index = 0; index < self->client_info->pub.display_sizes.monitorCount; index++)
         {
-            if (self->client_info->display_sizes.minfo_wm[index].is_primary)
+            if (self->client_info->pub.display_sizes.minfo_wm[index].is_primary)
             {
-                x = self->client_info->display_sizes.minfo_wm[index].left;
-                y = self->client_info->display_sizes.minfo_wm[index].top;
-                cx = self->client_info->display_sizes.minfo_wm[index].right;
-                cy = self->client_info->display_sizes.minfo_wm[index].bottom;
+                x = self->client_info->pub.display_sizes.minfo_wm[index].left;
+                y = self->client_info->pub.display_sizes.minfo_wm[index].top;
+                cx = self->client_info->pub.display_sizes.minfo_wm[index].right;
+                cy = self->client_info->pub.display_sizes.minfo_wm[index].bottom;
 
                 primary_width = cx - x;
                 primary_height = cy - y;

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -90,7 +90,7 @@ xrdp_mm_create(struct xrdp_wm *owner)
     LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_mm_create: bpp %d mcs_connection_type %d "
               "jpeg_codec_id %d v3_codec_id %d rfx_codec_id %d "
               "h264_codec_id %d",
-              self->wm->client_info->bpp,
+              self->wm->client_info->pub.bpp,
               self->wm->client_info->mcs_connection_type,
               self->wm->client_info->jpeg_codec_id,
               self->wm->client_info->v3_codec_id,
@@ -1348,7 +1348,7 @@ xrdp_mm_egfx_create_surfaces(struct xrdp_mm *self)
     struct xrdp_bitmap *screen;
 
     screen = self->wm->screen;
-    count = self->wm->client_info->display_sizes.monitorCount;
+    count = self->wm->client_info->pub.display_sizes.monitorCount;
     LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_mm_egfx_create_surfaces: "
               "monitor count %d", count);
     if (count < 1)
@@ -1370,7 +1370,7 @@ xrdp_mm_egfx_create_surfaces(struct xrdp_mm *self)
     for (index = 0; index < count; index++)
     {
         surface_id = index;
-        mi = self->wm->client_info->display_sizes.minfo_wm + index;
+        mi = self->wm->client_info->pub.display_sizes.minfo_wm + index;
         left = mi->left;
         top = mi->top;
         width = mi->right - mi->left + 1;
@@ -1510,11 +1510,11 @@ xrdp_mm_egfx_caps_advertise(void *user, int caps_count,
             "error %d best_index %d", error, best_index);
         error = xrdp_egfx_send_reset_graphics(self->egfx,
                                               screen->width, screen->height,
-                                              self->wm->client_info->display_sizes.monitorCount,
-                                              self->wm->client_info->display_sizes.minfo);
+                                              self->wm->client_info->pub.display_sizes.monitorCount,
+                                              self->wm->client_info->pub.display_sizes.minfo);
         LOG(LOG_LEVEL_INFO, "xrdp_mm_egfx_caps_advertise: xrdp_egfx_send_reset_graphics "
             "error %d monitorCount %d",
-            error, self->wm->client_info->display_sizes.monitorCount);
+            error, self->wm->client_info->pub.display_sizes.monitorCount);
         self->egfx_up = 1;
         xrdp_mm_egfx_create_surfaces(self);
         self->encoder = xrdp_encoder_create(self);
@@ -1664,7 +1664,7 @@ sync_dynamic_monitor_data(struct xrdp_wm *wm,
                           struct display_size_description *description)
 {
     struct display_size_description *display_sizes
-        = &(wm->client_info->display_sizes);
+        = &(wm->client_info->pub.display_sizes);
 
     display_sizes->monitorCount = description->monitorCount;
     display_sizes->session_width = description->session_width;
@@ -2057,7 +2057,7 @@ dynamic_monitor_process_queue(struct xrdp_mm *self)
         }
 
         const struct display_size_description *current_size
-                = &wm->client_info->display_sizes;
+                = &wm->client_info->pub.display_sizes;
 
         const int already_this_size = queue_head->session_width
                                       == current_size->session_width
@@ -3840,7 +3840,7 @@ xrdp_mm_draw_dirty(struct xrdp_mm *self)
     int rv = 0;
 
     LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_mm_draw_dirty:");
-    count = self->wm->client_info->display_sizes.monitorCount;
+    count = self->wm->client_info->pub.display_sizes.monitorCount;
     if (count < 1)
     {
         error = xrdp_region_get_bounds(self->wm->screen_dirty_region, &rect);
@@ -3873,7 +3873,7 @@ xrdp_mm_draw_dirty(struct xrdp_mm *self)
                 jndex++;
             }
             /* intercect monitor */
-            mi = self->wm->client_info->display_sizes.minfo_wm + index;
+            mi = self->wm->client_info->pub.display_sizes.minfo_wm + index;
             mon_rect.left = mi->left;
             mon_rect.top = mi->top;
             mon_rect.right = mi->right + 1;
@@ -4115,7 +4115,7 @@ server_chansrv_in_use(struct xrdp_mod *mod)
 /* Init the XKB layout */
 void
 server_init_xkb_layout(struct xrdp_mod *mod,
-                       struct xrdp_client_info *client_info)
+                       struct xrdp_client_info_all *client_info)
 {
     xrdp_init_xkb_layout(client_info);
 }

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -29,7 +29,7 @@
 #include "fifo.h"
 #include "guid.h"
 #include "scancode.h"
-#include "xrdp_client_info.h"
+#include "xrdp_client_info_all.h"
 #include "xrdp_tconfig.h"
 
 #define MAX_NR_CHANNELS 16
@@ -129,7 +129,7 @@ struct xrdp_mod
     int (*server_bell_trigger)(struct xrdp_mod *v);
     int (*server_chansrv_in_use)(struct xrdp_mod *v);
     void (*server_init_xkb_layout)(struct xrdp_mod *v,
-                                   struct xrdp_client_info *client_info);
+                                   struct xrdp_client_info_all *client_info);
     /* off screen bitmaps */
     int (*server_create_os_surface)(struct xrdp_mod *v, int rdpindex,
                                     int width, int height);
@@ -575,7 +575,7 @@ struct xrdp_wm
     int last_high_surrogate_key_up;
     int last_high_surrogate_key_down;
     /* client info */
-    struct xrdp_client_info *client_info;
+    struct xrdp_client_info_all *client_info;
     /* session log */
     struct list *log;
     struct xrdp_bitmap *log_wnd;

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -81,7 +81,7 @@ xrdp_wm_load_channel_config(struct xrdp_wm *self)
 /*****************************************************************************/
 struct xrdp_wm *
 xrdp_wm_create(struct xrdp_process *owner,
-               struct xrdp_client_info *client_info)
+               struct xrdp_client_info_all *client_info)
 {
     struct xrdp_wm *self = (struct xrdp_wm *)NULL;
     char event_name[256];
@@ -92,9 +92,9 @@ xrdp_wm_create(struct xrdp_process *owner,
 
     self = (struct xrdp_wm *)g_malloc(sizeof(struct xrdp_wm), 1);
     self->client_info = client_info;
-    self->screen = xrdp_bitmap_create(client_info->display_sizes.session_width,
-                                      client_info->display_sizes.session_height,
-                                      client_info->bpp,
+    self->screen = xrdp_bitmap_create(client_info->pub.display_sizes.session_width,
+                                      client_info->pub.display_sizes.session_height,
+                                      client_info->pub.bpp,
                                       WND_TYPE_SCREEN, self);
     self->screen->wm = self;
     self->pro_layer = owner;
@@ -2360,14 +2360,14 @@ xrdp_wm_show_log(struct xrdp_wm *self)
         primary_y_offset = 0;
 
         /* multimon scenario, draw log window on primary monitor */
-        if (self->client_info->display_sizes.monitorCount > 1)
+        if (self->client_info->pub.display_sizes.monitorCount > 1)
         {
-            for (index = 0; index < self->client_info->display_sizes.monitorCount; index++)
+            for (index = 0; index < self->client_info->pub.display_sizes.monitorCount; index++)
             {
-                if (self->client_info->display_sizes.minfo_wm[index].is_primary)
+                if (self->client_info->pub.display_sizes.minfo_wm[index].is_primary)
                 {
-                    primary_x_offset = self->client_info->display_sizes.minfo_wm[index].left;
-                    primary_y_offset = self->client_info->display_sizes.minfo_wm[index].top;
+                    primary_x_offset = self->client_info->pub.display_sizes.minfo_wm[index].left;
+                    primary_y_offset = self->client_info->pub.display_sizes.minfo_wm[index].top;
                     break;
                 }
             }

--- a/xup/xup.c
+++ b/xup/xup.c
@@ -201,7 +201,8 @@ lib_send_client_info(struct mod *mod)
     init_stream(s, 8192);
     s_push_layer(s, iso_hdr, 4);
     out_uint16_le(s, 104);
-    g_memcpy(s->p, &(mod->client_info), sizeof(mod->client_info));
+    // Only send the public bit of the client info
+    g_memcpy(s->p, &(mod->client_info), sizeof(struct xrdp_client_info));
     s->p += sizeof(mod->client_info);
     s_mark_end(s);
     len = (int)(s->end - s->data);
@@ -255,19 +256,19 @@ lib_mod_connect(struct mod *mod)
     }
     mod->server_init_xkb_layout(mod, &(mod->client_info));
     LOG(LOG_LEVEL_INFO, "XKB rules '%s' will be used by the module",
-        mod->client_info.xkb_rules);
+        mod->client_info.pub.xkb_rules);
 
-    if (mod->client_info.h264_frame_interval <= 0)
+    if (mod->client_info.pub.h264_frame_interval <= 0)
     {
-        mod->client_info.h264_frame_interval = DEFAULT_H264_FRAME_INTERVAL;
+        mod->client_info.pub.h264_frame_interval = DEFAULT_H264_FRAME_INTERVAL;
     }
-    if (mod->client_info.rfx_frame_interval <= 0)
+    if (mod->client_info.pub.rfx_frame_interval <= 0)
     {
-        mod->client_info.rfx_frame_interval = DEFAULT_RFX_FRAME_INTERVAL;
+        mod->client_info.pub.rfx_frame_interval = DEFAULT_RFX_FRAME_INTERVAL;
     }
-    if (mod->client_info.normal_frame_interval <= 0)
+    if (mod->client_info.pub.normal_frame_interval <= 0)
     {
-        mod->client_info.normal_frame_interval = DEFAULT_NORMAL_FRAME_INTERVAL;
+        mod->client_info.pub.normal_frame_interval = DEFAULT_NORMAL_FRAME_INTERVAL;
     }
 
     make_stream(s);
@@ -1985,15 +1986,15 @@ lib_mod_set_param(struct mod *mod, const char *name, const char *value)
     }
     else if (g_strcasecmp(name, "h264_frame_interval") == 0)
     {
-        mod->client_info.h264_frame_interval = g_atoi(value);
+        mod->client_info.pub.h264_frame_interval = g_atoi(value);
     }
     else if (g_strcasecmp(name, "rfx_frame_interval") == 0)
     {
-        mod->client_info.rfx_frame_interval = g_atoi(value);
+        mod->client_info.pub.rfx_frame_interval = g_atoi(value);
     }
     else if (g_strcasecmp(name, "normal_frame_interval") == 0)
     {
-        mod->client_info.normal_frame_interval = g_atoi(value);
+        mod->client_info.pub.normal_frame_interval = g_atoi(value);
     }
     else if (g_strcasecmp(name, "client_info") == 0)
     {

--- a/xup/xup.h
+++ b/xup/xup.h
@@ -38,14 +38,14 @@ enum caps_processing_status
 #include "os_calls.h"
 #include "defines.h"
 #include "log.h"
-#include "xrdp_client_info.h"
+#include "xrdp_client_info_all.h"
 #include "xrdp_constants.h"
 #include "xrdp_rail.h"
 
 #define CURRENT_MOD_VER 4
 
 struct source_info;
-struct xrdp_client_info;
+struct xrdp_client_info_all;
 
 struct mod
 {
@@ -124,7 +124,7 @@ struct mod
     int (*server_bell_trigger)(struct mod *v);
     int (*server_chansrv_in_use)(struct mod *v);
     void (*server_init_xkb_layout)(struct mod *v,
-                                   struct xrdp_client_info *client_info);
+                                   struct xrdp_client_info_all *client_info);
     /* off screen bitmaps */
     int (*server_create_os_surface)(struct mod *v, int rdpindex,
                                     int width, int height);
@@ -208,7 +208,7 @@ struct mod
     char ip[256];
     char port[256];
     int shift_state;
-    struct xrdp_client_info client_info;
+    struct xrdp_client_info_all client_info;
     int screen_shmem_id;
     int screen_shmem_id_mapped; /* boolean */
     char *screen_shmem_pixels;


### PR DESCRIPTION
Draft for comments.

The `xrdp_client_info` struct is refactored into items shared with xorgxrdp, and items which are private to xrdp.

The name `struct xrdp_client_info` is retained for xorgxrdp, for compatibility. The `struct xrdp_client_info_all` type is used within xrdp only.

@metalefty - what do you think of this approach? Does it help the maintainability or not? Any other suggestions?

I haven't tested this yet.