### PR TITLE
Add Apple Remote Desktop (ARD) authentication support for macOS

### DIFF
--- a/common/ssl_calls.c
+++ b/common/ssl_calls.c
@@ -24,6 +24,7 @@
 #endif
 
 #include <stdlib.h> /* needed for openssl headers */
+#include <string.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/rc4.h>
@@ -34,6 +35,12 @@
 #include <openssl/rsa.h>
 #include <openssl/dh.h>
 #include <openssl/crypto.h>
+#include <openssl/evp.h>
+#include <openssl/aes.h>
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#include <openssl/param_build.h>
+#include <openssl/core_names.h>
+#endif
 
 #include "os_calls.h"
 #include "string_calls.h"
@@ -1633,5 +1640,321 @@ const char
     return OpenSSL_version(OPENSSL_VERSION);
 #endif
 
+}
+
+/*****************************************************************************/
+/* DH key exchange for Apple ARD authentication */
+void *
+ssl_dh_create(int key_len, const unsigned char *generator,
+              const unsigned char *prime, const unsigned char *server_pubkey,
+              unsigned char *client_pubkey, unsigned char *shared_secret)
+{
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    /* OpenSSL 3.x uses EVP API for DH */
+    EVP_PKEY_CTX *pctx = NULL;
+    EVP_PKEY *params = NULL;
+    EVP_PKEY *dh_key = NULL;
+    EVP_PKEY *peer_key = NULL;
+    OSSL_PARAM_BLD *param_bld = NULL;
+    OSSL_PARAM *params_array = NULL;
+    BIGNUM *p = NULL;
+    BIGNUM *g = NULL;
+    BIGNUM *pub_key = NULL;
+    BIGNUM *peer_pub = NULL;
+    size_t shared_len = key_len;
+    int gen_value;
+
+    /* Convert generator (2 bytes big endian) to int */
+    gen_value = (generator[0] << 8) | generator[1];
+
+    /* Create BIGNUMs */
+    p = BN_bin2bn(prime, key_len, NULL);
+    g = BN_new();
+    BN_set_word(g, gen_value);
+    peer_pub = BN_bin2bn(server_pubkey, key_len, NULL);
+
+    if (!p || !g || !peer_pub)
+    {
+        LOG(LOG_LEVEL_ERROR, "ssl_dh_create: BN_bin2bn failed");
+        goto cleanup;
+    }
+
+    /* Build DH parameters */
+    param_bld = OSSL_PARAM_BLD_new();
+    if (!param_bld)
+    {
+        goto cleanup;
+    }
+
+    OSSL_PARAM_BLD_push_BN(param_bld, OSSL_PKEY_PARAM_FFC_P, p);
+    OSSL_PARAM_BLD_push_BN(param_bld, OSSL_PKEY_PARAM_FFC_G, g);
+    params_array = OSSL_PARAM_BLD_to_param(param_bld);
+
+    /* Create parameter key */
+    pctx = EVP_PKEY_CTX_new_from_name(NULL, "DH", NULL);
+    if (!pctx)
+    {
+        goto cleanup;
+    }
+
+    if (EVP_PKEY_fromdata_init(pctx) <= 0 ||
+        EVP_PKEY_fromdata(pctx, &params, EVP_PKEY_KEY_PARAMETERS, params_array) <= 0)
+    {
+        goto cleanup;
+    }
+    EVP_PKEY_CTX_free(pctx);
+    pctx = NULL;
+
+    /* Generate key pair */
+    pctx = EVP_PKEY_CTX_new(params, NULL);
+    if (!pctx || EVP_PKEY_keygen_init(pctx) <= 0 ||
+        EVP_PKEY_generate(pctx, &dh_key) <= 0)
+    {
+        goto cleanup;
+    }
+
+    /* Extract our public key */
+    if (EVP_PKEY_get_bn_param(dh_key, OSSL_PKEY_PARAM_PUB_KEY, &pub_key) <= 0)
+    {
+        goto cleanup;
+    }
+    BN_bn2binpad(pub_key, client_pubkey, key_len);
+
+    /* Create peer key for deriving shared secret */
+    OSSL_PARAM_BLD_free(param_bld);
+    param_bld = OSSL_PARAM_BLD_new();
+    OSSL_PARAM_BLD_push_BN(param_bld, OSSL_PKEY_PARAM_FFC_P, p);
+    OSSL_PARAM_BLD_push_BN(param_bld, OSSL_PKEY_PARAM_FFC_G, g);
+    OSSL_PARAM_BLD_push_BN(param_bld, OSSL_PKEY_PARAM_PUB_KEY, peer_pub);
+    OSSL_PARAM_free(params_array);
+    params_array = OSSL_PARAM_BLD_to_param(param_bld);
+
+    EVP_PKEY_CTX_free(pctx);
+    pctx = EVP_PKEY_CTX_new_from_name(NULL, "DH", NULL);
+    if (EVP_PKEY_fromdata_init(pctx) <= 0 ||
+        EVP_PKEY_fromdata(pctx, &peer_key, EVP_PKEY_PUBLIC_KEY, params_array) <= 0)
+    {
+        goto cleanup;
+    }
+
+    /* Derive shared secret */
+    EVP_PKEY_CTX_free(pctx);
+    pctx = EVP_PKEY_CTX_new(dh_key, NULL);
+    if (!pctx || EVP_PKEY_derive_init(pctx) <= 0 ||
+        EVP_PKEY_derive_set_peer(pctx, peer_key) <= 0)
+    {
+        goto cleanup;
+    }
+
+    /* First get the required size */
+    if (EVP_PKEY_derive(pctx, NULL, &shared_len) <= 0)
+    {
+        goto cleanup;
+    }
+
+    /* Derive into temp buffer to handle padding */
+    {
+        unsigned char *temp_secret = g_new(unsigned char, shared_len);
+        if (!temp_secret)
+        {
+            goto cleanup;
+        }
+        if (EVP_PKEY_derive(pctx, temp_secret, &shared_len) <= 0)
+        {
+            g_free(temp_secret);
+            goto cleanup;
+        }
+
+        /* Left-pad with zeros if needed (ARD requires exact key_len) */
+        g_memset(shared_secret, 0, key_len);
+        if ((int)shared_len >= key_len)
+        {
+            g_memcpy(shared_secret, temp_secret + (shared_len - key_len), key_len);
+        }
+        else
+        {
+            g_memcpy(shared_secret + (key_len - shared_len), temp_secret, shared_len);
+        }
+        g_free(temp_secret);
+    }
+
+    /* Success - return non-NULL */
+    EVP_PKEY_CTX_free(pctx);
+    EVP_PKEY_free(params);
+    EVP_PKEY_free(dh_key);
+    EVP_PKEY_free(peer_key);
+    OSSL_PARAM_BLD_free(param_bld);
+    OSSL_PARAM_free(params_array);
+    BN_free(p);
+    BN_free(g);
+    BN_free(pub_key);
+    BN_free(peer_pub);
+    return (void *)1; /* Return non-NULL to indicate success */
+
+cleanup:
+    if (pctx) EVP_PKEY_CTX_free(pctx);
+    if (params) EVP_PKEY_free(params);
+    if (dh_key) EVP_PKEY_free(dh_key);
+    if (peer_key) EVP_PKEY_free(peer_key);
+    if (param_bld) OSSL_PARAM_BLD_free(param_bld);
+    if (params_array) OSSL_PARAM_free(params_array);
+    if (p) BN_free(p);
+    if (g) BN_free(g);
+    if (pub_key) BN_free(pub_key);
+    if (peer_pub) BN_free(peer_pub);
+    return NULL;
+
+#else
+    /* OpenSSL 1.x - use deprecated DH API */
+    DH *dh = NULL;
+    BIGNUM *p_bn = NULL;
+    BIGNUM *g_bn = NULL;
+    BIGNUM *peer_pub_bn = NULL;
+    const BIGNUM *pub_key = NULL;
+    int gen_value;
+    int secret_len;
+
+    /* Convert generator (2 bytes big endian) to int */
+    gen_value = (generator[0] << 8) | generator[1];
+
+    dh = DH_new();
+    if (!dh)
+    {
+        LOG(LOG_LEVEL_ERROR, "ssl_dh_create: DH_new failed");
+        return NULL;
+    }
+
+    p_bn = BN_bin2bn(prime, key_len, NULL);
+    g_bn = BN_new();
+    BN_set_word(g_bn, gen_value);
+
+    if (!p_bn || !g_bn)
+    {
+        LOG(LOG_LEVEL_ERROR, "ssl_dh_create: BN creation failed");
+        DH_free(dh);
+        BN_free(p_bn);
+        BN_free(g_bn);
+        return NULL;
+    }
+
+    if (!DH_set0_pqg(dh, p_bn, NULL, g_bn))
+    {
+        LOG(LOG_LEVEL_ERROR, "ssl_dh_create: DH_set0_pqg failed");
+        DH_free(dh);
+        return NULL;
+    }
+
+    /* Generate key pair */
+    if (!DH_generate_key(dh))
+    {
+        LOG(LOG_LEVEL_ERROR, "ssl_dh_create: DH_generate_key failed");
+        DH_free(dh);
+        return NULL;
+    }
+
+    /* Get our public key */
+    DH_get0_key(dh, &pub_key, NULL);
+    BN_bn2binpad(pub_key, client_pubkey, key_len);
+
+    /* Compute shared secret */
+    peer_pub_bn = BN_bin2bn(server_pubkey, key_len, NULL);
+    secret_len = DH_compute_key(shared_secret, peer_pub_bn, dh);
+    BN_free(peer_pub_bn);
+
+    if (secret_len < 0)
+    {
+        LOG(LOG_LEVEL_ERROR, "ssl_dh_create: DH_compute_key failed");
+        DH_free(dh);
+        return NULL;
+    }
+
+    /* Pad shared secret with leading zeros if needed */
+    if (secret_len < key_len)
+    {
+        memmove(shared_secret + (key_len - secret_len), shared_secret, secret_len);
+        memset(shared_secret, 0, key_len - secret_len);
+    }
+
+    DH_free(dh);
+    return (void *)1; /* Return non-NULL to indicate success */
+#endif
+}
+
+/*****************************************************************************/
+void
+ssl_dh_delete(void *dh_info)
+{
+    /* Nothing to free - we return a dummy pointer */
+    (void)dh_info;
+}
+
+/*****************************************************************************/
+/* AES-128-ECB encryption for Apple ARD authentication */
+void *
+ssl_aes128_ecb_encrypt_info_create(const unsigned char *key)
+{
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+    if (!ctx)
+    {
+        return NULL;
+    }
+
+    if (EVP_EncryptInit_ex(ctx, EVP_aes_128_ecb(), NULL, key, NULL) != 1)
+    {
+        EVP_CIPHER_CTX_free(ctx);
+        return NULL;
+    }
+
+    /* Disable padding - Apple ARD uses exact block sizes */
+    EVP_CIPHER_CTX_set_padding(ctx, 0);
+
+    return ctx;
+#else
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+    if (!ctx)
+    {
+        return NULL;
+    }
+
+    if (EVP_EncryptInit_ex(ctx, EVP_aes_128_ecb(), NULL, key, NULL) != 1)
+    {
+        EVP_CIPHER_CTX_free(ctx);
+        return NULL;
+    }
+
+    EVP_CIPHER_CTX_set_padding(ctx, 0);
+
+    return ctx;
+#endif
+}
+
+/*****************************************************************************/
+void
+ssl_aes128_ecb_encrypt(void *aes_info, const unsigned char *in_data,
+                       unsigned char *out_data, int len)
+{
+    EVP_CIPHER_CTX *ctx = (EVP_CIPHER_CTX *)aes_info;
+    int out_len = 0;
+    int final_len = 0;
+
+    if (!ctx)
+    {
+        return;
+    }
+
+    EVP_EncryptUpdate(ctx, out_data, &out_len, in_data, len);
+    EVP_EncryptFinal_ex(ctx, out_data + out_len, &final_len);
+}
+
+/*****************************************************************************/
+void
+ssl_aes128_info_delete(void *aes_info)
+{
+    EVP_CIPHER_CTX *ctx = (EVP_CIPHER_CTX *)aes_info;
+    if (ctx)
+    {
+        EVP_CIPHER_CTX_free(ctx);
+    }
 }
 

