### PR TITLE
sesman.ini: Update well-known paths for Xorg

### DIFF
--- a/sesman/sesman.ini.in
+++ b/sesman/sesman.ini.in
@@ -160,13 +160,12 @@ EnableSyslog=true
 ; on your distribution and version. Find out the appropriate path for your
 ; environment. The typical path is known as follows:
 ;
-; Fedora 26 or later    :  param=/usr/libexec/Xorg
-; Debian 9 or later     :  param=/usr/lib/xorg/Xorg
-; Ubuntu 16.04 or later :  param=/usr/lib/xorg/Xorg
-; Arch Linux            :  param=/usr/lib/Xorg
-; CentOS 7              :  param=/usr/bin/Xorg or param=Xorg
-; CentOS 8              :  param=/usr/libexec/Xorg
-; FreeBSD (from 2022Q4) :  param=/usr/local/libexec/Xorg
+; Fedora 26 or later          :  param=/usr/libexec/Xorg
+; Alma/Rocky Linux 8 or later :  param=/usr/libexec/Xorg
+; Debian 9 or later           :  param=/usr/lib/xorg/Xorg
+; Ubuntu 16.04 or later       :  param=/usr/lib/xorg/Xorg
+; Arch Linux                  :  param=/usr/lib/Xorg
+; FreeBSD (from 2022Q4)       :  param=/usr/local/libexec/Xorg
 ;
 param=Xorg
 ; Leave the rest parameters as-is unless you understand what will happen.


### PR DESCRIPTION
Fixes #3661

Include explicit references for AlmaLinux and Rocky, and remove references to CentOS to better suit current audiences.