### PR TITLE
[V0.10] Disable smartcard code by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,11 +114,11 @@ jobs:
       CONF_FLAGS_amd64_max: "--enable-ipv6 --enable-jpeg --enable-fuse --enable-mp3lame
                   --enable-fdkaac --enable-opus --enable-rfxcodec --enable-painter
                   --enable-pixman --enable-utmp --with-imlib2 --with-freetype2 --enable-tests
-                  --enable-x264 --enable-openh264"
+                  --enable-x264 --enable-openh264 --enable-smartcard"
       CONF_FLAGS_i386_max: "--enable-ipv6 --enable-jpeg --enable-mp3lame
                   --enable-opus --enable-rfxcodec --enable-painter
                   --disable-pixman --with-imlib2 --with-freetype2
-                  --host=i686-linux --enable-tests"
+                  --host=i686-linux --enable-tests --enable-smartcard"
 
       PKG_CONFIG_PATH_i386: "/usr/lib/i386-linux-gnu/pkgconfig"
       CFLAGS_i386: "-m32"

--- a/configure.ac
+++ b/configure.ac
@@ -202,6 +202,11 @@ AC_ARG_WITH(imlib2, AS_HELP_STRING([--with-imlib2=ARG], [imlib2 library to use f
 
 AC_ARG_WITH(freetype2, AS_HELP_STRING([--with-freetype2=ARG], [freetype2 library to use for rendering fonts (ARG=yes/no/<abs-path>)]),,)
 
+AC_ARG_ENABLE(smartcard, AS_HELP_STRING([--enable-smartcard],
+              [Enable experimental smartcard code. Not for production. (default: no)]),
+              [], [enable_smartcard=no])
+AM_CONDITIONAL(XRDP_SMARTCARD, [test x$enable_smartcard = xyes])
+
 # Obsolete options
 AC_ARG_ENABLE(xrdpdebug, AS_HELP_STRING([--enable-xrdpdebug],
               [This option is no longer supported - use --enable-devel-all]))
@@ -653,56 +658,57 @@ AC_OUTPUT
 echo ""
 echo "xrdp will be compiled with:"
 echo ""
-echo "  mp3lame                 $enable_mp3lame"
-echo "  opus                    $enable_opus"
-echo "  fdkaac                  $enable_fdkaac"
-echo "  jpeg                    $enable_jpeg"
-echo "  turbo jpeg              $enable_tjpeg"
-echo "  rfxcodec                $enable_rfxcodec"
-echo "  x264                    $enable_x264"
-echo "  openh264                $enable_openh264"
-echo "  painter                 $enable_painter"
-echo "  pixman                  $enable_pixman"
-echo "  fuse                    $enable_fuse"
-echo "  ipv6                    $enable_ipv6"
-echo "  ipv6only                $enable_ipv6only"
-echo "  vsock                   $enable_vsock"
-echo "  auth mechanism          $auth_mech"
-echo "  rdpsndaudin             $enable_rdpsndaudin"
-echo "  utmp support            $enable_utmp"
+echo "  mp3lame                         $enable_mp3lame"
+echo "  opus                            $enable_opus"
+echo "  fdkaac                          $enable_fdkaac"
+echo "  jpeg                            $enable_jpeg"
+echo "  turbo jpeg                      $enable_tjpeg"
+echo "  rfxcodec                        $enable_rfxcodec"
+echo "  x264                            $enable_x264"
+echo "  openh264                        $enable_openh264"
+echo "  painter                         $enable_painter"
+echo "  pixman                          $enable_pixman"
+echo "  fuse                            $enable_fuse"
+echo "  ipv6                            $enable_ipv6"
+echo "  ipv6only                        $enable_ipv6only"
+echo "  vsock                           $enable_vsock"
+echo "  auth mechanism                  $auth_mech"
+echo "  rdpsndaudin                     $enable_rdpsndaudin"
+echo "  smartcard (not for production)  $enable_smartcard"
+echo "  utmp support                    $enable_utmp"
 if test x$enable_utmp = xyes; then
-    echo "    utmpx.ut_host         $ac_cv_utmpx_has_ut_host"
-    echo "    utmpx.ut_exit         $ac_cv_utmpx_has_ut_exit"
+    echo "    utmpx.ut_host                 $ac_cv_utmpx_has_ut_host"
+    echo "    utmpx.ut_exit                 $ac_cv_utmpx_has_ut_exit"
 fi
 if test -n "$with_systemdsystemunitdir" \
         -a "x$with_systemdsystemunitdir" != xno; then
-    echo "  systemd support         yes"
-    echo "    unit file directory   $with_systemdsystemunitdir"
+    echo "  systemd support                 yes"
+    echo "    unit file directory           $with_systemdsystemunitdir"
 else
-    echo "  systemd support         no"
+    echo "  systemd support                 no"
 fi
 
 echo
-echo "  with imlib2             $use_imlib2"
-echo "  with freetype2          $use_freetype2"
+echo "  with imlib2                     $use_imlib2"
+echo "  with freetype2                  $use_freetype2"
 
 echo
-echo "  development logging     $devel_logging"
-echo "  development streamcheck $devel_streamcheck"
+echo "  development logging             $devel_logging"
+echo "  development streamcheck         $devel_streamcheck"
 echo ""
-echo "  strict_locations        $enable_strict_locations"
-echo "  prefix                  $prefix"
-echo "  exec_prefix             $exec_prefix"
-echo "  libdir                  $libdir"
-echo "  bindir                  $bindir"
-echo "  sysconfdir              $sysconfdir"
-echo "  sysconfdir+subdir       $sysconfdir/$sysconfsubdir"
-echo "  pamconfdir              $pamconfdir"
-echo "  localstatedir           $localstatedir"
-echo "  runstatedir             $runstatedir"
-echo "  socketdir               $socketdir"
+echo "  strict_locations                $enable_strict_locations"
+echo "  prefix                          $prefix"
+echo "  exec_prefix                     $exec_prefix"
+echo "  libdir                          $libdir"
+echo "  bindir                          $bindir"
+echo "  sysconfdir                      $sysconfdir"
+echo "  sysconfdir+subdir               $sysconfdir/$sysconfsubdir"
+echo "  pamconfdir                      $pamconfdir"
+echo "  localstatedir                   $localstatedir"
+echo "  runstatedir                     $runstatedir"
+echo "  socketdir                       $socketdir"
 echo ""
-echo "  unit tests performable  $perform_unit_tests"
+echo "  unit tests performable          $perform_unit_tests"
 echo ""
 echo "  CFLAGS = $CFLAGS"
 echo "  LDFLAGS = $LDFLAGS"

--- a/sesman/chansrv/Makefile.am
+++ b/sesman/chansrv/Makefile.am
@@ -66,16 +66,25 @@ xrdp_chansrv_SOURCES = \
   irp.h \
   rail.c \
   rail.h \
-  smartcard.c \
   smartcard.h \
-  smartcard_pcsc.c \
-  smartcard_pcsc.h \
   sound.c \
   sound.h \
   xcommon.c \
   xcommon.h \
   audin.c \
   audin.h
+
+if XRDP_SMARTCARD
+AM_CPPFLAGS += -DXRDP_SMARTCARD
+xrdp_chansrv_SOURCES += \
+  smartcard.c \
+  smartcard_internal.h \
+  smartcard_pcsc.c \
+  smartcard_pcsc.h
+else
+xrdp_chansrv_SOURCES += \
+  smartcard_dummy.c
+endif
 
 xrdp_chansrv_LDFLAGS = \
   $(X_LIBS)

--- a/sesman/chansrv/devredir.c
+++ b/sesman/chansrv/devredir.c
@@ -526,10 +526,12 @@ devredir_send_server_core_cap_req(void)
     /* the header                     */
     xstream_wr_u32_le(s, 2);                /* Version                        */
 
+#ifdef XRDP_SMARTCARD
     /* setup smart card capability */
     xstream_wr_u16_le(s, CAP_SMARTCARD_TYPE);
     xstream_wr_u16_le(s, 8);
     xstream_wr_u32_le(s, 1);
+#endif
 
     /* send to client */
     bytes = xstream_len(s);

--- a/sesman/chansrv/smartcard.c
+++ b/sesman/chansrv/smartcard.c
@@ -42,6 +42,7 @@
 #include "os_calls.h"
 #include "string_calls.h"
 #include "smartcard.h"
+#include "smartcard_internal.h"
 #include "log.h"
 #include "irp.h"
 #include "devredir.h"

--- a/sesman/chansrv/smartcard.h
+++ b/sesman/chansrv/smartcard.h
@@ -19,160 +19,19 @@
 
 /*
  * smartcard redirection support
+ *
+ * External interface to the smartcard function
  */
 
-#ifndef _SMARTCARD_C
-#define _SMARTCARD_C
+#ifndef SMARTCARD_H
+#define SMARTCARD_H
 
-#include "parse.h"
-#include "irp.h"
-#include "trans.h"
-
-#define SCARD_SHARE_EXCLUSIVE       0x00000001
-#define SCARD_SHARE_SHARED          0x00000002
-#define SCARD_SHARE_DIRECT          0x00000003
-
-/* see [MS-RDPESC] 2.2.5 protocol identifier - Table A */
-#define SCARD_PROTOCOL_UNDEFINED    0x00000000
-#define SCARD_PROTOCOL_T0           0x00000001
-#define SCARD_PROTOCOL_T1           0x00000002
-#define SCARD_PROTOCOL_Tx           0x00000003
-#define SCARD_PROTOCOL_RAW          0x00010000
-
-/* see [MS-RDPESC] 2.2.5 protocol identifier - Table B */
-#define SCARD_PROTOCOL_DEFAULT      0x80000000
-#define SCARD_PROTOCOL_OPTIMAL      0x00000000
-
-/* initialization type */
-#define SCARD_LEAVE_CARD            0x00000000 /* do not do anything      */
-#define SCARD_RESET_CARD            0x00000001 /* reset smart card        */
-#define SCARD_UNPOWER_CARD          0x00000002 /* turn off and reset card */
-
-struct xrdp_scard_io_request
-{
-    tui32 dwProtocol;
-    tui32 cbPciLength;
-    int extra_bytes;
-    char *extra_data;
-};
-
-typedef struct reader_state
-{
-    char   reader_name[128];
-    tui32  current_state;
-    tui32  event_state;
-    tui32  atr_len; /* number of bytes in atr[] */
-    tui8   atr[36];
-
-    /*
-     * share mode flag, can be one of:
-     *  SCARD_SHARE_EXCLUSIVE  app not willing to share smartcard with other apps
-     *  SCARD_SHARE_SHARED     app willing to share smartcard with other apps
-     *  SCARD_SHARE_DIRECT     app demands direct control of smart card, hence
-     *                         it is not available to other readers
-     */
-    tui32  dwShareMode;
-
-    /*
-     * This field MUST have a value from Table A which is logically
-     * OR'ed with a value from Table B.
-     */
-    tui32  dwPreferredProtocols;
-
-    /*
-     * initialization type, must be one of the initialization type
-     * defined above
-     */
-    tui32  init_type;
-
-    /* required by scard_send_transmit(), scard_send_control() */
-    tui32 map0;
-    tui32 map1;
-    tui32 map2;
-    tui32 map3;
-    tui32 map4;
-    tui32 map5;
-    tui32 map6;
-
-    tui32 dwProtocol;
-    tui32 cbPciLength;
-    tui32 cbSendLength;
-    tui32 cbRecvLength;
-    tui32 dwControlCode;
-    tui32 cbOutBufferSize;
-    tui32 dwAttribId;
-    tui32 dwAttrLen;
-
-} READER_STATE;
+#include "arch.h"
 
 void scard_device_announce(tui32 device_id);
 int  scard_get_wait_objs(tbus *objs, int *count, int *timeout);
 int  scard_check_wait_objs(void);
 int  scard_init(void);
 int  scard_deinit(void);
-int  scard_send_establish_context(void *user_data, int scope);
-int  scard_send_release_context(void *user_data,
-                                char *context, int context_bytes);
-int  scard_send_is_valid_context(void *user_data,
-                                 char *context, int context_bytes);
-int  scard_send_list_readers(void *user_data,
-                             char *context, int context_bytes,
-                             char *groups, int cchReaders, int wide);
 
-int  scard_send_get_status_change(void *user_data,
-                                  char *context, int context_bytes,
-                                  int wide, tui32 timeout,
-                                  tui32 num_readers, READER_STATE *rsa);
-
-int  scard_send_connect(void *user_data,
-                        char *context, int context_bytes, int wide,
-                        READER_STATE *rs);
-
-int  scard_send_reconnect(void *user_data,
-                          char *context, int context_bytes,
-                          char *card, int card_bytes,
-                          READER_STATE *rs);
-
-int  scard_send_begin_transaction(void *user_data,
-                                  char *context, int context_bytes,
-                                  char *card, int card_bytes);
-int  scard_send_end_transaction(void *user_data,
-                                char *context, int context_bytes,
-                                char *card, int card_bytes,
-                                tui32 dwDisposition);
-int  scard_send_status(void *user_data, int wide,
-                       char *context, int context_bytes,
-                       char *card, int card_bytes,
-                       int cchReaderLen, int cbAtrLen);
-int  scard_send_disconnect(void *user_data,
-                           char *context, int context_bytes,
-                           char *card, int card_bytes,
-                           int dwDisposition);
-
-int  scard_send_transmit(void *user_data,
-                         char *context, int context_bytes,
-                         char *card, int card_bytes,
-                         char *send_data, int send_bytes, int recv_bytes,
-                         struct xrdp_scard_io_request *send_ior,
-                         struct xrdp_scard_io_request *recv_ior);
-
-int  scard_send_control(void *user_data,
-                        char *context, int context_bytes,
-                        char *card, int card_bytes,
-                        char *send_data, int send_bytes,
-                        int recv_bytes, int control_code);
-
-int  scard_send_cancel(void *user_data,
-                       char *context, int context_bytes);
-
-int  scard_send_get_attrib(void *user_data, char *card, int card_bytes,
-                           READER_STATE *rs);
-
-/*
- * Notes:
- *      SCardTransmit - partially done
- *      SCardControl - partially done
- *      SCardListReaderGroups - not supported
- *      SCardSetAttrib - not supported
- */
-#endif /* end #ifndef _SMARTCARD_C */
+#endif /* end #ifndef SMARTCARD_H */

--- a/sesman/chansrv/smartcard_dummy.c
+++ b/sesman/chansrv/smartcard_dummy.c
@@ -1,0 +1,67 @@
+/**
+ * xrdp: A Remote Desktop Protocol server.
+ *
+ * Copyright (C) Laxmikant Rashinkar 2013 LK.Rashinkar@gmail.com
+ * Copyright (C) Jay Sorg 2013 jay.sorg@gmail.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * @file sesman/chansrv/smartcard_dummy.c
+ *
+ * smartcard redirection support
+ *
+ * Dummy file used when smartcard support is not enabled.
+ */
+
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
+#include "smartcard.h"
+
+/*****************************************************************************/
+void
+scard_device_announce(tui32 device_id)
+{
+}
+
+/*****************************************************************************/
+int
+scard_get_wait_objs(tbus *objs, int *count, int *timeout)
+{
+    return 0;
+}
+
+/*****************************************************************************/
+int
+scard_check_wait_objs(void)
+{
+    return 0;
+}
+
+/*****************************************************************************/
+int
+scard_init(void)
+{
+    return 0;
+}
+
+/*****************************************************************************/
+int
+scard_deinit(void)
+{
+    return 0;
+}

--- a/sesman/chansrv/smartcard_internal.h
+++ b/sesman/chansrv/smartcard_internal.h
@@ -1,0 +1,175 @@
+/**
+ * xrdp: A Remote Desktop Protocol server.
+ *
+ * Copyright (C) Laxmikant Rashinkar 2013 LK.Rashinkar@gmail.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/*
+ * smartcard redirection support
+ *
+ * Routines internal to the smartcard function
+ */
+
+#ifndef SMARTCARD_INTERNAL_H
+#define SMARTCARD_INTERNAL_H
+
+#include "parse.h"
+#include "irp.h"
+#include "trans.h"
+
+#define SCARD_SHARE_EXCLUSIVE       0x00000001
+#define SCARD_SHARE_SHARED          0x00000002
+#define SCARD_SHARE_DIRECT          0x00000003
+
+/* see [MS-RDPESC] 2.2.5 protocol identifier - Table A */
+#define SCARD_PROTOCOL_UNDEFINED    0x00000000
+#define SCARD_PROTOCOL_T0           0x00000001
+#define SCARD_PROTOCOL_T1           0x00000002
+#define SCARD_PROTOCOL_Tx           0x00000003
+#define SCARD_PROTOCOL_RAW          0x00010000
+
+/* see [MS-RDPESC] 2.2.5 protocol identifier - Table B */
+#define SCARD_PROTOCOL_DEFAULT      0x80000000
+#define SCARD_PROTOCOL_OPTIMAL      0x00000000
+
+/* initialization type */
+#define SCARD_LEAVE_CARD            0x00000000 /* do not do anything      */
+#define SCARD_RESET_CARD            0x00000001 /* reset smart card        */
+#define SCARD_UNPOWER_CARD          0x00000002 /* turn off and reset card */
+
+struct xrdp_scard_io_request
+{
+    tui32 dwProtocol;
+    tui32 cbPciLength;
+    int extra_bytes;
+    char *extra_data;
+};
+
+typedef struct reader_state
+{
+    char   reader_name[128];
+    tui32  current_state;
+    tui32  event_state;
+    tui32  atr_len; /* number of bytes in atr[] */
+    tui8   atr[36];
+
+    /*
+     * share mode flag, can be one of:
+     *  SCARD_SHARE_EXCLUSIVE  app not willing to share smartcard with other apps
+     *  SCARD_SHARE_SHARED     app willing to share smartcard with other apps
+     *  SCARD_SHARE_DIRECT     app demands direct control of smart card, hence
+     *                         it is not available to other readers
+     */
+    tui32  dwShareMode;
+
+    /*
+     * This field MUST have a value from Table A which is logically
+     * OR'ed with a value from Table B.
+     */
+    tui32  dwPreferredProtocols;
+
+    /*
+     * initialization type, must be one of the initialization type
+     * defined above
+     */
+    tui32  init_type;
+
+    /* required by scard_send_transmit(), scard_send_control() */
+    tui32 map0;
+    tui32 map1;
+    tui32 map2;
+    tui32 map3;
+    tui32 map4;
+    tui32 map5;
+    tui32 map6;
+
+    tui32 dwProtocol;
+    tui32 cbPciLength;
+    tui32 cbSendLength;
+    tui32 cbRecvLength;
+    tui32 dwControlCode;
+    tui32 cbOutBufferSize;
+    tui32 dwAttribId;
+    tui32 dwAttrLen;
+
+} READER_STATE;
+
+int  scard_send_establish_context(void *user_data, int scope);
+int  scard_send_release_context(void *user_data,
+                                char *context, int context_bytes);
+int  scard_send_is_valid_context(void *user_data,
+                                 char *context, int context_bytes);
+int  scard_send_list_readers(void *user_data,
+                             char *context, int context_bytes,
+                             char *groups, int cchReaders, int wide);
+
+int  scard_send_get_status_change(void *user_data,
+                                  char *context, int context_bytes,
+                                  int wide, tui32 timeout,
+                                  tui32 num_readers, READER_STATE *rsa);
+
+int  scard_send_connect(void *user_data,
+                        char *context, int context_bytes, int wide,
+                        READER_STATE *rs);
+
+int  scard_send_reconnect(void *user_data,
+                          char *context, int context_bytes,
+                          char *card, int card_bytes,
+                          READER_STATE *rs);
+
+int  scard_send_begin_transaction(void *user_data,
+                                  char *context, int context_bytes,
+                                  char *card, int card_bytes);
+int  scard_send_end_transaction(void *user_data,
+                                char *context, int context_bytes,
+                                char *card, int card_bytes,
+                                tui32 dwDisposition);
+int  scard_send_status(void *user_data, int wide,
+                       char *context, int context_bytes,
+                       char *card, int card_bytes,
+                       int cchReaderLen, int cbAtrLen);
+int  scard_send_disconnect(void *user_data,
+                           char *context, int context_bytes,
+                           char *card, int card_bytes,
+                           int dwDisposition);
+
+int  scard_send_transmit(void *user_data,
+                         char *context, int context_bytes,
+                         char *card, int card_bytes,
+                         char *send_data, int send_bytes, int recv_bytes,
+                         struct xrdp_scard_io_request *send_ior,
+                         struct xrdp_scard_io_request *recv_ior);
+
+int  scard_send_control(void *user_data,
+                        char *context, int context_bytes,
+                        char *card, int card_bytes,
+                        char *send_data, int send_bytes,
+                        int recv_bytes, int control_code);
+
+int  scard_send_cancel(void *user_data,
+                       char *context, int context_bytes);
+
+int  scard_send_get_attrib(void *user_data, char *card, int card_bytes,
+                           READER_STATE *rs);
+
+/*
+ * Notes:
+ *      SCardTransmit - partially done
+ *      SCardControl - partially done
+ *      SCardListReaderGroups - not supported
+ *      SCardSetAttrib - not supported
+ */
+#endif /* end #ifndef SMARTCARD_INTERNAL_H */

--- a/sesman/chansrv/smartcard_pcsc.c
+++ b/sesman/chansrv/smartcard_pcsc.c
@@ -44,7 +44,7 @@
 
 #include "os_calls.h"
 #include "string_calls.h"
-#include "smartcard.h"
+#include "smartcard_internal.h"
 #include "log.h"
 #include "irp.h"
 #include "devredir.h"


### PR DESCRIPTION
The smartcard code is unfinished, and should not be employed in production due to the possibility that it may introduce security risks.

Rather than removing it, the code has been placed behind an --enable-smartcard switch. This allows developers to carry on working on the code, while removing any risk from production code.

The code continues to be build as part of CI, and any problems found by static analysis tools will be addressed.

Backport of #3758 