--- a/common/ssl_calls.h
+++ b/common/ssl_calls.h
@@ -93,6 +93,23 @@ int
 ssl_gen_key_xrdp1(int key_size_in_bits, const char *exp, int exp_len,
                   char *mod, int mod_len, char *pri, int pri_len);
 
+/* DH key exchange for Apple ARD authentication */
+void *
+ssl_dh_create(int key_len, const unsigned char *generator,
+              const unsigned char *prime, const unsigned char *server_pubkey,
+              unsigned char *client_pubkey, unsigned char *shared_secret);
+void
+ssl_dh_delete(void *dh_info);
+
+/* AES encryption for Apple ARD authentication */
+void *
+ssl_aes128_ecb_encrypt_info_create(const unsigned char *key);
+void
+ssl_aes128_ecb_encrypt(void *aes_info, const unsigned char *in_data,
+                       unsigned char *out_data, int len);
+void
+ssl_aes128_info_delete(void *aes_info);
+
 /* xrdp_tls.c */
 struct ssl_tls *
 ssl_tls_create(struct trans *trans, const char *key, const char *cert);

--- a/docs/macos/README.md
+++ b/docs/macos/README.md
@@ -1,0 +1,137 @@
+# macOS Screen Sharing Support for xrdp
+
+This directory contains helper scripts and documentation for connecting xrdp to macOS Screen Sharing using Apple Remote Desktop (ARD) authentication.
+
+## Overview
+
+xrdp can connect to macOS Screen Sharing (built-in VNC server) using the ARD authentication protocol (security type 30). This allows RDP clients to access macOS desktops through xrdp.
+
+## Requirements
+
+- macOS with Screen Sharing enabled (System Settings → General → Sharing → Screen Sharing)
+- xrdp compiled with ARD authentication support
+- SIP (System Integrity Protection) must be temporarily disabled to grant TCC permissions
+
+## Setup Steps
+
+### 1. Enable Screen Sharing on macOS
+
+1. Open **System Settings → General → Sharing**
+2. Enable **Screen Sharing**
+3. Configure allowed users
+
+### 2. Grant TCC Permissions (requires SIP disabled)
+
+macOS requires Screen Recording and Accessibility permissions for the Screen Sharing daemon. Since `screensharingd` is a system daemon, these permissions must be added directly to the TCC database.
+
+#### Disable SIP
+
+**Apple Silicon Mac:**
+1. Shut down your Mac completely
+2. Press and hold the power button until "Loading startup options" appears
+3. Click Options → Continue
+4. Open Utilities → Terminal
+5. Run: `csrutil disable`
+6. Restart
+
+**Intel Mac:**
+1. Shut down your Mac
+2. Turn on and immediately hold Cmd + R
+3. Open Utilities → Terminal
+4. Run: `csrutil disable`
+5. Restart
+
+#### Run the Permission Fix Script
+
+```bash
+sudo ./fix-screen-recording.sh
+```
+
+This script adds Screen Recording, Accessibility, PostEvent, and ListenEvent permissions for all Screen Sharing components.
+
+#### Re-enable SIP (recommended)
+
+After granting permissions and rebooting:
+1. Boot to Recovery Mode again
+2. Run: `csrutil enable`
+3. Restart
+
+### 3. Configure xrdp
+
+Add a macOS session to `/etc/xrdp/xrdp.ini`:
+
+```ini
+[macos]
+name=macOS Desktop
+lib=libvnc.dylib
+ip=127.0.0.1
+port=5900
+username=ask
+password=ask
+```
+
+### 4. Connect
+
+Use any RDP client to connect to xrdp on port 3389. Select the "macOS Desktop" session and enter your macOS username and password.
+
+## Scripts
+
+### fix-screen-recording.sh
+
+Bash script that modifies the macOS TCC database to grant Screen Recording and Accessibility permissions to Screen Sharing components. Must be run with `sudo` after disabling SIP.
+
+### test_vnc_pixels.py
+
+Python test script that connects directly to macOS Screen Sharing using ARD authentication and checks if the screen content is being captured (non-black pixels). Useful for debugging permission issues.
+
+Requirements:
+```bash
+pip3 install pycryptodome
+```
+
+Usage:
+```bash
+python3 test_vnc_pixels.py
+```
+
+## Troubleshooting
+
+### Black screen (all pixels are black)
+
+The Screen Sharing daemon doesn't have Screen Recording permission. Run `fix-screen-recording.sh` and reboot.
+
+### Mouse/keyboard not working
+
+The Screen Sharing daemon doesn't have Accessibility permission, or ARD privileges are not set to "Control". Run:
+
+```bash
+sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart -configure -allowAccessFor -allUsers -privs -all -restart -agent
+```
+
+### "Observe mode" only (can see but not control)
+
+ARD privileges are set to observe-only. Run the kickstart command above with `-privs -all` to enable full control.
+
+### Authentication failure
+
+- Verify username and password are correct
+- Check that the user is allowed in Screen Sharing settings
+- Ensure Screen Sharing is enabled
+
+## Technical Details
+
+### ARD Authentication Protocol (Security Type 30)
+
+1. Server sends: generator (2 bytes) + key length (2 bytes) + prime (key_len bytes) + server public key (key_len bytes)
+2. Client generates DH key pair, computes shared secret
+3. Client derives AES key: MD5(shared_secret)
+4. Client prepares credentials: 64 bytes username + 64 bytes password (null-terminated, random padding)
+5. Client sends: AES-128-ECB encrypted credentials (128 bytes) + client public key (key_len bytes)
+6. Server responds with security result (0 = success)
+
+### TCC Services Required
+
+- `kTCCServiceScreenCapture` - Screen Recording permission
+- `kTCCServiceAccessibility` - Accessibility (input control) permission
+- `kTCCServicePostEvent` - Permission to post input events
+- `kTCCServiceListenEvent` - Permission to listen for input events

--- a/docs/macos/README.md
+++ b/docs/macos/README.md
@@ -11,6 +11,7 @@ xrdp can connect to macOS Screen Sharing (built-in VNC server) using the ARD aut
 - macOS with Screen Sharing enabled (System Settings → General → Sharing → Screen Sharing)
 - xrdp compiled with ARD authentication support
 - SIP (System Integrity Protection) must be temporarily disabled to grant TCC permissions
+- Python 3 with pycryptodome (for test script only)
 
 ## Setup Steps
 
@@ -18,28 +19,37 @@ xrdp can connect to macOS Screen Sharing (built-in VNC server) using the ARD aut
 
 1. Open **System Settings → General → Sharing**
 2. Enable **Screen Sharing**
