### PR TITLE
[V0.10] xorgxrdp: Add logging hint

### DIFF
--- a/sesman/sesman.ini.in
+++ b/sesman/sesman.ini.in
@@ -158,6 +158,10 @@ param=xrdp/xorg.conf
 param=-noreset
 param=-nolisten
 param=tcp
+; Logging levels are 4 for debug and 5 for trace. Uncomment and
+; edit these lines to get debugging info in the xorgxrdp log file
+#param=-logverbose
+#param=5
 param=-logfile
 param=.xorgxrdp.%s.log
 


### PR DESCRIPTION
See neutrinolabs/xorgxrdp#414

Add commented out lines to the [Xorg] stanza in sesman.ini to get full logging for xorgxrdp

(cherry picked from commit fe32e2e2d40adbedfd2bd5b827f33b334df4cb5f)