### PR TITLE
[V0.10] Cursor improvements

### DIFF
--- a/libxrdp/libxrdp.c
+++ b/libxrdp/libxrdp.c
@@ -704,6 +704,25 @@ libxrdp_send_bitmap(struct xrdp_session *session, int width, int height,
 
 /*****************************************************************************/
 int EXPORT_CC
+libxrdp_send_pointer_system(struct xrdp_session *session, int pointer_type)
+{
+    struct stream *s;
+
+    make_stream(s);
+    init_stream(s, 8192);
+    xrdp_rdp_init_data((struct xrdp_rdp *)(session->rdp), s);
+    out_uint16_le(s, RDP_POINTER_SYSTEM);
+    out_uint16_le(s, 0); /* pad */
+    out_uint32_le(s, pointer_type);
+    s_mark_end(s);
+    xrdp_rdp_send_data((struct xrdp_rdp *)session->rdp, s,
+                       RDP_DATA_PDU_POINTER);
+    free_stream(s);
+    return 0;
+}
+
+/*****************************************************************************/
+int EXPORT_CC
 libxrdp_send_pointer(struct xrdp_session *session, int cache_idx,
                      char *data, char *mask, int x, int y, int bpp,
                      int width, int height)

--- a/libxrdp/libxrdp.c
+++ b/libxrdp/libxrdp.c
@@ -723,6 +723,26 @@ libxrdp_send_pointer_system(struct xrdp_session *session, int pointer_type)
 
 /*****************************************************************************/
 int EXPORT_CC
+libxrdp_send_pointer_position(struct xrdp_session *session, int x, int y)
+{
+    struct stream *s;
+
+    make_stream(s);
+    init_stream(s, 8192);
+    xrdp_rdp_init_data((struct xrdp_rdp *)(session->rdp), s);
+    out_uint16_le(s, RDP_POINTER_MOVE);
+    out_uint16_le(s, 0); /* pad */
+    out_uint16_le(s, x);
+    out_uint16_le(s, y);
+    s_mark_end(s);
+    xrdp_rdp_send_data((struct xrdp_rdp *)session->rdp, s,
+                       RDP_DATA_PDU_POINTER);
+    free_stream(s);
+    return 0;
+}
+
+/*****************************************************************************/
+int EXPORT_CC
 libxrdp_send_pointer(struct xrdp_session *session, int cache_idx,
                      char *data, char *mask, int x, int y, int bpp,
                      int width, int height)

--- a/libxrdp/libxrdpinc.h
+++ b/libxrdp/libxrdpinc.h
@@ -122,6 +122,8 @@ int
 libxrdp_send_bitmap(struct xrdp_session *session, int width, int height,
                     int bpp, char *data, int x, int y, int cx, int cy);
 int
+libxrdp_send_pointer_system(struct xrdp_session *session, int pointer_type);
+int
 libxrdp_send_pointer(struct xrdp_session *session, int cache_idx,
                      char *data, char *mask, int x, int y, int bpp,
                      int width, int height);

--- a/libxrdp/libxrdpinc.h
+++ b/libxrdp/libxrdpinc.h
@@ -124,6 +124,8 @@ libxrdp_send_bitmap(struct xrdp_session *session, int width, int height,
 int
 libxrdp_send_pointer_system(struct xrdp_session *session, int pointer_type);
 int
+libxrdp_send_pointer_position(struct xrdp_session *session, int x, int y);
+int
 libxrdp_send_pointer(struct xrdp_session *session, int cache_idx,
                      char *data, char *mask, int x, int y, int bpp,
                      int width, int height);

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -164,6 +164,8 @@ xrdp_wm_pu(struct xrdp_wm *self, struct xrdp_bitmap *control);
 int
 xrdp_wm_send_pointer_system(struct xrdp_wm *self, int pointer_type);
 int
+xrdp_wm_send_pointer_position(struct xrdp_wm *self, int x, int y);
+int
 xrdp_wm_send_pointer(struct xrdp_wm *self, int cache_idx,
                      char *data, char *mask, int x, int y, int bpp,
                      int width, int height);
@@ -568,6 +570,8 @@ server_paint_rects(struct xrdp_mod *mod, int num_drects, short *drects,
                    int flags, int frame_id);
 int
 server_set_pointer_system(struct xrdp_mod *mod, int pointer_type);
+int
+server_set_pointer_position(struct xrdp_mod *mod, int x, int y);
 int
 server_set_pointer(struct xrdp_mod *mod, int x, int y,
                    char *data, char *mask);

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -162,6 +162,8 @@ xrdp_wm_key_sync(struct xrdp_wm *self, int device_flags, int key_flags);
 int
 xrdp_wm_pu(struct xrdp_wm *self, struct xrdp_bitmap *control);
 int
+xrdp_wm_send_pointer_system(struct xrdp_wm *self, int pointer_type);
+int
 xrdp_wm_send_pointer(struct xrdp_wm *self, int cache_idx,
                      char *data, char *mask, int x, int y, int bpp,
                      int width, int height);
@@ -564,6 +566,8 @@ server_paint_rects(struct xrdp_mod *mod, int num_drects, short *drects,
                    int num_crects, short *crects,
                    char *data, int width, int height,
                    int flags, int frame_id);
+int
+server_set_pointer_system(struct xrdp_mod *mod, int pointer_type);
 int
 server_set_pointer(struct xrdp_mod *mod, int x, int y,
                    char *data, char *mask);

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -461,6 +461,7 @@ xrdp_mm_setup_mod1(struct xrdp_mm *self)
             self->mod->server_egfx_cmd = server_egfx_cmd;
             self->mod->server_set_pointer_large = server_set_pointer_large;
             self->mod->server_paint_rects_ex = server_paint_rects_ex;
+            self->mod->server_set_pointer_system = server_set_pointer_system;
             self->mod->si = &(self->wm->session->si);
         }
     }
