### PR TITLE
Refactor struct xrdp_client_info (rework)

### DIFF
--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -99,6 +99,51 @@ enum unicode_input_state
     UIS_SUPPORTED,       ///< Client supports Unicode, but it's not active
     UIS_ACTIVE           ///< Unicode input is active
 };
+
+/**
+ * Information about the xrdp client which is passed to xorgxrdp
+ *
+ * @note This structure is shared with xorgxrdp. If you change it,
+ *       you MUST bump the CLIENT_INFO_CURRENT_VERSION number so that
+ *       the mismatch can be detected.
+ */
+struct xorgxrdp_client_info
+{
+    int size; /* bytes for this structure */
+    int version; /* Should be CLIENT_INFO_CURRENT_VERSION */
+    int bpp;
+    int jpeg; /* non standard bitmap cache v2 cap */
+    int offscreen_support_level;
+    int offscreen_cache_size;
+    int offscreen_cache_entries;
+
+    char orders[32];
+    int order_flags_ex;
+    int pointer_flags; /* 0 color, 1 new, 2 no new */
+    int large_pointer_support_flags;
+
+    struct display_size_description display_sizes;
+
+    enum xrdp_capture_code capture_code;
+    int capture_format;
+
+    /* X11 keyboard layout - inferred from keyboard type/subtype */
+    char model[16];
+    char layout[16];
+    char variant[16];
+    char options[256];
+    char xkb_rules[32];
+    // A few x11 keycodes are needed by the xup module
+    int x11_keycode_caps_lock;
+    int x11_keycode_num_lock;
+    int x11_keycode_scroll_lock;
+
+    /* xorgxrdp: frame capture interval (milliseconds) */
+    int rfx_frame_interval;
+    int h264_frame_interval;
+    int normal_frame_interval;
+};
+
 /**
  * Information about the xrdp client
  *
@@ -109,9 +154,9 @@ enum unicode_input_state
  */
 struct xrdp_client_info
 {
-    int size; /* bytes for this structure */
-    int version; /* Should be CLIENT_INFO_CURRENT_VERSION */
-    int bpp;
+    /* Info shared with xorgxrdp */
+    struct xorgxrdp_client_info xup;
+
     /* bitmap cache info */
     int cache1_entries;
     int cache1_size;
@@ -147,12 +192,7 @@ struct xrdp_client_info
     int rdp5_performanceflags;
     int brush_cache_code; /* 0 = no cache 1 = 8x8 standard cache
                            2 = arbitrary dimensions */
-
     int max_bpp;
-    int jpeg; /* non standard bitmap cache v2 cap */
-    int offscreen_support_level;
-    int offscreen_cache_size;
-    int offscreen_cache_entries;
     int rfx;
 
     /* CAPSETTYPE_RAIL */
@@ -173,10 +213,7 @@ struct xrdp_client_info
     char jpeg_prop[64];
     int v3_codec_id;
     int rfx_min_pixel;
-    char orders[32];
-    int order_flags_ex;
     int use_bulk_comp;
-    int pointer_flags; /* 0 color, 1 new, 2 no new */
     int use_fast_path;
     int require_credentials; /* when true, credentials *must* be passed on cmd line */
 
@@ -184,7 +221,6 @@ struct xrdp_client_info
     int vmconnect; /* Used when used from inside Hyper-V */
 
     int multimon; /* 0 = deny , 1 = allow */
-    struct display_size_description display_sizes;
 
     int keyboard_type;
     int keyboard_subtype;
@@ -197,31 +233,9 @@ struct xrdp_client_info
     int mcs_early_capability_flags;
 
     int max_fastpath_frag_bytes;
-    int pad0; /* unused */
-    int capture_format;
 
     char certificate[1024];
     char key_file[1024];
-
-    /* X11 keyboard layout - inferred from keyboard type/subtype */
-    char model[16];
-    char layout[16];
-    char variant[16];
-    char options[256];
-    char xkb_rules[32];
-    // A few x11 keycodes are needed by the xup module
-    int x11_keycode_caps_lock;
-    int x11_keycode_num_lock;
-    int x11_keycode_scroll_lock;
-
-    /* xorgxrdp: frame capture interval (milliseconds) */
-    int rfx_frame_interval;
-    int h264_frame_interval;
-    int normal_frame_interval;
-
-    /* ==================================================================== */
-    /* Private to xrdp below this line */
-    /* ==================================================================== */
 
     /* codec */
     int h264_codec_id;
@@ -260,14 +274,12 @@ struct xrdp_client_info
     unsigned int session_physical_width; /* in mm */
     unsigned int session_physical_height; /* in mm */
 
-    int large_pointer_support_flags;
     int gfx;
 
     // Can we resize the desktop by using a Deactivation-Reactivation Sequence?
     enum client_resize_mode client_resize_mode;
 
     enum unicode_input_state unicode_input_support;
-    enum xrdp_capture_code capture_code;
 };
 
 enum xrdp_encoder_flags
@@ -285,8 +297,8 @@ enum xrdp_encoder_flags
 #define OUTPUT_SUPPRESSED_FOR_REASON(ci,reason) \
     (((ci)->suppress_output_mask & (unsigned int)reason) != 0)
 
-/* yyyymmdd of last incompatible change to xrdp_client_info */
+/* yyyymmdd of last change to xorgxrdp_client_info */
 /* also used for changes to all the xrdp installed headers */
-#define CLIENT_INFO_CURRENT_VERSION 20241118
+#define CLIENT_INFO_CURRENT_VERSION 20250404
 
 #endif

--- a/libxrdp/libxrdp.c
+++ b/libxrdp/libxrdp.c
@@ -291,7 +291,7 @@ libxrdp_send_palette(struct xrdp_session *session, int *palette)
     int color = 0;
     struct stream *s = (struct stream *)NULL;
 
-    if (session->client_info->bpp > 8)
+    if (session->client_info->xup.bpp > 8)
     {
         return 0;
     }
@@ -750,7 +750,7 @@ libxrdp_send_pointer(struct xrdp_session *session, int cache_idx,
         height = 32;
     }
     /* error check */
