### PR TITLE
RFB authentication: Undefined behaviour fix

### DIFF
--- a/sesman/sesexec/env.c
+++ b/sesman/sesexec/env.c
@@ -53,6 +53,12 @@ env_check_password_file(const char *filename, const char *passwd)
     void *des;
     void *sha1;
 
+    if (filename == NULL)
+    {
+        LOG(LOG_LEVEL_WARNING, "Cannot write VNC password hash to NULL file");
+        return 1;
+    }
+
     /*
      * If we're in FIPS mode, do not write the GUID to disk after it's
      * been encrypted with an insecure algorithm.
@@ -63,7 +69,7 @@ env_check_password_file(const char *filename, const char *passwd)
         return 1;
     }
     /* create password hash from password */
-    passwd_bytes = g_strlen(passwd);
+    passwd_bytes = (passwd == NULL) ? 0 : strlen(passwd);
     sha1 = ssl_sha1_info_create();
     ssl_sha1_clear(sha1);
     ssl_sha1_transform(sha1, "xrdp_vnc", 8);

--- a/sesman/sesexec/session.c
+++ b/sesman/sesexec/session.c
@@ -441,7 +441,6 @@ prepare_xvnc_xserver_params(const struct session_parameters *s,
         g_snprintf(depth, sizeof(depth), "%d", s->bpp);
 
         guid_to_str(&s->guid, guid_str);
-        env_check_password_file(passwd_file, guid_str);
 
         /* get path of Xvnc from config */
         xserver = (const char *)list_get_item(g_cfg->vnc_params, 0);
@@ -457,6 +456,7 @@ prepare_xvnc_xserver_params(const struct session_parameters *s,
         if (passwd_file != NULL)
         {
             /* RFB authorization */
+            env_check_password_file(passwd_file, guid_str);
             list_add_strdup_multi(params,
                                   "-rfbauth", passwd_file,
                                   NULL);


### PR DESCRIPTION
[As reported](/neutrinolabs/xrdp/discussions/3634#discussioncomment-15772485) by @qtlin, when using a UDS VNC session, the following log message is displayed:

```
[WARN ] Cannot write VNC password hash to file (null): Bad address
```

There are two problems here:
1) We're passing a NULL to `open()` and `vsnprintf(...,"..%s..",...)` which is Undefined Behaviour in both instances.
2) We're trying to write to a filename we don't have.

There are two commits here. This first hardens `env_check_passwd_file()` to prevent UB if a NULL is passed in for either parameter, and the second avoids calling the routine at all, unless we need it.