@@ -4465,6 +4466,17 @@ server_egfx_cmd(struct xrdp_mod *mod,
     tc_mutex_unlock(mm->encoder->mutex);
     /* signal xrdp_encoder thread */
     g_set_wait_obj(mm->encoder->xrdp_encoder_event_to_proc);
+    return 0;
+}
+
+/*****************************************************************************/
+int
+server_set_pointer_system(struct xrdp_mod *mod, int pointer_type)
+{
+    struct xrdp_wm *wm;
+
+    wm = (struct xrdp_wm *)(mod->wm);
+    xrdp_wm_send_pointer_system(wm, pointer_type);
     return 0;
 }
 

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -462,6 +462,7 @@ xrdp_mm_setup_mod1(struct xrdp_mm *self)
             self->mod->server_set_pointer_large = server_set_pointer_large;
             self->mod->server_paint_rects_ex = server_paint_rects_ex;
             self->mod->server_set_pointer_system = server_set_pointer_system;
+            self->mod->server_set_pointer_position = server_set_pointer_position;
             self->mod->si = &(self->wm->session->si);
         }
     }
@@ -4477,6 +4478,17 @@ server_set_pointer_system(struct xrdp_mod *mod, int pointer_type)
 
     wm = (struct xrdp_wm *)(mod->wm);
     xrdp_wm_send_pointer_system(wm, pointer_type);
+    return 0;
+}
+
+/*****************************************************************************/
+int
+server_set_pointer_position(struct xrdp_mod *mod, int x, int y)
+{
+    struct xrdp_wm *wm;
+
+    wm = (struct xrdp_wm *)(mod->wm);
+    xrdp_wm_send_pointer_position(wm, x, y);
     return 0;
 }
 

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -195,7 +195,8 @@ struct xrdp_mod
     int (*server_egfx_cmd)(struct xrdp_mod *v,
                            char *cmd, int cmd_bytes,
                            char *data, int data_bytes);
-    tintptr server_dumby[100 - 50]; /* align, 100 minus the number of server
+    int (*server_set_pointer_system)(struct xrdp_mod *v, int pointer_type);
+    tintptr server_dumby[100 - 51]; /* align, 100 minus the number of server
                                      functions above */
     /* common */
     tintptr handle; /* pointer to self as int */

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -196,7 +196,8 @@ struct xrdp_mod
                            char *cmd, int cmd_bytes,
                            char *data, int data_bytes);
     int (*server_set_pointer_system)(struct xrdp_mod *v, int pointer_type);
-    tintptr server_dumby[100 - 51]; /* align, 100 minus the number of server
+    int (*server_set_pointer_position)(struct xrdp_mod *v, int x, int y);
+    tintptr server_dumby[100 - 52]; /* align, 100 minus the number of server
                                      functions above */
     /* common */
     tintptr handle; /* pointer to self as int */

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -423,6 +423,13 @@ xrdp_wm_send_pointer_system(struct xrdp_wm *self, int pointer_type)
 
 /*****************************************************************************/
 int
