### PR TITLE
Fix `PAM_TTY` item being set to uninitialized data in PAM userpass lib

### DIFF
--- a/sesman/libsesman/verify_user_pam_userpass.c
+++ b/sesman/libsesman/verify_user_pam_userpass.c
@@ -69,7 +69,6 @@ common_pam_login(struct auth_info *auth_info,
                  int need_pam_authenticate)
 {
     int perror;
-    char service_name[256];
 
     perror = pam_start(SERVICE, auth_info->userpass.user,
                        &(auth_info->pamc), &(auth_info->ph));
@@ -92,7 +91,7 @@ common_pam_login(struct auth_info *auth_info,
         }
     }
 
-    perror = pam_set_item(auth_info->ph, PAM_TTY, service_name);
+    perror = pam_set_item(auth_info->ph, PAM_TTY, SERVICE);
     if (perror != PAM_SUCCESS)
     {
         LOG(LOG_LEVEL_ERROR, "pam_set_item(PAM_TTY) failed: %s",


### PR DESCRIPTION
The local variable it referenced was never initialized before use. I replaced it with a reference to the seemingly intended `SERVICE` preprocessor constant, which is also used in the `pam_start` call slightly above.