### PR TITLE
[V0.10] pass frame id back to main thread in jpeg encode

### DIFF
--- a/xrdp/xrdp_encoder.c
+++ b/xrdp/xrdp_encoder.c
@@ -522,6 +522,7 @@ process_enc_jpg(struct xrdp_encoder *self, XRDP_ENC_DATA *enc)
         enc_done->y = y;
         enc_done->cx = cx;
         enc_done->cy = cy;
+        enc_done->frame_id = enc->u.sc.frame_id;
         /* done with msg */
         /* inform main thread done */
         tc_mutex_lock(mutex);


### PR DESCRIPTION
Back-port of #3648

Fixes a regression introduced by GFX support.

(cherry picked from commit 74c2cf31d211b037c2c4b9593b706055dcfb2183)