-    if ((session->client_info->pointer_flags & 1) == 0)
+    if ((session->client_info->xup.pointer_flags & 1) == 0)
     {
         if (bpp != 24)
         {
@@ -781,7 +781,7 @@ libxrdp_send_pointer(struct xrdp_session *session, int cache_idx,
             return 1;
         }
 
-        if ((session->client_info->pointer_flags & 1) != 0)
+        if ((session->client_info->xup.pointer_flags & 1) != 0)
         {
             out_uint16_le(s, bpp); /* TS_FP_POINTERATTRIBUTE -> newPointerUpdateData.xorBpp */
         }
@@ -790,7 +790,7 @@ libxrdp_send_pointer(struct xrdp_session *session, int cache_idx,
     {
         LOG_DEVEL(LOG_LEVEL_DEBUG, "libxrdp_send_pointer: slowpath");
         xrdp_rdp_init_data((struct xrdp_rdp *)session->rdp, s);
-        if ((session->client_info->pointer_flags & 1) == 0)
+        if ((session->client_info->xup.pointer_flags & 1) == 0)
         {
             out_uint16_le(s, RDP_POINTER_COLOR);
             out_uint16_le(s, 0); /* pad */
@@ -869,7 +869,7 @@ libxrdp_send_pointer(struct xrdp_session *session, int cache_idx,
     s_mark_end(s);
     if (session->client_info->use_fast_path & 1) /* fastpath output supported */
     {
-        if ((session->client_info->pointer_flags & 1) == 0)
+        if ((session->client_info->xup.pointer_flags & 1) == 0)
         {
             LOG_DEVEL(LOG_LEVEL_TRACE, "Sending [MS-RDPBCGR] TS_FP_COLORPOINTERATTRIBUTE "
                       "cachedPointerUpdateData = { cacheIndex %d, "
@@ -907,7 +907,7 @@ libxrdp_send_pointer(struct xrdp_session *session, int cache_idx,
     }
     else
     {
-        if ((session->client_info->pointer_flags & 1) == 0)
+        if ((session->client_info->xup.pointer_flags & 1) == 0)
         {
             LOG_DEVEL(LOG_LEVEL_TRACE, "Sending [MS-RDPBCGR] TS_COLORPOINTERATTRIBUTE "
                       "cacheIndex %d, "

--- a/libxrdp/xrdp_caps.c
+++ b/libxrdp/xrdp_caps.c
@@ -1034,8 +1034,10 @@ unsigned int calculate_multifragmentupdate_len(const struct xrdp_rdp *self)
 {
     unsigned int result = MAX_MULTIFRAGMENTUPDATE_SIZE;
 
-    unsigned int x_tiles = (self->client_info.xup.display_sizes.session_width + 63) / 64;
-    unsigned int y_tiles = (self->client_info.xup.display_sizes.session_height + 63) / 64;
+    unsigned int x_tiles =
+        (self->client_info.xup.display_sizes.session_width + 63) / 64;
+    unsigned int y_tiles =
+        (self->client_info.xup.display_sizes.session_height + 63) / 64;
 
     /* Check for overflow on calculation if bad parameters are supplied */
     if ((x_tiles * y_tiles  + 1) < (UINT_MAX / 16384))
@@ -1123,6 +1125,8 @@ xrdp_caps_send_demand_active(struct xrdp_rdp *self)
               "CAPSTYPE_GENERAL TODO");
 
     /* Output bitmap capability set */
+    unsigned int width = self->client_info.xup.display_sizes.session_width;
+    unsigned int height = self->client_info.xup.display_sizes.session_height;
     caps_count++;
     out_uint16_le(s, CAPSTYPE_BITMAP);
     out_uint16_le(s, CAPSTYPE_BITMAP_LEN);
@@ -1130,22 +1134,24 @@ xrdp_caps_send_demand_active(struct xrdp_rdp *self)
     out_uint16_le(s, 1); /* Receive 1 BPP */
     out_uint16_le(s, 1); /* Receive 4 BPP */
     out_uint16_le(s, 1); /* Receive 8 BPP */
-    out_uint16_le(s, self->client_info.xup.display_sizes.session_width); /* width */
-    out_uint16_le(s, self->client_info.xup.display_sizes.session_height); /* height */
+    out_uint16_le(s, width); /* width */
+    out_uint16_le(s, height); /* height */
     out_uint16_le(s, 0); /* Pad */
     out_uint16_le(s, 1); /* Allow resize */
     out_uint16_le(s, 1); /* bitmap compression */
     out_uint16_le(s, 0); /* unknown */
     out_uint16_le(s, 0); /* unknown */
     out_uint16_le(s, 0); /* pad */
-    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_send_demand_active: Server Capability "
+    LOG_DEVEL(LOG_LEVEL_TRACE,
+              "xrdp_caps_send_demand_active: Server Capability "
               "CAPSTYPE_BITMAP TODO");
 
     /* Output font capability set */
     caps_count++;
     out_uint16_le(s, CAPSTYPE_FONT);
     out_uint16_le(s, CAPSTYPE_FONT_LEN);
-    LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_send_demand_active: Server Capability "
+    LOG_DEVEL(LOG_LEVEL_TRACE,
+              "xrdp_caps_send_demand_active: Server Capability "
               "CAPSTYPE_FONT");
 
     /* Output order capability set */

--- a/libxrdp/xrdp_caps.c
+++ b/libxrdp/xrdp_caps.c
@@ -59,7 +59,7 @@ xrdp_caps_send_monitorlayout(struct xrdp_rdp *self)
         return 1;
     }
 
-    description = &self->client_info.display_sizes;
+    description = &self->client_info.xup.display_sizes;
 
     out_uint32_le(s, description->monitorCount); /* monitorCount (4 bytes) */
 
@@ -186,7 +186,7 @@ xrdp_caps_process_order(struct xrdp_rdp *self, struct stream *s,
     in_uint8s(s, 2); /* Number of fonts */
     in_uint16_le(s, cap_flags); /* Capability flags */
     in_uint8a(s, order_caps, 32); /* Orders supported */
-    g_memcpy(self->client_info.orders, order_caps, 32);
+    g_memcpy(self->client_info.xup.orders, order_caps, 32);
 
     LOG_DEVEL(LOG_LEVEL_TRACE, "TS_ORDER_CAPABILITYSET: terminalDescriptor (ignored as per protocol spec)");
     LOG_DEVEL(LOG_LEVEL_TRACE, "TS_ORDER_CAPABILITYSET: desktopSaveXGranularity (ignored as per protocol spec)");
@@ -230,7 +230,7 @@ xrdp_caps_process_order(struct xrdp_rdp *self, struct stream *s,
 
     if (cap_flags & 0x80) /* ORDER_FLAGS_EXTRA_SUPPORT */
     {
-        self->client_info.order_flags_ex = ex_flags;
+        self->client_info.xup.order_flags_ex = ex_flags;
         if (ex_flags & XR_ORDERFLAGS_EX_CACHE_BITMAP_REV3_SUPPORT)
         {
             LOG_DEVEL(LOG_LEVEL_INFO, "Client Capability: bitmap cache v3 supported");
@@ -315,7 +315,7 @@ xrdp_caps_process_bmpcache2(struct xrdp_rdp *self, struct stream *s,
         return 1;
     }
     self->client_info.bitmap_cache_version |= 2;
-    Bpp = (self->client_info.bpp + 7) / 8;
+    Bpp = (self->client_info.xup.bpp + 7) / 8;
     in_uint16_le(s, i); /* cache flags */
     self->client_info.bitmap_cache_persist_enable = i;
     in_uint8s(s, 2); /* number of caches in set, 3 */
@@ -379,9 +379,9 @@ xrdp_caps_process_pointer(struct xrdp_rdp *self, struct stream *s,
         LOG(LOG_LEVEL_ERROR, "xrdp_caps_process_pointer: error");
         return 1;
     }
-    no_new_cursor = self->client_info.pointer_flags & 2;
+    no_new_cursor = self->client_info.xup.pointer_flags & 2;
     in_uint16_le(s, colorPointerFlag);
-    self->client_info.pointer_flags = colorPointerFlag;
+    self->client_info.xup.pointer_flags = colorPointerFlag;
     in_uint16_le(s, i);
     i = MIN(i, 32);
     self->client_info.pointer_cache_entries = i;
@@ -402,7 +402,7 @@ xrdp_caps_process_pointer(struct xrdp_rdp *self, struct stream *s,
     {
         LOG(LOG_LEVEL_INFO, "xrdp_caps_process_pointer: new(color) cursor is "
             "disabled by config");
-        self->client_info.pointer_flags = 0;
+        self->client_info.xup.pointer_flags = 0;
     }
     return 0;
 }
@@ -504,16 +504,16 @@ xrdp_caps_process_offscreen_bmpcache(struct xrdp_rdp *self, struct stream *s,
         return 1;
     }
     in_uint32_le(s, i32);
-    self->client_info.offscreen_support_level = i32;
+    self->client_info.xup.offscreen_support_level = i32;
     in_uint16_le(s, i32);
-    self->client_info.offscreen_cache_size = i32 * 1024;
+    self->client_info.xup.offscreen_cache_size = i32 * 1024;
     in_uint16_le(s, i32);
-    self->client_info.offscreen_cache_entries = i32;
+    self->client_info.xup.offscreen_cache_entries = i32;
     LOG(LOG_LEVEL_INFO, "xrdp_process_offscreen_bmpcache: support level %d "
         "cache size %d bytes cache entries %d",
-        self->client_info.offscreen_support_level,
-        self->client_info.offscreen_cache_size,
-        self->client_info.offscreen_cache_entries);
+        self->client_info.xup.offscreen_support_level,
+        self->client_info.xup.offscreen_cache_size,
+        self->client_info.xup.offscreen_cache_entries);
     return 0;
 }
 
@@ -704,7 +704,7 @@ xrdp_caps_process_largepointer(struct xrdp_rdp *self, struct stream *s,
     int largePointerSupportFlags;
 
     in_uint16_le(s, largePointerSupportFlags);
-    self->client_info.large_pointer_support_flags = largePointerSupportFlags;
+    self->client_info.xup.large_pointer_support_flags = largePointerSupportFlags;
     return 0;
 }
 
@@ -955,52 +955,52 @@ xrdp_caps_process_confirm_active(struct xrdp_rdp *self, struct stream *s)
     }
 
     if (self->client_info.no_orders_supported &&
-            (self->client_info.offscreen_support_level != 0))
+            (self->client_info.xup.offscreen_support_level != 0))
     {
         LOG(LOG_LEVEL_WARNING, "Client Capability: not enough orders "
             "supported by client, client wants off screen bitmap but "
             "offscreen bitmaps disabled");
-        self->client_info.offscreen_support_level = 0;
-        self->client_info.offscreen_cache_size = 0;
-        self->client_info.offscreen_cache_entries = 0;
+        self->client_info.xup.offscreen_support_level = 0;
+        self->client_info.xup.offscreen_cache_size = 0;
+        self->client_info.xup.offscreen_cache_entries = 0;
     }
 
     if (self->client_info.use_fast_path)
     {
-        if ((self->client_info.large_pointer_support_flags & LARGE_POINTER_FLAG_96x96) &&
+        if ((self->client_info.xup.large_pointer_support_flags & LARGE_POINTER_FLAG_96x96) &&
                 (self->client_info.max_fastpath_frag_bytes < 38055))
         {
             LOG(LOG_LEVEL_WARNING, "Client Capability: client requested "
                 "LARGE_POINTER_FLAG_96x96 but max_fastpath_frag_bytes(%d) is less then "
                 "the required size of 38055, 96x96 large cursor support disabled",
                 self->client_info.max_fastpath_frag_bytes);
-            self->client_info.large_pointer_support_flags &= ~LARGE_POINTER_FLAG_96x96;
+            self->client_info.xup.large_pointer_support_flags &= ~LARGE_POINTER_FLAG_96x96;
         }
-        if ((self->client_info.large_pointer_support_flags & LARGE_POINTER_FLAG_384x384) &&
+        if ((self->client_info.xup.large_pointer_support_flags & LARGE_POINTER_FLAG_384x384) &&
                 (self->client_info.max_fastpath_frag_bytes < 608299))
         {
             LOG(LOG_LEVEL_WARNING, "Client Capability: client requested "
                 "LARGE_POINTER_FLAG_384x384 but max_fastpath_frag_bytes(%d) is less then "
                 "the required size of 608299, 384x384 large cursor support disabled",
                 self->client_info.max_fastpath_frag_bytes);
-            self->client_info.large_pointer_support_flags &= ~LARGE_POINTER_FLAG_384x384;
+            self->client_info.xup.large_pointer_support_flags &= ~LARGE_POINTER_FLAG_384x384;
         }
     }
     else
     {
-        if (self->client_info.large_pointer_support_flags != 0)
+        if (self->client_info.xup.large_pointer_support_flags != 0)
         {
             LOG(LOG_LEVEL_WARNING, "Client Capability: client requested "
                 "large pointers but use_fast_path is false, "
                 "all large cursor support disabled");
-            self->client_info.large_pointer_support_flags = 0;
+            self->client_info.xup.large_pointer_support_flags = 0;
         }
     }
-    if (self->client_info.large_pointer_support_flags & LARGE_POINTER_FLAG_96x96)
+    if (self->client_info.xup.large_pointer_support_flags & LARGE_POINTER_FLAG_96x96)
     {
         LOG(LOG_LEVEL_INFO, "Client Capability: LARGE_POINTER_FLAG_96x96 supported");
     }
-    if (self->client_info.large_pointer_support_flags & LARGE_POINTER_FLAG_384x384)
+    if (self->client_info.xup.large_pointer_support_flags & LARGE_POINTER_FLAG_384x384)
     {
         LOG(LOG_LEVEL_INFO, "Client Capability: LARGE_POINTER_FLAG_384x384 supported");
     }
@@ -1034,8 +1034,8 @@ unsigned int calculate_multifragmentupdate_len(const struct xrdp_rdp *self)
 {
     unsigned int result = MAX_MULTIFRAGMENTUPDATE_SIZE;
 
-    unsigned int x_tiles = (self->client_info.display_sizes.session_width + 63) / 64;
-    unsigned int y_tiles = (self->client_info.display_sizes.session_height + 63) / 64;
+    unsigned int x_tiles = (self->client_info.xup.display_sizes.session_width + 63) / 64;
+    unsigned int y_tiles = (self->client_info.xup.display_sizes.session_height + 63) / 64;
 
     /* Check for overflow on calculation if bad parameters are supplied */
     if ((x_tiles * y_tiles  + 1) < (UINT_MAX / 16384))
@@ -1126,12 +1126,12 @@ xrdp_caps_send_demand_active(struct xrdp_rdp *self)
     caps_count++;
     out_uint16_le(s, CAPSTYPE_BITMAP);
     out_uint16_le(s, CAPSTYPE_BITMAP_LEN);
-    out_uint16_le(s, self->client_info.bpp); /* Preferred BPP */
+    out_uint16_le(s, self->client_info.xup.bpp); /* Preferred BPP */
     out_uint16_le(s, 1); /* Receive 1 BPP */
     out_uint16_le(s, 1); /* Receive 4 BPP */
     out_uint16_le(s, 1); /* Receive 8 BPP */
-    out_uint16_le(s, self->client_info.display_sizes.session_width); /* width */
-    out_uint16_le(s, self->client_info.display_sizes.session_height); /* height */
+    out_uint16_le(s, self->client_info.xup.display_sizes.session_width); /* width */
+    out_uint16_le(s, self->client_info.xup.display_sizes.session_height); /* height */
     out_uint16_le(s, 0); /* Pad */
     out_uint16_le(s, 1); /* Allow resize */
     out_uint16_le(s, 1); /* bitmap compression */
@@ -1402,7 +1402,7 @@ xrdp_caps_send_demand_active(struct xrdp_rdp *self)
     int early_cap_flags = self->client_info.mcs_early_capability_flags;
 
     if ((early_cap_flags & RNS_UD_CS_SUPPORT_MONITOR_LAYOUT_PDU) != 0 &&
-            self->client_info.display_sizes.monitorCount > 0 &&
+            self->client_info.xup.display_sizes.monitorCount > 0 &&
             self->client_info.multimon == 1)
     {
         LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_caps_send_demand_active: sending monitor layout pdu");

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -1313,10 +1313,10 @@ xrdp_rdp_process_data_font(struct xrdp_rdp *self, struct stream *s)
 
         /* This is also the end of an Deactivation-reactivation
          * sequence [MS-RDPBCGR] 1.3.1.3 */
+        int width = self->client_info.xup.display_sizes.session_width;
+        int height = self->client_info.xup.display_sizes.session_height;
         xrdp_rdp_suppress_output(self, 0, XSO_REASON_DEACTIVATE_REACTIVATE,
-                                 0, 0,
-                                 self->client_info.xup.display_sizes.session_width,
-                                 self->client_info.xup.display_sizes.session_height);
+                                 0, 0, width, height);
 
         if (self->session->callback != 0)
         {

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -39,7 +39,8 @@
 
 /*****************************************************************************/
 static int
-xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
+xrdp_rdp_read_config(const char *xrdp_ini,
+                     struct xrdp_client_info *client_info)
 {
     int index = 0;
     struct list *items = (struct list *)NULL;
@@ -135,7 +136,7 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
         }
         else if (g_strcasecmp(item, "new_cursors") == 0)
         {
-            client_info->pointer_flags = g_text2bool(value) == 0 ? 2 : 0;
+            client_info->xup.pointer_flags = g_text2bool(value) == 0 ? 2 : 0;
         }
         else if (g_strcasecmp(item, "require_credentials") == 0)
         {
@@ -389,8 +390,8 @@ xrdp_rdp_create(struct xrdp_session *session, struct trans *trans)
     self->rfx_enc = rfx_context_new();
     rfx_context_set_cpu_opt(self->rfx_enc, xrdp_rdp_detect_cpu());
 #endif
-    self->client_info.size = sizeof(self->client_info);
-    self->client_info.version = CLIENT_INFO_CURRENT_VERSION;
+    self->client_info.xup.size = sizeof(self->client_info.xup);
+    self->client_info.xup.version = CLIENT_INFO_CURRENT_VERSION;
     LOG_DEVEL(LOG_LEVEL_TRACE, "out xrdp_rdp_create");
     return self;
 }
@@ -1314,8 +1315,8 @@ xrdp_rdp_process_data_font(struct xrdp_rdp *self, struct stream *s)
          * sequence [MS-RDPBCGR] 1.3.1.3 */
         xrdp_rdp_suppress_output(self, 0, XSO_REASON_DEACTIVATE_REACTIVATE,
                                  0, 0,
-                                 self->client_info.display_sizes.session_width,
-                                 self->client_info.display_sizes.session_height);
+                                 self->client_info.xup.display_sizes.session_width,
+                                 self->client_info.xup.display_sizes.session_height);
 
         if (self->session->callback != 0)
         {

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -1993,17 +1993,12 @@ xrdp_sec_process_mcs_data_monitors(struct xrdp_sec *self, struct stream *s)
     error = libxrdp_process_monitor_stream(s, description, 0);
     if (error == 0)
     {
-        client_info->xup.display_sizes.monitorCount = description->monitorCount;
-
         LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_process_mcs_data_monitors:"
                   " Received [MS-RDPBCGR] TS_UD_CS_MONITOR"
                   " flags 0x%8.8x, monitorCount %d",
                   flags, description->monitorCount);
 
-        client_info->xup.display_sizes.session_width = description->session_width;
-        client_info->xup.display_sizes.session_height = description->session_height;
-        g_memcpy(client_info->xup.display_sizes.minfo, description->minfo, sizeof(struct monitor_info) * CLIENT_MONITOR_DATA_MAXIMUM_MONITORS);
-        g_memcpy(client_info->xup.display_sizes.minfo_wm, description->minfo_wm, sizeof(struct monitor_info) * CLIENT_MONITOR_DATA_MAXIMUM_MONITORS);
+        client_info->xup.display_sizes = *description;
     }
 
     g_free(description);

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -1502,16 +1502,16 @@ xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec *self, struct stream *s)
         return 1;
     }
     in_uint32_le(s, version);
-    in_uint16_le(s, client_info->display_sizes.session_width);
-    in_uint16_le(s, client_info->display_sizes.session_height);
+    in_uint16_le(s, client_info->xup.display_sizes.session_width);
+    in_uint16_le(s, client_info->xup.display_sizes.session_height);
     in_uint16_le(s, colorDepth);
     switch (colorDepth)
     {
         case RNS_UD_COLOR_4BPP:
-            client_info->bpp = 4;
+            client_info->xup.bpp = 4;
             break;
         case RNS_UD_COLOR_8BPP:
-            client_info->bpp = 8;
+            client_info->xup.bpp = 8;
             break;
     }
     in_uint8s(s, 2); /* SASSequence */
@@ -1541,8 +1541,8 @@ xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec *self, struct stream *s)
               "keyboardSubType 0x%8.8x, keyboardFunctionKey (ignored), "
               "imeFileName (ignored)",
               version,
-              client_info->display_sizes.session_width,
-              client_info->display_sizes.session_height,
+              client_info->xup.display_sizes.session_width,
+              client_info->xup.display_sizes.session_height,
               (colorDepth == RNS_UD_COLOR_4BPP ? "RNS_UD_COLOR_4BPP" :
                colorDepth == RNS_UD_COLOR_8BPP ? "RNS_UD_COLOR_8BPP" :
                "unknown"),
@@ -1570,19 +1570,19 @@ xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec *self, struct stream *s)
     switch (postBeta2ColorDepth)
     {
         case RNS_UD_COLOR_4BPP:
-            client_info->bpp = 4;
+            client_info->xup.bpp = 4;
             break;
         case RNS_UD_COLOR_8BPP :
-            client_info->bpp = 8;
+            client_info->xup.bpp = 8;
             break;
         case RNS_UD_COLOR_16BPP_555:
-            client_info->bpp = 15;
+            client_info->xup.bpp = 15;
             break;
         case RNS_UD_COLOR_16BPP_565:
-            client_info->bpp = 16;
+            client_info->xup.bpp = 16;
             break;
         case RNS_UD_COLOR_24BPP:
-            client_info->bpp = 24;
+            client_info->xup.bpp = 24;
             break;
     }
     if (!s_check_rem(s, 2))
@@ -1614,7 +1614,7 @@ xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec *self, struct stream *s)
               highColorDepth == 0x0010 ? "HIGH_COLOR_16BPP" :
               highColorDepth == 0x0018 ? "HIGH_COLOR_24BPP" :
               "unknown");
-    client_info->bpp = highColorDepth;
+    client_info->xup.bpp = highColorDepth;
 
     if (!s_check_rem(s, 2))
     {
@@ -1645,12 +1645,12 @@ xrdp_sec_process_mcs_data_CS_CORE(struct xrdp_sec *self, struct stream *s)
     if ((earlyCapabilityFlags & RNS_UD_CS_WANT_32BPP_SESSION)
             && (supportedColorDepths & RNS_UD_32BPP_SUPPORT))
     {
-        client_info->bpp = 32;
+        client_info->xup.bpp = 32;
     }
 #ifdef XRDP_RFXCODEC
     if (earlyCapabilityFlags & RNS_UD_CS_SUPPORT_DYNVC_GFX_PROTOCOL)
     {
-        if (client_info->bpp < 32)
+        if (client_info->xup.bpp < 32)
         {
             LOG(LOG_LEVEL_WARNING,
                 "client requested gfx protocol with insufficient color depth");
@@ -1993,17 +1993,17 @@ xrdp_sec_process_mcs_data_monitors(struct xrdp_sec *self, struct stream *s)
     error = libxrdp_process_monitor_stream(s, description, 0);
     if (error == 0)
     {
-        client_info->display_sizes.monitorCount = description->monitorCount;
+        client_info->xup.display_sizes.monitorCount = description->monitorCount;
 
         LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_sec_process_mcs_data_monitors:"
                   " Received [MS-RDPBCGR] TS_UD_CS_MONITOR"
                   " flags 0x%8.8x, monitorCount %d",
                   flags, description->monitorCount);
 
-        client_info->display_sizes.session_width = description->session_width;
-        client_info->display_sizes.session_height = description->session_height;
-        g_memcpy(client_info->display_sizes.minfo, description->minfo, sizeof(struct monitor_info) * CLIENT_MONITOR_DATA_MAXIMUM_MONITORS);
-        g_memcpy(client_info->display_sizes.minfo_wm, description->minfo_wm, sizeof(struct monitor_info) * CLIENT_MONITOR_DATA_MAXIMUM_MONITORS);
+        client_info->xup.display_sizes.session_width = description->session_width;
+        client_info->xup.display_sizes.session_height = description->session_height;
+        g_memcpy(client_info->xup.display_sizes.minfo, description->minfo, sizeof(struct monitor_info) * CLIENT_MONITOR_DATA_MAXIMUM_MONITORS);
+        g_memcpy(client_info->xup.display_sizes.minfo_wm, description->minfo_wm, sizeof(struct monitor_info) * CLIENT_MONITOR_DATA_MAXIMUM_MONITORS);
     }
 
     g_free(description);
@@ -2047,7 +2047,7 @@ xrdp_sec_process_mcs_data_monitors_ex(struct xrdp_sec *self, struct stream *s)
         return SEC_PROCESS_MONITORS_ERR;
     }
 
-    return libxrdp_process_monitor_ex_stream(s, &client_info->display_sizes);
+    return libxrdp_process_monitor_ex_stream(s, &client_info->xup.display_sizes);
 }
 
 /*****************************************************************************/
@@ -2157,15 +2157,15 @@ xrdp_sec_process_mcs_data(struct xrdp_sec *self)
 
     if (client_info->max_bpp > 0)
     {
-        if (client_info->bpp > client_info->max_bpp)
+        if (client_info->xup.bpp > client_info->max_bpp)
         {
             LOG(LOG_LEVEL_WARNING, "Client requested %d bpp color depth, "
                 "but the server configuration is limited to %d bpp. "
                 "Downgrading the color depth to %d bits-per-pixel.",
-                client_info->bpp,
+                client_info->xup.bpp,
                 client_info->max_bpp,
                 client_info->max_bpp);
-            client_info->bpp = client_info->max_bpp;
+            client_info->xup.bpp = client_info->max_bpp;
         }
     }
 

--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -1994,7 +1994,7 @@ lfreerdp_pre_connect(freerdp *instance)
 
     // Multi Monitor Settings
     const struct display_size_description *display_sizes =
-            &mod->client_info.display_sizes;
+            &mod->client_info.xup.display_sizes;
     instance->settings->num_monitors = display_sizes->monitorCount;
 
     for (index = 0; index < display_sizes->monitorCount; index++)

--- a/tests/libxrdp/test_xrdp_sec_process_mcs_data_monitors.c
+++ b/tests/libxrdp/test_xrdp_sec_process_mcs_data_monitors.c
@@ -92,25 +92,25 @@ START_TEST(test_xrdp_sec_process_mcs_data_monitors__with_single_monitor_happy_pa
     int error = xrdp_sec_process_mcs_data_monitors(sec_layer, s);
     ck_assert_int_eq(error, 0);
 
-    ck_assert_int_eq(client_info->display_sizes.monitorCount, 1);
+    ck_assert_int_eq(client_info->xup.display_sizes.monitorCount, 1);
 
     // Verify normal monitor
-    ck_assert_int_eq(client_info->display_sizes.minfo[0].left, 0);
-    ck_assert_int_eq(client_info->display_sizes.minfo[0].top, 0);
-    ck_assert_int_eq(client_info->display_sizes.minfo[0].right, 3840);
-    ck_assert_int_eq(client_info->display_sizes.minfo[0].bottom, 2160);
-    ck_assert_int_eq(client_info->display_sizes.minfo[0].is_primary, 1);
+    ck_assert_int_eq(client_info->xup.display_sizes.minfo[0].left, 0);
+    ck_assert_int_eq(client_info->xup.display_sizes.minfo[0].top, 0);
+    ck_assert_int_eq(client_info->xup.display_sizes.minfo[0].right, 3840);
+    ck_assert_int_eq(client_info->xup.display_sizes.minfo[0].bottom, 2160);
+    ck_assert_int_eq(client_info->xup.display_sizes.minfo[0].is_primary, 1);
 
     // Verify normalized monitor
-    ck_assert_int_eq(client_info->display_sizes.minfo_wm[0].left, 0);
-    ck_assert_int_eq(client_info->display_sizes.minfo_wm[0].top, 0);
-    ck_assert_int_eq(client_info->display_sizes.minfo_wm[0].right, 3840);
-    ck_assert_int_eq(client_info->display_sizes.minfo_wm[0].bottom, 2160);
-    ck_assert_int_eq(client_info->display_sizes.minfo_wm[0].is_primary, 1);
+    ck_assert_int_eq(client_info->xup.display_sizes.minfo_wm[0].left, 0);
+    ck_assert_int_eq(client_info->xup.display_sizes.minfo_wm[0].top, 0);
+    ck_assert_int_eq(client_info->xup.display_sizes.minfo_wm[0].right, 3840);
+    ck_assert_int_eq(client_info->xup.display_sizes.minfo_wm[0].bottom, 2160);
+    ck_assert_int_eq(client_info->xup.display_sizes.minfo_wm[0].is_primary, 1);
 
     // Verify geometry (+1 greater than )
-    ck_assert_int_eq(client_info->display_sizes.session_width, 3841);
-    ck_assert_int_eq(client_info->display_sizes.session_height, 2161);
+    ck_assert_int_eq(client_info->xup.display_sizes.session_width, 3841);
+    ck_assert_int_eq(client_info->xup.display_sizes.session_height, 2161);
 
     free_stream(s);
 }
@@ -141,25 +141,25 @@ START_TEST(test_xrdp_sec_process_mcs_data_monitors__when_no_primary_monitor_is_s
     int error = xrdp_sec_process_mcs_data_monitors(sec_layer, s);
     ck_assert_int_eq(error, 0);
 
-    ck_assert_int_eq(client_info->display_sizes.monitorCount, 1);
+    ck_assert_int_eq(client_info->xup.display_sizes.monitorCount, 1);
 
     // Verify normal monitor
-    ck_assert_int_eq(client_info->display_sizes.minfo[0].left, 0);
-    ck_assert_int_eq(client_info->display_sizes.minfo[0].top, 0);
-    ck_assert_int_eq(client_info->display_sizes.minfo[0].right, 3840);
-    ck_assert_int_eq(client_info->display_sizes.minfo[0].bottom, 2160);
-    ck_assert_int_eq(client_info->display_sizes.minfo[0].is_primary, 1);
+    ck_assert_int_eq(client_info->xup.display_sizes.minfo[0].left, 0);
+    ck_assert_int_eq(client_info->xup.display_sizes.minfo[0].top, 0);
+    ck_assert_int_eq(client_info->xup.display_sizes.minfo[0].right, 3840);
+    ck_assert_int_eq(client_info->xup.display_sizes.minfo[0].bottom, 2160);
+    ck_assert_int_eq(client_info->xup.display_sizes.minfo[0].is_primary, 1);
 
     // Verify normalized monitor
-    ck_assert_int_eq(client_info->display_sizes.minfo_wm[0].left, 0);
-    ck_assert_int_eq(client_info->display_sizes.minfo_wm[0].top, 0);
-    ck_assert_int_eq(client_info->display_sizes.minfo_wm[0].right, 3840);
-    ck_assert_int_eq(client_info->display_sizes.minfo_wm[0].bottom, 2160);
-    ck_assert_int_eq(client_info->display_sizes.minfo_wm[0].is_primary, 1);
+    ck_assert_int_eq(client_info->xup.display_sizes.minfo_wm[0].left, 0);
+    ck_assert_int_eq(client_info->xup.display_sizes.minfo_wm[0].top, 0);
+    ck_assert_int_eq(client_info->xup.display_sizes.minfo_wm[0].right, 3840);
+    ck_assert_int_eq(client_info->xup.display_sizes.minfo_wm[0].bottom, 2160);
+    ck_assert_int_eq(client_info->xup.display_sizes.minfo_wm[0].is_primary, 1);
 
     // Verify geometry (+1 greater than )
-    ck_assert_int_eq(client_info->display_sizes.session_width, 3841);
-    ck_assert_int_eq(client_info->display_sizes.session_height, 2161);
+    ck_assert_int_eq(client_info->xup.display_sizes.session_width, 3841);
+    ck_assert_int_eq(client_info->xup.display_sizes.session_height, 2161);
 
     free_stream(s);
 }

--- a/vnc/vnc.c
+++ b/vnc/vnc.c
@@ -2493,10 +2493,10 @@ lib_mod_set_param(struct vnc *v, const char *name, const char *value)
          * Use minfo_wm, as this is normalised for a top-left of (0,0)
          * as required by RFC6143 */
         init_client_layout(v,
-                           client_info->display_sizes.session_width,
-                           client_info->display_sizes.session_height,
-                           client_info->display_sizes.monitorCount,
-                           client_info->display_sizes.minfo_wm);
+                           client_info->xup.display_sizes.session_width,
+                           client_info->xup.display_sizes.session_height,
+                           client_info->xup.display_sizes.monitorCount,
+                           client_info->xup.display_sizes.minfo_wm);
         log_screen_layout(LOG_LEVEL_DEBUG, "client_info", &v->client_layout);
     }
 

--- a/xrdp/lang.c
+++ b/xrdp/lang.c
@@ -687,9 +687,9 @@ scan_overrides_kbtype_tables(toml_table_t *kb_type,
         read_param_set(subtable,
                        layouts_table_str, layouts_table_str_len,
                        map_table_str, map_table_str_len,
-                       client_info->model, sizeof(client_info->model),
-                       client_info->variant, sizeof(client_info->variant),
-                       client_info->options, sizeof(client_info->options));
+                       client_info->xup.model, sizeof(client_info->xup.model),
+                       client_info->xup.variant, sizeof(client_info->xup.variant),
+                       client_info->xup.options, sizeof(client_info->xup.options));
     }
 }
 
@@ -724,9 +724,9 @@ read_toml_config(struct xrdp_client_info *client_info,
     read_param_set(defaults,
                    layouts_table_str, sizeof(layouts_table_str),
                    map_table_str, sizeof(map_table_str),
-                   client_info->model, sizeof(client_info->model),
-                   client_info->variant, sizeof(client_info->variant),
-                   client_info->options, sizeof(client_info->options));
+                   client_info->xup.model, sizeof(client_info->xup.model),
+                   client_info->xup.variant, sizeof(client_info->xup.variant),
+                   client_info->xup.options, sizeof(client_info->xup.options));
 
     if (layouts_table_str[0] == '\0' || map_table_str[0] == '\0')
     {
@@ -797,7 +797,7 @@ read_toml_config(struct xrdp_client_info *client_info,
     // lookup the corresponding X11 layout in the map table, e.g. if we
     // matched 0xe0200411 to 'rdp_layout_jp, copy 'jp' for the client.
     if (!get_toml_string(map_table, layout_name,
-                         client_info->layout, sizeof(client_info->layout)))
+                         client_info->xup.layout, sizeof(client_info->xup.layout)))
     {
         LOG(LOG_LEVEL_ERROR, "Can't find layout name %s in map table %s",
             layout_name, map_table_str);
@@ -841,9 +841,9 @@ xrdp_init_xkb_layout(struct xrdp_client_info *client_info)
     }
     /* infer model/variant */
     /* TODO specify different X11 keyboard models/variants */
-    client_info->model[0] = '\0';
-    client_info->variant[0] = '\0';
-    strlcpy(client_info->layout, "us", sizeof(client_info->layout));
+    client_info->xup.model[0] = '\0';
+    client_info->xup.variant[0] = '\0';
+    strlcpy(client_info->xup.layout, "us", sizeof(client_info->xup.layout));
     if (client_info->keyboard_subtype == 0)
     {
         /* default - standard subtype */
@@ -875,27 +875,27 @@ xrdp_init_xkb_layout(struct xrdp_client_info *client_info)
             read_toml_config(client_info, keyboard_cfg_file, tfile);
             LOG(LOG_LEVEL_INFO, "xrdp_init_xkb_layout: model [%s] variant [%s] "
                 "layout [%s] options [%s]",
-                client_info->model, client_info->variant,
-                client_info->layout, client_info->options);
+                client_info->xup.model, client_info->xup.variant,
+                client_info->xup.layout, client_info->xup.options);
             toml_free(tfile);
         }
     }
 
     // Initialise the rules and a few keycodes for xorgxrdp
-    strlcpy(client_info->xkb_rules, scancode_get_xkb_rules(),
-            sizeof(client_info->xkb_rules));
+    strlcpy(client_info->xup.xkb_rules, scancode_get_xkb_rules(),
+            sizeof(client_info->xup.xkb_rules));
     if (keylayout_supports_caps_lock(client_info->keylayout))
     {
-        client_info->x11_keycode_caps_lock =
+        client_info->xup.x11_keycode_caps_lock =
             scancode_to_x11_keycode(SCANCODE_CAPS_KEY);
     }
     else
     {
         LOG(LOG_LEVEL_INFO, "xrdp_init_xkb_layout: caps lock is not supported");
-        client_info->x11_keycode_caps_lock = 0;
+        client_info->xup.x11_keycode_caps_lock = 0;
     }
-    client_info->x11_keycode_num_lock =
+    client_info->xup.x11_keycode_num_lock =
         scancode_to_x11_keycode(SCANCODE_NUMLOCK_KEY);
-    client_info->x11_keycode_scroll_lock =
+    client_info->xup.x11_keycode_scroll_lock =
         scancode_to_x11_keycode(SCANCODE_SCROLL_KEY);
 }

--- a/xrdp/lang.c
+++ b/xrdp/lang.c
@@ -688,8 +688,10 @@ scan_overrides_kbtype_tables(toml_table_t *kb_type,
                        layouts_table_str, layouts_table_str_len,
                        map_table_str, map_table_str_len,
                        client_info->xup.model, sizeof(client_info->xup.model),
-                       client_info->xup.variant, sizeof(client_info->xup.variant),
-                       client_info->xup.options, sizeof(client_info->xup.options));
+                       client_info->xup.variant,
+                       sizeof(client_info->xup.variant),
+                       client_info->xup.options,
+                       sizeof(client_info->xup.options));
     }
 }
 
