### PR TITLE
Fix stray carriage returns in xrdp-sesadmin output

### DIFF
--- a/sesman/tools/sesadmin.c
+++ b/sesman/tools/sesadmin.c
@@ -156,14 +156,14 @@ print_session(const struct scp_session_info *s)
         printf("\tConnection state: connected\n");
         printf("\tConnected client IP: %s\n", s->client_ip);
         printf("\tConnected client name: %s\n", s->client_name);
-        printf("\tConnection start time: %s\n",
+        printf("\tConnection start time: %s",
                ctime(&s->last_connect_disconnect));
     }
     else
     {
         printf("\tConnection state: disconnected\n");
-        printf("\tConnection end time: %s\n",
-               (s->last_connect_disconnect == 0) ? "-" :
+        printf("\tConnection end time: %s",
+               (s->last_connect_disconnect == 0) ? "-\n" :
                ctime(&s->last_connect_disconnect));
     }
     g_free(username);


### PR DESCRIPTION
The ctime() function adds a carriage return to its output, and this has not properly been taken into account with recent additions (cd98b013f1b5f838d559575a6b8aae4d6262e670)