### PR TITLE
Fix V0.10.4 'vmconnect' regression

### DIFF
--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -172,7 +172,6 @@ struct xrdp_client_info
     int require_credentials; /* when true, credentials *must* be passed on cmd line */
 
     int security_layer; /* SECURITY_LAYER_* */
-    int vmconnect; /* Used when used from inside Hyper-V */
 
     int multimon; /* 0 = deny , 1 = allow */
     struct display_size_description display_sizes;
@@ -254,7 +253,7 @@ struct xrdp_client_info
     // Can we resize the desktop by using a Deactivation-Reactivation Sequence?
     enum client_resize_mode client_resize_mode;
 
-    int pad1; /* unused; unicode_input_state */
+    int vmconnect; /* Used when used from inside Hyper-V */
 };
 
 enum xrdp_encoder_flags


### PR DESCRIPTION
'struct xrdp_client_info' has changed in incompatible ways between v0.10.3 and v0.10.4 which means xorgxrdp can work with one or the other, but not both.

The incompatibility was introduced in 89688f2da6972dd19ed8cf4964f033c933aaea67

@metalefty - once again my apologies for failing to spot this in review. My current thinking is a release of v0.10.4_1 is in order. I'll update the NEWS accordingly.