### PR TITLE
Fix: Segfault at 0x18 due to race condition between UI destruction and event dispatching

### DIFF
--- a/xrdp/xrdp_bitmap.c
+++ b/xrdp/xrdp_bitmap.c
@@ -708,34 +708,42 @@ xrdp_bitmap_invalidate(struct xrdp_bitmap *self, struct xrdp_rect *rect)
     }
     else if (self->type == WND_TYPE_SCREEN) /* 2 */
     {
-        if (self->wm->mm->mod != 0)
+        struct xrdp_wm *wm = self->wm;
+        if (wm == 0)
         {
-            if (self->wm->mm->mod->mod_event != 0)
+            return 0;
+        }
+        struct xrdp_mm *mm = wm->mm;
+        if (mm == 0)
+        {
+            return 0;
+        }
+        struct xrdp_mod *m = mm->mod;
+        if (m != 0 && m->mod_event != 0)
+        {
+            if (rect != 0)
             {
-                if (rect != 0)
-                {
-                    x = rect->left;
-                    y = rect->top;
-                    w = rect->right - rect->left;
-                    h = rect->bottom - rect->top;
+                x = rect->left;
+                y = rect->top;
+                w = rect->right - rect->left;
+                h = rect->bottom - rect->top;
 
-                    if (check_bounds(self->wm->screen, &x, &y, &w, &h))
-                    {
-                        self->wm->mm->mod->mod_event(self->wm->mm->mod, WM_INVALIDATE,
-                                                     MAKELONG(y, x), MAKELONG(h, w),
-                                                     0, 0);
-                    }
-                }
-                else
+                if (check_bounds(self->wm->screen, &x, &y, &w, &h))
                 {
-                    x = 0;
-                    y = 0;
-                    w = self->wm->screen->width;
-                    h = self->wm->screen->height;
-                    self->wm->mm->mod->mod_event(self->wm->mm->mod, WM_INVALIDATE,
-                                                 MAKELONG(y, x), MAKELONG(h, w),
-                                                 0, 0);
+                    m->mod_event(m, WM_INVALIDATE,
+                                 MAKELONG(y, x), MAKELONG(h, w),
+                                 0, 0);
                 }
+            }
+            else
+            {
+                x = 0;
+                y = 0;
+                w = self->wm->screen->width;
+                h = self->wm->screen->height;
+                m->mod_event(m, WM_INVALIDATE,
+                             MAKELONG(y, x), MAKELONG(h, w),
+                             0, 0);
             }
         }
         else
@@ -1144,7 +1152,11 @@ xrdp_bitmap_def_proc(struct xrdp_bitmap *self, int msg,
 
         if (self->focused_control != 0)
         {
-            xrdp_bitmap_def_proc(self->focused_control, msg, param1, param2);
+            struct xrdp_bitmap *fc = self->focused_control;
+            if (fc != 0 && fc->wm != 0)
+            {
+                xrdp_bitmap_def_proc(fc, msg, param1, param2);
+            }
         }
     }
     else if (self->type == WND_TYPE_EDIT)
@@ -1270,9 +1282,10 @@ xrdp_bitmap_def_proc(struct xrdp_bitmap *self, int msg,
                     self->item_index--;
                     xrdp_bitmap_invalidate(self, 0);
 
-                    if (self->parent->notify != 0)
+                    struct xrdp_bitmap *p = self->parent;
+                    if (p != 0 && p->notify != 0)
                     {
-                        self->parent->notify(self->parent, self, CB_ITEMCHANGE, 0, 0);
+                        p->notify(p, self, CB_ITEMCHANGE, 0, 0);
                     }
                 }
             }
@@ -1287,9 +1300,10 @@ xrdp_bitmap_def_proc(struct xrdp_bitmap *self, int msg,
                     self->item_index++;
                     xrdp_bitmap_invalidate(self, 0);
 
-                    if (self->parent->notify != 0)
+                    struct xrdp_bitmap *p = self->parent;
+                    if (p != 0 && p->notify != 0)
                     {
-                        self->parent->notify(self->parent, self, CB_ITEMCHANGE, 0, 0);
+                        p->notify(p, self, CB_ITEMCHANGE, 0, 0);
                     }
                 }
             }
