### PR TITLE
[V0.10] coverity fixes

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -3519,6 +3519,23 @@ g_setenv(const char *name, const char *value, int rewrite)
 #endif
 }
 
+
+/*****************************************************************************/
+/* does not work in win32 */
+void
+g_setenv_log(const char *name, const char *value, int rewrite)
+{
+#if defined(_WIN32)
+    return 0;
+#else
+    if (setenv(name, value, rewrite) != 0)
+    {
+        LOG(LOG_LEVEL_WARNING, "Unable to set environment variable '%s' [%s]",
+            name, g_get_strerror());
+    }
+#endif
+}
+
 /*****************************************************************************/
 /* does not work in win32 */
 char *

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -376,6 +376,17 @@ int      g_setpgid(int pid, int pgid);
 void     g_clearenv(void);
 int      g_setenv(const char *name, const char *value, int rewrite);
 char    *g_getenv(const char *name);
+/**
+ * Calls g_setenv(), logging failures
+ *
+ * @param name Name to set
+ * @param value String to set $name to
+ * @param rewrite Set to non-zero to allow rewriting of existing names
+ *
+ * Unlike g_setenv() this function returns no value. Use this function if the
+ * only reasonable thing to do on failure is to log it.
+ */
+void     g_setenv_log(const char *name, const char *value, int rewrite);
 int      g_exit(int exit_code);
 int      g_getpid(void);
 int      g_sigterm(int pid);

--- a/libxrdp/xrdp_iso.c
+++ b/libxrdp/xrdp_iso.c
@@ -68,7 +68,7 @@ protocol_mask_to_str(int protocol, char *buff, int bufflen)
         /* String is empty */
         rlen = g_snprintf(buff, bufflen, "RDP");
     }
-    else if (rlen < bufflen)
+    else if (rlen > 0 && rlen < bufflen)
     {
         rlen += g_snprintf(buff + rlen, bufflen - rlen, "%cRDP", delim);
     }

