### PR TITLE
Allow username-affixed token to be used with INFO_AUTOLOGON flag set in client

### DIFF
--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -600,17 +600,6 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
             return 1;
         }
     }
-    else if (self->rdp_layer->client_info.enable_token_login
-             && len_user > 0
-             && len_password == 0
-             && (sep = g_strchr(self->rdp_layer->client_info.username, '\x1f')) != NULL)
-    {
-        LOG(LOG_LEVEL_DEBUG, "Client supplied a Logon token. Overwriting password with logon token.");
-        g_strncpy(self->rdp_layer->client_info.password, sep + 1,
-                  sizeof(self->rdp_layer->client_info.password) - 1);
-        self->rdp_layer->client_info.username[sep - self->rdp_layer->client_info.username] = '\0';
-        self->rdp_layer->client_info.rdp_autologin = 1;
-    }
     else
     {
         // Skip the password
@@ -619,6 +608,17 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
             return 1;
         }
         in_uint8s(s, len_password + 2);
+    }
+    if (self->rdp_layer->client_info.enable_token_login
+            && len_user > 0
+            && len_password == 0
+            && (sep = g_strchr(self->rdp_layer->client_info.username, '\x1f')) != NULL)
+    {
+        LOG(LOG_LEVEL_DEBUG, "Client supplied a Logon token. Overwriting password with logon token.");
+        g_strncpy(self->rdp_layer->client_info.password, sep + 1,
+                  sizeof(self->rdp_layer->client_info.password) - 1);
+        self->rdp_layer->client_info.username[sep - self->rdp_layer->client_info.username] = '\0';
+        self->rdp_layer->client_info.rdp_autologin = 1;
     }
     if (self->rdp_layer->client_info.domain_user_separator[0] != '\0'
             && self->rdp_layer->client_info.domain[0] != '\0')


### PR DESCRIPTION
This PR simply implements the suggestion by @matt335672 given in https://github.com/neutrinolabs/xrdp/pull/2392#issuecomment-1278831710 based on the fix provided by @galeksandrp in https://github.com/neutrinolabs/xrdp/pull/2392 to the token-affixed-to-username scheme originally introduced in https://github.com/neutrinolabs/xrdp/pull/1668. The PR seems to have been abandoned by the original poster, so I figure I might as well open a new one. Of course if @galeksandrp would prefer to follow up on their original PR instead I will be happy to close this one.

This will allow the "token-based" login to work with clients such as the current version of `mstsc.exe` and `remmina`, which don't necessarily expose the INFO_AUTOLOGON flag for easy configuration. 

Fundamentally, just like when the feature was originally added, this provides a cross-platform means by which users can log on using short-lived compact tokens (which may simply contain something like a securely encrypted timestamp and username) so that a web service can authenticate a user using e.g. [pam-jwt](https://github.com/bolkedebruin/pam-jwt) or a similar tool.

I have manually tested with Remmina on a Fedora 43 client and a Rocky 8 server. Will test with mstsc.exe ASAP. ETA: Can verify that it also works with mstsc.exe 10.0.26100.1 (WinBuild.160101.0800).