### PR TITLE
Fix Possible race condition in g_create_path()

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -2764,7 +2764,10 @@ g_create_path(const char *path)
 
             if (!g_directory_exist(copypath))
             {
-                if (!g_create_dir(copypath))
+                // Create and check again to avoid a race with another
+                // process making the same traversal
+                (void)g_create_dir(copypath);
+                if (!g_directory_exist(copypath))
                 {
                     status = 0;
                     break;


### PR DESCRIPTION
A minor issue found in #3587 

Not needed in v0.10.x, as we don't have the same race possibilities.

(cherry picked from commit 2e597120443c7dcb0b32f6078999098a364f9543)