### PR TITLE
Update to cppcheck 2.18.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,7 @@ jobs:
       CC: gcc
       # This is required to use a version of cppcheck other than that
       # supplied with the operating system
-      CPPCHECK_VER: "2.17.1"
+      CPPCHECK_VER: "2.18.0"
       CPPCHECK_REPO: https://github.com/danmar/cppcheck.git
     steps:
       # Set steps.os.outputs.image to the specific OS (e.g. 'ubuntu20')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,7 @@ jobs:
       CC: gcc
       # This is required to use a version of cppcheck other than that
       # supplied with the operating system
-      CPPCHECK_VER: "2.18.0"
+      CPPCHECK_VER: "2.18.3"
       CPPCHECK_REPO: https://github.com/danmar/cppcheck.git
     steps:
       # Set steps.os.outputs.image to the specific OS (e.g. 'ubuntu20')

--- a/scripts/run_cppcheck.sh
+++ b/scripts/run_cppcheck.sh
@@ -86,6 +86,7 @@ if [ -z "$CPPCHECK_FLAGS" ]; then
     CPPCHECK_FLAGS="--quiet --force --std=c11 --std=c++11 --inline-suppr \
                     --enable=warning --error-exitcode=1 -i third_party \
                     --suppress=uninitMemberVar:ulalaca/ulalaca.cpp \
+                    --suppress=dangerousTypeCast:ulalaca/XrdpStream.template.cpp \
                     --suppress=shiftTooManyBits:libxrdp/xrdp_mppc_enc.c"
 
     # Check for flags added in later versions

--- a/xrdp/xrdp_tconfig.c
+++ b/xrdp/xrdp_tconfig.c
@@ -225,6 +225,7 @@ tconfig_load_gfx_x264_ct(toml_table_t *tfile, const int connection_type,
                   datum.u.s,
                   sizeof(param[connection_type].preset) - 1);
         free(datum.u.s);
+        datum.u.s = NULL;
     }
     else if (connection_type == 0)
     {
@@ -245,6 +246,7 @@ tconfig_load_gfx_x264_ct(toml_table_t *tfile, const int connection_type,
                   datum.u.s,
                   sizeof(param[connection_type].tune) - 1);
         free(datum.u.s);
+        datum.u.s = NULL;
     }
     else if (connection_type == 0)
     {
@@ -265,6 +267,7 @@ tconfig_load_gfx_x264_ct(toml_table_t *tfile, const int connection_type,
                   datum.u.s,
                   sizeof(param[connection_type].profile) - 1);
         free(datum.u.s);
+        datum.u.s = NULL; // Prevent double-free warning with cppcheck 2.18.0
     }
     else if (connection_type == 0)
     {


### PR DESCRIPTION
Update to cppcheck 2.18.0

This version of cppcheck is generating false positives on xrdp/xrdp_tconfig.c. This change works around that, but I've also sent a message to https://sourceforge.net/p/cppcheck/discussion/general/ to raise an issue. There's no issue yet, as are some hoops to jump through. However, I've sent this test program which illustrates the false positive:-

```c
#include <stdlib.h>

struct test
{
    int valid;
    char *mem;
};

static struct test get_alloc(void)
{
    struct test result = {0, NULL};

    if ((result.mem = malloc(10)) != NULL)
    {
        result.valid = 1;
    }

    return result;
}

int main()
{
    struct test t;

    t = get_alloc();
    if (t.valid)
    {
        free(t.mem);
    }

    t = get_alloc();
    if (t.valid)
    {
        free(t.mem);
    }
}
```

Then:-

```
$ ~/cppcheck.local/2.18.0/bin/cppcheck temp.c
Checking temp.c ...
temp.c:34:9: error: Memory pointed to by 'mem' is freed twice. [doubleFree]
        free(t.mem);
        ^
temp.c:28:9: note: Memory pointed to by 'mem' is freed twice.
        free(t.mem);
        ^
temp.c:34:9: note: Memory pointed to by 'mem' is freed twice.
        free(t.mem);
        ^
```
I'm marking this draft for now, pending a response from the cppcheck team.

@firewave - you asked to be notified of any cppcheck issues.