--- a/sesman/libsesman/verify_user_pam.c
+++ b/sesman/libsesman/verify_user_pam.c
@@ -528,12 +528,12 @@ auth_set_env(struct auth_info *auth_info)
             for (pam_env = pam_envlist; *pam_env != NULL; ++pam_env)
             {
                 char *str = *pam_env;
-                int eq_pos = g_pos(str, "=");
+                char *eq_pos = strchr(str, '=');
 
-                if (eq_pos > 0)
+                if (eq_pos != NULL)
                 {
-                    str[eq_pos] = '\0';
-                    g_setenv(str, str + eq_pos + 1, 1);
+                    *eq_pos = '\0';
+                    g_setenv_log(str, eq_pos + 1, 1);
                 }
 
                 g_free(str);

--- a/sesman/libsesman/verify_user_pam_userpass.c
+++ b/sesman/libsesman/verify_user_pam_userpass.c
@@ -338,12 +338,12 @@ auth_set_env(struct auth_info *auth_info)
             for (pam_env = pam_envlist; *pam_env != NULL; ++pam_env)
             {
                 char *str = *pam_env;
-                int eq_pos = g_pos(str, "=");
+                char *eq_pos = strchr(str, '=');
 
-                if (eq_pos > 0)
+                if (eq_pos != NULL)
                 {
-                    str[eq_pos] = '\0';
-                    g_setenv(str, str + eq_pos + 1, 1);
+                    *eq_pos = '\0';
+                    g_setenv_log(str, eq_pos + 1, 1);
                 }
 
                 g_free(str);

--- a/sesman/sesexec/env.c
+++ b/sesman/sesexec/env.c
@@ -144,33 +144,33 @@ env_set_user(int uid, char **passwd_file, int display,
 
         if (error == 0)
         {
-            g_setenv("PATH", "/sbin:/bin:/usr/bin:/usr/local/bin", 1);
+            g_setenv_log("PATH", "/sbin:/bin:/usr/bin:/usr/local/bin", 1);
         }
 #endif
         if (error == 0)
         {
-            g_setenv("SHELL", pw_shell, 1);
-            g_setenv("USER", pw_username, 1);
-            g_setenv("LOGNAME", pw_username, 1);
+            g_setenv_log("SHELL", pw_shell, 1);
+            g_setenv_log("USER", pw_username, 1);
+            g_setenv_log("LOGNAME", pw_username, 1);
             g_snprintf(text, sizeof(text), "%d", uid);
-            g_setenv("UID", text, 1);
-            g_setenv("HOME", pw_dir, 1);
+            g_setenv_log("UID", text, 1);
+            g_setenv_log("HOME", pw_dir, 1);
             g_set_current_dir(pw_dir);
             g_snprintf(text, sizeof(text), ":%d.0", display);
-            g_setenv("DISPLAY", text, 1);
+            g_setenv_log("DISPLAY", text, 1);
             // Use our PID as the XRDP_SESSION value
             g_snprintf(text, sizeof(text), "%d", g_pid);
-            g_setenv("XRDP_SESSION", text, 1);
+            g_setenv_log("XRDP_SESSION", text, 1);
             /* XRDP_SOCKET_PATH should be set here. It's used by
              * xorgxrdp and the pulseaudio plugin */
             g_snprintf(text, sizeof(text), XRDP_SOCKET_PATH, uid);
-            g_setenv("XRDP_SOCKET_PATH", text, 1);
+            g_setenv_log("XRDP_SOCKET_PATH", text, 1);
             /* pulse sink socket */
             g_snprintf(text, sizeof(text), CHANSRV_PORT_OUT_BASE_STR, display);
-            g_setenv("XRDP_PULSE_SINK_SOCKET", text, 1);
+            g_setenv_log("XRDP_PULSE_SINK_SOCKET", text, 1);
             /* pulse source socket */
             g_snprintf(text, sizeof(text), CHANSRV_PORT_IN_BASE_STR, display);
-            g_setenv("XRDP_PULSE_SOURCE_SOCKET", text, 1);
+            g_setenv_log("XRDP_PULSE_SOURCE_SOCKET", text, 1);
             if ((env_names != 0) && (env_values != 0) &&
                     (env_names->count == env_values->count))
             {
@@ -178,7 +178,7 @@ env_set_user(int uid, char **passwd_file, int display,
                 {
                     name = (char *) list_get_item(env_names, index),
                     value = (char *) list_get_item(env_values, index),
-                    g_setenv(name, value, 1);
+                    g_setenv_log(name, value, 1);
                 }
             }
             g_gethostname(hostname, 255);

--- a/sesman/sesexec/session.c
+++ b/sesman/sesexec/session.c
@@ -357,19 +357,19 @@ prepare_xorg_xserver_params(const struct session_parameters *s,
 
         /* some args are passed via env vars */
         g_snprintf(text, sizeof(text), "%d", s->width);
-        g_setenv("XRDP_START_WIDTH", text, 1);
+        g_setenv_log("XRDP_START_WIDTH", text, 1);
 
         g_snprintf(text, sizeof(text), "%d", s->height);
-        g_setenv("XRDP_START_HEIGHT", text, 1);
+        g_setenv_log("XRDP_START_HEIGHT", text, 1);
 
         g_snprintf(text, sizeof(text), "%d", g_cfg->sess.max_idle_time);
-        g_setenv("XRDP_SESMAN_MAX_IDLE_TIME", text, 1);
+        g_setenv_log("XRDP_SESMAN_MAX_IDLE_TIME", text, 1);
 
         g_snprintf(text, sizeof(text), "%d", g_cfg->sess.max_disc_time);
-        g_setenv("XRDP_SESMAN_MAX_DISC_TIME", text, 1);
+        g_setenv_log("XRDP_SESMAN_MAX_DISC_TIME", text, 1);
 
         g_snprintf(text, sizeof(text), "%d", g_cfg->sess.kill_disconnected);
-        g_setenv("XRDP_SESMAN_KILL_DISCONNECTED", text, 1);
+        g_setenv_log("XRDP_SESMAN_KILL_DISCONNECTED", text, 1);
 
         /* get path of Xorg from config */
         xserver = (const char *)list_get_item(g_cfg->xorg_params, 0);

--- a/sesman/sesexec_control.c
+++ b/sesman/sesexec_control.c
@@ -165,11 +165,7 @@ sesexec_start(struct pre_session_item *psi)
                  * in the environment */
                 char buff[64];
                 g_snprintf(buff, sizeof(buff), "%d", sck[1]);
-                if (g_setenv("EICP_FD", buff, 1) < 0)
-                {
-                    LOG(LOG_LEVEL_ERROR, "Can't set EICP_FD [%s]",
-                        g_get_strerror());
-                }
+                g_setenv_log("EICP_FD", buff, 1);
 
                 /* [Development] Log all file descriptors not marked cloexec
                  * other than stdin, stdout, stderr, and the EICP fd in sck[1].

--- a/xrdp/xrdp_font.c
+++ b/xrdp/xrdp_font.c
@@ -287,13 +287,13 @@ xrdp_font_create(struct xrdp_wm *wm, unsigned int dpi)
                 in_uint8s(s, 6);
                 datasize = FONT_DATASIZE(f);
 
-                if (datasize < 0 || datasize > 512)
+                if (datasize > 512)
                 {
                     /* shouldn't happen */
                     LOG(LOG_LEVEL_ERROR,
                         "xrdp_font_create: "
                         "datasize for U+%x wrong "
-                        "width %d, height %d, datasize %d",
+                        "width %d, height %d, datasize %u",
                         char_count, f->width, f->height, datasize);
                     break;
                 }

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -2913,7 +2913,13 @@ parse_chansrvport(const char *value, char *dest, int dest_size, int uid)
     int rv = 0;
     int dnum = 0;
 
-    if (g_strncmp(value, "DISPLAY(", 8) == 0)
+    if (value == NULL)
+    {
+        LOG(LOG_LEVEL_WARNING,
+            "unexpectedly empty chansrvport string encountered");
+        rv = -1;
+    }
+    else if (g_strncmp(value, "DISPLAY(", 8) == 0)
     {
         const char *p = value + 8;
         const char *end = p;
@@ -3212,11 +3218,16 @@ xrdp_mm_connect_sm(struct xrdp_mm *self)
 
                     gw_username = xrdp_mm_get_value(self, "pamusername");
                     gw_password = xrdp_mm_get_value(self, "pampassword");
-                    if (!g_strcmp(gw_username, "same"))
+                    // gw_username shouldn't be NULL here, but we'll
+                    // check it anyway before dereferencing.
+                    if (gw_username != NULL &&
+                            !g_strcmp(gw_username, "same"))
                     {
                         gw_username = xrdp_mm_get_value(self, "username");
                     }
 
+                    // Default the password to the usual one if the
+                    // user hasn't specified one, or specified 'same'
                     if (gw_password == NULL ||
                             !g_strcmp(gw_password, "same"))
                     {
@@ -3333,7 +3344,6 @@ xrdp_mm_connect_sm(struct xrdp_mm *self)
                 if (self->use_chansrv)
                 {
                     char portbuff[XRDP_SOCKETS_MAXPATH];
-
                     if (self->use_sesman)
                     {
                         g_snprintf(portbuff, sizeof(portbuff),
@@ -3344,16 +3354,25 @@ xrdp_mm_connect_sm(struct xrdp_mm *self)
                     else
                     {
                         const char *cp = xrdp_mm_get_value(self, "chansrvport");
-                        portbuff[0] = '\0';
-                        parse_chansrvport(cp, portbuff, sizeof(portbuff),
-                                          self->uid);
-
-                        xrdp_wm_log_msg(self->wm, LOG_LEVEL_INFO,
-                                        "Connecting to chansrv on %s",
-                                        portbuff);
+                        if (parse_chansrvport(cp, portbuff, sizeof(portbuff),
+                                              self->uid) == 0)
+                        {
+                            xrdp_wm_log_msg(self->wm, LOG_LEVEL_INFO,
+                                            "Connecting to chansrv on %s",
+                                            portbuff);
+                        }
+                        else
+                        {
+                            // An error has already been logged
+                            portbuff[0] = '\0';
+                        }
                     }
-                    xrdp_mm_update_allowed_channels(self);
-                    xrdp_mm_chansrv_connect(self, portbuff);
+
+                    if (portbuff[0] != '\0')
+                    {
+                        xrdp_mm_update_allowed_channels(self);
+                        xrdp_mm_chansrv_connect(self, portbuff);
+                    }
                 }
             }
             break;

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -2059,6 +2059,7 @@ callback(intptr_t id, int msg, intptr_t param1, intptr_t param2,
             xrdp_mm_suppress_output(wm->mm, param1,
                                     LOWORD(param2), HIWORD(param2),
                                     LOWORD(param3), HIWORD(param3));
+            break;
         case 0x555a:
             // "yeah, up_and_running"
             xrdp_mm_up_and_running(wm->mm);


### PR DESCRIPTION
Backport of #3505 with a couple of differences:-

- 468156 does not apply to v0.10
- As part of 468139, some uses of `g_strncpy()` were replaced with `strlcpy()`. This call has not been back-ported to V0.10.x