@@ -797,7 +799,8 @@ read_toml_config(struct xrdp_client_info *client_info,
     // lookup the corresponding X11 layout in the map table, e.g. if we
     // matched 0xe0200411 to 'rdp_layout_jp, copy 'jp' for the client.
     if (!get_toml_string(map_table, layout_name,
-                         client_info->xup.layout, sizeof(client_info->xup.layout)))
+                         client_info->xup.layout,
+                         sizeof(client_info->xup.layout)))
     {
         LOG(LOG_LEVEL_ERROR, "Can't find layout name %s in map table %s",
             layout_name, map_table_str);

--- a/xrdp/xrdp_egfx.c
+++ b/xrdp/xrdp_egfx.c
@@ -667,7 +667,7 @@ xrdp_egfx_send_wire_to_surface2(struct xrdp_egfx *egfx, int surface_id,
 /******************************************************************************/
 struct stream *
 xrdp_egfx_reset_graphics(struct xrdp_egfx_bulk *bulk, int width, int height,
-                         int monitor_count, struct monitor_info *mi)
+                         int monitor_count, const struct monitor_info *mi)
 {
     int bytes;
     int index;
@@ -745,7 +745,8 @@ xrdp_egfx_reset_graphics(struct xrdp_egfx_bulk *bulk, int width, int height,
 /******************************************************************************/
 int
 xrdp_egfx_send_reset_graphics(struct xrdp_egfx *egfx, int width, int height,
-                              int monitor_count, struct monitor_info *mi)
+                              int monitor_count,
+                              const struct monitor_info *mi)
 {
     int error;
     struct stream *s;

--- a/xrdp/xrdp_egfx.h
+++ b/xrdp/xrdp_egfx.h
@@ -228,9 +228,10 @@ xrdp_egfx_send_wire_to_surface2(struct xrdp_egfx *egfx, int surface_id,
  */
 struct stream *
 xrdp_egfx_reset_graphics(struct xrdp_egfx_bulk *bulk, int width, int height,
-                         int monitor_count, struct monitor_info *mi);
+                         int monitor_count, const struct monitor_info *mi);
 int
 xrdp_egfx_send_reset_graphics(struct xrdp_egfx *egfx, int width, int height,
-                              int monitor_count, struct monitor_info *mi);
+                              int monitor_count,
+                              const struct monitor_info *mi);
 
 #endif

--- a/xrdp/xrdp_encoder.c
+++ b/xrdp/xrdp_encoder.c
@@ -203,7 +203,7 @@ xrdp_encoder_create(struct xrdp_mm *mm)
             return 0;
         }
     }
