### PR TITLE
Coverity: Fix TAINTED_SCALAR warning

### DIFF
--- a/xrdpapi/connectmon.c
+++ b/xrdpapi/connectmon.c
@@ -112,11 +112,22 @@ main(int argc, char **argv)
         log_start_from_param(lc);
     }
 
-    if (argc > 1 && atoi(argv[1]) > 0)
+    if (argc > 1 && atoi(argv[1]) >= 0)
     {
         changes = atoi(argv[1]);
+        if (changes > 1000)
+        {
+            changes = 1000; // Use 0 for more than this
+        }
     }
-    printf("Connection monitor : exiting after %d state changes\n", changes);
+    if (changes > 0)
+    {
+        printf("Connection monitor : exiting after %d state changes\n", changes);
+    }
+    else
+    {
+        printf("Connection monitor\n");
+    }
 
     print_current_connection_state();
 
@@ -128,7 +139,7 @@ main(int argc, char **argv)
     else
     {
         int count = 0;
-        while (count < changes && result == 0)
+        while (result == 0)
         {
             struct pollfd pollarg =
             {
@@ -138,6 +149,11 @@ main(int argc, char **argv)
             };
             int pollstat;
             LRESULT cbresult;
+
+            if (changes > 0 && count >= changes)
+            {
+                break;
+            }
 
             if ((pollstat = poll(&pollarg, 1, -1)) < 0)
             {


### PR DESCRIPTION
Address a Coverity TAINTED SCALAR warning introduced by #3673 

```
*** CID 898977:         Insecure data handling  (TAINTED_SCALAR)
/xrdpapi/connectmon.c: 131             in main()
125         {
126             result = 1; // Error occurred (should be logged)
127         }
128         else
129         {
130             int count = 0;
>>>     CID 898977:         Insecure data handling  (TAINTED_SCALAR)
>>>     Using tainted variable "changes" as a loop boundary.
131             while (count < changes && result == 0)
132             {
133                 struct pollfd pollarg =
134                 {
135                     .fd = fd,
136                     .events = (POLLIN | POLLERR),
```