### PR TITLE
[V0.10] vmconnect mode: support all security modes when used in a Hyper-V environment

### DIFF
--- a/common/ms-rdpbcgr.h
+++ b/common/ms-rdpbcgr.h
@@ -35,7 +35,12 @@
 #define PROTOCOL_RDSTLS                0x00000004
 #define PROTOCOL_HYBRID_EX             0x00000008
 
-/* Negotiation packet flags (2.2.1.2.1) */
+/* Negotiation request packet flags (2.2.1.1.1) */
+#define RESTRICTED_ADMIN_MODE_REQUIRED          0x00000001
+#define REDIRECTED_AUTHENTICATION_MODE_REQUIRED 0x00000002
+#define CORRELATION_INFO_PRESENT                0x00000008
+
+/* Negotiation response packet flags (2.2.1.2.1) */
 #define EXTENDED_CLIENT_DATA_SUPPORTED            0x01
 #define DYNVC_GFX_PROTOCOL_SUPPORTED              0x02
 #define NEGRSP_RESERVED                           0x04

--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -172,6 +172,8 @@ struct xrdp_client_info
     int require_credentials; /* when true, credentials *must* be passed on cmd line */
 
     int security_layer; /* SECURITY_LAYER_* */
+    int vmconnect; /* Used when used from inside Hyper-V */
+
     int multimon; /* 0 = deny , 1 = allow */
     struct display_size_description display_sizes;
 

--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -67,6 +67,12 @@ struct display_size_description
     unsigned int session_height;
 };
 
+/* Values used for the security_layer */
+/* TODO: Make this an enum, and move it below xrdp_client_info */
+#define SECURITY_LAYER_NEGOTIATE 0
+#define SECURITY_LAYER_RDP 1
+#define SECURITY_LAYER_TLS 2
+
 enum client_resize_mode
 {
     CRMODE_NONE,
@@ -165,7 +171,7 @@ struct xrdp_client_info
     int use_fast_path;
     int require_credentials; /* when true, credentials *must* be passed on cmd line */
 
-    int security_layer; /* 0 = rdp, 1 = tls , 2 = hybrid */
+    int security_layer; /* SECURITY_LAYER_* */
     int multimon; /* 0 = deny , 1 = allow */
     struct display_size_description display_sizes;
 

--- a/docs/man/xrdp.ini.5.in
+++ b/docs/man/xrdp.ini.5.in
@@ -30,11 +30,11 @@ examples can be found within xrdp.ini itself.
 
 .TP
 \fBvmconnect\fR=\fI[true|false]\fR
-(Hyper-V VMs only). Allows the user to skip some unnecessary security
-checks when a virtual machine running xrdp is hosted on Hyper-V,
-and the user connects to it via the vmms service on TCP port 2179.
-In this configuration, RDP security is handled by the vmms service, and
-security features which are not yet added to xrdp itself can be supported.
+(Hyper-V VMs only). Enables a wider support of security protocols when a
+virtual machine running xrdp is hosted on Hyper-V, and the user connects
+to it via the vmms service on TCP port 2179. In this configuration,
+RDP security is handled by the vmms service, and security features which
+are not yet added to xrdp itself can be supported.
 
 This parameter is required in environments which do not support 'classic'
 RDP encryption.

--- a/docs/man/xrdp.ini.5.in
+++ b/docs/man/xrdp.ini.5.in
@@ -24,6 +24,25 @@ All options and values (except for file names and paths) are case insensitive, a
 The options to be specified in the \fB[Globals]\fR section are the following:
 
 .TP
+\fBport\fR=\fIport_specification [ port_specification ... ]\fR
+Specify the port(s) that xrdp should listen on. More instructions and
+examples can be found within xrdp.ini itself.
+
+.TP
+\fBvmconnect\fR=\fI[true|false]\fR
+(Hyper-V VMs only). Allows the user to skip some unnecessary security
+checks when a virtual machine running xrdp is hosted on Hyper-V,
+and the user connects to it via the vmms service on TCP port 2179.
+In this configuration, RDP security is handled by the vmms service, and
+security features which are not yet added to xrdp itself can be supported.
+
+This parameter is required in environments which do not support 'classic'
+RDP encryption.
+
+The parameter is ignored for connections which are not made to the
+virtual machine over the vsock transport.
+
+.TP
 \fBautorun\fP=\fIsession_name\fP
 Section name for automatic login. If set and the client supplies valid
 username and password, the user will be logged in automatically using the

--- a/libxrdp/xrdp_iso.c
+++ b/libxrdp/xrdp_iso.c
@@ -129,40 +129,25 @@ xrdp_iso_negotiate_security(struct xrdp_iso *self)
         protostr);
     security_type_mask &= self->requestedProtocol;
 
