### PR TITLE
[V0.10] Refactor static channel name handling

### DIFF
--- a/libxrdp/libxrdp.c
+++ b/libxrdp/libxrdp.c
@@ -1278,7 +1278,7 @@ libxrdp_query_channel(struct xrdp_session *session, int channel_id,
 
     if (channel_name != 0)
     {
-        g_strncpy(channel_name, channel_item->name, CHANNEL_NAME_LEN + 1);
+        g_strncpy(channel_name, channel_item->name, CHANNEL_NAME_LEN);
         LOG(LOG_LEVEL_DEBUG, "libxrdp_query_channel - Channel %d name %s",
             channel_id, channel_name);
     }

--- a/libxrdp/libxrdp.c
+++ b/libxrdp/libxrdp.c
@@ -1278,7 +1278,7 @@ libxrdp_query_channel(struct xrdp_session *session, int channel_id,
 
     if (channel_name != 0)
     {
-        g_strncpy(channel_name, channel_item->name, 8);
+        g_strncpy(channel_name, channel_item->name, CHANNEL_NAME_LEN + 1);
         LOG(LOG_LEVEL_DEBUG, "libxrdp_query_channel - Channel %d name %s",
             channel_id, channel_name);
     }

--- a/libxrdp/libxrdp.h
+++ b/libxrdp/libxrdp.h
@@ -50,7 +50,7 @@ struct xrdp_iso
 /* used in mcs */
 struct mcs_channel_item
 {
-    char name[16];
+    char name[CHANNEL_NAME_LEN + 1];
     int flags;
     int chanid;
     int disabled;

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -2186,31 +2186,19 @@ xrdp_sec_process_mcs_data_channels(struct xrdp_sec *self, struct stream *s)
             g_free(channel_item);
             return 1;
         }
-        in_uint8a(s, channel_item->name, 8);
+
+        in_uint8a(s, channel_item->name, CHANNEL_NAME_LEN + 1);
+        // The channel name *should* be null-terminated. Add a back-stop
+        // terminator in case it isn't.
+        channel_item->name[CHANNEL_NAME_LEN] = '\0';
         in_uint32_le(s, channel_item->flags);
 
-        if (g_strlen(channel_item->name) > 0 && g_strlen(channel_item->name) < 8)
-        {
-            LOG_DEVEL(LOG_LEVEL_TRACE, "Received [MS-RDPBCGR] "
-                      "TS_UD_CS_NET.CHANNEL_DEF %d, name %s, options 0x%8.8x",
-                      index, channel_item->name, channel_item->flags);
-            channel_item->chanid = next_mcs_channel_id++;
-            list_add_item(self->mcs_layer->channel_list,
-                          (intptr_t) channel_item);
-            LOG(LOG_LEVEL_DEBUG,
-                "Adding channel: name %s, channel id %d, flags 0x%8.8x",
-                channel_item->name, channel_item->chanid, channel_item->flags);
-        }
-        else
-        {
-            LOG_DEVEL(LOG_LEVEL_WARNING, "Received [MS-RDPBCGR] "
-                      "TS_UD_CS_NET.CHANNEL_DEF %d, skipped because of "
-                      "malformed channel name.", index);
-            LOG_DEVEL_HEXDUMP(LOG_LEVEL_WARNING,
-                              "[MS-RDPBCGR] TS_UD_CS_NET.CHANNEL_DEF name",
-                              channel_item->name, 8);
-            g_free(channel_item);
-        }
+        channel_item->chanid = next_mcs_channel_id++;
+        list_add_item(self->mcs_layer->channel_list,
+                      (intptr_t) channel_item);
+        LOG(LOG_LEVEL_DEBUG,
+            "Adding channel: name %s, channel id %d, flags 0x%8.8x",
+            channel_item->name, channel_item->chanid, channel_item->flags);
     }
 
     /* Set the user channel as well */

--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -1800,7 +1800,7 @@ lfreerdp_pre_connect(freerdp *instance)
     int num_chans;
     int target_chan;
     int ch_flags;
-    char ch_name[256];
+    char ch_name[CHANNEL_NAME_LEN + 1];
     const char *ch_names[MAX_FREERDP_CHANNELS];
     char *dst_ch_name;
 

--- a/sesman/chansrv/chansrv.c
+++ b/sesman/chansrv/chansrv.c
@@ -367,7 +367,7 @@ process_message_channel_setup(struct stream *s)
     {
         ci = &(g_chan_items[g_num_chan_items]);
         g_memset(ci->name, 0, sizeof(ci->name));
-        in_uint8a(s, ci->name, 8);
+        in_uint8a(s, ci->name, CHANNEL_NAME_LEN + 1);
         in_uint16_le(s, ci->id);
         in_uint16_le(s, ci->flags);
         LOG_DEVEL(LOG_LEVEL_DEBUG, "process_message_channel_setup: chan name '%s' "

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -608,9 +608,7 @@ xrdp_mm_trans_send_channel_setup(struct xrdp_mm *self, struct trans *trans)
     int chan_flags;
     int size;
     struct stream *s;
-    char chan_name[256];
-
-    g_memset(chan_name, 0, sizeof(char) * 256);
+    char chan_name[CHANNEL_NAME_LEN + 1];
 
     s = trans_get_out_s(trans, 8192);
 
@@ -630,7 +628,7 @@ xrdp_mm_trans_send_channel_setup(struct xrdp_mm *self, struct trans *trans)
         if (libxrdp_query_channel(self->wm->session, chan_id, chan_name,
                                   &chan_flags) == 0)
         {
-            out_uint8a(s, chan_name, 8);
+            out_uint8a(s, chan_name, CHANNEL_NAME_LEN + 1);
             out_uint16_le(s, chan_id);
             out_uint16_le(s, chan_flags);
             ++output_chan_count;

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -47,11 +47,12 @@ xrdp_wm_load_channel_config(struct xrdp_wm *self)
 
         for (chan_id = 0 ; chan_id < chan_count ; ++chan_id)
         {
-            char chan_name[16];
+            char chan_name[CHANNEL_NAME_LEN + 1];
             if (libxrdp_query_channel(self->session, chan_id, chan_name,
                                       NULL) == 0)
             {
                 int disabled = 1; /* Channels disabled if not found */
+                int found = 0;
                 int index;
 
                 for (index = 0; index < names->count; index++)
@@ -60,9 +61,17 @@ xrdp_wm_load_channel_config(struct xrdp_wm *self)
                     const char *r = (const char *)list_get_item(values, index);
                     if (g_strcasecmp(q, chan_name) == 0)
                     {
+                        found = 1;
                         disabled = !g_text2bool(r);
                         break;
                     }
+                }
+                if (!found)
+                {
+                    LOG(LOG_LEVEL_WARNING,
+                        "Static channel '%s' from the client"
+                        " is not named in the [Channels] section",
+                        chan_name);
                 }
                 disabled_str = (disabled) ? "disabled" : "enabled";
                 LOG(LOG_LEVEL_DEBUG, "xrdp_wm_load_channel_config: "


### PR DESCRIPTION
~~This PR is currently based on v0.10.2. For the reasons for this, s~~See #3498

~~It will be rebased after user testing. Until it is rebased, it cannot be merged, and the CI won't work.~~

Changes are:-
1) Remove 'magic numbers' related to static channel name lengths, and replace with `CHANNEL_NAME_LEN`, or `CHANNEL_NAME_LEN + 1`, as appropriate.
2) Always add static channel definitions, even if they are malformed.
3) Log channels which the client sends, which aren't named in the `[Channels]` section of `xrdp.ini`.