@@ -1314,16 +1328,16 @@ xrdp_bitmap_def_proc(struct xrdp_bitmap *self, int msg,
         }
         else if (msg == WM_LBUTTONUP)
         {
-            if (self->popped_from != 0)
+            struct xrdp_bitmap *pf = self->popped_from;
+            if (pf != 0)
             {
-                self->popped_from->item_index = self->item_index;
-                xrdp_bitmap_invalidate(self->popped_from, 0);
+                pf->item_index = self->item_index;
+                xrdp_bitmap_invalidate(pf, 0);
 
-                if (self->popped_from->parent->notify != 0)
+                struct xrdp_bitmap *p = pf->parent;
+                if (p != 0 && p->notify != 0)
                 {
-                    self->popped_from->parent->notify(self->popped_from->parent,
-                                                      self->popped_from,
-                                                      CB_ITEMCHANGE, 0, 0);
+                    p->notify(p, pf, CB_ITEMCHANGE, 0, 0);
                 }
             }
         }

--- a/xrdp/xrdp_bitmap_common.c
+++ b/xrdp/xrdp_bitmap_common.c
@@ -195,17 +195,17 @@ xrdp_bitmap_delete(struct xrdp_bitmap *self)
 
     if (self->wm != 0)
     {
-        if (self->wm->focused_window != 0)
-        {
-            if (self->wm->focused_window->focused_control == self)
-            {
-                self->wm->focused_window->focused_control = 0;
-            }
-        }
-
         if (self->wm->focused_window == self)
         {
             self->wm->focused_window = 0;
+        }
+
+        if (self->wm->popup_wnd != 0)
+        {
+            if (self->wm->popup_wnd == self || self->wm->popup_wnd->popped_from == self)
+            {
+                self->wm->popup_wnd = 0;
+            }
         }
 
         if (self->wm->dragging_window == self)
@@ -216,11 +216,6 @@ xrdp_bitmap_delete(struct xrdp_bitmap *self)
         if (self->wm->button_down == self)
         {
             self->wm->button_down = 0;
-        }
-
-        if (self->wm->popup_wnd == self)
-        {
-            self->wm->popup_wnd = 0;
         }
 
         if (self->wm->login_window == self)

--- a/xrdp/xrdp_login_wnd.c
+++ b/xrdp/xrdp_login_wnd.c
@@ -60,9 +60,10 @@ xrdp_wm_login_help_notify(struct xrdp_bitmap *wnd,
     {
         if (sender->id == 1) /* ok button */
         {
-            if (sender->owner->notify != 0)
+            struct xrdp_bitmap *o = wnd->owner;
+            if (o != 0 && o->notify != 0)
             {
-                wnd->owner->notify(wnd->owner, wnd, 100, 1, 0); /* ok */
+                o->notify(o, wnd, 100, 1, 0); /* ok */
             }
         }
     }

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -1317,9 +1317,10 @@ xrdp_mm_update_module_frame_ack(struct xrdp_mm *self)
     {
         // Can't pass the ack to the encoder. Tell the module all
         // frames are ACK'd
-        if (self->mod != NULL)
+        struct xrdp_mod *m = self->mod;
+        if (m != NULL)
         {
-            self->mod->mod_frame_ack(self->mod, 0, INT_MAX);
+            m->mod_frame_ack(m, 0, INT_MAX);
         }
     }
     else
@@ -1332,10 +1333,11 @@ xrdp_mm_update_module_frame_ack(struct xrdp_mm *self)
                 LOG_DEVEL(LOG_LEVEL_DEBUG, "xrdp_mm_update_module_ack: "
                           "frame_id_server %d", encoder->frame_id_server);
                 encoder->frame_id_server_sent = encoder->frame_id_server;
-                if (self->mod != NULL)
+                struct xrdp_mod *m = self->mod;
+                if (m != NULL)
                 {
-                    self->mod->mod_frame_ack(self->mod, 0,
-                                             encoder->frame_id_server);
+                    m->mod_frame_ack(m, 0,
+                                     encoder->frame_id_server);
                 }
             }
         }
@@ -5528,9 +5530,12 @@ xrdp_mm_setup_mod2(struct xrdp_mm *self)
                 int key_flags = self->last_sync_key_flags;
                 int device_flags = self->last_sync_device_flags;
                 self->last_sync_saved = 0;
