### PR TITLE
[V0.10] do not change xvnc port when not using sesman

### DIFF
--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -498,7 +498,10 @@ xrdp_mm_setup_mod2(struct xrdp_mm *self)
         {
             if (self->code == XVNC_SESSION_CODE)
             {
-                g_snprintf(text, sizeof(text), "%d", 5900 + self->display);
+                if (self->use_sesman)
+                {
+                    g_snprintf(text, sizeof(text), "%d", 5900 + self->display);
+                }
             }
             else if (self->code == XORG_SESSION_CODE ||
                      self->code == XVNC_UDS_SESSION_CODE)


### PR DESCRIPTION
Backport of #3671 to v0.10

(cherry picked from commit ba36dacf95d466232bd7ac39f897479885f396a7)