-3. Configure allowed users
+3. Click the (i) info button and configure allowed users
+4. Note: VNC viewers using password-only authentication should set a VNC password here
 
 ### 2. Grant TCC Permissions (requires SIP disabled)
 
 macOS requires Screen Recording and Accessibility permissions for the Screen Sharing daemon. Since `screensharingd` is a system daemon, these permissions must be added directly to the TCC database.
 
+**Important:** On macOS 13+ (Ventura and later), TCC entries require proper code signature requirements (`csreq`) to be validated. The `fix-screen-recording.sh` script handles this automatically.
+
 #### Disable SIP
 
-**Apple Silicon Mac:**
+**Apple Silicon Mac (M1/M2/M3/M4):**
 1. Shut down your Mac completely
 2. Press and hold the power button until "Loading startup options" appears
-3. Click Options → Continue
-4. Open Utilities → Terminal
-5. Run: `csrutil disable`
-6. Restart
+3. Click **Options** → **Continue**
+4. Select your user and enter password if prompted
+5. Open **Utilities → Terminal**
+6. Run: `csrutil disable`
+7. Restart
 
 **Intel Mac:**
 1. Shut down your Mac
-2. Turn on and immediately hold Cmd + R
-3. Open Utilities → Terminal
+2. Turn on and immediately hold **Cmd + R**
+3. Open **Utilities → Terminal**
 4. Run: `csrutil disable`
 5. Restart
+
+**Virtualization Framework VMs (Parallels, UTM, etc.):**
+- Parallels: **Actions → Start in Recovery Mode** or hold Cmd+R during boot
+- UTM: Edit VM settings → System → enable "Boot into Recovery"
+- VMware Fusion: **Virtual Machine → Start in Recovery Mode**
 
 #### Run the Permission Fix Script
 
@@ -47,11 +57,29 @@ macOS requires Screen Recording and Accessibility permissions for the Screen Sha
 sudo ./fix-screen-recording.sh
 ```
 
-This script adds Screen Recording, Accessibility, PostEvent, and ListenEvent permissions for all Screen Sharing components.
+This script:
+- Generates proper code signature requirements for Apple system binaries
+- Adds Screen Recording (`kTCCServiceScreenCapture`) permissions
+- Adds Accessibility (`kTCCServiceAccessibility`) permissions
+- Adds PostEvent and ListenEvent permissions for input control
+- Creates a backup of the TCC database before modification
+
+**Important:** Reboot after running the script for changes to take effect.
+
+#### Enable Full Control Privileges
+
+After rebooting, enable ARD control privileges:
+
+```bash
+sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart \
+    -configure -allowAccessFor -allUsers -privs -all -restart -agent
+```
+
+This grants all users full control access (not just observe-only).
 
 #### Re-enable SIP (recommended)
 
-After granting permissions and rebooting:
+After granting permissions and verifying everything works:
 1. Boot to Recovery Mode again
 2. Run: `csrutil enable`
 3. Restart
@@ -70,7 +98,22 @@ username=ask
 password=ask
 ```
 
-### 4. Connect
+**Note:** After running `make install`, the xrdp.ini file may be overwritten. Re-add the `[macos]` section if needed.
+
+### 4. Start xrdp
+
+```bash
+sudo /usr/local/sbin/xrdp --nodaemon &
+sudo /usr/local/sbin/xrdp-sesman --nodaemon &
+```
+
+Or if you've set up launchd services:
+```bash
+sudo launchctl load /Library/LaunchDaemons/xrdp.plist
+sudo launchctl load /Library/LaunchDaemons/xrdp-sesman.plist
+```
+
+### 5. Connect
 
 Use any RDP client to connect to xrdp on port 3389. Select the "macOS Desktop" session and enter your macOS username and password.
 
@@ -78,60 +121,203 @@ Use any RDP client to connect to xrdp on port 3389. Select the "macOS Desktop" s
 
 ### fix-screen-recording.sh
 
-Bash script that modifies the macOS TCC database to grant Screen Recording and Accessibility permissions to Screen Sharing components. Must be run with `sudo` after disabling SIP.
+Bash script that modifies the macOS TCC database to grant Screen Recording and Accessibility permissions to Screen Sharing components.
+
+**Features:**
+- Checks SIP status before proceeding
+- Creates timestamped backup of TCC database
+- Generates proper `csreq` code signature requirements for system binaries
+- Adds permissions for multiple bundle IDs and binary paths
+- Verifies entries after insertion
+
+**Usage:**
+```bash
+sudo ./fix-screen-recording.sh
+```
+
+**Must be run after disabling SIP.**
 
 ### test_vnc_pixels.py
 
 Python test script that connects directly to macOS Screen Sharing using ARD authentication and checks if the screen content is being captured (non-black pixels). Useful for debugging permission issues.
 
-Requirements:
+**Features:**
+- Full ARD authentication implementation
+- Detailed connection diagnostics
+- Pixel analysis to verify screen capture is working
+- Prompts for credentials (no hardcoded passwords)
+- Supports environment variables for automation
+
+**Requirements:**
 ```bash
 pip3 install pycryptodome
 ```
 
-Usage:
+**Usage:**
 ```bash
+# Interactive (prompts for credentials)
 python3 test_vnc_pixels.py
+
+# With command-line arguments
+python3 test_vnc_pixels.py -u username -H 127.0.0.1 -p 5900
+
+# With environment variables
+VNC_USERNAME=user VNC_PASSWORD=pass python3 test_vnc_pixels.py
 ```
+
+**Options:**
+- `-u, --username` - Username (or set `VNC_USERNAME` env var)
+- `-H, --host` - VNC host (default: 127.0.0.1)
+- `-p, --port` - VNC port (default: 5900)
 
 ## Troubleshooting
 
 ### Black screen (all pixels are black)
 
-The Screen Sharing daemon doesn't have Screen Recording permission. Run `fix-screen-recording.sh` and reboot.
+**Cause:** Screen Sharing daemon doesn't have Screen Recording permission.
+
+**Solution:**
+1. Ensure SIP is disabled: `csrutil status`
+2. Run `sudo ./fix-screen-recording.sh`
+3. **Reboot** (required for TCC changes to take effect)
+4. Test with: `python3 test_vnc_pixels.py`
 
 ### Mouse/keyboard not working
 
-The Screen Sharing daemon doesn't have Accessibility permission, or ARD privileges are not set to "Control". Run:
+**Cause:** Missing Accessibility permission or ARD privileges set to "Observe only".
 
-```bash
-sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart -configure -allowAccessFor -allUsers -privs -all -restart -agent
-```
+**Solution:**
+1. Run the fix script to add Accessibility permissions:
+   ```bash
+   sudo ./fix-screen-recording.sh
+   ```
 
-### "Observe mode" only (can see but not control)
+2. Enable full control with kickstart:
+   ```bash
+   sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart \
+       -configure -allowAccessFor -allUsers -privs -all -restart -agent
+   ```
 
-ARD privileges are set to observe-only. Run the kickstart command above with `-privs -all` to enable full control.
+3. Reboot and reconnect
 
-### Authentication failure
+### "Observe mode" indicator (purple icon, can see but not control)
 
-- Verify username and password are correct
-- Check that the user is allowed in Screen Sharing settings
-- Ensure Screen Sharing is enabled
+**Cause:** ARD privileges are set to observe-only.
+
+**Solution:** Run the kickstart command above with `-privs -all` to enable full control.
+
+### Authentication failure ("Authentication or authorisation failure")
+
+**Possible causes and solutions:**
+
+1. **Wrong credentials:** Verify username and password are correct for a local macOS user
+
+2. **User not allowed:** Check System Settings → Sharing → Screen Sharing → allowed users
+
+3. **Screen Sharing disabled:** Ensure Screen Sharing is enabled in System Settings
+
+4. **ARD authentication issue:** The server might not support ARD auth. Check VNC logs.
+
+### Connection refused on port 5900
+
+**Cause:** Screen Sharing is not running.
+
+**Solution:**
+1. Enable Screen Sharing in System Settings → Sharing
+2. Verify it's listening: `netstat -an | grep 5900`
+
+### Permission changes not taking effect
+
+**Cause:** TCC daemon caches permissions.
+
+**Solution:** Reboot the Mac. TCC changes require a reboot to take effect.
 
 ## Technical Details
 
 ### ARD Authentication Protocol (Security Type 30)
 
-1. Server sends: generator (2 bytes) + key length (2 bytes) + prime (key_len bytes) + server public key (key_len bytes)
-2. Client generates DH key pair, computes shared secret
-3. Client derives AES key: MD5(shared_secret)
-4. Client prepares credentials: 64 bytes username + 64 bytes password (null-terminated, random padding)
-5. Client sends: AES-128-ECB encrypted credentials (128 bytes) + client public key (key_len bytes)
-6. Server responds with security result (0 = success)
+The Apple Remote Desktop authentication protocol uses Diffie-Hellman key exchange with AES encryption:
+
+1. **Server → Client:**
+   - Generator (2 bytes, big-endian)
+   - Key length (2 bytes, big-endian, typically 128 = 1024-bit DH)
+   - Prime (key_len bytes)
+   - Server public key (key_len bytes)
+
+2. **Client computes:**
+   - Generates DH private key
+   - Computes client public key: `g^private mod prime`
+   - Computes shared secret: `server_pubkey^private mod prime`
+   - Derives AES key: `MD5(shared_secret)`
+
+3. **Client prepares credentials:**
+   - 64 bytes for username (null-terminated, random padding after)
+   - 64 bytes for password (null-terminated, random padding after)
+   - Total: 128 bytes
+
+4. **Client → Server:**
+   - AES-128-ECB encrypted credentials (128 bytes)
+   - Client public key (key_len bytes)
+
+   **Important:** The order is encrypted credentials FIRST, then public key.
+
+5. **Server → Client:**
+   - Security result (4 bytes): 0 = success, non-zero = failure
 
 ### TCC Services Required
 