-    /* In VMConnect mode, we support everything. */
-    if (client_info->vmconnect && (self->requestedProtocol > PROTOCOL_RDP))
+    if (security_type_mask & PROTOCOL_HYBRID_EX)
     {
-        if (security_type_mask & PROTOCOL_HYBRID_EX)
-        {
-            LOG(LOG_LEVEL_INFO, "Selected HYBRID_EX security");
-            self->selectedProtocol = PROTOCOL_HYBRID_EX;
-            got_protocol = 1;
-        }
-        else if (security_type_mask & PROTOCOL_HYBRID)
-        {
-            LOG(LOG_LEVEL_INFO, "Selected HYBRID security");
-            self->selectedProtocol = PROTOCOL_HYBRID;
-            got_protocol = 1;
-        }
-        else if (security_type_mask & PROTOCOL_SSL)
-        {
-            LOG(LOG_LEVEL_INFO, "Selected TLS security");
-            self->selectedProtocol = PROTOCOL_SSL;
-            got_protocol = 1;
-        }
-        else
-        {
-            /* Impossible */
-            LOG(LOG_LEVEL_ERROR, "Impossible case.");
-            rv = 1;
-        }
+        /* Currently supported by VMConnect mode only */
+        LOG(LOG_LEVEL_INFO, "Selected HYBRID_EX security");
+        self->selectedProtocol = PROTOCOL_HYBRID_EX;
+        got_protocol = 1;
     }
-    /* Is there a match on SSL/TLS? */
+    else if (security_type_mask & PROTOCOL_HYBRID)
+    {
+        /* Currently supported by VMConnect mode only */
+        LOG(LOG_LEVEL_INFO, "Selected HYBRID security");
+        self->selectedProtocol = PROTOCOL_HYBRID;
+        got_protocol = 1;
+    }
     else if ((security_type_mask & PROTOCOL_SSL) != 0)
     {
-        /* Can we do TLS? (basic check) */
-        if (g_file_readable(client_info->certificate) &&
-                g_file_readable(client_info->key_file))
+        /* Can we do TLS? (basic check). VMConnect is exempt. */
+        if ((g_file_readable(client_info->certificate) &&
+                g_file_readable(client_info->key_file)) || client_info->vmconnect)
         {
             LOG(LOG_LEVEL_INFO, "Selected TLS security");
             self->selectedProtocol = PROTOCOL_SSL;

--- a/libxrdp/xrdp_iso.c
+++ b/libxrdp/xrdp_iso.c
@@ -72,6 +72,17 @@ xrdp_iso_create(struct xrdp_mcs *owner, struct trans *trans)
     self = (struct xrdp_iso *) g_malloc(sizeof(struct xrdp_iso), 1);
     self->mcs_layer = owner;
     self->trans = trans;
+
+    // See if we're running in vmconnect mode on this connection
+    struct xrdp_client_info *client_info = &(self->mcs_layer->sec_layer->rdp_layer->client_info);
+    if (client_info->vmconnect && trans->mode != TRANS_MODE_VSOCK)
+    {
+        char desc[MAX_PEER_DESCSTRLEN];
+        g_sck_get_peer_description(trans->sck, desc, sizeof(desc));
+        LOG(LOG_LEVEL_INFO, "Disabling vmconnect mode for connection from %s",
+            desc);
+        client_info->vmconnect = 0;
+    }
     return self;
 }
 

--- a/libxrdp/xrdp_iso.c
+++ b/libxrdp/xrdp_iso.c
@@ -60,20 +60,7 @@ protocol_mask_to_str(int protocol, char *buff, int bufflen)
         BITMASK_STRING_END_OF_LIST
     };
 