+xrdp_wm_send_pointer_position(struct xrdp_wm *self, int x, int y)
+{
+    return libxrdp_send_pointer_position(self->session, x, y);
+}
+
+/*****************************************************************************/
+int
 xrdp_wm_send_pointer(struct xrdp_wm *self, int cache_idx,
                      char *data, char *mask, int x, int y, int bpp,
                      int width, int height)

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -416,6 +416,13 @@ xrdp_wm_load_pointer(struct xrdp_wm *self, char *file_name, char *data,
 
 /*****************************************************************************/
 int
+xrdp_wm_send_pointer_system(struct xrdp_wm *self, int pointer_type)
+{
+    return libxrdp_send_pointer_system(self->session, pointer_type);
+}
+
+/*****************************************************************************/
+int
 xrdp_wm_send_pointer(struct xrdp_wm *self, int cache_idx,
                      char *data, char *mask, int x, int y, int bpp,
                      int width, int height)

--- a/xup/xup.c
+++ b/xup/xup.c
@@ -1468,6 +1468,21 @@ process_server_set_pointer_system(struct mod *amod, struct stream *s)
 /******************************************************************************/
 /* return error */
 static int
+process_server_set_pointer_position(struct mod *amod, struct stream *s)
+{
+    int rv;
+    int x;
+    int y;
+
+    in_uint16_le(s, x);
+    in_uint16_le(s, y);
+    rv = amod->server_set_pointer_position(amod, x, y);
+    return rv;
+}
+
+/******************************************************************************/
+/* return error */
+static int
 send_server_version_message(struct mod *mod, struct stream *s)
 {
     /* send version message */
@@ -1702,6 +1717,9 @@ lib_mod_process_orders(struct mod *mod, int type, struct stream *s)
             break;
         case 65: /* server_set_pointer_system */
             rv = process_server_set_pointer_system(mod, s);
+            break;
+        case 66: /* server_set_pointer_position */
+            rv = process_server_set_pointer_position(mod, s);
             break;
         default:
             LOG_DEVEL(LOG_LEVEL_WARNING,

--- a/xup/xup.c
+++ b/xup/xup.c
@@ -1455,6 +1455,19 @@ process_server_paint_rect_shmfd(struct mod *amod, struct stream *s)
 /******************************************************************************/
 /* return error */
 static int
+process_server_set_pointer_system(struct mod *amod, struct stream *s)
+{
+    int rv;
+    int pointer_type;
+
+    in_uint32_le(s, pointer_type);
+    rv = amod->server_set_pointer_system(amod, pointer_type);
+    return rv;
+}
+
+/******************************************************************************/
+/* return error */
+static int
 send_server_version_message(struct mod *mod, struct stream *s)
 {
     /* send version message */
@@ -1686,6 +1699,9 @@ lib_mod_process_orders(struct mod *mod, int type, struct stream *s)
             break;
         case 64: /* server_paint_rect_shmfd */
             rv = process_server_paint_rect_shmfd(mod, s);
+            break;
+        case 65: /* server_set_pointer_system */
+            rv = process_server_set_pointer_system(mod, s);
             break;
         default:
             LOG_DEVEL(LOG_LEVEL_WARNING,

--- a/xup/xup.h
+++ b/xup/xup.h
@@ -177,7 +177,8 @@ struct mod
                            char *cmd, int cmd_bytes,
                            char *data, int data_bytes);
     int (*server_set_pointer_system)(struct mod *v, int pointer_type);
-    tintptr server_dumby[100 - 51]; /* align, 100 minus the number of server
+    int (*server_set_pointer_position)(struct mod *v, int x, int y);
+    tintptr server_dumby[100 - 52]; /* align, 100 minus the number of server
                                      functions above */
     /* common */
     tintptr handle; /* pointer to self as long */

--- a/xup/xup.h
+++ b/xup/xup.h
@@ -176,7 +176,8 @@ struct mod
     int (*server_egfx_cmd)(struct mod *v,
                            char *cmd, int cmd_bytes,
                            char *data, int data_bytes);
-    tintptr server_dumby[100 - 50]; /* align, 100 minus the number of server
+    int (*server_set_pointer_system)(struct mod *v, int pointer_type);
+    tintptr server_dumby[100 - 51]; /* align, 100 minus the number of server
                                      functions above */
     /* common */
     tintptr handle; /* pointer to self as long */


### PR DESCRIPTION
Adds support for a couple of xorgxrdp features backported from `devel`.

See neutrinolabs/xorgxrdp#380, neutrinolabs/xorgxrdp#405 and neutrinolabs/xorgxrdp#407