### PR TITLE
User shell environment fix

### DIFF
--- a/sesman/sesexec/session.c
+++ b/sesman/sesexec/session.c
@@ -255,38 +255,40 @@ start_window_manager(const struct login_info *login_info,
         }
     }
 
-    if (g_cfg->sec.allow_alternate_shell &&
-            g_cfg->sec.pass_shell_as_env != NULL &&
-            g_cfg->sec.pass_shell_as_env[0] != '0')
+    if (s->shell[0] != '\0')
     {
-        // Pass the shell in to the standard startwm scripts
-        // in an environment variable
-        LOG(LOG_LEVEL_INFO,
-            "Setting variable '%s' to the specified shell of '%s'",
-            g_cfg->sec.pass_shell_as_env,
-            s->shell);
-        g_setenv_log(g_cfg->sec.pass_shell_as_env, s->shell, 1);
-    }
-    else if (s->shell[0] != '\0')
-    {
-        // Try to execute the shell directly (if permitted)
         if (g_cfg->sec.allow_alternate_shell)
         {
-            if (g_strchr(s->shell, ' ') != 0 || g_strchr(s->shell, '\t') != 0)
+            if (g_cfg->sec.pass_shell_as_env != NULL &&
+                    g_cfg->sec.pass_shell_as_env[0] != '\0')
             {
+                // Pass the shell in to the standard startwm scripts
+                // in an environment variable
                 LOG(LOG_LEVEL_INFO,
-                    "Using user requested window manager on "
-                    "display %u with embedded arguments using a shell: %s",
-                    s->display, s->shell);
-                const char *argv[] = {"sh", "-c", s->shell, NULL};
-                g_execvp("/bin/sh", (char **)argv);
+                    "Setting variable '%s' to the specified shell of '%s'",
+                    g_cfg->sec.pass_shell_as_env,
+                    s->shell);
+                g_setenv_log(g_cfg->sec.pass_shell_as_env, s->shell, 1);
             }
             else
             {
-                LOG(LOG_LEVEL_INFO,
-                    "Using user requested window manager on "
-                    "display %d: %s", s->display, s->shell);
-                g_execlp3(s->shell, s->shell, 0);
+                // Try to execute the shell directly (if permitted)
+                if (g_strchr(s->shell, ' ') != 0 || g_strchr(s->shell, '\t') != 0)
+                {
+                    LOG(LOG_LEVEL_INFO,
+                        "Using user requested window manager on "
+                        "display %u with embedded arguments using a shell: %s",
+                        s->display, s->shell);
+                    const char *argv[] = {"sh", "-c", s->shell, NULL};
+                    g_execvp("/bin/sh", (char **)argv);
+                }
+                else
+                {
+                    LOG(LOG_LEVEL_INFO,
+                        "Using user requested window manager on "
+                        "display %d: %s", s->display, s->shell);
+                    g_execlp3(s->shell, s->shell, 0);
+                }
             }
         }
         else


### PR DESCRIPTION
There is currently a typo in the check if the configuration for the environment variable is set.

Checking tough I saw that the environment variable value is set to an empty string if the user does not set a shell.
The second commit contains a rewrite that only sets the environment variable if the user actually set a shell.
This is to prevent the case where the default value of the environment variable is already set by `[SessionVariables] in sesman.ini

But @matt335672 may have wanted this to behave that way. This is the reason why the PR contains two commits and is marked as draft. Once we decide what to merge I will either drop the second or first commit