-                self->mod->mod_event(self->mod, WM_KEYBRD_SYNC, key_flags,
-                                     device_flags, key_flags, device_flags);
-
+                struct xrdp_mod *m = self->mod;
+                if (m != 0 && m->mod_event != 0)
+                {
+                    m->mod_event(m, WM_KEYBRD_SYNC, key_flags,
+                                 device_flags, key_flags, device_flags);
+                }
             }
         }
         else
@@ -5566,10 +5571,11 @@ xrdp_mm_setup_mod2(struct xrdp_mm *self)
 
         if (self->mod != 0)
         {
-            if (self->mod->mod_event != 0)
+            struct xrdp_mod *m = self->mod;
+            if (m != 0 && m->mod_event != 0)
             {
-                self->mod->mod_event(self->mod, WM_KEYBRD_SYNC, key_flags,
-                                     device_flags, key_flags, device_flags);
+                m->mod_event(m, WM_KEYBRD_SYNC, key_flags,
+                             device_flags, key_flags, device_flags);
             }
         }
     }

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -1201,12 +1201,9 @@ xrdp_wm_mouse_move(struct xrdp_wm *self, int x, int y)
             self->current_pointer = self->screen->pointer;
         }
 
-        if (self->mm->mod != 0) /* if screen is mod controlled */
+        if (self->mm != 0 && self->mm->mod != 0 && self->mm->mod->mod_event != 0)
         {
-            if (self->mm->mod->mod_event != 0)
-            {
-                self->mm->mod->mod_event(self->mm->mod, WM_MOUSEMOVE, x, y, 0, 0);
-            }
+            self->mm->mod->mod_event(self->mm->mod, WM_MOUSEMOVE, x, y, 0, 0);
         }
     }
 
@@ -1242,7 +1239,11 @@ xrdp_wm_mouse_move(struct xrdp_wm *self, int x, int y)
             {
                 if (b->notify != 0)
                 {
-                    b->notify(b->owner, b, 2, x, y);
+                    struct xrdp_bitmap *o = b->owner;
+                    if (o != 0)
+                    {
+                        b->notify(o, b, 2, x, y);
+                    }
                 }
             }
         }