-    if (client_info->bpp < 24)
+    if (client_info->xup.bpp < 24)
     {
         return 0;
     }
@@ -221,8 +221,8 @@ xrdp_encoder_create(struct xrdp_mm *mm)
         self->codec_id = client_info->jpeg_codec_id;
         self->in_codec_mode = 1;
         self->codec_quality = client_info->jpeg_prop[0];
-        client_info->capture_code = CC_SIMPLE;
-        client_info->capture_format = XRDP_a8b8g8r8;
+        client_info->xup.capture_code = CC_SIMPLE;
+        client_info->xup.capture_format = XRDP_a8b8g8r8;
         self->process_enc = process_enc_jpg;
     }
 #if defined(XRDP_X264) || defined(XRDP_OPENH264)
@@ -231,8 +231,8 @@ xrdp_encoder_create(struct xrdp_mm *mm)
         LOG(LOG_LEVEL_INFO,
             "xrdp_encoder_create: starting h264 codec session gfx");
         self->in_codec_mode = 1;
-        client_info->capture_code = CC_GFX_A2;
-        client_info->capture_format = XRDP_nv12_709fr;
+        client_info->xup.capture_code = CC_GFX_A2;
+        client_info->xup.capture_format = XRDP_nv12_709fr;
         self->gfx = 1;
     }
     else if (mm->libh264_loaded && client_info->h264_codec_id != 0)