-- `kTCCServiceScreenCapture` - Screen Recording permission
-- `kTCCServiceAccessibility` - Accessibility (input control) permission
-- `kTCCServicePostEvent` - Permission to post input events
-- `kTCCServiceListenEvent` - Permission to listen for input events
+The following TCC (Transparency, Consent, and Control) services must be granted:
+
+| Service | Purpose |
+|---------|---------|
+| `kTCCServiceScreenCapture` | Screen Recording - capture screen content |
+| `kTCCServiceAccessibility` | Accessibility - control mouse/keyboard |
+| `kTCCServicePostEvent` | Post input events to the system |
+| `kTCCServiceListenEvent` | Listen for input events |
+
+### Code Signature Requirements
+
+On macOS 13+, TCC entries for system binaries require proper `csreq` (code signature requirement) blobs. The fix script generates these using:
+
+```bash
+codesign -dr - /path/to/binary
+csreq -r- -b /tmp/csreq.bin
+```
+
+The resulting binary blob is stored in the TCC database's `csreq` column.
+
+### Related Files and Paths
+
+| Path | Description |
+|------|-------------|
+| `/Library/Application Support/com.apple.TCC/TCC.db` | System TCC database |
+| `~/Library/Application Support/com.apple.TCC/TCC.db` | User TCC database |
+| `/System/Library/CoreServices/RemoteManagement/screensharingd.bundle` | Screen Sharing daemon |
+| `/System/Library/CoreServices/RemoteManagement/ARDAgent.app` | ARD Agent |
+| `/Library/Preferences/com.apple.RemoteManagement.plist` | ARD configuration |
+| `/etc/xrdp/xrdp.ini` | xrdp configuration |
+| `/etc/xrdp/sesman.ini` | xrdp session manager configuration |
+
+### macOS-Specific Configuration Notes
+
+**sesman.ini:** On macOS, change `SessionSockdirGroup` from `root` to `wheel`:
+```ini
+SessionSockdirGroup=wheel
+```
+
+**Library paths:** After `make install`, you may need to fix dylib paths:
+```bash
+install_name_tool -change /path/to/old/lib.dylib /usr/local/lib/xrdp/lib.dylib /usr/local/sbin/xrdp
+```
+
+## Tested Configurations
+
+- macOS 26.2 (Tahoe) on Apple Silicon VM (Virtualization Framework)
+- xrdp compiled from source with OpenSSL 3.x
+- RDP clients: Microsoft Remote Desktop, Remmina
+
+## References
+
+- [Apple Remote Desktop Authentication](https://cafbit.com/post/apple_remote_desktop_quirks/) - Protocol details
+- [gtk-vnc ARD implementation](https://github.com/jwendell/gtk-vnc/blob/master/src/vncconnection.c) - Reference implementation
+- [RFB Protocol Specification](https://github.com/rfbproto/rfbproto) - VNC/RFB protocol

--- a/docs/macos/fix-screen-recording.sh
+++ b/docs/macos/fix-screen-recording.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+#
+# Fix Screen Recording Permission for macOS Screen Sharing
+#
+# IMPORTANT: This script must be run AFTER disabling SIP.
+#
+# To disable SIP:
+#   Intel Mac: Reboot, hold Cmd+R, open Terminal, run: csrutil disable
+#   Apple Silicon: Shut down, hold power button, Options > Terminal, run: csrutil disable
+#
+# After running this script, re-enable SIP for security:
+#   Reboot to Recovery Mode and run: csrutil enable
+#
+
+set -e
+
+TCC_DB="/Library/Application Support/com.apple.TCC/TCC.db"
+
+echo "============================================"
+echo "Screen Recording Permission Fix for screensharingd"
+echo "============================================"
+echo
+
+# Check if running as root
+if [ "$EUID" -ne 0 ]; then
+    echo "ERROR: This script must be run with sudo"
+    echo "Usage: sudo $0"
+    exit 1
+fi
+
+# Check SIP status
+SIP_STATUS=$(csrutil status 2>&1)
+echo "SIP Status: $SIP_STATUS"
+echo
+
+if echo "$SIP_STATUS" | grep -q "enabled"; then
+    echo "============================================"
+    echo "ERROR: SIP is still enabled!"
+    echo "============================================"
+    echo
+    echo "You must disable SIP first:"
+    echo
+    echo "For Intel Mac:"
+    echo "  1. Shut down your Mac"
+    echo "  2. Turn on and immediately hold Cmd + R"
+    echo "  3. Open Utilities > Terminal"
+    echo "  4. Run: csrutil disable"
+    echo "  5. Restart and run this script again"
+    echo
+    echo "For Apple Silicon (M1/M2/M3):"
+    echo "  1. Shut down your Mac completely"
+    echo "  2. Press and hold power button until 'Loading startup options'"
+    echo "  3. Click Options > Continue"
+    echo "  4. Select your user, enter password"
+    echo "  5. Open Utilities > Terminal"
+    echo "  6. Run: csrutil disable"
+    echo "  7. Restart and run this script again"
+    echo
+    exit 1
+fi
+
+echo "SIP is disabled. Proceeding with TCC database modification..."
+echo
+
+# Check if TCC database exists
+if [ ! -f "$TCC_DB" ]; then
+    echo "ERROR: TCC database not found at: $TCC_DB"
+    exit 1
+fi
+
+# Backup TCC database
+BACKUP="$TCC_DB.backup.$(date +%Y%m%d_%H%M%S)"
+echo "Creating backup: $BACKUP"
+cp "$TCC_DB" "$BACKUP"
+
+# Get current timestamp
+TIMESTAMP=$(date +%s)
+
+# Function to add TCC entry with csreq
+add_tcc_entry() {
+    local SERVICE="$1"
+    local CLIENT="$2"
+    local CLIENT_TYPE="$3"
+    local CSREQ_HEX="$4"
+
+    echo "  Adding: $CLIENT -> $SERVICE"
+
+    if [ -n "$CSREQ_HEX" ]; then
+        sqlite3 "$TCC_DB" "INSERT OR REPLACE INTO access (service, client, client_type, auth_value, auth_reason, auth_version, csreq, indirect_object_identifier, indirect_object_identifier_type, flags, last_modified) VALUES ('$SERVICE', '$CLIENT', $CLIENT_TYPE, 2, 4, 1, X'$CSREQ_HEX', 'UNUSED', 0, 0, $TIMESTAMP);"
+    else
+        sqlite3 "$TCC_DB" "INSERT OR REPLACE INTO access (service, client, client_type, auth_value, auth_reason, auth_version, indirect_object_identifier, indirect_object_identifier_type, flags, last_modified) VALUES ('$SERVICE', '$CLIENT', $CLIENT_TYPE, 2, 4, 1, 'UNUSED', 0, 0, $TIMESTAMP);"
+    fi
+}
+
+# Helper to add both Screen Capture and Accessibility permissions
+add_screen_and_input() {
+    local CLIENT="$1"
+    local CLIENT_TYPE="$2"
+    local CSREQ_HEX="$3"
+
+    add_tcc_entry "kTCCServiceScreenCapture" "$CLIENT" "$CLIENT_TYPE" "$CSREQ_HEX"
+    add_tcc_entry "kTCCServiceAccessibility" "$CLIENT" "$CLIENT_TYPE" "$CSREQ_HEX"
+    add_tcc_entry "kTCCServicePostEvent" "$CLIENT" "$CLIENT_TYPE" "$CSREQ_HEX"
+    add_tcc_entry "kTCCServiceListenEvent" "$CLIENT" "$CLIENT_TYPE" "$CSREQ_HEX"
+}
+
+# Function to generate csreq hex from a binary path
+generate_csreq() {
+    local BINARY="$1"
+    local TMPFILE="/tmp/csreq_$$"
+
+    if [ -f "$BINARY" ]; then
+        # Get the designated requirement
+        local REQ=$(codesign -dr - "$BINARY" 2>&1 | grep "designated =>" | sed 's/designated => //')
+        if [ -n "$REQ" ]; then
+            echo "$REQ" | csreq -r- -b "$TMPFILE" 2>/dev/null
+            if [ -f "$TMPFILE" ]; then
+                xxd -p "$TMPFILE" | tr -d '\n'
+                rm -f "$TMPFILE"
+                return
+            fi
+        fi
+    fi
+    echo ""
+}
+
+echo "Adding Screen Recording + Accessibility permissions for all Screen Sharing components..."
+echo
+
+# Add with proper csreq where possible
+echo "Generating code signature requirements..."
+
+# screensharingd
+CSREQ=$(generate_csreq "/System/Library/CoreServices/RemoteManagement/screensharingd.bundle/Contents/MacOS/screensharingd")
+add_screen_and_input "com.apple.screensharing.daemon" 0 "$CSREQ"
+
+# ARDAgent
+CSREQ=$(generate_csreq "/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/MacOS/ARDAgent")
+add_screen_and_input "com.apple.RemoteDesktop.agent" 0 "$CSREQ"
+
+# ScreenSharingSubscriber
+CSREQ=$(generate_csreq "/System/Library/PrivateFrameworks/RemoteManagement.framework/XPCServices/ScreenSharingSubscriber.xpc/Contents/MacOS/ScreenSharingSubscriber")
+add_screen_and_input "com.apple.remotemanagement.ScreenSharingSubscriber" 0 "$CSREQ"
+
+# Also add path-based entries
+add_screen_and_input "/System/Library/CoreServices/RemoteManagement/screensharingd.bundle/Contents/MacOS/screensharingd" 1 ""
+add_screen_and_input "/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/MacOS/ARDAgent" 1 ""
+add_screen_and_input "/System/Library/PrivateFrameworks/RemoteManagement.framework/XPCServices/ScreenSharingSubscriber.xpc/Contents/MacOS/ScreenSharingSubscriber" 1 ""
+add_screen_and_input "/usr/libexec/screensharingd" 1 ""
+
+# Generic bundle IDs
+add_screen_and_input "com.apple.screensharing" 0 ""
+add_screen_and_input "com.apple.screensharing.agent" 0 ""
+add_screen_and_input "com.apple.RemoteDesktop" 0 ""
+add_screen_and_input "com.apple.RemoteManagement" 0 ""
+
+# xrdp components
+add_screen_and_input "/usr/local/sbin/xrdp" 1 ""
+add_screen_and_input "/usr/local/sbin/xrdp-sesman" 1 ""
+add_screen_and_input "/usr/local/sbin/xrdp-chansrv" 1 ""
+add_screen_and_input "/usr/local/lib/xrdp/libvnc.0.dylib" 1 ""
+
+echo
+echo "Done!"
+echo
+
+# Verify the entries
+echo "Verifying Screen Capture entries:"
+sqlite3 "$TCC_DB" "SELECT client, auth_value FROM access WHERE service='kTCCServiceScreenCapture';" | head -10
+echo
+echo "Verifying Accessibility entries:"
+sqlite3 "$TCC_DB" "SELECT client, auth_value FROM access WHERE service='kTCCServiceAccessibility';" | head -10
+echo
+
+echo "============================================"
+echo "SUCCESS! Screen Recording permissions granted."
+echo "============================================"
+echo
+echo "Next steps:"
+echo "  1. Restart the Screen Sharing service:"
+echo "     sudo launchctl unload /System/Library/LaunchDaemons/com.apple.screensharing.plist"
+echo "     sudo launchctl load /System/Library/LaunchDaemons/com.apple.screensharing.plist"
+echo
+echo "  2. Test with: python3 ~/xrdp-deps/test_vnc_pixels.py"
+echo
+echo "  3. IMPORTANT: Re-enable SIP for security!"
+echo "     Reboot to Recovery Mode and run: csrutil enable"
+echo

--- a/docs/macos/test_vnc_pixels.py
+++ b/docs/macos/test_vnc_pixels.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""
+Extended VNC test client with diagnostics for macOS Screen Sharing
+"""
+import socket, hashlib, struct, sys, getpass, os
+from Crypto.Cipher import AES
+from Crypto.Random import get_random_bytes
+
+def test_vnc(username=None, password=None, host='127.0.0.1', port=5900):
+    print("=" * 60)
+    print("VNC Connection Test with Extended Diagnostics")
+    print("=" * 60)
+
+    # Get credentials if not provided
+    if username is None:
+        username = os.environ.get('VNC_USERNAME') or input("Username: ")
+    if password is None:
+        password = os.environ.get('VNC_PASSWORD') or getpass.getpass("Password: ")
+
+    sock = socket.socket()
+    sock.settimeout(10)
+
+    print(f"\n[1] Connecting to {host}:{port}...")
+    try:
+        sock.connect((host, port))
+        print("    Connected!")
+    except Exception as e:
+        print(f"    FAILED: {e}")
+        return
+
+    # Protocol version
+    server_version = sock.recv(12)
+    print(f"\n[2] Server version: {server_version.decode().strip()}")
+    sock.send(b'RFB 003.008\n')
+    print("    Sent client version: RFB 003.008")
+
+    # Security types
+    num = sock.recv(1)[0]
+    sec_types = sock.recv(num)
+    print(f"\n[3] Security types offered: {list(sec_types)}")
+    print("    (30 = Apple ARD, 2 = VNC Auth, 1 = None)")
+
+    if 30 not in sec_types:
+        print("    WARNING: ARD (30) not offered!")
+        sock.close()
+        return
+
+    # Select ARD auth
+    sock.send(bytes([30]))
+    print("    Selected: 30 (Apple ARD)")
+
+    # DH parameters
+    gen = int.from_bytes(sock.recv(2), 'big')
+    klen = int.from_bytes(sock.recv(2), 'big')
+    prime = int.from_bytes(sock.recv(klen), 'big')
+    spub = int.from_bytes(sock.recv(klen), 'big')
+    print(f"\n[4] DH Parameters received:")
+    print(f"    Generator: {gen}")
+    print(f"    Key length: {klen} bytes ({klen*8} bits)")
+
+    # Generate client keys
+    priv = int.from_bytes(get_random_bytes(klen), 'big')
+    cpub = pow(gen, priv, prime)
+    secret = pow(spub, priv, prime)
+    aes_key = hashlib.md5(secret.to_bytes(klen, 'big')).digest()
+
+    # Prepare credentials (64 bytes username + 64 bytes password, null-terminated, random padding)
+    creds = bytearray(get_random_bytes(128))
+    uname_bytes = username.encode('utf-8')[:63]
+    pass_bytes = password.encode('utf-8')[:63]
+    creds[0:len(uname_bytes)] = uname_bytes
+    creds[len(uname_bytes)] = 0
+    creds[64:64+len(pass_bytes)] = pass_bytes
+    creds[64+len(pass_bytes)] = 0
+
+    # Send encrypted credentials + public key
+    encrypted = AES.new(aes_key, AES.MODE_ECB).encrypt(bytes(creds))
+    sock.send(encrypted + cpub.to_bytes(klen, 'big'))
+    print("\n[5] Sent ARD credentials")
+
+    # Auth result
+    result = int.from_bytes(sock.recv(4), 'big')
+    print(f"\n[6] Auth result: {result} {'(SUCCESS)' if result == 0 else '(FAILED)'}")
+
+    if result != 0:
+        # Try to get error message
+        try:
+            err_len = int.from_bytes(sock.recv(4), 'big')
+            err_msg = sock.recv(err_len).decode('utf-8', errors='replace')
+            print(f"    Error message: {err_msg}")
+        except:
+            pass
+        sock.close()
+        return
+
+    # ClientInit - request shared session
+    sock.send(bytes([1]))
+    print("\n[7] Sent ClientInit (shared=1)")
+
+    # ServerInit
+    init = sock.recv(24)
+    w = int.from_bytes(init[0:2], 'big')
+    h = int.from_bytes(init[2:4], 'big')
+    bpp = init[4]
+    depth = init[5]
+    big_endian = init[6]
+    true_color = init[7]
+    name_len = int.from_bytes(init[20:24], 'big')
+    name = sock.recv(name_len).decode('utf-8', errors='replace')
+
+    print(f"\n[8] ServerInit received:")
+    print(f"    Screen size: {w}x{h}")
+    print(f"    Bits per pixel: {bpp}")
+    print(f"    Depth: {depth}")
+    print(f"    Big endian: {big_endian}")
+    print(f"    True color: {true_color}")
+    print(f"    Desktop name: '{name}'")
+
+    # Set pixel format (32-bit BGRA)
+    sock.send(struct.pack('>BBBB BBBBHHH BBB BBB',
+        0, 0, 0, 0,        # message type + padding
+        32, 24, 0, 1,      # bpp, depth, big-endian, true-color
+        255, 255, 255,     # max RGB values
+        16, 8, 0,          # RGB shifts
+        0, 0, 0))          # padding
+    print("\n[9] Set pixel format: 32-bit BGRA")
+
+    # Set encodings (raw only)
+    sock.send(struct.pack('>BBH i', 2, 0, 1, 0))  # 0 = raw encoding
+    print("    Set encoding: Raw (0)")
+
+    # Request framebuffer update
+    sock.send(struct.pack('>BBHHHH', 3, 0, 0, 0, w, h))
+    print(f"\n[10] Requested framebuffer update for {w}x{h}")
+
+    # Wait for response
+    print("\n[11] Waiting for framebuffer data...")
+    try:
+        msg = sock.recv(4, socket.MSG_PEEK)
+        msg_type = msg[0]
+        print(f"    Message type: {msg_type}")
+
+        if msg_type == 0:  # FramebufferUpdate
+            sock.recv(1)  # consume message type
+            padding = sock.recv(1)
+            num_rects = int.from_bytes(sock.recv(2), 'big')
+            print(f"    Number of rectangles: {num_rects}")
+
+            total_non_black = 0
+            total_pixels = 0
+
+            for i in range(num_rects):
+                rect_header = sock.recv(12)
+                rx = int.from_bytes(rect_header[0:2], 'big')
+                ry = int.from_bytes(rect_header[2:4], 'big')
+                rw = int.from_bytes(rect_header[4:6], 'big')
+                rh = int.from_bytes(rect_header[6:8], 'big')
+                encoding = int.from_bytes(rect_header[8:12], 'big', signed=True)
+
+                print(f"\n    Rectangle {i+1}:")
+                print(f"      Position: ({rx}, {ry})")
+                print(f"      Size: {rw}x{rh}")
+                print(f"      Encoding: {encoding}")
+
+                if encoding == 0:  # Raw
+                    pixel_count = rw * rh
+                    byte_count = pixel_count * 4  # 32-bit
+                    print(f"      Expected bytes: {byte_count}")
+
+                    # Read pixel data in chunks
+                    pixels = b''
+                    remaining = byte_count
+                    while remaining > 0:
+                        chunk = sock.recv(min(remaining, 65536))
+                        if not chunk:
+                            break
+                        pixels += chunk
+                        remaining -= len(chunk)
+
+                    print(f"      Received bytes: {len(pixels)}")
+
+                    # Analyze pixels
+                    non_black = 0
+                    black = 0
+                    sample_colors = []
+
+                    for j in range(0, min(len(pixels), byte_count), 4):
+                        b, g, r, a = pixels[j], pixels[j+1], pixels[j+2], pixels[j+3] if j+3 < len(pixels) else 0
+                        if (r, g, b) != (0, 0, 0):
+                            non_black += 1
+                            if len(sample_colors) < 5:
+                                sample_colors.append((r, g, b))
+                        else:
+                            black += 1
+
+                    total_non_black += non_black
+                    total_pixels += pixel_count
+
+                    print(f"      Black pixels: {black}")
+                    print(f"      Non-black pixels: {non_black}")
+                    if sample_colors:
+                        print(f"      Sample non-black colors (RGB): {sample_colors}")
+                else:
+                    print(f"      Skipping non-raw encoding")
+
+            print("\n" + "=" * 60)
+            if total_pixels > 0:
+                pct = 100 * total_non_black // total_pixels
+                print(f"RESULT: {total_non_black}/{total_pixels} non-black pixels ({pct}%)")
+                if pct > 0:
+                    print("SUCCESS! Screen content is being captured!")
+                else:
+                    print("FAILED: All pixels are black")
+                    print("\nPossible causes:")
+                    print("  1. TCC database change requires REBOOT to take effect")
+                    print("  2. Screen Sharing service needs restart")
+                    print("  3. Different bundle ID needs permission")
+            else:
+                print("No pixel data received")
+
+        elif msg_type == 2:  # Bell
+            print("    Received Bell message")
+        elif msg_type == 3:  # ServerCutText
+            print("    Received ServerCutText message")
+        else:
+            print(f"    Unknown message type: {msg_type}")
+            raw = sock.recv(100)
+            print(f"    Raw data: {raw[:50].hex()}")
+
+    except socket.timeout:
+        print("    TIMEOUT waiting for response")
+    except Exception as e:
+        print(f"    ERROR: {e}")
+
+    sock.close()
+    print("\n[12] Connection closed")
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description='Test VNC connection to macOS Screen Sharing')
+    parser.add_argument('-u', '--username', help='Username (or set VNC_USERNAME env var)')
+    parser.add_argument('-H', '--host', default='127.0.0.1', help='VNC host (default: 127.0.0.1)')
+    parser.add_argument('-p', '--port', type=int, default=5900, help='VNC port (default: 5900)')
+    args = parser.parse_args()
+
+    test_vnc(username=args.username, host=args.host, port=args.port)

--- a/packaging/macos/build-pkg.sh
+++ b/packaging/macos/build-pkg.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+#
+# Build macOS .pkg installer for xrdp with ARD support
+#
+# Usage: ./build-pkg.sh [version]
+# Example: ./build-pkg.sh 0.10.0
+#
+
+set -e
+
+VERSION="${1:-0.10.0}"
+ARCH=$(uname -m)  # arm64 or x86_64
+PKG_NAME="xrdp-${VERSION}-macos-${ARCH}"
+BUILD_DIR="/tmp/xrdp-pkg-build"
+INSTALL_PREFIX="/usr/local"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+XRDP_SRC="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+echo "============================================"
+echo "Building xrdp $VERSION for macOS $ARCH"
+echo "============================================"
+echo ""
+
+# Clean up previous build
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR/root"
+mkdir -p "$BUILD_DIR/scripts"
+mkdir -p "$BUILD_DIR/resources"
+
+# Build xrdp from source if not already built
+if [ ! -f "$XRDP_SRC/xrdp/xrdp" ]; then
+    echo "Building xrdp from source..."
+    cd "$XRDP_SRC"
+
+    if [ ! -f "configure" ]; then
+        ./bootstrap
+    fi
+
+    ./configure --prefix="$INSTALL_PREFIX" \
+        --enable-vsock \
+        --disable-pam \
+        --with-socketdir=/var/run/xrdp
+
+    make -j$(sysctl -n hw.ncpu)
+fi
+
+# Install to staging directory
+echo "Installing to staging directory..."
+cd "$XRDP_SRC"
+make DESTDIR="$BUILD_DIR/root" install
+
+# Copy additional files
+echo "Adding macOS-specific files..."
+
+# Create share directory for our files
+mkdir -p "$BUILD_DIR/root$INSTALL_PREFIX/share/xrdp"
+
+# Copy launchd plists
+cp "$SCRIPT_DIR/com.xrdp.xrdp.plist" "$BUILD_DIR/root$INSTALL_PREFIX/share/xrdp/"
+cp "$SCRIPT_DIR/com.xrdp.sesman.plist" "$BUILD_DIR/root$INSTALL_PREFIX/share/xrdp/"
+
+# Copy fix-screen-recording.sh
+if [ -f "$XRDP_SRC/docs/macos/fix-screen-recording.sh" ]; then
+    cp "$XRDP_SRC/docs/macos/fix-screen-recording.sh" "$BUILD_DIR/root$INSTALL_PREFIX/share/xrdp/"
+    chmod +x "$BUILD_DIR/root$INSTALL_PREFIX/share/xrdp/fix-screen-recording.sh"
+fi
+
+# Copy test script
+if [ -f "$XRDP_SRC/docs/macos/test_vnc_pixels.py" ]; then
+    cp "$XRDP_SRC/docs/macos/test_vnc_pixels.py" "$BUILD_DIR/root$INSTALL_PREFIX/share/xrdp/"
+fi
+
+# Copy README
+if [ -f "$XRDP_SRC/docs/macos/README.md" ]; then
+    cp "$XRDP_SRC/docs/macos/README.md" "$BUILD_DIR/root$INSTALL_PREFIX/share/xrdp/"
+fi
+
+# Copy install scripts
+cp "$SCRIPT_DIR/preinstall" "$BUILD_DIR/scripts/"
+cp "$SCRIPT_DIR/postinstall" "$BUILD_DIR/scripts/"
+chmod +x "$BUILD_DIR/scripts/preinstall"
+chmod +x "$BUILD_DIR/scripts/postinstall"
+
+# Create welcome message
+cat > "$BUILD_DIR/resources/welcome.html" << 'EOF'
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; padding: 20px; }
+        h1 { color: #333; }
+        .note { background: #fff3cd; padding: 15px; border-radius: 8px; margin: 20px 0; }
+    </style>
+</head>
+<body>
+    <h1>xrdp for macOS</h1>
+    <p>This package installs xrdp with Apple Remote Desktop (ARD) authentication support, allowing you to connect to your Mac using any RDP client.</p>
+
+    <div class="note">
+        <strong>Important:</strong> After installation, you'll need to:
+        <ol>
+            <li>Enable Screen Sharing in System Settings</li>
+            <li>Disable SIP temporarily to grant permissions</li>
+            <li>Run the provided setup script</li>
+        </ol>
+        <p>See the README at /usr/local/share/xrdp/README.md for detailed instructions.</p>
+    </div>
+</body>
+</html>
+EOF
+
+# Create conclusion message
+cat > "$BUILD_DIR/resources/conclusion.html" << 'EOF'
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; padding: 20px; }
+        h1 { color: #28a745; }
+        code { background: #f4f4f4; padding: 2px 6px; border-radius: 4px; }
+        .steps { background: #e7f5ff; padding: 15px; border-radius: 8px; margin: 20px 0; }
+    </style>
+</head>
+<body>
+    <h1>Installation Complete!</h1>
+    <p>xrdp has been installed and configured to start automatically.</p>
+
+    <div class="steps">
+        <strong>Next Steps:</strong>
+        <ol>
+            <li>Enable Screen Sharing: System Settings → General → Sharing → Screen Sharing</li>
+            <li>Boot to Recovery Mode and run: <code>csrutil disable</code></li>
+            <li>Reboot and run: <code>sudo /usr/local/share/xrdp/fix-screen-recording.sh</code></li>
+            <li>Reboot one more time</li>
+            <li>Connect using any RDP client to port 3389</li>
+        </ol>
+    </div>
+
+    <p>For detailed instructions, see: <code>/usr/local/share/xrdp/README.md</code></p>
+</body>
+</html>
+EOF
+
+# Build component package
+echo "Building component package..."
+pkgbuild \
+    --root "$BUILD_DIR/root" \
+    --scripts "$BUILD_DIR/scripts" \
+    --identifier "com.xrdp.xrdp" \
+    --version "$VERSION" \
+    --install-location "/" \
+    "$BUILD_DIR/xrdp-component.pkg"
+
+# Create distribution.xml
+cat > "$BUILD_DIR/distribution.xml" << EOF
+<?xml version="1.0" encoding="utf-8"?>
+<installer-gui-script minSpecVersion="2">
+    <title>xrdp $VERSION</title>
+    <organization>com.xrdp</organization>
+    <domains enable_localSystem="true"/>
+    <options customize="never" require-scripts="true" rootVolumeOnly="true"/>
+
+    <welcome file="welcome.html"/>
+    <conclusion file="conclusion.html"/>
+
+    <choices-outline>
+        <line choice="default">
+            <line choice="com.xrdp.xrdp"/>
+        </line>
+    </choices-outline>
+
+    <choice id="default"/>
+    <choice id="com.xrdp.xrdp" visible="false">
+        <pkg-ref id="com.xrdp.xrdp"/>
+    </choice>
+
+    <pkg-ref id="com.xrdp.xrdp" version="$VERSION" onConclusion="none">xrdp-component.pkg</pkg-ref>
+</installer-gui-script>
+EOF
+
+# Build product archive
+echo "Building final installer package..."
+productbuild \
+    --distribution "$BUILD_DIR/distribution.xml" \
+    --resources "$BUILD_DIR/resources" \
+    --package-path "$BUILD_DIR" \
+    "$SCRIPT_DIR/$PKG_NAME.pkg"
+
+echo ""
+echo "============================================"
+echo "Package built successfully!"
+echo "============================================"
+echo ""
+echo "Output: $SCRIPT_DIR/$PKG_NAME.pkg"
+echo ""
+echo "To install: sudo installer -pkg $SCRIPT_DIR/$PKG_NAME.pkg -target /"
+echo ""
+
+# Clean up
+rm -rf "$BUILD_DIR"
+
+exit 0

--- a/packaging/macos/com.xrdp.sesman.plist
+++ b/packaging/macos/com.xrdp.sesman.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.xrdp.sesman</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/sbin/xrdp-sesman</string>
+        <string>--nodaemon</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardErrorPath</key>
+    <string>/var/log/xrdp-sesman.err</string>
+    <key>StandardOutPath</key>
+    <string>/var/log/xrdp-sesman.log</string>
+    <key>WorkingDirectory</key>
+    <string>/usr/local/sbin</string>
+</dict>
+</plist>

--- a/packaging/macos/com.xrdp.xrdp.plist
+++ b/packaging/macos/com.xrdp.xrdp.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.xrdp.xrdp</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/sbin/xrdp</string>
+        <string>--nodaemon</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardErrorPath</key>
+    <string>/var/log/xrdp.err</string>
+    <key>StandardOutPath</key>
+    <string>/var/log/xrdp.log</string>
+    <key>WorkingDirectory</key>
+    <string>/usr/local/sbin</string>
+</dict>
+</plist>

--- a/packaging/macos/postinstall
+++ b/packaging/macos/postinstall
@@ -1,0 +1,96 @@
+#!/bin/bash
+#
+# xrdp post-installation script for macOS
+#
+
+set -e
+
+INSTALL_PREFIX="/usr/local"
+LAUNCHD_DIR="/Library/LaunchDaemons"
+CONFIG_DIR="/etc/xrdp"
+
+echo "xrdp post-installation setup..."
+
+# Create xrdp user/group if needed (optional, xrdp can run as root)
+# dscl . -read /Groups/xrdp >/dev/null 2>&1 || dscl . -create /Groups/xrdp
+
+# Fix library paths for all xrdp binaries
+echo "Fixing library paths..."
+for binary in xrdp xrdp-sesman xrdp-chansrv; do
+    if [ -f "$INSTALL_PREFIX/sbin/$binary" ]; then
+        # Fix common library references
+        for lib in libcommon libxrdp libipm libsesman libtoml; do
+            install_name_tool -change \
+                "$lib.0.dylib" \
+                "$INSTALL_PREFIX/lib/xrdp/$lib.0.dylib" \
+                "$INSTALL_PREFIX/sbin/$binary" 2>/dev/null || true
+        done
+    fi
+done
+
+# Configure sesman.ini for macOS (wheel group instead of root)
+if [ -f "$CONFIG_DIR/sesman.ini" ]; then
+    echo "Configuring sesman.ini for macOS..."
+    sed -i '' 's/^SessionSockdirGroup=root/SessionSockdirGroup=wheel/' "$CONFIG_DIR/sesman.ini" 2>/dev/null || true
+fi
+
+# Add macOS session to xrdp.ini if not present
+if [ -f "$CONFIG_DIR/xrdp.ini" ]; then
+    if ! grep -q "\[macos\]" "$CONFIG_DIR/xrdp.ini"; then
+        echo "Adding macOS session to xrdp.ini..."
+        cat >> "$CONFIG_DIR/xrdp.ini" << 'EOF'
+
+[macos]
+name=macOS Desktop
+lib=libvnc.dylib
+ip=127.0.0.1
+port=5900
+username=ask
+password=ask
+EOF
+    fi
+fi
+
+# Install launchd plists
+echo "Installing launchd services..."
+cp "$INSTALL_PREFIX/share/xrdp/com.xrdp.xrdp.plist" "$LAUNCHD_DIR/" 2>/dev/null || true
+cp "$INSTALL_PREFIX/share/xrdp/com.xrdp.sesman.plist" "$LAUNCHD_DIR/" 2>/dev/null || true
+
+# Set correct permissions
+chmod 644 "$LAUNCHD_DIR/com.xrdp.xrdp.plist" 2>/dev/null || true
+chmod 644 "$LAUNCHD_DIR/com.xrdp.sesman.plist" 2>/dev/null || true
+chown root:wheel "$LAUNCHD_DIR/com.xrdp.xrdp.plist" 2>/dev/null || true
+chown root:wheel "$LAUNCHD_DIR/com.xrdp.sesman.plist" 2>/dev/null || true
+
+# Create log directory
+mkdir -p /var/log
+touch /var/log/xrdp.log /var/log/xrdp.err
+touch /var/log/xrdp-sesman.log /var/log/xrdp-sesman.err
+
+# Load services
+echo "Starting xrdp services..."
+launchctl load "$LAUNCHD_DIR/com.xrdp.xrdp.plist" 2>/dev/null || true
+launchctl load "$LAUNCHD_DIR/com.xrdp.sesman.plist" 2>/dev/null || true
+
+echo ""
+echo "============================================"
+echo "xrdp installation complete!"
+echo "============================================"
+echo ""
+echo "IMPORTANT: To connect to macOS Screen Sharing, you need to:"
+echo ""
+echo "1. Enable Screen Sharing:"
+echo "   System Settings → General → Sharing → Screen Sharing"
+echo ""
+echo "2. Grant TCC permissions (requires SIP disabled):"
+echo "   - Boot to Recovery Mode and run: csrutil disable"
+echo "   - Reboot and run: sudo $INSTALL_PREFIX/share/xrdp/fix-screen-recording.sh"
+echo "   - Reboot again"
+echo ""
+echo "3. Enable full control:"
+echo "   sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart -configure -allowAccessFor -allUsers -privs -all -restart -agent"
+echo ""
+echo "Connect using any RDP client to port 3389."
+echo ""
+
+exit 0

--- a/packaging/macos/preinstall
+++ b/packaging/macos/preinstall
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# xrdp pre-installation script for macOS
+#
+
+set -e
+
+LAUNCHD_DIR="/Library/LaunchDaemons"
+
+echo "Preparing xrdp installation..."
+
+# Stop existing services if running
+echo "Stopping existing xrdp services..."
+launchctl unload "$LAUNCHD_DIR/com.xrdp.xrdp.plist" 2>/dev/null || true
+launchctl unload "$LAUNCHD_DIR/com.xrdp.sesman.plist" 2>/dev/null || true
+
+# Kill any running xrdp processes
+pkill -f xrdp-sesman 2>/dev/null || true
+pkill -f "xrdp " 2>/dev/null || true
+
+# Wait for processes to stop
+sleep 1
+
+echo "Ready to install xrdp."
+
+exit 0

--- a/vnc/rfb.h
+++ b/vnc/rfb.h
@@ -64,13 +64,15 @@ enum sec_type
     SEC_TYPE_INVALID = 0,
     SEC_TYPE_NONE = 1,
     SEC_TYPE_VNC_AUTH = 2,
-    SEC_TYPE_MAX = SEC_TYPE_VNC_AUTH // Max supported security type
+    SEC_TYPE_APPLE_ARD = 30,  // Apple Remote Desktop authentication
+    SEC_TYPE_MAX = SEC_TYPE_APPLE_ARD // Max supported security type
 };
 
 #define SEC_TYPE_TO_STR(st) \
     (((st) == SEC_TYPE_INVALID) ? "Invalid" : \
      ((st) == SEC_TYPE_NONE) ? "None" : \
-     ((st) == SEC_TYPE_VNC_AUTH) ? "VNC Auth" : "Unknown")
+     ((st) == SEC_TYPE_VNC_AUTH) ? "VNC Auth" : \
+     ((st) == SEC_TYPE_APPLE_ARD) ? "Apple ARD" : "Unknown")
 
 /* Constructs an RFB version from a major and minor version */
 #define MAKE_RFBPROTO_VER(maj,min) ((maj * 1000) + (min))

--- a/vnc/vnc.c
+++ b/vnc/vnc.c
@@ -1872,12 +1872,21 @@ negotiate_protocol_version(struct vnc *v, unsigned char *next_char)
     }
     else if (major == 3)
     {
-        /* RFC6143 section 6 states that unknown 3.x versions should
-         * be treated as 3.3 */
+        /* Apple Screen Sharing uses 3.889. Treat versions >= 3.8 as 3.8
+         * to enable better security negotiation */
         LOG(LOG_LEVEL_INFO, "RFB server reports version %d.%d.",
             major, minor);
 
-        minor = 3;
+        if (minor >= 8)
+        {
+            minor = 8;
+        }
+        else
+        {
+            /* RFC6143 section 6 states that unknown 3.x versions < 3.8
+             * should be treated as 3.3 */
+            minor = 3;
+        }
         version = MAKE_RFBPROTO_VER(major, minor);
         LOG(LOG_LEVEL_INFO, "Proposing RFB version %d.%d to server",
             major, minor);
@@ -2101,6 +2110,192 @@ negotiate_security_type(struct vnc *v, unsigned int rfbproto_version,
                 LOG(LOG_LEVEL_ERROR, "Can't send VNC auth response to server");
                 goto fail;
             }
+            break;
+        }
+        case SEC_TYPE_APPLE_ARD:
+        {
+            /* Apple Remote Desktop authentication (security type 30)
+             * Uses Diffie-Hellman key exchange + AES encrypted credentials
+             * Protocol:
+             * 1. Server sends: generator (2 bytes) + key length (2 bytes) +
+             *                  prime (key_length bytes) + server public key (key_length bytes)
+             * 2. Client generates DH key pair, computes shared secret
+             * 3. Client sends: client public key (key_length bytes) +
+             *                  AES128-encrypted credentials (128 bytes)
+             */
+            unsigned char generator[2];
+            unsigned char key_len_bytes[2];
+            int key_len;
+            unsigned char *prime = NULL;
+            unsigned char *server_pubkey = NULL;
+            unsigned char *client_pubkey = NULL;
+            unsigned char *shared_secret = NULL;
+            unsigned char credentials[128];
+            unsigned char encrypted_creds[128];
+
+            LOG(LOG_LEVEL_INFO, "Starting Apple ARD authentication");
+
+            /* Read generator (2 bytes) */
+            init_stream(s, 4);
+            if (trans_force_read_s(v->trans, s, 2) != 0)
+            {
+                LOG(LOG_LEVEL_ERROR, "Can't read ARD generator");
+                goto fail;
+            }
+            in_uint8a(s, generator, 2);
+
+            /* Read key length (2 bytes, big endian) */
+            init_stream(s, 4);
+            if (trans_force_read_s(v->trans, s, 2) != 0)
+            {
+                LOG(LOG_LEVEL_ERROR, "Can't read ARD key length");
+                goto fail;
+            }
+            in_uint8a(s, key_len_bytes, 2);
+            key_len = (key_len_bytes[0] << 8) | key_len_bytes[1];
+
+            LOG(LOG_LEVEL_INFO, "ARD key length: %d bytes", key_len);
+
+            if (key_len <= 0 || key_len > 1024)
+            {
+                LOG(LOG_LEVEL_ERROR, "Invalid ARD key length: %d", key_len);
+                goto fail;
+            }
+
+            prime = (unsigned char *)g_malloc(key_len, 1);
+            server_pubkey = (unsigned char *)g_malloc(key_len, 1);
+            client_pubkey = (unsigned char *)g_malloc(key_len, 1);
+            shared_secret = (unsigned char *)g_malloc(key_len, 1);
+
+            if (!prime || !server_pubkey || !client_pubkey || !shared_secret)
+            {
+                LOG(LOG_LEVEL_ERROR, "Memory allocation failed for ARD");
+                g_free(prime);
+                g_free(server_pubkey);
+                g_free(client_pubkey);
+                g_free(shared_secret);
+                goto fail;
+            }
+
+            /* Read prime (key_len bytes) */
+            init_stream(s, key_len + 16);
+            if (trans_force_read_s(v->trans, s, key_len) != 0)
+            {
+                LOG(LOG_LEVEL_ERROR, "Can't read ARD prime");
+                g_free(prime);
+                g_free(server_pubkey);
+                g_free(client_pubkey);
+                g_free(shared_secret);
+                goto fail;
+            }
+            in_uint8a(s, prime, key_len);
+
+            /* Read server public key (key_len bytes) */
+            init_stream(s, key_len + 16);
+            if (trans_force_read_s(v->trans, s, key_len) != 0)
+            {
+                LOG(LOG_LEVEL_ERROR, "Can't read ARD server public key");
+                g_free(prime);
+                g_free(server_pubkey);
+                g_free(client_pubkey);
+                g_free(shared_secret);
+                goto fail;
+            }
+            in_uint8a(s, server_pubkey, key_len);
+
+            /* Generate client DH key pair and compute shared secret */
+            {
+                /* Use OpenSSL for DH key generation */
+                void *dh = ssl_dh_create(key_len, generator, prime, server_pubkey,
+                                         client_pubkey, shared_secret);
+                if (dh == NULL)
+                {
+                    LOG(LOG_LEVEL_ERROR, "Failed to generate DH keys for ARD");
+                    g_free(prime);
+                    g_free(server_pubkey);
+                    g_free(client_pubkey);
+                    g_free(shared_secret);
+                    goto fail;
+                }
+                ssl_dh_delete(dh);
+            }
+
+            /* Prepare credentials: 64 bytes username + 64 bytes password
+             * Both are null-terminated, unused bytes filled with random data */
+
+            /* Fill entire buffer with random data first */
+            g_random((char *)credentials, 128);
+
+            /* Copy username (first 64 bytes), null-terminated */
+            {
+                int ulen = g_strlen(v->username);
+                if (ulen > 63) ulen = 63;
+                g_memcpy(credentials, v->username, ulen);
+                credentials[ulen] = '\0';  /* Null terminator after username */
+            }
+
+            /* Copy password (next 64 bytes), null-terminated */
+            {
+                int plen = g_strlen(v->password);
+                if (plen > 63) plen = 63;
+                g_memcpy(credentials + 64, v->password, plen);
+                credentials[64 + plen] = '\0';  /* Null terminator after password */
+            }
+
+            LOG(LOG_LEVEL_DEBUG, "ARD credentials prepared: username len=%d, password len=%d",
+                (int)g_strlen(v->username), (int)g_strlen(v->password));
+
+            /* Derive AES key from shared secret using MD5 hash */
+            {
+                void *md5 = ssl_md5_info_create();
+                unsigned char aes_key_bytes[16];
+                void *aes_ctx;
+
+                ssl_md5_clear(md5);
+                ssl_md5_transform(md5, (char *)shared_secret, key_len);
+                ssl_md5_complete(md5, (char *)aes_key_bytes);
+                ssl_md5_info_delete(md5);
+
+                /* Encrypt credentials with AES-128-ECB */
+                aes_ctx = ssl_aes128_ecb_encrypt_info_create(aes_key_bytes);
+                if (aes_ctx)
+                {
+                    ssl_aes128_ecb_encrypt(aes_ctx, credentials, encrypted_creds, 128);
+                    ssl_aes128_info_delete(aes_ctx);
+                }
+                else
+                {
+                    LOG(LOG_LEVEL_ERROR, "Failed to create AES context for ARD");
+                    g_free(prime);
+                    g_free(server_pubkey);
+                    g_free(client_pubkey);
+                    g_free(shared_secret);
+                    goto fail;
+                }
+            }
+
+            /* Send encrypted credentials + client public key (order matters!) */
+            init_stream(s, key_len + 128 + 16);
+            out_uint8a(s, encrypted_creds, 128);
+            out_uint8a(s, client_pubkey, key_len);
+            s_mark_end(s);
+
+            if (trans_force_write_s(v->trans, s) != 0)
+            {
+                LOG(LOG_LEVEL_ERROR, "Can't send ARD authentication response");
+                g_free(prime);
+                g_free(server_pubkey);
+                g_free(client_pubkey);
+                g_free(shared_secret);
+                goto fail;
+            }
+
+            g_free(prime);
+            g_free(server_pubkey);
+            g_free(client_pubkey);
+            g_free(shared_secret);
+
+            LOG(LOG_LEVEL_INFO, "ARD authentication response sent");
             break;
         }
         default:


### PR DESCRIPTION
## Summary

- Implements Apple Remote Desktop (ARD) authentication (Security Type 30) for VNC connections to macOS Screen Sharing
- Adds Diffie-Hellman key exchange with AES-128-ECB credential encryption
- Includes macOS installer packaging (.pkg) with launchd auto-start configuration
- Provides documentation and helper scripts for TCC permissions setup

## Details

### ARD Authentication
- Full DH-1024 key exchange implementation in `ssl_calls.c`
- Supports both OpenSSL 1.x and 3.x APIs
- Handles proper credential encoding (64-byte username + 64-byte password blocks)

### macOS Packaging
- Creates ARM and Intel installer packages via `build-pkg.sh`
- launchd plist files for automatic service startup
- Pre/post install scripts for configuration

### Documentation
- Complete setup guide in `docs/macos/README.md`
- TCC permission fix script for Screen Recording access
- VNC test script for connection diagnostics

## Test Plan

- [ ] Build on macOS ARM (Apple Silicon)
- [ ] Build on macOS Intel
- [ ] Test ARD authentication against macOS Screen Sharing
- [ ] Verify screen capture works after TCC permissions granted
- [ ] Test installer package installation and service auto-start

🤖 Generated with [Claude Code](https://claude.com/claude-code)