@@ -1364,92 +1365,89 @@ xrdp_wm_mouse_click(struct xrdp_wm *self, int x, int y, int but, int down)
 
     if (control == 0)
     {
-        if (self->mm->mod != 0) /* if screen is mod controlled */
+        if (self->mm != 0 && self->mm->mod != 0 && self->mm->mod->mod_event != 0)
         {
-            if (self->mm->mod->mod_event != 0)
+            if (down)
             {
-                if (down)
-                {
-                    self->mm->mod->mod_event(self->mm->mod, WM_MOUSEMOVE, x, y, 0, 0);
-                }
-                if (but == 1 && down)
-                {
-                    self->mm->mod->mod_event(self->mm->mod, WM_LBUTTONDOWN, x, y, 0, 0);
-                }
-                else if (but == 1 && !down)
-                {
-                    self->mm->mod->mod_event(self->mm->mod, WM_LBUTTONUP, x, y, 0, 0);
-                }
+                self->mm->mod->mod_event(self->mm->mod, WM_MOUSEMOVE, x, y, 0, 0);
+            }
+            if (but == 1 && down)
+            {
+                self->mm->mod->mod_event(self->mm->mod, WM_LBUTTONDOWN, x, y, 0, 0);
+            }
+            else if (but == 1 && !down)
+            {
+                self->mm->mod->mod_event(self->mm->mod, WM_LBUTTONUP, x, y, 0, 0);
+            }
 
-                if (but == 2 && down)
-                {
-                    self->mm->mod->mod_event(self->mm->mod, WM_RBUTTONDOWN, x, y, 0, 0);
-                }
-                else if (but == 2 && !down)
-                {
-                    self->mm->mod->mod_event(self->mm->mod, WM_RBUTTONUP, x, y, 0, 0);
-                }
+            if (but == 2 && down)
+            {
+                self->mm->mod->mod_event(self->mm->mod, WM_RBUTTONDOWN, x, y, 0, 0);
+            }
+            else if (but == 2 && !down)
+            {
+                self->mm->mod->mod_event(self->mm->mod, WM_RBUTTONUP, x, y, 0, 0);
+            }
 
-                if (but == 3 && down)
-                {
-                    self->mm->mod->mod_event(self->mm->mod, WM_BUTTON3DOWN, x, y, 0, 0);
-                }
-                else if (but == 3 && !down)
-                {
-                    self->mm->mod->mod_event(self->mm->mod, WM_BUTTON3UP, x, y, 0, 0);
-                }
+            if (but == 3 && down)
+            {
+                self->mm->mod->mod_event(self->mm->mod, WM_BUTTON3DOWN, x, y, 0, 0);
+            }
+            else if (but == 3 && !down)
+            {
+                self->mm->mod->mod_event(self->mm->mod, WM_BUTTON3UP, x, y, 0, 0);
+            }
 
-                if (but == 8 && down)
-                {
-                    self->mm->mod->mod_event(self->mm->mod, WM_BUTTON8DOWN, x, y, 0, 0);
-                }
-                else if (but == 8 && !down)
-                {
-                    self->mm->mod->mod_event(self->mm->mod, WM_BUTTON8UP, x, y, 0, 0);
-                }
-                if (but == 9 && down)
-                {
-                    self->mm->mod->mod_event(self->mm->mod, WM_BUTTON9DOWN, x, y, 0, 0);
-                }
-                else if (but == 9 && !down)
-                {
-                    self->mm->mod->mod_event(self->mm->mod, WM_BUTTON9UP, x, y, 0, 0);
-                }
-                /* vertical scroll */
+            if (but == 8 && down)
+            {
+                self->mm->mod->mod_event(self->mm->mod, WM_BUTTON8DOWN, x, y, 0, 0);
+            }
+            else if (but == 8 && !down)
+            {
+                self->mm->mod->mod_event(self->mm->mod, WM_BUTTON8UP, x, y, 0, 0);
+            }
+            if (but == 9 && down)
+            {
+                self->mm->mod->mod_event(self->mm->mod, WM_BUTTON9DOWN, x, y, 0, 0);
+            }
+            else if (but == 9 && !down)
+            {
+                self->mm->mod->mod_event(self->mm->mod, WM_BUTTON9UP, x, y, 0, 0);
+            }
+            /* vertical scroll */
 
-                if (but == 4)
-                {
-                    self->mm->mod->mod_event(self->mm->mod, WM_BUTTON4DOWN,
-                                             self->mouse_x, self->mouse_y, 0, 0);
-                    self->mm->mod->mod_event(self->mm->mod, WM_BUTTON4UP,
-                                             self->mouse_x, self->mouse_y, 0, 0);
-                }
+            if (but == 4)
+            {
+                self->mm->mod->mod_event(self->mm->mod, WM_BUTTON4DOWN,
+                                         self->mouse_x, self->mouse_y, 0, 0);
+                self->mm->mod->mod_event(self->mm->mod, WM_BUTTON4UP,
+                                         self->mouse_x, self->mouse_y, 0, 0);
+            }
 
-                if (but == 5)
-                {
-                    self->mm->mod->mod_event(self->mm->mod, WM_BUTTON5DOWN,
-                                             self->mouse_x, self->mouse_y, 0, 0);
-                    self->mm->mod->mod_event(self->mm->mod, WM_BUTTON5UP,
-                                             self->mouse_x, self->mouse_y, 0, 0);
-                }
+            if (but == 5)
+            {
+                self->mm->mod->mod_event(self->mm->mod, WM_BUTTON5DOWN,
+                                         self->mouse_x, self->mouse_y, 0, 0);
+                self->mm->mod->mod_event(self->mm->mod, WM_BUTTON5UP,
+                                         self->mouse_x, self->mouse_y, 0, 0);
+            }
 
-                /* horizontal scroll */
+            /* horizontal scroll */
 
-                if (but == 6)
-                {
-                    self->mm->mod->mod_event(self->mm->mod, WM_BUTTON6DOWN,
-                                             self->mouse_x, self->mouse_y, 0, 0);
-                    self->mm->mod->mod_event(self->mm->mod, WM_BUTTON6UP,
-                                             self->mouse_x, self->mouse_y, 0, 0);
-                }
+            if (but == 6)
+            {
+                self->mm->mod->mod_event(self->mm->mod, WM_BUTTON6DOWN,
+                                         self->mouse_x, self->mouse_y, 0, 0);
+                self->mm->mod->mod_event(self->mm->mod, WM_BUTTON6UP,
+                                         self->mouse_x, self->mouse_y, 0, 0);
+            }
 
-                if (but == 7)
-                {
-                    self->mm->mod->mod_event(self->mm->mod, WM_BUTTON7DOWN,
-                                             self->mouse_x, self->mouse_y, 0, 0);
-                    self->mm->mod->mod_event(self->mm->mod, WM_BUTTON7UP,
-                                             self->mouse_x, self->mouse_y, 0, 0);
-                }
+            if (but == 7)
+            {
+                self->mm->mod->mod_event(self->mm->mod, WM_BUTTON7DOWN,
+                                         self->mouse_x, self->mouse_y, 0, 0);
+                self->mm->mod->mod_event(self->mm->mod, WM_BUTTON7UP,
+                                         self->mouse_x, self->mouse_y, 0, 0);
             }
         }
     }