@@ -240,8 +240,8 @@ xrdp_encoder_create(struct xrdp_mm *mm)
         LOG(LOG_LEVEL_INFO, "xrdp_encoder_create: starting h264 codec session");
         self->codec_id = client_info->h264_codec_id;
         self->in_codec_mode = 1;
-        client_info->capture_code = CC_SUF_A2;
-        client_info->capture_format = XRDP_nv12;
+        client_info->xup.capture_code = CC_SUF_A2;
+        client_info->xup.capture_format = XRDP_nv12;
         self->process_enc = process_enc_h264;
     }
 #endif
@@ -251,7 +251,7 @@ xrdp_encoder_create(struct xrdp_mm *mm)
         LOG(LOG_LEVEL_INFO,
             "xrdp_encoder_create: starting gfx rfx pro codec session");
         self->in_codec_mode = 1;
-        client_info->capture_code = CC_GFX_PRO;
+        client_info->xup.capture_code = CC_GFX_PRO;
         self->gfx = 1;
         self->num_quants = 2;
         self->quant_idx_y = 0;
@@ -281,7 +281,7 @@ xrdp_encoder_create(struct xrdp_mm *mm)
         LOG(LOG_LEVEL_INFO, "xrdp_encoder_create: starting rfx codec session");
         self->codec_id = client_info->rfx_codec_id;
         self->in_codec_mode = 1;
