### PR TITLE
Prevent possible double-free on chansrv exit

### DIFF
--- a/sesman/chansrv/sound.c
+++ b/sesman/chansrv/sound.c
@@ -1351,6 +1351,7 @@ sound_deinit(void)
 #endif
 
     fifo_delete(g_in_fifo, NULL);
+    g_in_fifo = NULL;
 
     return 0;
 }


### PR DESCRIPTION
Found while debugging another PR. If chansrv is running on a console session, CTRL-C can result in a double-free of `g_in_fifo`.