-    int rlen = g_bitmask_to_str(protocol, bits, delim, buff, bufflen);
-
-    /* Append "RDP" */
-    if (rlen == 0)
-    {
-        /* String is empty */
-        rlen = g_snprintf(buff, bufflen, "RDP");
-    }
-    else if (rlen > 0 && rlen < bufflen)
-    {
-        rlen += g_snprintf(buff + rlen, bufflen - rlen, "%cRDP", delim);
-    }
-
-    return rlen;
+    return g_bitmask_to_str(protocol, bits, delim, buff, bufflen);
 }
 
 /*****************************************************************************/
@@ -105,95 +92,82 @@ xrdp_iso_delete(struct xrdp_iso *self)
 static int
 xrdp_iso_negotiate_security(struct xrdp_iso *self)
 {
-    char requested_str[64];
-    const char *selected_str = "";
-    const char *configured_str = "";
-
     int rv = 0;
     struct xrdp_client_info *client_info = &(self->mcs_layer->sec_layer->rdp_layer->client_info);
+    char protostr[64];
+    int got_protocol = 0;
+    int security_type_mask;
 
-    /* Can we do TLS/SSL? (basic check) */
-    int ssl_capable = g_file_readable(client_info->certificate) &&
-                      g_file_readable(client_info->key_file);
+    /* Map the configuration from xrdp.ini to a mask of allowed
+     * security types ([MS-RDPBCGR] 2.2.1.2.1)
+     *
+     * There's some oddness around PROTOCOL_RDP. This value is 0,
+     * for compatibility reasons, and it's OK for the server to
+     * suggest RDP as the fallback protocol if nothing else is
+     * agreed on. Nowadays, classic RDP security should
+     * not be used, if at all avoidable */
 
-    /* Work out what's actually configured in xrdp.ini. The
-     * selection happens later, but we can do some error checking here */
-    switch (client_info->security_layer)
+    /* At present we only support SSL and RDP security */
+    if (client_info->security_layer == SECURITY_LAYER_RDP)
     {
-        case PROTOCOL_RDP:
-            configured_str = "RDP";
-            break;
-
-        case PROTOCOL_SSL:
-            /* We *must* use TLS. Check we can offer it, and it's requested */
-            if (ssl_capable)
-            {
-                configured_str = "SSL";
-                if ((self->requestedProtocol & PROTOCOL_SSL) == 0)
-                {
-                    LOG(LOG_LEVEL_ERROR, "Server requires TLS for security, "
-                        "but the client did not request TLS.");
-                    self->failureCode = SSL_REQUIRED_BY_SERVER;
-                    rv = 1; /* error */
-                }
-            }
-            else
-            {
-                configured_str = "";
-                LOG(LOG_LEVEL_ERROR, "Cannot accept TLS connections because "
-                    "certificate or private key file is not readable. "
-                    "certificate file: [%s], private key file: [%s]",
-                    client_info->certificate, client_info->key_file);
-                self->failureCode = SSL_CERT_NOT_ON_SERVER;
-                rv = 1; /* error */
-            }
-            break;
-        case PROTOCOL_HYBRID:
-        case PROTOCOL_HYBRID_EX:
-        default:
-            /* We don't yet support CredSSP */
-            if (ssl_capable)
-            {
-                configured_str = "SSL|RDP";
-            }
-            else
-            {
-                /*
-                 * Tell the user we can't offer TLS, but this isn't fatal */
-                configured_str = "RDP";
-                LOG(LOG_LEVEL_WARNING, "Cannot accept TLS connections because "
-                    "certificate or private key file is not readable. "
-                    "certificate file: [%s], private key file: [%s]",
-                    client_info->certificate, client_info->key_file);
-            }
-            break;
-    }
-
-    /* Currently the choice comes down to RDP or SSL */
-    if (rv != 0)
-    {
-        self->selectedProtocol = PROTOCOL_RDP;
-        selected_str = "";
-    }
-    else if (ssl_capable && (self->requestedProtocol &
-                             client_info->security_layer &
-                             PROTOCOL_SSL) != 0)
-    {
-        self->selectedProtocol = PROTOCOL_SSL;
-        selected_str = "SSL";
+        security_type_mask = PROTOCOL_RDP;
     }
     else
     {
-        self->selectedProtocol = PROTOCOL_RDP;
-        selected_str = "RDP";
+        security_type_mask = PROTOCOL_SSL;
     }
 
-    protocol_mask_to_str(self->requestedProtocol,
-                         requested_str, sizeof(requested_str));
+    /* Logically 'and' this value with the mask requested by the client, and
+     * see what's left */
+    protocol_mask_to_str(self->requestedProtocol, protostr, sizeof(protostr));
+    LOG(LOG_LEVEL_INFO, "Client requested security types (RDP assumed) : %s",
+        protostr);
+    security_type_mask &= self->requestedProtocol;
 
-    LOG(LOG_LEVEL_INFO, "Security protocol: configured [%s], requested [%s],"
-        " selected [%s]",
-        configured_str, requested_str, selected_str);
+    /* Is there a match on SSL/TLS? */
+    if ((security_type_mask & PROTOCOL_SSL) != 0)
+    {
+        /* Can we do TLS? (basic check) */
+        if (g_file_readable(client_info->certificate) &&
+                g_file_readable(client_info->key_file))
+        {
+            LOG(LOG_LEVEL_INFO, "Selected TLS security");
+            self->selectedProtocol = PROTOCOL_SSL;
+            got_protocol = 1;
+        }
+        else
+        {
+            LOG(LOG_LEVEL_WARNING, "Cannot accept TLS connections because "
+                "certificate or private key file is not readable. "
+                "certificate file: [%s], private key file: [%s]",
+                client_info->certificate, client_info->key_file);
+
+            /* If we're configured to ONLY use TLS, this is a problem.
+             * If not, we can fall back to RDP */
+            if (client_info->security_layer == SECURITY_LAYER_TLS)
+            {
+                LOG(LOG_LEVEL_ERROR,
+                    "Server requires TLS (security_layer=tls)");
+                self->failureCode = SSL_CERT_NOT_ON_SERVER;
+                rv = 1;
+            }
+        }
+    }
+    else if (client_info->security_layer == SECURITY_LAYER_TLS)
+    {
+        /* We don't have a match on TLS, but we'll accept nothing less */
+        LOG(LOG_LEVEL_ERROR, "Server requires TLS (security_layer=tls)");
+        self->failureCode = SSL_REQUIRED_BY_SERVER;
+        rv = 1;
+    }
+
+    /* If we haven't got a match so far, and we haven't got a fail,
+     * try RDP */
+    if (!got_protocol && !rv)
+    {
+        self->selectedProtocol = PROTOCOL_RDP;
+        LOG(LOG_LEVEL_INFO, "Selected classic RDP security");
+    }
 
     return rv;
 }