-        client_info->capture_code = CC_SUF_RFX;
+        client_info->xup.capture_code = CC_SUF_RFX;
         self->process_enc = process_enc_rfx;
         self->codec_handle_rfx = rfxcodec_encode_create(mm->wm->screen->width,
                                  mm->wm->screen->height,

--- a/xrdp/xrdp_login_wnd.c
+++ b/xrdp/xrdp_login_wnd.c
@@ -674,7 +674,7 @@ xrdp_login_wnd_get_monitor_dpi(struct xrdp_wm *self)
 {
     unsigned int result = 0;
     const struct display_size_description *display_sizes =
-            &self->client_info->display_sizes;
+            &self->client_info->xup.display_sizes;
     unsigned int height_pixels = 0;
     unsigned int height_mm = 0;
 
@@ -797,16 +797,16 @@ xrdp_login_wnd_create(struct xrdp_wm *self)
     }
 
     /* multimon scenario, draw login window on primary monitor */
-    if (self->client_info->display_sizes.monitorCount > 1)
+    if (self->client_info->xup.display_sizes.monitorCount > 1)
     {
-        for (index = 0; index < self->client_info->display_sizes.monitorCount; index++)
+        for (index = 0; index < self->client_info->xup.display_sizes.monitorCount; index++)
         {
-            if (self->client_info->display_sizes.minfo_wm[index].is_primary)
+            if (self->client_info->xup.display_sizes.minfo_wm[index].is_primary)
             {
-                x = self->client_info->display_sizes.minfo_wm[index].left;
-                y = self->client_info->display_sizes.minfo_wm[index].top;
-                cx = self->client_info->display_sizes.minfo_wm[index].right;
-                cy = self->client_info->display_sizes.minfo_wm[index].bottom;
+                x = self->client_info->xup.display_sizes.minfo_wm[index].left;
+                y = self->client_info->xup.display_sizes.minfo_wm[index].top;
+                cx = self->client_info->xup.display_sizes.minfo_wm[index].right;
+                cy = self->client_info->xup.display_sizes.minfo_wm[index].bottom;
 
                 primary_width = cx - x;
                 primary_height = cy - y;

--- a/xrdp/xrdp_login_wnd.c
+++ b/xrdp/xrdp_login_wnd.c
@@ -797,16 +797,19 @@ xrdp_login_wnd_create(struct xrdp_wm *self)
     }
 
     /* multimon scenario, draw login window on primary monitor */
-    if (self->client_info->xup.display_sizes.monitorCount > 1)
+    const struct display_size_description *display_sizes =
+            &self->client_info->xup.display_sizes;
+
+    if (display_sizes->monitorCount > 1)
     {
-        for (index = 0; index < self->client_info->xup.display_sizes.monitorCount; index++)
+        for (index = 0; index < display_sizes->monitorCount; index++)
         {
-            if (self->client_info->xup.display_sizes.minfo_wm[index].is_primary)
+            if (display_sizes->minfo_wm[index].is_primary)
             {
-                x = self->client_info->xup.display_sizes.minfo_wm[index].left;
-                y = self->client_info->xup.display_sizes.minfo_wm[index].top;
-                cx = self->client_info->xup.display_sizes.minfo_wm[index].right;
-                cy = self->client_info->xup.display_sizes.minfo_wm[index].bottom;
+                x = display_sizes->minfo_wm[index].left;
+                y = display_sizes->minfo_wm[index].top;
+                cx = display_sizes->minfo_wm[index].right;
+                cy = display_sizes->minfo_wm[index].bottom;
 
                 primary_width = cx - x;
                 primary_height = cy - y;

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -90,7 +90,7 @@ xrdp_mm_create(struct xrdp_wm *owner)
     LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_mm_create: bpp %d mcs_connection_type %d "
               "jpeg_codec_id %d v3_codec_id %d rfx_codec_id %d "
               "h264_codec_id %d",
-              self->wm->client_info->bpp,
+              self->wm->client_info->xup.bpp,
               self->wm->client_info->mcs_connection_type,
               self->wm->client_info->jpeg_codec_id,
               self->wm->client_info->v3_codec_id,
@@ -1346,7 +1346,7 @@ xrdp_mm_egfx_create_surfaces(struct xrdp_mm *self)
     struct xrdp_bitmap *screen;
 
     screen = self->wm->screen;
-    count = self->wm->client_info->display_sizes.monitorCount;
+    count = self->wm->client_info->xup.display_sizes.monitorCount;
     LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_mm_egfx_create_surfaces: "
               "monitor count %d", count);
     if (count < 1)
@@ -1368,7 +1368,7 @@ xrdp_mm_egfx_create_surfaces(struct xrdp_mm *self)
     for (index = 0; index < count; index++)
     {
         surface_id = index;
-        mi = self->wm->client_info->display_sizes.minfo_wm + index;
+        mi = self->wm->client_info->xup.display_sizes.minfo_wm + index;
         left = mi->left;
         top = mi->top;
         width = mi->right - mi->left + 1;
@@ -1508,11 +1508,11 @@ xrdp_mm_egfx_caps_advertise(void *user, int caps_count,
             "error %d best_index %d", error, best_index);
         error = xrdp_egfx_send_reset_graphics(self->egfx,
                                               screen->width, screen->height,
-                                              self->wm->client_info->display_sizes.monitorCount,
-                                              self->wm->client_info->display_sizes.minfo);
+                                              self->wm->client_info->xup.display_sizes.monitorCount,
+                                              self->wm->client_info->xup.display_sizes.minfo);
         LOG(LOG_LEVEL_INFO, "xrdp_mm_egfx_caps_advertise: xrdp_egfx_send_reset_graphics "
             "error %d monitorCount %d",
-            error, self->wm->client_info->display_sizes.monitorCount);
+            error, self->wm->client_info->xup.display_sizes.monitorCount);
         self->egfx_up = 1;
         xrdp_mm_egfx_create_surfaces(self);
         self->encoder = xrdp_encoder_create(self);
@@ -1662,7 +1662,7 @@ sync_dynamic_monitor_data(struct xrdp_wm *wm,
                           struct display_size_description *description)
 {
     struct display_size_description *display_sizes
-        = &(wm->client_info->display_sizes);
+        = &(wm->client_info->xup.display_sizes);
 
     display_sizes->monitorCount = description->monitorCount;
     display_sizes->session_width = description->session_width;
@@ -2055,7 +2055,7 @@ dynamic_monitor_process_queue(struct xrdp_mm *self)
         }
 
         const struct display_size_description *current_size
-                = &wm->client_info->display_sizes;
+                = &wm->client_info->xup.display_sizes;
 
         const int already_this_size = queue_head->session_width
                                       == current_size->session_width
@@ -3857,7 +3857,7 @@ xrdp_mm_draw_dirty(struct xrdp_mm *self)
     int rv = 0;
 
     LOG_DEVEL(LOG_LEVEL_TRACE, "xrdp_mm_draw_dirty:");
-    count = self->wm->client_info->display_sizes.monitorCount;
+    count = self->wm->client_info->xup.display_sizes.monitorCount;
     if (count < 1)
     {
         error = xrdp_region_get_bounds(self->wm->screen_dirty_region, &rect);
@@ -3890,7 +3890,7 @@ xrdp_mm_draw_dirty(struct xrdp_mm *self)
                 jndex++;
             }
             /* intercect monitor */
-            mi = self->wm->client_info->display_sizes.minfo_wm + index;
+            mi = self->wm->client_info->xup.display_sizes.minfo_wm + index;
             mon_rect.left = mi->left;
             mon_rect.top = mi->top;
             mon_rect.right = mi->right + 1;

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -1506,13 +1506,15 @@ xrdp_mm_egfx_caps_advertise(void *user, int caps_count,
                                            ver_flags[best_index].flags);
         LOG(LOG_LEVEL_INFO, "xrdp_mm_egfx_caps_advertise: xrdp_egfx_send_capsconfirm "
             "error %d best_index %d", error, best_index);
+        const struct display_size_description *display_sizes =
+                &self->wm->client_info->xup.display_sizes;
         error = xrdp_egfx_send_reset_graphics(self->egfx,
                                               screen->width, screen->height,
-                                              self->wm->client_info->xup.display_sizes.monitorCount,
-                                              self->wm->client_info->xup.display_sizes.minfo);
-        LOG(LOG_LEVEL_INFO, "xrdp_mm_egfx_caps_advertise: xrdp_egfx_send_reset_graphics "
-            "error %d monitorCount %d",
-            error, self->wm->client_info->xup.display_sizes.monitorCount);
+                                              display_sizes->monitorCount,
+                                              display_sizes->minfo);
+        LOG(LOG_LEVEL_INFO, "xrdp_mm_egfx_caps_advertise: "
+            "xrdp_egfx_send_reset_graphics error %d monitorCount %d",
+            error, display_sizes->monitorCount);
         self->egfx_up = 1;
         xrdp_mm_egfx_create_surfaces(self);
         self->encoder = xrdp_encoder_create(self);

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -101,8 +101,9 @@ xrdp_wm_create(struct xrdp_process *owner,
 
     self = (struct xrdp_wm *)g_malloc(sizeof(struct xrdp_wm), 1);
     self->client_info = client_info;
-    self->screen = xrdp_bitmap_create(client_info->xup.display_sizes.session_width,
-                                      client_info->xup.display_sizes.session_height,
+    unsigned int session_width = client_info->xup.display_sizes.session_width;
+    unsigned int session_height = client_info->xup.display_sizes.session_height;
+    self->screen = xrdp_bitmap_create(session_width, session_height,
                                       client_info->xup.bpp,
                                       WND_TYPE_SCREEN, self);
     self->screen->wm = self;
@@ -2370,14 +2371,16 @@ xrdp_wm_show_log(struct xrdp_wm *self)
         primary_y_offset = 0;
 
         /* multimon scenario, draw log window on primary monitor */
-        if (self->client_info->xup.display_sizes.monitorCount > 1)
+        const struct display_size_description *display_sizes =
+                &self->client_info->xup.display_sizes;
+        if (display_sizes->monitorCount > 1)
         {
-            for (index = 0; index < self->client_info->xup.display_sizes.monitorCount; index++)
+            for (index = 0; index < display_sizes->monitorCount; index++)
             {
-                if (self->client_info->xup.display_sizes.minfo_wm[index].is_primary)
+                if (display_sizes->minfo_wm[index].is_primary)
                 {
-                    primary_x_offset = self->client_info->xup.display_sizes.minfo_wm[index].left;
-                    primary_y_offset = self->client_info->xup.display_sizes.minfo_wm[index].top;
+                    primary_x_offset = display_sizes->minfo_wm[index].left;
+                    primary_y_offset = display_sizes->minfo_wm[index].top;
                     break;
                 }
             }

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -101,9 +101,9 @@ xrdp_wm_create(struct xrdp_process *owner,
 
     self = (struct xrdp_wm *)g_malloc(sizeof(struct xrdp_wm), 1);
     self->client_info = client_info;
-    self->screen = xrdp_bitmap_create(client_info->display_sizes.session_width,
-                                      client_info->display_sizes.session_height,
-                                      client_info->bpp,
+    self->screen = xrdp_bitmap_create(client_info->xup.display_sizes.session_width,
+                                      client_info->xup.display_sizes.session_height,
+                                      client_info->xup.bpp,
                                       WND_TYPE_SCREEN, self);
     self->screen->wm = self;
     self->pro_layer = owner;
@@ -2370,14 +2370,14 @@ xrdp_wm_show_log(struct xrdp_wm *self)
         primary_y_offset = 0;
 
         /* multimon scenario, draw log window on primary monitor */
-        if (self->client_info->display_sizes.monitorCount > 1)
+        if (self->client_info->xup.display_sizes.monitorCount > 1)
         {
-            for (index = 0; index < self->client_info->display_sizes.monitorCount; index++)
+            for (index = 0; index < self->client_info->xup.display_sizes.monitorCount; index++)
             {
-                if (self->client_info->display_sizes.minfo_wm[index].is_primary)
+                if (self->client_info->xup.display_sizes.minfo_wm[index].is_primary)
                 {
-                    primary_x_offset = self->client_info->display_sizes.minfo_wm[index].left;
-                    primary_y_offset = self->client_info->display_sizes.minfo_wm[index].top;
+                    primary_x_offset = self->client_info->xup.display_sizes.minfo_wm[index].left;
+                    primary_y_offset = self->client_info->xup.display_sizes.minfo_wm[index].top;
                     break;
                 }
             }

--- a/xup/xup.c
+++ b/xup/xup.c
@@ -201,7 +201,8 @@ lib_send_client_info(struct mod *mod)
     init_stream(s, 8192);
     s_push_layer(s, iso_hdr, 4);
     out_uint16_le(s, 104);
-    g_memcpy(s->p, &(mod->client_info), sizeof(mod->client_info));
+    // Only send the public bit of the client info
+    g_memcpy(s->p, &(mod->client_info.xup), sizeof(mod->client_info.xup));
     s->p += sizeof(mod->client_info);
     s_mark_end(s);
     len = (int)(s->end - s->data);
@@ -255,19 +256,19 @@ lib_mod_connect(struct mod *mod)
     }
     mod->server_init_xkb_layout(mod, &(mod->client_info));
     LOG(LOG_LEVEL_INFO, "XKB rules '%s' will be used by the module",
-        mod->client_info.xkb_rules);
+        mod->client_info.xup.xkb_rules);
 
-    if (mod->client_info.h264_frame_interval <= 0)
+    if (mod->client_info.xup.h264_frame_interval <= 0)
     {
-        mod->client_info.h264_frame_interval = DEFAULT_H264_FRAME_INTERVAL;
+        mod->client_info.xup.h264_frame_interval = DEFAULT_H264_FRAME_INTERVAL;
     }
-    if (mod->client_info.rfx_frame_interval <= 0)
+    if (mod->client_info.xup.rfx_frame_interval <= 0)
     {
-        mod->client_info.rfx_frame_interval = DEFAULT_RFX_FRAME_INTERVAL;
+        mod->client_info.xup.rfx_frame_interval = DEFAULT_RFX_FRAME_INTERVAL;
     }
-    if (mod->client_info.normal_frame_interval <= 0)
+    if (mod->client_info.xup.normal_frame_interval <= 0)
     {
-        mod->client_info.normal_frame_interval = DEFAULT_NORMAL_FRAME_INTERVAL;
+        mod->client_info.xup.normal_frame_interval = DEFAULT_NORMAL_FRAME_INTERVAL;
     }
 
     make_stream(s);
@@ -1985,15 +1986,15 @@ lib_mod_set_param(struct mod *mod, const char *name, const char *value)
     }
     else if (g_strcasecmp(name, "h264_frame_interval") == 0)
     {
-        mod->client_info.h264_frame_interval = g_atoi(value);
+        mod->client_info.xup.h264_frame_interval = g_atoi(value);
     }
     else if (g_strcasecmp(name, "rfx_frame_interval") == 0)
     {
-        mod->client_info.rfx_frame_interval = g_atoi(value);
+        mod->client_info.xup.rfx_frame_interval = g_atoi(value);
     }
     else if (g_strcasecmp(name, "normal_frame_interval") == 0)
     {
-        mod->client_info.normal_frame_interval = g_atoi(value);
+        mod->client_info.xup.normal_frame_interval = g_atoi(value);
     }
     else if (g_strcasecmp(name, "client_info") == 0)
     {


### PR DESCRIPTION
Rework of #3490 

The struct 'struct xorgxrdp_client_info' is factored out of 'struct xrdp_client_info'. This represents the items which are required to be passed to xorgxrdp.

This PR also requires a small change to xorgxrdp (neutrinolabs/xorgxrdp#384).

**Edit:** Because line lengths of some lines are increased because of the need for a `xup` member to access some data, I've added three commits to tidy up some source lines more than 80 characters in length. These commits should not change any functionality and could stand on their own.

**Edit:** `pub` member of client_info renamed to `xup`.