@@ -1628,23 +1626,19 @@ xrdp_wm_key(struct xrdp_wm *self, int keyboard_flags, int key_code)
         }
     }
 
-    if (self->mm->mod != 0)
+    if (self->mm->mod != 0 && self->mm->mod->mod_event != 0)
     {
-        // Backend module loaded...
-        if (self->mm->mod->mod_event != 0)
-        {
-            // ..and able to take events. Check the scancode maps to
-            // a real key in the currently loaded keymap
-            ki = get_key_info_from_kbd_event
-                 (keyboard_flags, key_code, self->keys, self->caps_lock,
-                  self->num_lock, self->scroll_lock,
-                  &(self->keymap));
+        // ..and able to take events. Check the scancode maps to
+        // a real key in the currently loaded keymap
+        ki = get_key_info_from_kbd_event
+             (keyboard_flags, key_code, self->keys, self->caps_lock,
+              self->num_lock, self->scroll_lock,
+              &(self->keymap));
 
-            if (ki != 0)
-            {
-                self->mm->mod->mod_event(self->mm->mod, msg, ki->chr, ki->sym,
-                                         key_code, keyboard_flags);
-            }
+        if (ki != 0)
+        {
+            self->mm->mod->mod_event(self->mm->mod, msg, ki->chr, ki->sym,
+                                     key_code, keyboard_flags);
         }
     }
     else if (self->focused_window != 0)
@@ -2088,7 +2082,7 @@ xrdp_wm_process_channel_data(struct xrdp_wm *self,
         }
         else
         {
-            if (self->mm->mod->mod_event != 0)
+            if (self->mm->mod != 0 && self->mm->mod->mod_event != 0)
             {
                 rv = self->mm->mod->mod_event(self->mm->mod, WM_CHANNEL_DATA,
                                               param1, param2, param3, param4);


### PR DESCRIPTION
### Summary
High-load environments trigger a Segfault at offset `0x18` in `xrdp` due to a logical race condition between UI cleanup and stale event dispatching.

### 1. Symptom & Physical Interpretation
* **Error**: `kernel: xrdp[...] segfault at 18 ip ...`
* **Physical Offset**: The crash address `0x18` (24 bytes) corresponds to vital function pointers: `notify` in `struct xrdp_bitmap` and `mod_event` in `struct xrdp_mod`.

### 2. Root Cause: Asynchronous Event Queue Gap
The crash is caused by a logical race condition between the **UI Destruction Phase** and **Pending Message Dispatch**. When a user authenticates successfully, the login window is destroyed, but the event loop may still attempt to dispatch stale events via now-NULL pointers.

### 3. Proposed Solution: Local Variable Snapshotting
This PR implements a snapshotting strategy and enhanced NULL checks across 3 commits:
1. **UI Notify Safety**: Guarding all UI-level notification callbacks.
2. **Backend Robustness**: Multi-level validation for module event dispatching.
3. **Lifecycle Cleanup**: Ensuring global state pointers are cleared during object deletion.

This effectively turns potential fatal crashes into safe 'silent skips' during cleanup phases.