--- a/libxrdp/xrdp_iso.c
+++ b/libxrdp/xrdp_iso.c
@@ -116,6 +116,11 @@ xrdp_iso_negotiate_security(struct xrdp_iso *self)
     {
         security_type_mask = PROTOCOL_SSL;
     }
+    /* But VMConnect mode supports everything. */
+    if (client_info->vmconnect)
+    {
+        security_type_mask |= PROTOCOL_HYBRID | PROTOCOL_HYBRID_EX;
+    }
 
     /* Logically 'and' this value with the mask requested by the client, and
      * see what's left */
@@ -124,8 +129,36 @@ xrdp_iso_negotiate_security(struct xrdp_iso *self)
         protostr);
     security_type_mask &= self->requestedProtocol;
 
+    /* In VMConnect mode, we support everything. */
+    if (client_info->vmconnect && (self->requestedProtocol > PROTOCOL_RDP))
+    {
+        if (security_type_mask & PROTOCOL_HYBRID_EX)
+        {
+            LOG(LOG_LEVEL_INFO, "Selected HYBRID_EX security");
+            self->selectedProtocol = PROTOCOL_HYBRID_EX;
+            got_protocol = 1;
+        }
+        else if (security_type_mask & PROTOCOL_HYBRID)
+        {
+            LOG(LOG_LEVEL_INFO, "Selected HYBRID security");
+            self->selectedProtocol = PROTOCOL_HYBRID;
+            got_protocol = 1;
+        }
+        else if (security_type_mask & PROTOCOL_SSL)
+        {
+            LOG(LOG_LEVEL_INFO, "Selected TLS security");
+            self->selectedProtocol = PROTOCOL_SSL;
+            got_protocol = 1;
+        }
+        else
+        {
+            /* Impossible */
+            LOG(LOG_LEVEL_ERROR, "Impossible case.");
+            rv = 1;
+        }
+    }
     /* Is there a match on SSL/TLS? */
