### PR TITLE
[V0.10] waitforx: remove unneeded header

### DIFF
--- a/waitforx/waitforx.c
+++ b/waitforx/waitforx.c
@@ -2,7 +2,6 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/signal.h>
 #include <unistd.h>
 
 #include "config_ac.h"


### PR DESCRIPTION
Backport of #3678 

The sys/signal.h is essentially a redirect to signal.h, without further logic. However when using musl libc, a warning (which is treated as an error) is also emitted about this:

| /usr/include/sys/signal.h:1:2: error: #warning redirecting incorrect #include <sys/signal.h> to <signal.h> [-Werror=cpp]
|     1 | #warning redirecting incorrect #include <sys/signal.h> to <signal.h>

Remove sys/signal.h header to solve the problem - the signal.h header is already included in this file.


(cherry picked from commit 4417646cdad9a3ca6d003296326eb412c52291b8)