### PR TITLE
Fix Coverity regression

### DIFF
--- a/vnc/vnc.c
+++ b/vnc/vnc.c
@@ -1370,7 +1370,10 @@ lib_framebuffer_look_for_forwarded_layout(struct vnc *v)
                 g_sleep(100);
             }
 
-            error = send_update_request_for_resize_status(v);
+            if (error != 0)
+            {
+                error = send_update_request_for_resize_status(v);
+            }
         }
     }
 


### PR DESCRIPTION
Fix Coverity regression introduced by 0ff175c85e1944321934155524358b888dc1121c :

```
*** CID 893283:         Code maintainability issues  (UNUSED_VALUE)
/vnc/vnc.c: 1360             in lib_framebuffer_look_for_forwarded_layout()
1354                 {
1355                     LOG(LOG_LEVEL_DEBUG,
1356                         "VNC_RESIZE: VNC server forwarded resize complete");
1357                     free(v->forward_timer);
1358                     v->forward_timer = NULL;
1359                     v->server_layout = layout;
>>>     CID 893283:         Code maintainability issues  (UNUSED_VALUE)
>>>     Assigning value from "v->server_monitor_resize_done(v)" to "error" here, but that stored value is overwritten before it can be used.
1360                     error = v->server_monitor_resize_done(v);
1361                     v->resize_status = VRS_DONE;
1362                 }
1363                 else
1364                 {
1365                     LOG(LOG_LEVEL_DEBUG,
```