### PR TITLE
Coverity: fix recent regressions

### DIFF
--- a/xrdp/xrdp_bitmap.c
+++ b/xrdp/xrdp_bitmap.c
@@ -711,12 +711,12 @@ xrdp_bitmap_invalidate(struct xrdp_bitmap *self, struct xrdp_rect *rect)
         struct xrdp_wm *wm = self->wm;
         if (wm == 0)
         {
-            return 0;
+            goto bail;
         }
         struct xrdp_mm *mm = wm->mm;
         if (mm == 0)
         {
-            return 0;
+            goto bail;
         }
         struct xrdp_mod *m = mm->mod;
         if (m != 0 && m->mod_event != 0)
@@ -1022,6 +1022,7 @@ xrdp_bitmap_invalidate(struct xrdp_bitmap *self, struct xrdp_rect *rect)
         }
     }
 
+bail:
     xrdp_painter_end_update(painter);
     xrdp_painter_delete(painter);
     return 0;

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -5436,15 +5436,21 @@ xrdp_mm_setup_mod2(struct xrdp_mm *self)
     int rv;
     int key_flags;
     int device_flags;
+    struct xrdp_mod *mod = self->mod;
+
+    if (self->mod == 0)
+    {
+        return 1;
+    }
 
     rv = 1; /* failure */
     g_memset(text, 0, sizeof(text));
 
     if (!g_is_wait_obj_set(self->wm->pro_layer->self_term_event))
     {
-        if (self->mod->mod_start(self->mod, self->wm->screen->width,
-                                 self->wm->screen->height,
-                                 self->wm->screen->bpp) != 0)
+        if (mod->mod_start(mod, self->wm->screen->width,
+                           self->wm->screen->height,
+                           self->wm->screen->bpp) != 0)
         {
             xrdp_mm_set_fatal(self, ERRINFO_SERVER_DWM_CRASH);
         }
@@ -5492,30 +5498,30 @@ xrdp_mm_setup_mod2(struct xrdp_mm *self)
 
         /* always set these */
 
-        self->mod->mod_set_param(self->mod, "client_info",
-                                 (const char *) (self->wm->session->client_info));
+        mod->mod_set_param(mod, "client_info",
+                           (const char *) (self->wm->session->client_info));
 
         name = self->wm->session->client_info->client_name;
-        self->mod->mod_set_param(self->mod, "client_name", name);
+        mod->mod_set_param(mod, "client_name", name);
         g_snprintf(text, 255, "%d", self->wm->session->client_info->keylayout);
-        self->mod->mod_set_param(self->mod, "keylayout", text);
+        mod->mod_set_param(mod, "keylayout", text);
         if (guid_is_set(&self->guid))
         {
-            self->mod->mod_set_param(self->mod, "guid", (char *) &self->guid);
+            mod->mod_set_param(mod, "guid", (char *) &self->guid);
         }
 
         for (i = 0; i < self->login_names->count; i++)
         {
             name = (const char *) list_get_item(self->login_names, i);
             value = (const char *) list_get_item(self->login_values, i);
-            self->mod->mod_set_param(self->mod, name, value);
+            mod->mod_set_param(mod, name, value);
         }
 
         /* connect
         *
          * If we got an fd for the display server from sesman, this
          * call will use it */
-        if (self->mod->mod_connect(self->mod, self->sesman_display_fd) == 0)
+        if (mod->mod_connect(mod, self->sesman_display_fd) == 0)
         {
             rv = 0; /* connect success */
 
@@ -5530,11 +5536,10 @@ xrdp_mm_setup_mod2(struct xrdp_mm *self)
                 int key_flags = self->last_sync_key_flags;
                 int device_flags = self->last_sync_device_flags;
                 self->last_sync_saved = 0;
-                struct xrdp_mod *m = self->mod;
-                if (m != 0 && m->mod_event != 0)
+                if (mod->mod_event != 0)
                 {
-                    m->mod_event(m, WM_KEYBRD_SYNC, key_flags,
-                                 device_flags, key_flags, device_flags);
+                    mod->mod_event(mod, WM_KEYBRD_SYNC, key_flags,
+                                   device_flags, key_flags, device_flags);
                 }
             }
         }
@@ -5569,14 +5574,10 @@ xrdp_mm_setup_mod2(struct xrdp_mm *self)
             key_flags |= 4;
         }
 
-        if (self->mod != 0)
+        if (mod->mod_event != 0)
         {
-            struct xrdp_mod *m = self->mod;
-            if (m != 0 && m->mod_event != 0)
-            {
-                m->mod_event(m, WM_KEYBRD_SYNC, key_flags,
-                             device_flags, key_flags, device_flags);
-            }
+            mod->mod_event(mod, WM_KEYBRD_SYNC, key_flags,
+                           device_flags, key_flags, device_flags);
         }
     }
 


### PR DESCRIPTION
Coverity scan is back up, and has reported the following regressions on #3719:

```
** CID 899745:       Null pointer dereferences  (REVERSE_INULL)
/xrdp/xrdp_mm.c: 5534           in xrdp_mm_setup_mod2()


_____________________________________________________________________________________________
*** CID 899745:         Null pointer dereferences  (REVERSE_INULL)
/xrdp/xrdp_mm.c: 5534             in xrdp_mm_setup_mod2()
5528                 if (self->last_sync_saved)
5529                 {
5530                     int key_flags = self->last_sync_key_flags;
5531                     int device_flags = self->last_sync_device_flags;
5532                     self->last_sync_saved = 0;
5533                     struct xrdp_mod *m = self->mod;
>>>     CID 899745:         Null pointer dereferences  (REVERSE_INULL)
>>>     Null-checking "m" suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
5534                     if (m != 0 && m->mod_event != 0)
5535                     {
5536                         m->mod_event(m, WM_KEYBRD_SYNC, key_flags,
5537                                      device_flags, key_flags, device_flags);
5538                     }
5539                 }

** CID 899744:       Resource leaks  (RESOURCE_LEAK)
/xrdp/xrdp_bitmap.c: 719           in xrdp_bitmap_invalidate()


_____________________________________________________________________________________________
*** CID 899744:         Resource leaks  (RESOURCE_LEAK)
/xrdp/xrdp_bitmap.c: 719             in xrdp_bitmap_invalidate()
713             {
714                 return 0;
715             }
716             struct xrdp_mm *mm = wm->mm;
717             if (mm == 0)
718             {
>>>     CID 899744:         Resource leaks  (RESOURCE_LEAK)
>>>     Variable "painter" going out of scope leaks the storage it points to.
719                 return 0;
720             }
721             struct xrdp_mod *m = mm->mod;
722             if (m != 0 && m->mod_event != 0)
723             {
724                 if (rect != 0)
```

I've put together this PR to address these reports.

The change to `xrdp_bitmap_invalidate()` simply makes sure the allocated painter is deallocated in the event of an error.

The change to `xrdp_mm_setup_mod2()` moves the null module check earlier, and allocates a local variable for readability.

@tsz8899 - please can you review?