### PR TITLE
Fix compilation failure in Deepin 20 (glibc < 2.38)

### DIFF
--- a/sesman/ercp_process.c
+++ b/sesman/ercp_process.c
@@ -35,6 +35,7 @@
 #include "ercp.h"
 #include "ercp_process.h"
 #include "session_list.h"
+#include "string_calls.h"
 
 /******************************************************************************/
 static int

--- a/sesman/sesexec/ercp_server.c
+++ b/sesman/sesexec/ercp_server.c
@@ -36,6 +36,7 @@
 #include "os_calls.h"
 #include "session.h"
 #include "sesman_config.h"
+#include "string_calls.h"
 #include "trans.h"
 
 #include "ercp.h"


### PR DESCRIPTION
Thanks to @tsz8899 for raising this issue in comments.

Building on Deepin 20 produces the following errors:-

```
ercp_server.c: In function ‘handle_connect_session_request’:
ercp_server.c:115:17: error: implicit declaration of function ‘strlcpy’; did you mean ‘strncpy’? [-Werror=implicit-function-declaration]
                 strlcpy(g_client_ip, client_ip, sizeof(g_client_ip));
                 ^~~~~~~
                 strncpy
. . .
ercp_process.c: In function ‘process_client_connect_event’:
ercp_process.c:107:9: error: implicit declaration of function ‘strlcpy’; did you mean ‘strncpy’? [-Werror=implicit-function-declaration]
         strlcpy(si->client_ip, client_ip, sizeof(si->client_ip));
         ^~~~~~~
         strncpy
```

The `strlcpy()` function was added to xrdp in #3477. On systems with glibc 2.38 or later, [strlcpy() is part of glibc](https://www.gnu.org/software/libc/manual/2.38/html_node/Truncating-Strings.html#index-strlcpy). On other systems, an implementation copied from OpenBSD is used. This implementation lives in the 'string calls' module. The build system detects when a built-in version of strlcpy is available, and if it is the xrdp implementation is disabled.

Deepin uses glibc 2.28, and so the strlcpy() call from the string calls module is required.