### PR TITLE
xorgxrdp: Add logging hint

### DIFF
--- a/sesman/sesman.ini.in
+++ b/sesman/sesman.ini.in
@@ -177,6 +177,10 @@ param=xrdp/xorg.conf
 param=-noreset
 param=-nolisten
 param=tcp
+; Logging levels are 4 for debug and 5 for trace. Uncomment and
+; edit these lines to get debugging info in the xorgxrdp log file
+#param=-logverbose
+#param=5
 param=-logfile
 param=.xorgxrdp.%s.log
 


### PR DESCRIPTION
See neutrinolabs/xorgxrdp#411 and neutrinolabs/xorgxrdp#412

Add commented out lines to the [Xorg] stanza in sesman.ini to get full logging for xorgxrdp