### PR TITLE
session management: Allow for restricted shells

### DIFF
--- a/docs/man/sesman.ini.5.in
+++ b/docs/man/sesman.ini.5.in
@@ -366,6 +366,13 @@ because the system is unable to check whether the user is an administrator.
 If set to \fB0\fR, \fBfalse\fR or \fBno\fR, prevent usage of alternate shells by users.
 
 .TP
+\fBPassShellAsEnv\fR=\fI<name-of-environment-variable>\fR
+If this is set, alternate shells are not actioned directly, but
+passed in to the default window manager in the specified environment
+variable. This allows the system manager more control over exactly
+what alternate shells are permitted.
+
+.TP
 \fBXorgNoNewPrivileges\fR=\fI[true|false]\fR
 Only applicable on Linux. If set to \fB0\fR, \fBfalse\fR or \fBno\fR, do
 not use the kernel's \fIno_new_privs\fR restriction when invoking the Xorg

--- a/docs/man/sesman.ini.5.in
+++ b/docs/man/sesman.ini.5.in
@@ -372,6 +372,9 @@ passed in to the default window manager in the specified environment
 variable. This allows the system manager more control over exactly
 what alternate shells are permitted.
 
+This will override any setting of the same environment variable
+in the \fB[SessionVariables]\fR section.
+
 .TP
 \fBXorgNoNewPrivileges\fR=\fI[true|false]\fR
 Only applicable on Linux. If set to \fB0\fR, \fBfalse\fR or \fBno\fR, do

--- a/sesman/libsesman/sesman_config.c
+++ b/sesman/libsesman/sesman_config.c
@@ -72,6 +72,7 @@
 #define SESMAN_CFG_SEC_RESTRICT_OUTBOUND_CLIPBOARD "RestrictOutboundClipboard"
 #define SESMAN_CFG_SEC_RESTRICT_INBOUND_CLIPBOARD  "RestrictInboundClipboard"
 #define SESMAN_CFG_SEC_ALLOW_ALTERNATE_SHELL       "AllowAlternateShell"
+#define SESMAN_CFG_SEC_PASS_SHELL_AS_ENV           "PassShellAsEnv"
 #define SESMAN_CFG_SEC_XORG_NO_NEW_PRIVILEGES      "XorgNoNewPrivileges"
 #define SESMAN_CFG_SEC_SESSION_SOCKDIR_GROUP       "SessionSockdirGroup"
 