-    if ((security_type_mask & PROTOCOL_SSL) != 0)
+    else if ((security_type_mask & PROTOCOL_SSL) != 0)
     {
         /* Can we do TLS? (basic check) */
         if (g_file_readable(client_info->certificate) &&
@@ -190,10 +223,17 @@ xrdp_iso_process_rdp_neg_req(struct xrdp_iso *self, struct stream *s)
     /* The type field has already been read to determine that this function
        should be called */
     in_uint8(s, flags); /* flags */
-    if (flags != 0x0 && flags != 0x8 && flags != 0x1)
+    if ((flags & 0x0000000b) != flags)
     {
         LOG(LOG_LEVEL_ERROR,
             "Unsupported [MS-RDPBCGR] RDP_NEG_REQ flags: 0x%2.2x", flags);
+        return 1;
+    }
+
+    /* If both flags are set, it means 'OR', so fail only if only the one is set. */
+    if ((flags & REDIRECTED_AUTHENTICATION_MODE_REQUIRED) && !(flags & RESTRICTED_ADMIN_MODE_REQUIRED))
+    {
+        LOG(LOG_LEVEL_ERROR, "[MS-RDPBCGR] RDP_NEG_REQ: RemoteGuard isn't supported !");
         return 1;
     }
 
@@ -359,8 +399,11 @@ xrdp_iso_send_cc(struct xrdp_iso *self)
     char *holdp;
     char *len_ptr;
     char *len_indicator_ptr;
+    char flags;
     int len;
     int len_indicator;
+
+    struct xrdp_client_info *client_info = &(self->mcs_layer->sec_layer->rdp_layer->client_info);
 
     make_stream(s);
     init_stream(s, 8192);
@@ -395,10 +438,17 @@ xrdp_iso_send_cc(struct xrdp_iso *self)
         }
         else
         {
+            flags = EXTENDED_CLIENT_DATA_SUPPORTED;
+
+            if (client_info->vmconnect)
+            {
+                /* NLA is handled by the host and not us. */
+                flags |= RESTRICTED_ADMIN_MODE_SUPPORTED;
+            }
+
             /* [MS-RDPBCGR] RDP_NEG_RSP */
             out_uint8(s, RDP_NEG_RSP);                    /* type*/
-            //TODO: hardcoded flags
-            out_uint8(s, EXTENDED_CLIENT_DATA_SUPPORTED); /* flags */
+            out_uint8(s, flags);                          /* flags */
             out_uint16_le(s, 8);                          /* length (must be 8) */
             out_uint32_le(s, self->selectedProtocol);     /* selectedProtocol */
             LOG_DEVEL(LOG_LEVEL_TRACE, "Adding structure [MS-RDPBCGR] RDP_NEG_RSP "

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -193,26 +193,22 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
         {
             if (g_strcasecmp(value, "rdp") == 0)
             {
-                client_info->security_layer = PROTOCOL_RDP;
+                client_info->security_layer = SECURITY_LAYER_RDP;
             }
             else if (g_strcasecmp(value, "tls") == 0)
             {
-                client_info->security_layer = PROTOCOL_SSL;
-            }
-            else if (g_strcasecmp(value, "hybrid") == 0)
-            {
-                client_info->security_layer = PROTOCOL_SSL | PROTOCOL_HYBRID;
+                client_info->security_layer = SECURITY_LAYER_TLS;
             }
             else if (g_strcasecmp(value, "negotiate") == 0)
             {
-                client_info->security_layer = PROTOCOL_SSL | PROTOCOL_HYBRID | PROTOCOL_HYBRID_EX;
+                client_info->security_layer = SECURITY_LAYER_NEGOTIATE;
             }
             else
             {
                 LOG(LOG_LEVEL_WARNING, "security_layer=%s is not "
                     "recognized, will use security_layer=negotiate",
                     value);
-                client_info->security_layer = PROTOCOL_SSL | PROTOCOL_HYBRID | PROTOCOL_HYBRID_EX;
+                client_info->security_layer = SECURITY_LAYER_NEGOTIATE;
             }
         }
         else if (g_strcasecmp(item, "certificate") == 0)

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -211,6 +211,10 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
                 client_info->security_layer = SECURITY_LAYER_NEGOTIATE;
             }
         }
+        else if (g_strcasecmp(item, "vmconnect") == 0)
+        {
+            client_info->vmconnect = g_text2bool(value);
+        }
         else if (g_strcasecmp(item, "certificate") == 0)
         {
             g_memset(client_info->certificate, 0, sizeof(char) * 1024);

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -2514,7 +2514,11 @@ xrdp_sec_incoming(struct xrdp_sec *self)
     }
 
     /* initialize selected security layer */
-    if (iso->selectedProtocol > PROTOCOL_RDP)
+    if (self->rdp_layer->client_info.vmconnect && iso->selectedProtocol > PROTOCOL_RDP)
+    {
+        /* Security handled by host: do nothing. */
+    }
+    else if (iso->selectedProtocol > PROTOCOL_RDP)
     {
         /* init tls security */
 

--- a/xrdp/xrdp.c
+++ b/xrdp/xrdp.c
@@ -332,6 +332,9 @@ read_xrdp_ini_startup_params(struct xrdp_startup_params *startup_params)
 
             else if (g_strcasecmp(name, "use_vsock") == 0)
             {
+                LOG(LOG_LEVEL_WARNING,
+                    "Config parameter 'use_vsock' is obsolete. "
+                    "Use 'port=vsock://...' instead");
                 startup_params->use_vsock = g_text2bool(val);
             }
 

--- a/xrdp/xrdp.ini.in
+++ b/xrdp/xrdp.ini.in
@@ -22,11 +22,6 @@ fork=true
 ;   port=vsock://<cid>:<port>
 port=3389
 
-; 'port' above should be connected to with vsock instead of tcp
-; use this only with number alone in port above
-; prefer use vsock://<cid>:<port> above
-use_vsock=false
-
 ; if used inside a Hyper-V VM through vmconnect and bound on vsock,
 ; turn this on to enable wider security protocol support.
 #vmconnect=true

--- a/xrdp/xrdp.ini.in
+++ b/xrdp/xrdp.ini.in
@@ -27,6 +27,10 @@ port=3389
 ; prefer use vsock://<cid>:<port> above
 use_vsock=false
 
+; if used inside a Hyper-V VM with vmconnect, turn this on to enable
+; wider protocol support.
+#vmconnect=true
+
 ; Unprivileged User name and group to run the xrdp daemon.
 ; It is HIGHLY RECOMMENDED you set these values. See the xrdp.ini(5)
 ; manpage for more information on setting and checking these.

--- a/xrdp/xrdp.ini.in
+++ b/xrdp/xrdp.ini.in
@@ -27,8 +27,8 @@ port=3389
 ; prefer use vsock://<cid>:<port> above
 use_vsock=false
 
-; if used inside a Hyper-V VM with vmconnect, turn this on to enable
-; wider protocol support.
+; if used inside a Hyper-V VM through vmconnect and bound on vsock,
+; turn this on to enable wider security protocol support.
 #vmconnect=true
 
 ; Unprivileged User name and group to run the xrdp daemon.


### PR DESCRIPTION
Backport of #3514 to V0.10

~~Draft for now, as testing required which I may not have time to do for several days.~~ The first commit in this PR makes xrdp_iso.c and xrdp_rdp.c from v0.10 more like that from devel so the cherry-picks work cleanly.

@metalefty - I'm assuming we want this in V0.10?