### PR TITLE
[V0.10] Allow for empty UTF8_STRING to be pasted

### DIFF
--- a/sesman/chansrv/clipboard.c
+++ b/sesman/chansrv/clipboard.c
@@ -1810,7 +1810,7 @@ clipboard_event_selection_notify(XEvent *xevent)
             {
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_event_selection_notify: UTF8_STRING "
                           "data_size %d", data_size);
-                if ((g_clip_s2c.incr_in_progress == 0) && (data_size > 0))
+                if ((g_clip_s2c.incr_in_progress == 0) && (data_size >= 0))
                 {
                     g_free(g_clip_s2c.data);
                     g_clip_s2c.total_bytes = data_size;


### PR DESCRIPTION
Fixes #3580 (for v0.10.x)

The current code doesn't allow for an empty string to be pasted to the clipboard on the X11 side.  This is done by some lock screen programs to prevent information leakage.

(cherry picked from commit 8099299ab0a959001658f767a9235db2f55953e1)