### PR TITLE
Only add systemd-dev for systemd versions >= 255

### DIFF
--- a/scripts/install_xrdp_build_dependencies_with_apt.sh
+++ b/scripts/install_xrdp_build_dependencies_with_apt.sh
@@ -72,7 +72,11 @@ esac
 
 # We need systemd-dev for Debian-based systems using systemd
 if command -v systemctl >/dev/null; then
-    PACKAGES="$PACKAGES systemd-dev"
+    # Check for systemd version >= 255
+    set -- $(systemctl --version)
+    if [ "$#" -gt 2 ] && [ "$1" = systemd ] && [ "$2" -ge 255 ]; then
+        PACKAGES="$PACKAGES systemd-dev"
+    fi
 fi
 
 case "$ARCH"


### PR DESCRIPTION
(cherry picked from commit 93871c9182c139452af4e2f8f40b1b592ffa7092)

This addresses a regression I introduced in #3501 which prevents xrdp building on older systemd-based systems.