### PR TITLE
ulalaca: Don't redefine char16_t and char32_t

### DIFF
--- a/common/arch.h
+++ b/common/arch.h
@@ -49,6 +49,8 @@ typedef int bool_t;
 // Define Unicode character types
 #if defined(HAVE_UCHAR_H)
 #include <uchar.h>
+#elif defined (__APPLE__) && defined(__cplusplus)
+// char16_t and char32_t are in stdint.h (C++ only)
 #elif defined(HAVE_STDINT_H)
 typedef uint_least16_t char16_t;
 typedef uint_least32_t char32_t;


### PR DESCRIPTION
See #3681 

On MacOS, stdint.h is provided by the compiler for C, and by the SDK for C++.

OSX 14.4 appears to define char16_t and char32_t within stdint.h for C++.  Defining them again results in:

```
../common/arch.h:53:24: error: cannot combine with previous 'type-name' declaration specifier
typedef uint_least16_t char16_t;
                       ^
../common/arch.h:53:1: warning: typedef requires a name [-Wmissing-declarations]
typedef uint_least16_t char16_t;
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../common/arch.h:54:24: error: cannot combine with previous 'type-name' declaration specifier
typedef uint_least32_t char32_t;
                       ^
../common/arch.h:54:1: warning: typedef requires a name [-Wmissing-declarations]
typedef uint_least32_t char32_t;
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```