### PR TITLE
pass frame id back to main thread in jpeg encode

### DIFF
--- a/xrdp/xrdp_encoder.c
+++ b/xrdp/xrdp_encoder.c
@@ -522,6 +522,7 @@ process_enc_jpg(struct xrdp_encoder *self, XRDP_ENC_DATA *enc)
         enc_done->y = y;
         enc_done->cx = cx;
         enc_done->cy = cy;
+        enc_done->frame_id = enc->u.sc.frame_id;
         /* done with msg */
         /* inform main thread done */
         tc_mutex_lock(mutex);


### PR DESCRIPTION
It seems jpeg has been broke since we did gfx, this simple fix re-enables jpeg.