### PR TITLE
Improve systemd support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -726,6 +726,13 @@ if test x$enable_utmp = xyes; then
     echo "    utmpx.ut_host         $ac_cv_utmpx_has_ut_host"
     echo "    utmpx.ut_exit         $ac_cv_utmpx_has_ut_exit"
 fi
+if test -n "$with_systemdsystemunitdir" \
+        -a "x$with_systemdsystemunitdir" != xno; then
+    echo "  systemd support         yes"
+    echo "    unit file directory   $with_systemdsystemunitdir"
+else
+    echo "  systemd support         no"
+fi
 
 echo
 echo "  with imlib2             $use_imlib2"

--- a/scripts/install_xrdp_build_dependencies_with_apt.sh
+++ b/scripts/install_xrdp_build_dependencies_with_apt.sh
@@ -70,6 +70,11 @@ case `lsb_release -si`/`lsb_release -sr` in
     *) LIBFREETYPE_DEV=libfreetype-dev
 esac
 
+# We need systemd-dev for Debian-based systems using systemd
+if command -v systemctl >/dev/null; then
+    PACKAGES="$PACKAGES systemd-dev"
+fi
+
 case "$ARCH"
 in
     amd64)


### PR DESCRIPTION
Fixes #3497 

Later versions of Ubuntu (e.g. 24.10 and later) do not install the systemd-dev package by default. This breaks the systemd-detection mechanism.

Add this package in for non-systemd-based Debian distributions. Also log what we are doing for systemd as part of the configure.