### PR TITLE
Correct sense of test

### DIFF
--- a/vnc/vnc.c
+++ b/vnc/vnc.c
@@ -1370,7 +1370,7 @@ lib_framebuffer_look_for_forwarded_layout(struct vnc *v)
                 g_sleep(100);
             }
 
-            if (error != 0)
+            if (error == 0)
             {
                 error = send_update_request_for_resize_status(v);
             }


### PR DESCRIPTION
issue with 2a022ad681830656a433a122e493c4c6359dd4a2 uncovered during Wayland testing on Trixie