### PR TITLE
Fill in all fields for TS_DEACTIVATE_ALL_PDU

### DIFF
--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -1597,6 +1597,8 @@ xrdp_rdp_disconnect(struct xrdp_rdp *self)
 int
 xrdp_rdp_send_deactivate(struct xrdp_rdp *self)
 {
+    // See [MS-RDPBCGR] 2.2.3.1.1
+    const char source_descriptor[] = { '\0' };
     struct stream *s;
 
     make_stream(s);
@@ -1608,12 +1610,13 @@ xrdp_rdp_send_deactivate(struct xrdp_rdp *self)
         LOG(LOG_LEVEL_ERROR, "xrdp_rdp_send_deactivate: xrdp_rdp_init failed");
         return 1;
     }
+    out_uint32_le(s, self->share_id);
+    out_uint16_le(s, sizeof(source_descriptor));
+    out_uint8p(s, source_descriptor, sizeof(source_descriptor));
 
-    /* TODO: why are all the fields missing from the TS_DEACTIVATE_ALL_PDU? */
     s_mark_end(s);
     LOG_DEVEL(LOG_LEVEL_TRACE, "Sending [MS-RDPBCGR] TS_DEACTIVATE_ALL_PDU "
-              "shareID <not set>, lengthSourceDescriptor <not set>, "
-              "sourceDescriptor <not set>");
+              "shareID %d, sourceDescriptor 0x0", self->share_id);
 
     if (xrdp_rdp_send(self, s, PDUTYPE_DEACTIVATEALLPDU) != 0)
     {


### PR DESCRIPTION
See Devolutions/IronRDP#314, and in particular [this comment](/Devolutions/IronRDP/issues/314#issuecomment-3254275590)

At the moment our TS_DEACTIVATE_ALL_PDU is not compliant with [MS-RDPBCGR], but rather emulates what Windows XP does.