### PR TITLE
waitforx: remove unneded header

### DIFF
--- a/waitforx/waitforx.c
+++ b/waitforx/waitforx.c
@@ -3,7 +3,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
-#include <sys/signal.h>
 #include <unistd.h>
 #include <limits.h>
 


### PR DESCRIPTION
The sys/signal.h is essentially a redirect to signal.h, without further logic. However when using musl libc, a warning (which is treated as an error) is also emitted about this:

| /usr/include/sys/signal.h:1:2: error: #warning redirecting incorrect #include <sys/signal.h> to <signal.h> [-Werror=cpp]
|     1 | #warning redirecting incorrect #include <sys/signal.h> to <signal.h>

Remove sys/signal.h header to solve the problem - the signal.h header is already included in this file.