### PR TITLE
do not change port when not using sesman

### DIFF
--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -5324,7 +5324,10 @@ xrdp_mm_setup_mod2(struct xrdp_mm *self)
         }
         else if (self->code == XVNC_SESSION_CODE)
         {
-            g_snprintf(text, sizeof(text), "%d", 5900 + self->display);
+            if (self->use_sesman)
+            {
+                g_snprintf(text, sizeof(text), "%d", 5900 + self->display);
+            }
         }
         else if (self->code == XORG_SESSION_CODE ||
                  self->code == XVNC_UDS_SESSION_CODE)


### PR DESCRIPTION
There is an issue where vnc-any does not work correctly when the port is set to 5901.
Even when sesman is not used, xrdp still references the display number and rewrites the port to 5900 + display. Since the display is always 0 in this mode, the connection is always forced to port 5900.

This patch modifies the behavior so that when sesman is not used, xrdp will no longer rewrite the VNC port, allowing vnc-any to work as intended.