@@ -319,6 +320,7 @@ config_read_security(int file, struct config_security *sc,
     sc->restrict_outbound_clipboard = 0;
     sc->restrict_inbound_clipboard = 0;
     sc->allow_alternate_shell = 1;
+    sc->pass_shell_as_env = g_strdup("");
     sc->xorg_no_new_privileges = 1;
     sc->ts_users = g_strdup("");
     sc->ts_admins = g_strdup("");
@@ -389,6 +391,11 @@ config_read_security(int file, struct config_security *sc,
         {
             sc->allow_alternate_shell =
                 g_text2bool(value);
+        }
+        else if (0 == g_strcasecmp(buf, SESMAN_CFG_SEC_PASS_SHELL_AS_ENV))
+        {
+            g_free(sc->pass_shell_as_env);
+            sc->pass_shell_as_env = g_strdup(value);
         }
         else if (0 == g_strcasecmp(buf, SESMAN_CFG_SEC_XORG_NO_NEW_PRIVILEGES))
         {
@@ -705,6 +712,7 @@ config_dump(struct config_sesman *config)
     g_writeln("    XAuthorityInSystemDir:     %d", sc->xauth_in_sysdir);
     g_writeln("    AlwaysGroupCheck:          %d", sc->ts_always_group_check);
     g_writeln("    AllowAlternateShell:       %d", sc->allow_alternate_shell);
+    g_writeln("    PassShellAsEnv:            %s", sc->pass_shell_as_env);
 #ifdef HAVE_SYS_PRCTL_H
     g_writeln("    XorgNoNewPrivileges:       %d", sc->xorg_no_new_privileges);
 #endif
@@ -773,6 +781,7 @@ config_free(struct config_sesman *cs)
         list_delete(cs->xorg_params);
         list_delete(cs->env_names);
         list_delete(cs->env_values);
+        g_free(cs->sec.pass_shell_as_env);
         g_free(cs->sec.ts_users);
         g_free(cs->sec.ts_admins);
         g_free(cs->sec.session_sockdir_group);

--- a/sesman/libsesman/sesman_config.h
+++ b/sesman/libsesman/sesman_config.h
@@ -110,6 +110,13 @@ struct config_security
      */
     int allow_alternate_shell;
 
+    /**
+     * @var pass_shell_as_env
+     * @brief Passes alternate shells in the environment
+     * @details name of environment variable to receive alternate shell
+     */
+    char *pass_shell_as_env;
+
     /*
      * @var xorg_no_new_privileges
      * @brief if the Xorg X11 server should be started with no_new_privs (Linux only)

--- a/sesman/sesexec/session.c
+++ b/sesman/sesexec/session.c
@@ -257,8 +257,21 @@ start_window_manager(const struct login_info *login_info,
         }
     }
 
-    if (s->shell[0] != '\0')
+    if (g_cfg->sec.allow_alternate_shell &&
+            g_cfg->sec.pass_shell_as_env != NULL &&
+            g_cfg->sec.pass_shell_as_env[0] != '0')
     {
+        // Pass the shell in to the standard startwm scripts
+        // in an environment variable
+        LOG(LOG_LEVEL_INFO,
+            "Setting variable '%s' to the specified shell of '%s'",
+            g_cfg->sec.pass_shell_as_env,
+            s->shell);
+        g_setenv(g_cfg->sec.pass_shell_as_env, s->shell, 1);
+    }
+    else if (s->shell[0] != '\0')
+    {
+        // Try to execute the shell directly (if permitted)
         if (g_cfg->sec.allow_alternate_shell)
         {
             if (g_strchr(s->shell, ' ') != 0 || g_strchr(s->shell, '\t') != 0)

--- a/sesman/sesman.ini.in
+++ b/sesman/sesman.ini.in
@@ -45,6 +45,13 @@ RestrictOutboundClipboard=none
 RestrictInboundClipboard=none
 ; Set to 'no' to prevent users from logging in with alternate shells
 #AllowAlternateShell=true
+; Normally, alternate shells (if permitted) are executed directly, as
+; specified.
+; If this is set, alternate shells are not actioned directly, but
+; passed in to the default window manager in the specified environment
+; variable. This allows the system manager more control over exactly
+; what alternate shells are permitted.
+#PassShellAsEnv=XRDP_ALTERNATE_SHELL
 ; On Linux systems, the Xorg X11 server is normally invoked using
 ; no_new_privs to avoid problems if the executable is suid. This may,
 ; however, interfere with the use of security modules such as AppArmor.

--- a/sesman/sesman.ini.in
+++ b/sesman/sesman.ini.in
@@ -51,6 +51,8 @@ RestrictInboundClipboard=none
 ; passed in to the default window manager in the specified environment
 ; variable. This allows the system manager more control over exactly
 ; what alternate shells are permitted.
+; This will override any setting of the same environment variable
+; in the [SessionVariables] section.
 #PassShellAsEnv=XRDP_ALTERNATE_SHELL
 ; On Linux systems, the Xorg X11 server is normally invoked using
 ; no_new_privs to avoid problems if the executable is suid. This may,

--- a/sesman/startwm.sh
+++ b/sesman/startwm.sh
@@ -93,6 +93,9 @@ wm_start()
     # <your preferred desktop> shall be one of "ls -1 /usr/share/xsessions/|cut -d. -f1"
     # e.g.  [ -n "$XRDP_SESSION" ] && export DESKTOP_SESSION=ubuntu
 
+    # Alternatively, set "PassShellAsEnv=DESKTOP_SESSION" in sesman.ini, which
+    # lets the user specify the required session directly.
+
     # STARTUP is the default startup command.
     # if $1 is empty and STARTUP was not set
     # /etc/X11/Xsession.d/50x11-common_determine-startup will fallback to


### PR DESCRIPTION
Fixes #3624 

Allows the `AlternateShell` specified by the user in the TS_INFO_PACKET to be passed to startwm.sh as an environment variable.

Draft PR for now, as I've not finished module testing yet; I'm going to be a bit busy for a few days IRL.

~~One thing I'd really like to test is using `PassShellAsEnv=DESKTOP_SESSION` to allow the user to specify which desktop they'd like to run on Debian/Ubuntu. I've added a comment about this to `startwm.sh`~~

**Update 2025-10-20:** Running on Ubuntu 24-04, I'm able to choose between XFCE and GNOME sessions by using `PassShellAsEnv=DESKTOP_SESSION`, and setting the startup shell to either `ubuntu or `xfce`.

@akarl10, @metalefty, @gumerov-r - any comments will be very welcome. 