### PR TITLE
Fix more inconsistencies with [MS-RDPBCGR]

### DIFF
--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -1109,7 +1109,8 @@ xrdp_rdp_send_synchronise(struct xrdp_rdp *self)
 /*****************************************************************************/
 /* Send a [MS-RDPBCGR] TS_CONTROL_PDU message */
 static int
-xrdp_rdp_send_control(struct xrdp_rdp *self, int action)
+xrdp_rdp_send_control(struct xrdp_rdp *self, int action,
+                      int grant_id, int control_id)
 {
     struct stream *s;
 
@@ -1124,8 +1125,8 @@ xrdp_rdp_send_control(struct xrdp_rdp *self, int action)
     }
 
     out_uint16_le(s, action);
-    out_uint16_le(s, 0); /* userid */
-    out_uint32_le(s, 1002); /* control id */
+    out_uint16_le(s, grant_id);
+    out_uint32_le(s, control_id);
     s_mark_end(s);
     LOG_DEVEL(LOG_LEVEL_TRACE, "Sending [MS-RDPBCGR] TS_CONTROL_PDU "
               "action %d, grantId 0, controlId 1002", action);
@@ -1162,8 +1163,9 @@ xrdp_rdp_process_data_control(struct xrdp_rdp *self, struct stream *s)
                   "TS_SYNCHRONIZE_PDU, TS_CONTROL_PDU with CTRLACTION_COOPERATE, "
                   " and TS_CONTROL_PDU with CTRLACTION_GRANTED_CONTROL");
         xrdp_rdp_send_synchronise(self);
-        xrdp_rdp_send_control(self, RDP_CTL_COOPERATE);
-        xrdp_rdp_send_control(self, RDP_CTL_GRANT_CONTROL);
+        xrdp_rdp_send_control(self, RDP_CTL_COOPERATE, 0, 0);
+        xrdp_rdp_send_control(self, RDP_CTL_GRANT_CONTROL,
+                              self->mcs_channel, 0x03ea);
     }
     else
     {


### PR DESCRIPTION
IronRDP has highlighted an inconsistency with the spec for the 'Cooperate' and 'Granted Control' Control PDUs sent from the server to the client:-

```
2025-09-05T10:39:37.557097Z  WARN ThreadId(04) crates/ironrdp-connector/src/connection_finalization.rs:170: Server Control (Cooperate) has non-zero grant_id or control_id control_pdu.grant_id=0 control_pdu.control_id=1002 user_channel_id=1007
2025-09-05T10:39:37.557191Z  WARN ThreadId(04) crates/ironrdp-connector/src/connection_finalization.rs:188: Server Control (Granted Control) had invalid grant_id, expected 1007, but got 0
```

From [MS-RDPBCGR]:-

> 3.3.5.3.20 Sending Control PDU - Cooperate
> The structure and fields of the Control (Cooperate) PDU are described in section 2.2.1.20, and the techniques described in section 3.3.5.1 demonstrate how to initialize the contents of the PDU. The grantId and controlId fields SHOULD be set to zero. The contents of this PDU SHOULD NOT be compressed.
>
> 3.3.5.3.21 Sending Control PDU - Granted Control
> The structure and fields of the Control (Granted Control) PDU are described in section 2.2.1.21, and the techniques described in section 3.3.5.1 demonstrate how to initialize the contents of the PDU. The grantId field SHOULD be set to the User Channel ID (held in the User Channel ID store (3.3.1.2)), while the controlId field SHOULD be set to the MCS server channel ID (held in the Server Channel ID store (section 3.3.1.5)). The contents of this PDU SHOULD NOT be compressed.

This PR simply makes our PDUs consistent with the spec and prevents the warnings being generated.