### PR TITLE
interactive pam conv

### DIFF
--- a/libipm/scp.c
+++ b/libipm/scp.c
@@ -922,3 +922,45 @@ scp_send_close_connection_request(struct trans *trans)
                (int)E_SCP_CLOSE_CONNECTION_REQUEST,
                NULL);
 }
+
+/*****************************************************************************/
+
+int
+scp_send_prompt_request(struct trans *trans, const char *prompt,
+                        enum scp_prompt_type prompt_type)
+{
+    return libipm_msg_out_simple_send(
+               trans,
+               (int)E_SCP_PROMPT_REQUEST,
+               "si", prompt, prompt_type);
+}
+
+/*****************************************************************************/
+
+int
+scp_get_prompt_request(struct trans *trans, char **prompt,
+                       enum scp_prompt_type *prompt_type)
+{
+    int rv = libipm_msg_in_parse(trans, "si", prompt, prompt_type);
+    return rv;
+}
+
+/*****************************************************************************/
+
+int
+scp_send_prompt_response(struct trans *trans, const char *response)
+{
+    return libipm_msg_out_simple_send(
+               trans,
+               (int)E_SCP_PROMPT_RESPONSE,
+               "s", response);
+}
+
+/*****************************************************************************/
+
+int
+scp_get_prompt_response(struct trans *trans, char **response)
+{
+    int rv = libipm_msg_in_parse(trans, "s", response);
+    return rv;
+}

--- a/libipm/scp.h
+++ b/libipm/scp.h
@@ -65,8 +65,21 @@ enum scp_msg_code
     E_SCP_CREATE_SOCKDIR_REQUEST,
     E_SCP_CREATE_SOCKDIR_RESPONSE,
 
-    E_SCP_CLOSE_CONNECTION_REQUEST
-    // No E_SCP_CLOSE_CONNECTION_RESPONSE
+    E_SCP_CLOSE_CONNECTION_REQUEST,
+    // No E_SCP_CLOSE_CONNECTION_RESPONSE,
+
+    E_SCP_PROMPT_REQUEST,
+    E_SCP_PROMPT_RESPONSE,
+
+    E_SCP_END
+};
+
+enum scp_prompt_type
+{
+    SCP_PROMPT_ECHO_OFF = 1,
+    SCP_PROMPT_ECHO_ON,
+    SCP_PROMPT_ERROR_MSG,
+    SCP_PROMPT_TEXT_INFO
 };
 
 /* Common facilities */
@@ -586,5 +599,17 @@ scp_get_create_sockdir_response(struct trans *trans,
 int
 scp_send_close_connection_request(struct trans *trans);
 
+int
+scp_send_prompt_request(struct trans *trans, const char *prompt,
+                        enum scp_prompt_type prompt_type);
+
+int
+scp_get_prompt_request(struct trans *trans, char **prompt,
+                       enum scp_prompt_type *prompt_type);
+int
+scp_send_prompt_response(struct trans *trans, const char *response);
+
+int
+scp_get_prompt_response(struct trans *trans, char **response);
 
 #endif /* SCP_H */

--- a/sesman/libsesman/sesman_auth.h
+++ b/sesman/libsesman/sesman_auth.h
@@ -31,7 +31,9 @@
  * Opaque type used to represent an authentication handle
  */
 struct auth_info;
+
 #include "scp_application_types.h"
+#include "trans.h"
 
 /**
  *
@@ -45,7 +47,8 @@ struct auth_info;
  */
 struct auth_info *
 auth_userpass(const char *user, const char *pass,
-              const char *client_ip, enum scp_login_status *errorcode);
+              const char *client_ip, enum scp_login_status *errorcode,
+              struct trans *scp_trans);
 
 /**
  *

--- a/sesman/libsesman/verify_user.c
+++ b/sesman/libsesman/verify_user.c
@@ -63,7 +63,8 @@ struct auth_info
 /* returns non-NULL for success */
 struct auth_info *
 auth_userpass(const char *user, const char *pass,
-              const char *client_ip, enum scp_login_status *errorcode)
+              const char *client_ip, enum scp_login_status *errorcode,
+              struct trans *scp_trans)
 {
     const char *encr = NULL;
     struct passwd *spw;

--- a/sesman/libsesman/verify_user_bsd.c
+++ b/sesman/libsesman/verify_user_bsd.c
@@ -69,7 +69,8 @@ struct auth_info
 /* returns non-NULL for success */
 struct auth_info *
 auth_userpass(const char *const_user, const char *const_pass,
-              const char *client_ip, enum scp_login_status *errorcode)
+              const char *client_ip, enum scp_login_status *errorcode,
+              struct trans *scp_trans)
 {
     /* Need a non-NULL pointer to return to indicate success */
     static struct auth_info success = {0};

--- a/sesman/libsesman/verify_user_pam.c
+++ b/sesman/libsesman/verify_user_pam.c
@@ -33,14 +33,16 @@
 #include "log.h"
 #include "string_calls.h"
 #include "sesman_auth.h"
+#include "scp.h"
 
-#include <stdio.h>
 #include <security/pam_appl.h>
 
 /* Allows the conversation function to find required items */
 struct conv_func_data
 {
     const char *pass;
+    struct trans *scp_trans;
+    int pass_used;
 };
 
 struct auth_info
@@ -89,6 +91,177 @@ msg_style_to_str(int msg_style, char *buff, unsigned int bufflen)
     return result;
 }
 
+/****************************************************************************/
+
+static int
+conv_echo_off(struct conv_func_data *cf_data, const struct pam_message *msg,
+              struct pam_response *reply)
+{
+    int error;
+    int rv = PAM_CONV_ERR;
+    enum scp_msg_code code;
+    char *response;
+    enum scp_prompt_type prompt_type = SCP_PROMPT_ECHO_OFF;
+
+    LOG(LOG_LEVEL_INFO, "PAM_PROMPT_ECHO_OFF");
+    LOG_DEVEL(LOG_LEVEL_INFO, "PAM_PROMPT_ECHO_OFF %s", msg->msg);
+    if ((cf_data != NULL) && (cf_data->pass != NULL) &&
+            (cf_data->pass[0] != 0) && (cf_data->pass_used == 0))
+    {
+        /* use password if available */
+        reply->resp = g_strdup(cf_data->pass);
+        /* only use password once */
+        cf_data->pass_used = 1;
+        rv = PAM_SUCCESS;
+    }
+    else if ((cf_data != NULL) && (cf_data->scp_trans != NULL))
+    {
+        error = scp_send_prompt_request(cf_data->scp_trans, msg->msg,
+                                        prompt_type);
+        LOG_DEVEL(LOG_LEVEL_INFO, "scp_send_prompt_request %d", error);
+        if (error == 0)
+        {
+            error = scp_msg_in_wait_available(cf_data->scp_trans);
+            LOG_DEVEL(LOG_LEVEL_INFO, "scp_msg_in_wait_available %d", error);
+            code = scp_msg_in_get_msgno(cf_data->scp_trans);
+            if (code == E_SCP_PROMPT_RESPONSE)
+            {
+                error = scp_get_prompt_response(cf_data->scp_trans,
+                                                &response);
+                LOG_DEVEL(LOG_LEVEL_INFO, "scp_get_prompt_response rv %d "
+                          "response [%s]", error, response);
+                if (error == 0)
+                {
+                    reply->resp = g_strdup(response);
+                    rv = PAM_SUCCESS;
+                }
+                else
+                {
+                    LOG(LOG_LEVEL_ERROR, "scp_get_prompt_response failed %d",
+                        error);
+                }
+            }
+            else
+            {
+                LOG(LOG_LEVEL_ERROR, "scp_msg_in_get_msgno returned "
+                    "unexpected code %d expected E_SCP_PROMPT_RESPONSE",
+                    code);
+            }
+            scp_msg_in_reset(cf_data->scp_trans);
+        }
+        else
+        {
+            LOG(LOG_LEVEL_ERROR, "scp_send_prompt_request failed %d", error);
+        }
+    }
+    return rv;
+}
+
+/****************************************************************************/
+
+static int
+conv_echo_on(struct conv_func_data *cf_data, const struct pam_message *msg,
+             struct pam_response *reply)
+{
+    int error;
+    int rv = PAM_CONV_ERR;
+    enum scp_msg_code code;
+    char *response;
+    enum scp_prompt_type prompt_type = SCP_PROMPT_ECHO_ON;
+
+    LOG(LOG_LEVEL_INFO, "PAM_PROMPT_ECHO_ON");
+    LOG_DEVEL(LOG_LEVEL_INFO, "PAM_PROMPT_ECHO_ON %s", msg->msg);
+    if ((cf_data != NULL) && (cf_data->scp_trans != NULL))
+    {
+        error = scp_send_prompt_request(cf_data->scp_trans, msg->msg,
+                                        prompt_type);
+        LOG_DEVEL(LOG_LEVEL_INFO, "scp_send_prompt_request %d", error);
+        if (error == 0)
+        {
+            error = scp_msg_in_wait_available(cf_data->scp_trans);
+            LOG_DEVEL(LOG_LEVEL_INFO, "scp_msg_in_wait_available %d", error);
+            code = scp_msg_in_get_msgno(cf_data->scp_trans);
+            if (code == E_SCP_PROMPT_RESPONSE)
+            {
+                error = scp_get_prompt_response(cf_data->scp_trans,
+                                                &response);
+                LOG_DEVEL(LOG_LEVEL_INFO, "scp_get_prompt_response rv %d "
+                          "response [%s]", error, response);
+                if (error == 0)
+                {
+                    reply->resp = strdup(response);
+                    rv = PAM_SUCCESS;
+                }
+                else
+                {
+                    LOG(LOG_LEVEL_ERROR, "scp_get_prompt_response failed %d",
+                        error);
+                }
+            }
+            else
+            {
+                LOG(LOG_LEVEL_ERROR, "scp_msg_in_get_msgno returned "
+                    "unexpected code %d expected E_SCP_PROMPT_RESPONSE",
+                    code);
+            }
+            scp_msg_in_reset(cf_data->scp_trans);
+        }
+        else
+        {
+            LOG(LOG_LEVEL_ERROR, "scp_send_prompt_request failed %d", error);
+        }
+    }
+    return rv;
+}
+
+/****************************************************************************/
+
+static int
+conv_error_msg(struct conv_func_data *cf_data, const struct pam_message *msg,
+               struct pam_response *reply)
+{
+    int error;
+    enum scp_prompt_type prompt_type = SCP_PROMPT_ERROR_MSG;
+
+    LOG(LOG_LEVEL_INFO, "PAM_ERROR_MSG");
+    LOG_DEVEL(LOG_LEVEL_INFO, "PAM_ERROR_MSG %s", msg->msg);
+    if (cf_data != NULL && cf_data->scp_trans != NULL)
+    {
+        error = scp_send_prompt_request(cf_data->scp_trans, msg->msg,
+                                        prompt_type);
+        LOG_DEVEL(LOG_LEVEL_INFO, "scp_send_prompt_request %d", error);
+        if (error != 0)
+        {
+            LOG(LOG_LEVEL_ERROR, "scp_send_prompt_request failed %d", error);
+        }
+    }
+    return PAM_SUCCESS;
+}
+
+/****************************************************************************/
+
+static int
+conv_text_info(struct conv_func_data *cf_data, const struct pam_message *msg,
+               struct pam_response *reply)
+{
+    int error;
+    enum scp_prompt_type prompt_type = SCP_PROMPT_TEXT_INFO;
+
+    LOG(LOG_LEVEL_INFO, "PAM_TEXT_INFO");
+    LOG_DEVEL(LOG_LEVEL_INFO, "PAM_TEXT_INFO %s", msg->msg);
+    if (cf_data != NULL && cf_data->scp_trans != NULL)
+    {
+        error = scp_send_prompt_request(cf_data->scp_trans, msg->msg,
+                                        prompt_type);
+        LOG_DEVEL(LOG_LEVEL_INFO, "scp_send_prompt_request %d", error);
+        if (error != 0)
+        {
+            LOG(LOG_LEVEL_ERROR, "scp_send_prompt_request failed %d", error);
+        }
+    }
+    return PAM_SUCCESS;
+}
+
 /***************************************************************************//**
  * Provides the PAM conversation callback function
  *
@@ -123,6 +296,8 @@ verify_pam_conv(int num_msg, const struct pam_message **msg,
     char sb[64];
     int rv = PAM_SUCCESS;
 
+    conv_func_data = (struct conv_func_data *) appdata_ptr;
+
     if (num_msg <= 0 || num_msg > PAM_MAX_NUM_MSG)
     {
         rv = PAM_CONV_ERR;
@@ -136,34 +311,26 @@ verify_pam_conv(int num_msg, const struct pam_message **msg,
         for (i = 0; i < num_msg && rv == PAM_SUCCESS; i++)
         {
             LOG_DEVEL(LOG_LEVEL_INFO, "Handling struct pam_message"
-                      " { style = %s, msg = \"%s\" }",
+                      " { style = %s, msg = \"%s\" } pid %d",
                       msg_style_to_str(msg[i]->msg_style, sb, sizeof (sb)),
-                      msg[i]->msg == NULL ? "<null>" : msg[i]->msg);
+                      msg[i]->msg == NULL ? "<null>" : msg[i]->msg, g_getpid());
 
             switch (msg[i]->msg_style)
             {
                 case PAM_PROMPT_ECHO_OFF: /* password */
-                    conv_func_data = (struct conv_func_data *) appdata_ptr;
-                    /* Check this function isn't being called
-                     * later than we expected */
-                    if (conv_func_data == NULL || conv_func_data->pass == NULL)
-                    {
-                        LOG(LOG_LEVEL_ERROR,
-                            "verify_pam_conv: Password unavailable");
-                        reply[i].resp = g_strdup("????");
-                    }
-                    else
-                    {
-                        reply[i].resp = g_strdup(conv_func_data->pass);
-                    }
+                    rv = conv_echo_off(conv_func_data, msg[i], reply + i);
+                    break;
+
+                case PAM_PROMPT_ECHO_ON:
+                    rv = conv_echo_on(conv_func_data, msg[i], reply + i);
                     break;
 
                 case PAM_ERROR_MSG:
-                    LOG(LOG_LEVEL_ERROR, "PAM: %s", msg[i]->msg);
+                    rv = conv_error_msg(conv_func_data, msg[i], reply + i);
                     break;
 
                 case PAM_TEXT_INFO:
-                    LOG(LOG_LEVEL_INFO, "PAM: %s", msg[i]->msg);
+                    rv = conv_text_info(conv_func_data, msg[i], reply + i);
                     break;
 
                 default:
@@ -242,7 +409,8 @@ common_pam_login(struct auth_info *auth_info,
                  const char *user,
                  const char *pass,
                  const char *client_ip,
-                 int authentication_required)
+                 int authentication_required,
+                 struct trans *scp_trans)
 {
     int perror;
     char service_name[256];
@@ -254,6 +422,8 @@ common_pam_login(struct auth_info *auth_info,
      * structure which allows us to pass this to pam_start()
      */
     conv_func_data.pass = (authentication_required) ? pass : NULL;
+    conv_func_data.scp_trans = scp_trans;
+    conv_func_data.pass_used = 0;
     pamc.conv = verify_pam_conv;
     pamc.appdata_ptr = (void *) &conv_func_data;
 
@@ -304,8 +474,19 @@ common_pam_login(struct auth_info *auth_info,
        been authenticated.
      */
     perror = pam_acct_mgmt(auth_info->ph, 0);
-
-    if (perror != PAM_SUCCESS)
+    if (perror == PAM_NEW_AUTHTOK_REQD)
+    {
+        /* password has expired and needs to be changed */
+        perror = pam_chauthtok(auth_info->ph, PAM_CHANGE_EXPIRED_AUTHTOK);
+        if (perror != PAM_SUCCESS)
+        {
+            LOG(LOG_LEVEL_ERROR, "pam_chauthtok failed: %s",
+                pam_strerror(auth_info->ph, perror));
+            pam_end(auth_info->ph, perror);
+            return E_SCP_LOGIN_NOT_AUTHORIZED;
+        }
+    }
+    else if (perror != PAM_SUCCESS)
     {
         LOG(LOG_LEVEL_ERROR, "pam_acct_mgmt failed: %s",
             pam_strerror(auth_info->ph, perror));
@@ -333,7 +514,8 @@ common_pam_login(struct auth_info *auth_info,
 
 struct auth_info *
 auth_userpass(const char *user, const char *pass,
-              const char *client_ip, enum scp_login_status *errorcode)
+              const char *client_ip, enum scp_login_status *errorcode,
+              struct trans *scp_trans)
 {
     struct auth_info *auth_info;
     enum scp_login_status status;
@@ -345,7 +527,7 @@ auth_userpass(const char *user, const char *pass,
     }
     else
     {
-        status = common_pam_login(auth_info, user, pass, client_ip, 1);
+        status = common_pam_login(auth_info, user, pass, client_ip, 1, scp_trans);
 
         if (status != E_SCP_LOGIN_OK)
         {
@@ -377,7 +559,7 @@ auth_uds(const char *user, enum scp_login_status *errorcode)
     }
     else
     {
-        status = common_pam_login(auth_info, user, NULL, NULL, 0);
+        status = common_pam_login(auth_info, user, NULL, NULL, 0, NULL);
 
         if (status != E_SCP_LOGIN_OK)
         {

--- a/sesman/sesexec/login_info.c
+++ b/sesman/sesexec/login_info.c
@@ -84,11 +84,13 @@ log_authfail_message(const char *username, const char *ip_addr)
  *
  * @post If E_SCP_LOGIN_OK is returned, g_login_info is filled in
  */
+#if 0
 static enum scp_login_status
-authenticate_and_authorize_connection(const char *supplied_username,
-                                      const char *password,
-                                      const char *ip_addr,
-                                      struct login_info *login_info)
+authenticate_and_authorize_connection1(const char *supplied_username,
+                                       const char *password,
+                                       const char *ip_addr,
+                                       struct login_info *login_info,
+                                       struct trans *scp_trans)
 {
     int uid;
     char *username; // From reverse-looking up the UID
@@ -133,7 +135,7 @@ authenticate_and_authorize_connection(const char *supplied_username,
                 username, uid);
         }
 
-        auth_info = auth_userpass(username, password, ip_addr, &status);
+        auth_info = auth_userpass(username, password, ip_addr, &status, scp_trans);
 
         /* Sanity check on result of call */
         if ((auth_info != NULL && status != E_SCP_LOGIN_OK) ||
@@ -205,6 +207,121 @@ authenticate_and_authorize_connection(const char *supplied_username,
             g_sleep(FAILED_LOGIN_CONSTANT_TIME - elapsed_ms);
         }
     }
+    return status;
+}
+#endif
+
+static enum scp_login_status
+authenticate_and_authorize_connection(const char *supplied_username,
+                                      const char *password,
+                                      const char *ip_addr,
+                                      struct login_info *login_info,
+                                      struct trans *scp_trans)
+{
+    int uid;
+    char *username = NULL; // From reverse-looking up the UID
+    enum scp_login_status status;
+    struct auth_info *auth_info;
+
+    status = E_SCP_LOGIN_NOT_AUTHENTICATED;
+    auth_info = auth_userpass(supplied_username, password, ip_addr, &status, scp_trans);
+
+    /* Sanity check on result of call */
+    if ((auth_info != NULL && status != E_SCP_LOGIN_OK) ||
+            (auth_info == NULL && status == E_SCP_LOGIN_OK))
+    {
+        LOG(LOG_LEVEL_ERROR, "Bugcheck; inconsistent auth result. "
+            "info = %p, status = %d", (void *)auth_info, (int)status);
+        status = E_SCP_LOGIN_GENERAL_ERROR;
+        auth_end(auth_info);
+        auth_info = NULL;
+    }
+
+    if (g_getuser_info_by_name(supplied_username,
+                               &uid, NULL, NULL, NULL, NULL) != 0)
+    {
+        /* we can't get a UID for the user */
+        LOG(LOG_LEVEL_ERROR, "Can't get UID for user %s",
+            supplied_username);
+        log_authfail_message(supplied_username, ip_addr);
+        status = E_SCP_LOGIN_NOT_AUTHENTICATED;
+        auth_end(auth_info);
+        auth_info = NULL;
+    }
+    else if (g_getuser_info_by_uid(uid,
+                                   &username,
+                                   NULL, NULL, NULL, NULL) != 0)
+    {
+        LOG(LOG_LEVEL_ERROR, "Can't reverse lookup UID %d", uid);
+        status = E_SCP_LOGIN_NOT_AUTHENTICATED;
+        auth_end(auth_info);
+        auth_info = NULL;
+    }
+    else
+    {
+        if (g_strcmp(username, supplied_username) != 0)
+        {
+            /*
+             * If using a federated naming service (e.g. AD), the username
+             * supplied may not match that name mapped to by the UID. We
+             * will generate a warning in this instance so the user can see
+             * what is being used
+             */
+            LOG(LOG_LEVEL_WARNING,
+                "Using username %s for the session (from UID %d)",
+                username, uid);
+        }
+    }
+
+    /* Group access allowed? */
+    if (status == E_SCP_LOGIN_OK &&
+            !access_login_allowed(&g_cfg->sec, username))
+    {
+        LOG(LOG_LEVEL_INFO, "Username okay but group problem for "
+            "user: %s", username);
+        status = E_SCP_LOGIN_NOT_AUTHORIZED;
+        auth_end(auth_info);
+        auth_info = NULL;
+    }
+
+    switch (status)
+    {
+        case E_SCP_LOGIN_OK:
+        {
+            char *dup_username = g_strdup(username);
+            char *dup_ip_addr = g_strdup(ip_addr);
+
+            if (dup_username == NULL || dup_ip_addr == NULL)
+            {
+                LOG(LOG_LEVEL_ERROR, "%s : Memory allocation failed",
+                    __func__);
+                g_free(dup_username);
+                g_free(dup_ip_addr);
+                status = E_SCP_LOGIN_NO_MEMORY;
+                auth_end(auth_info);
+                auth_info = NULL;
+            }
+            else
+            {
+                LOG(LOG_LEVEL_INFO, "Access permitted for user: %s",
+                    username);
+                login_info->uid = uid;
+                login_info->username = dup_username;
+                login_info->ip_addr = dup_ip_addr;
+                login_info->auth_info = auth_info;
+            }
+        }
+        break;
+
+        case E_SCP_LOGIN_NOT_AUTHENTICATED:
+            log_authfail_message(username, ip_addr);
+            break;
+
+        default:
+            break;
+    }
+
+    g_free(username);
     return status;
 }
 
@@ -292,7 +409,8 @@ login_info_sys_login_user(struct trans *scp_trans,
             status = authenticate_and_authorize_connection(username,
                      password,
                      ip_addr,
-                     result);
+                     result,
+                     scp_trans);
 
             if (status != E_SCP_LOGIN_OK)
             {

--- a/sesman/tools/authtest.c
+++ b/sesman/tools/authtest.c
@@ -293,7 +293,7 @@ main(int argc, char **argv)
         else
         {
             auth_info = auth_userpass(amp.username, amp.password,
-                                      NULL, &errorcode);
+                                      NULL, &errorcode, NULL);
         }
         scp_login_status_to_str(errorcode, errstr, sizeof(errstr));
         LOG(LOG_LEVEL_INFO,

--- a/tests/xrdp/Makefile.am
+++ b/tests/xrdp/Makefile.am
@@ -73,6 +73,7 @@ test_xrdp_LDADD = \
     $(top_builddir)/xrdp/xrdp_encoder.o \
     $(top_builddir)/xrdp/xrdp_process.o \
     $(top_builddir)/xrdp/xrdp_login_wnd.o \
+    $(top_builddir)/xrdp/xrdp_prompt.o \
     $(top_builddir)/xrdp/xrdp_tconfig.o \
     $(top_builddir)/xrdp/xrdp_main_utils.o \
     $(top_builddir)/libpainter/src/libpainter.la \

--- a/xrdp/Makefile.am
+++ b/xrdp/Makefile.am
@@ -70,6 +70,7 @@ xrdp_SOURCES = \
   xrdp_font.c \
   xrdp_listen.c \
   xrdp_login_wnd.c \
+  xrdp_prompt.c \
   xrdp_mm.c \
   xrdp_mm_ccp.c \
   xrdp_mm.h \

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -580,4 +580,10 @@ xrdp_mm_egfx_send_planar_bitmap(struct xrdp_mm *self,
 int
 xrdp_mm_ccp_data_in(struct trans *trans);
 
+int
+xrdp_prompt_create(struct xrdp_bitmap *wnd, struct xrdp_bitmap **prompt_wnd);
+int
+xrdp_prompt_add_prompt(struct xrdp_bitmap *prompt_wnd, const char *prompt,
+                       int hide_chars);
+
 #endif

--- a/xrdp/xrdp_bitmap_common.c
+++ b/xrdp/xrdp_bitmap_common.c
@@ -227,6 +227,11 @@ xrdp_bitmap_delete(struct xrdp_bitmap *self)
         {
             self->wm->log_wnd = 0;
         }
+
+        if (self->wm->prompt_wnd == self)
+        {
+            self->wm->prompt_wnd = NULL;
+        }
     }
 
     if (self->child_list != 0)

--- a/xrdp/xrdp_login_wnd.c
+++ b/xrdp/xrdp_login_wnd.c
@@ -1110,6 +1110,8 @@ load_xrdp_config(struct xrdp_config *config, const char *xrdp_ini, int bpp)
         DEFAULT_FONT_PIXEL_SIZE + DEFAULT_COMBO_MARGIN_H;
     globals->ls_unscaled.help_wnd_width = DEFAULT_WND_HELP_W;
     globals->ls_unscaled.help_wnd_height = DEFAULT_WND_HELP_H;
+    globals->ls_unscaled.prompt_wnd_width = DEFAULT_WND_PROMPT_W;
+    globals->ls_unscaled.prompt_wnd_height = DEFAULT_WND_PROMPT_H;
 
     /* open xrdp.ini file */
     if ((fd = g_file_open_ro(xrdp_ini)) < 0)
@@ -1573,6 +1575,8 @@ xrdp_login_wnd_scale_config_values(struct xrdp_wm *self)
         scaled->combo_height = fheight + DEFAULT_COMBO_MARGIN_H;
         scaled->help_wnd_width = SCALE_AND_ROUND(unscaled->help_wnd_width);
         scaled->help_wnd_height = SCALE_AND_ROUND(unscaled->help_wnd_height);
+        scaled->prompt_wnd_width = SCALE_AND_ROUND(unscaled->prompt_wnd_width);
+        scaled->prompt_wnd_height = SCALE_AND_ROUND(unscaled->prompt_wnd_height);
 #undef SCALE_AND_ROUND
     }
 }

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -2859,6 +2859,35 @@ xrdp_mm_process_connect_session_response(struct xrdp_mm *self)
 }
 
 /*****************************************************************************/
+static int
+xrdp_mm_process_prompt_request(struct xrdp_mm *self)
+{
+    char *prompt;
+    enum scp_prompt_type prompt_type;
+    int error;
+
+    LOG(LOG_LEVEL_INFO, "xrdp_mm_process_prompt_request");
+    error = scp_get_prompt_request(self->sesman_trans,
+                                   &prompt, &prompt_type);
+    LOG(LOG_LEVEL_INFO, "scp_get_prompt_request rv %d prompt [%s] "
+        "prompt_type [%d]", error, prompt, prompt_type);
+    if (error == 0)
+    {
+        if (self->wm->prompt_wnd == NULL)
+        {
+            xrdp_prompt_create(self->wm->screen, &self->wm->prompt_wnd);
+        }
+        if (self->wm->prompt_wnd != NULL)
+        {
+            xrdp_prompt_add_prompt(self->wm->prompt_wnd, prompt,
+                                   prompt_type == SCP_PROMPT_ECHO_OFF);
+        }
+    }
+
+    return 0;
+}
+
+/*****************************************************************************/
 /* This is the callback registered for sesman communication replies over SCP */
 static int
 xrdp_mm_scp_data_in(struct trans *trans)
@@ -2884,6 +2913,10 @@ xrdp_mm_scp_data_in(struct trans *trans)
 
             case E_SCP_CONNECT_SESSION_RESPONSE:
                 rv = xrdp_mm_process_connect_session_response(self);
+                break;
+
+            case E_SCP_PROMPT_REQUEST:
+                rv = xrdp_mm_process_prompt_request(self);
                 break;
 
             default:

--- a/xrdp/xrdp_prompt.c
+++ b/xrdp/xrdp_prompt.c
@@ -1,0 +1,379 @@
+
+/**
+ * xrdp: A Remote Desktop Protocol server.
+ *
+ * Copyright (C) Jay Sorg 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * prompt dialog
+ */
+
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
+#include "xrdp.h"
+#include "string_calls.h"
+#include "scp.h"
+
+#define PROMPT_OK_BUT_ID    1
+#define PROMPT_CAN_BUT_ID   2
+#define PROMPT_EDIT_ID      3
+#define PROMPT_NUM_LABELS   10
+/* id 4 to 13 are the labels for text */
+#define PROMPT_LABEL0_ID     4
+#define PROMPT_LABEL1_ID     5
+#define PROMPT_LABEL2_ID     6
+#define PROMPT_LABEL3_ID     7
+#define PROMPT_LABEL4_ID     8
+#define PROMPT_LABEL5_ID     9
+#define PROMPT_LABEL6_ID     10
+#define PROMPT_LABEL7_ID     11
+#define PROMPT_LABEL8_ID     12
+#define PROMPT_LABEL9_ID     13
+
+/*****************************************************************************/
+static int
+xrdp_wm_prompt_notify(struct xrdp_bitmap *wnd,
+                      struct xrdp_bitmap *sender,
+                      int msg, long param1, long param2)
+{
+    struct trans *sesman_trans;
+    int error;
+    struct xrdp_bitmap *edit;
+
+    LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_wm_prompt_notify:");
+
+    if ((sender == NULL) || (wnd == NULL) || (wnd->owner == NULL))
+    {
+        return 0;
+    }
+
+    if (msg == 1) /* click */
+    {
+        if (sender->id == PROMPT_OK_BUT_ID) /* ok button */
+        {
+            sesman_trans = wnd->wm->mm->sesman_trans;
+            if (sesman_trans != NULL)
+            {
+                edit = xrdp_bitmap_get_child_by_id(wnd->wm->prompt_wnd,
+                                                   PROMPT_EDIT_ID);
+                if (edit != NULL)
+                {
+                    error = scp_send_prompt_response(sesman_trans,
+                                                     edit->caption1);
+                    LOG(LOG_LEVEL_INFO, "scp_send_prompt_response rv %d",
+                        error);
+                    g_memset(edit->caption1, 0, 256);
+                    edit->edit_pos = 0;
+                }
+            }
+        }
+    }
+
+    return 0;
+}
+
+/*****************************************************************************/
+int
+xrdp_prompt_create(struct xrdp_bitmap *wnd, struct xrdp_bitmap **aprompt_wnd)
+{
+    const char *ok_string = "OK";
+    const char *can_string = "Cancel";
+    int but_width;
+    int but_height;
+    int edit_width;
+    int edit_height;
+    int index;
+    int margin_size;
+    int wnd_width;
+    int wnd_height;
+    struct xrdp_painter *p;
+    struct xrdp_bitmap *line_wnd;
+
+    struct xrdp_bitmap *prompt_wnd;
+    struct xrdp_bitmap *edit;
+    struct xrdp_bitmap *can_but;
+    struct xrdp_bitmap *ok_but;
+
+    LOG(LOG_LEVEL_INFO, "xrdp_prompt_create:");
+
+    margin_size = 15;
+    wnd_width =  wnd->wm->xrdp_config->cfg_globals.ls_scaled.prompt_wnd_width;
+    wnd_height = wnd->wm->xrdp_config->cfg_globals.ls_scaled.prompt_wnd_height;
+
+    prompt_wnd = xrdp_bitmap_create(wnd_width, wnd_height,
+                                    wnd->wm->screen->bpp,
+                                    WND_TYPE_WND, wnd->wm);
+    list_insert_item(wnd->wm->screen->child_list, 0, (long)prompt_wnd);
+
+    prompt_wnd->parent = wnd->wm->screen;
+    prompt_wnd->owner = wnd;
+    wnd->modal_dialog = prompt_wnd;
+    prompt_wnd->bg_color = wnd->wm->grey;
+    prompt_wnd->left = wnd->wm->screen->width / 2 - prompt_wnd->width / 2;
+    prompt_wnd->top = wnd->wm->screen->height / 2 - prompt_wnd->height / 2;
+    prompt_wnd->notify = xrdp_wm_prompt_notify;
+    set_string(&prompt_wnd->caption1, "Prompt");
+
+    but_height = wnd->wm->xrdp_config->cfg_globals.ls_scaled.default_btn_height;
+    p = xrdp_painter_create(wnd->wm, wnd->wm->session);
+    xrdp_painter_font_needed(p);
+
+    edit_width = prompt_wnd->width - margin_size * 2;
+    edit_height = wnd->wm->xrdp_config->cfg_globals.ls_scaled.edit_height;
+
+    /* response edit */
+    edit = xrdp_bitmap_create(edit_width, edit_height, wnd->wm->screen->bpp,
+                              WND_TYPE_EDIT, wnd->wm);
+    list_insert_item(prompt_wnd->child_list, 0, (intptr_t)edit);
+    edit->parent = prompt_wnd;
+    edit->owner = prompt_wnd;
+    edit->left = margin_size;
+    edit->top = prompt_wnd->height - but_height - edit_height -
+                margin_size * 2;
+    edit->id = PROMPT_EDIT_ID;
+    edit->tab_stop = 1;
+    edit->pointer = 1; /* I beam */
+    edit->caption1 = (char *)g_malloc(256, 1);
+
+    /* cancel button */
+    but_width = xrdp_painter_text_width(p, can_string) + DEFAULT_BUTTON_MARGIN_W;
+    can_but = xrdp_bitmap_create(but_width, but_height, wnd->wm->screen->bpp,
+                                 WND_TYPE_BUTTON, wnd->wm);
+    list_insert_item(prompt_wnd->child_list, 0, (intptr_t)can_but);
+    can_but->parent = prompt_wnd;
+    can_but->owner = prompt_wnd;
+    can_but->left = prompt_wnd->width - but_width - margin_size;
+    can_but->top = prompt_wnd->height - but_height - margin_size;
+    can_but->id = PROMPT_CAN_BUT_ID;
+    can_but->tab_stop = 1;
+    set_string(&can_but->caption1, can_string);
+
+    /* ok button */
+    but_width = xrdp_painter_text_width(p, ok_string) + DEFAULT_BUTTON_MARGIN_W;
+    ok_but = xrdp_bitmap_create(but_width, but_height, wnd->wm->screen->bpp,
+                                WND_TYPE_BUTTON, wnd->wm);
+    list_insert_item(prompt_wnd->child_list, 0, (intptr_t)ok_but);
+    ok_but->parent = prompt_wnd;
+    ok_but->owner = prompt_wnd;
+    ok_but->left = can_but->left - but_width - margin_size;
+    ok_but->top = prompt_wnd->height - but_height - margin_size;
+    ok_but->id = PROMPT_OK_BUT_ID;
+    ok_but->tab_stop = 1;
+    set_string(&ok_but->caption1, ok_string);
+
+    for (index = 0; index < PROMPT_NUM_LABELS; index++)
+    {
+        line_wnd = xrdp_bitmap_create(edit_width, edit_height,
+                                      wnd->wm->screen->bpp,
+                                      WND_TYPE_LABEL, wnd->wm);
+        list_insert_item(prompt_wnd->child_list, 0, (intptr_t) line_wnd);
+        line_wnd->parent = prompt_wnd;
+        line_wnd->owner = prompt_wnd;
+        line_wnd->left = margin_size;
+        line_wnd->top = edit->top - edit_height;
+        line_wnd->top -= edit_height * index;
+        line_wnd->id = PROMPT_LABEL0_ID + index;
+    }
+
+    xrdp_painter_delete(p);
+
+    prompt_wnd->default_button = ok_but;
+    prompt_wnd->focused_control = edit;
+
+    xrdp_bitmap_invalidate(prompt_wnd, 0);
+    xrdp_wm_set_focused(wnd->wm, prompt_wnd);
+
+    *aprompt_wnd = prompt_wnd;
+
+    return 0;
+}
+
+/*****************************************************************************/
+static int
+xrdp_prompt_add_prompt_scroll(struct xrdp_bitmap *prompt_wnd,
+                              const char *line_text)
+{
+    struct xrdp_bitmap *line_wnd;
+    struct xrdp_bitmap *line_wnd1;
+    int index;
+
+    LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_prompt_add_prompt2: line_text [%s]",
+              line_text);
+    line_wnd1 = NULL;
+    if ((line_text != NULL) && (line_text[0] != 0))
+    {
+        for (index = 0; index < PROMPT_NUM_LABELS - 1; index++)
+        {
+            line_wnd = xrdp_bitmap_get_child_by_id(prompt_wnd,
+                                                   PROMPT_LABEL9_ID - index);
+            line_wnd1 = xrdp_bitmap_get_child_by_id(prompt_wnd,
+                                                    PROMPT_LABEL8_ID - index);
+            LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_prompt_add_prompt2: "
+                      "line_wnd %p line_wnd1 %p", line_wnd, line_wnd1);
+            if ((line_wnd != NULL) && (line_wnd1 != NULL))
+            {
+                set_string(&line_wnd->caption1, line_wnd1->caption1);
+            }
+        }
+        line_wnd = xrdp_bitmap_get_child_by_id(prompt_wnd, PROMPT_LABEL0_ID);
+        if (line_wnd != NULL)
+        {
+            set_string(&line_wnd->caption1, line_text);
+        }
+    }
+    return 0;
+}
+
+/*****************************************************************************/
+static int
+xrdp_prompt_add_prompt_wrap(struct xrdp_bitmap *prompt_wnd,
+                            const char *line_text,
+                            struct xrdp_painter *p)
+{
+    int text_width;
+    int label_width;
+    int dest_idx;
+    int save_dest_idx;
+    int save_count;
+    char line[256];
+    struct xrdp_bitmap *label_wnd;
+    const char *src;
+    char *dest;
+    char32_t ch;
+
+    LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_prompt_add_prompt1: line_text [%s]",
+              line_text);
+    if (line_text == NULL)
+    {
+        return 0;
+    }
+    if (line_text[0] == 0)
+    {
+        return 0;
+    }
+    label_wnd = xrdp_bitmap_get_child_by_id(prompt_wnd, PROMPT_LABEL0_ID);
+    if (label_wnd == NULL)
+    {
+        return 1;
+    }
+    label_width = label_wnd->width;
+    text_width = xrdp_painter_text_width(p, line_text);
+    if (text_width <= label_width)
+    {
+        return xrdp_prompt_add_prompt_scroll(prompt_wnd, line_text);
+    }
+    // have to wrap
+    dest_idx = 0;
+    save_dest_idx = -1;
+    dest = line;
+    src = line_text;
+    while (src[0] != 0)
+    {
+        ch = utf8_get_next_char(&src, NULL);
+        LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_prompt_add_prompt1: ch [%d] "
+                  "src [%s]", ch, src);
+        if (ch == ' ')
+        {
+            /* Record this as a potential break point */
+            save_dest_idx = dest_idx;
+        }
+        dest_idx += utf_char32_to_utf8(ch, dest + dest_idx);
+        dest[dest_idx] = 0;
+        LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_prompt_add_prompt1: dest_idx [%d] "
+                  "dest [%s]", dest_idx, dest);
+        if (dest_idx >= sizeof(line) - 6)
+        {
+            return 1;
+        }
+        /* check line width */
+        if (xrdp_painter_text_width(p, dest) > label_width)
+        {
+            if (save_dest_idx == -1)
+            {
+                xrdp_prompt_add_prompt_scroll(prompt_wnd, dest);
+                dest[0] = 0;
+                dest_idx = 0;
+            }
+            else
+            {
+                ch = dest[save_dest_idx];
+                dest[save_dest_idx] = 0;
+                xrdp_prompt_add_prompt_scroll(prompt_wnd, dest);
+                dest[save_dest_idx] = ch;
+                /* save_dest_idx should always be < dest_idx */
+                save_dest_idx++; /* skip space */
+                save_count = dest_idx - save_dest_idx;
+                g_memmove(dest, dest + save_dest_idx, save_count);
+                dest_idx = save_count;
+                dest[dest_idx] = 0;
+                save_dest_idx = -1;
+            }
+        }
+    }
+    xrdp_prompt_add_prompt_scroll(prompt_wnd, dest);
+    return 0;
+}
+
+/*****************************************************************************/
+int
+xrdp_prompt_add_prompt(struct xrdp_bitmap *prompt_wnd, const char *prompt,
+                       int hide_chars)
+{
+    int index;
+    int jndex;
+    char line[256];
+    struct xrdp_painter *p;
+    struct xrdp_bitmap *wnd;
+    struct xrdp_bitmap *edit;
+
+    LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_prompt_add_prompt:");
+    LOG_DEVEL(LOG_LEVEL_INFO, "xrdp_prompt_add_prompt: prompt %s", prompt);
+
+    wnd = prompt_wnd;
+    p = xrdp_painter_create(wnd->wm, wnd->wm->session);
+    xrdp_painter_font_needed(p);
+
+    /* the prompt may contain many lines, here we seperate them out */
+    line[0] = 0;
+    index = 0;
+    jndex = 0;
+    while (prompt[jndex] != 0)
+    {
+        if (prompt[jndex] < 0x20)
+        {
+            xrdp_prompt_add_prompt_wrap(wnd, line, p);
+            line[0] = 0;
+            index = 0;
+            jndex++;
+            continue;
+        }
+        line[index] = prompt[jndex];
+        index = index < (sizeof(line) - 1) ? index + 1 : (sizeof(line) - 1);
+        line[index] = 0;
+        jndex++;
+    }
+    xrdp_prompt_add_prompt_wrap(wnd, line, p);
+    xrdp_painter_delete(p);
+
+    edit = xrdp_bitmap_get_child_by_id(wnd, PROMPT_EDIT_ID);
+    if (edit != 0)
+    {
+        edit->password_char = hide_chars ? '*' : 0;
+    }
+
+    xrdp_bitmap_invalidate(wnd, 0);
+    return 0;
+}

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -592,6 +592,7 @@ struct xrdp_wm
 
     struct xrdp_region *screen_dirty_region;
     unsigned int last_screen_draw_time;
+    struct xrdp_bitmap *prompt_wnd;
 };
 
 /* rdp process */
@@ -717,6 +718,8 @@ struct xrdp_bitmap
 #define DEFAULT_WND_HELP_H    300
 #define DEFAULT_WND_LOG_W     400
 #define DEFAULT_WND_LOG_H     400
+#define DEFAULT_WND_PROMPT_W  400
+#define DEFAULT_WND_PROMPT_H  340
 #define DEFAULT_WND_SPECIAL_H 100
 
 /* font */
@@ -798,6 +801,8 @@ struct xrdp_ls_dimensions
     int combo_height;         /* Height of a combo box */
     int help_wnd_width;        /* Width of login help window */
     int help_wnd_height;       /* Height of login help window */
+    int prompt_wnd_width;        /* Width of login help window */
+    int prompt_wnd_height;       /* Height of login help window */
 };
 
 struct xrdp_cfg_globals

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -2365,7 +2365,7 @@ xrdp_wm_show_log(struct xrdp_wm *self)
     uint32_t index;
     int primary_x_offset;
     int primary_y_offset;
-
+    struct xrdp_rect prompt_rect;
 
     if (self->hide_log_window)
     {
@@ -2373,6 +2373,16 @@ xrdp_wm_show_log(struct xrdp_wm *self)
         self->session->client_info->rdp_autologin = 0;
         xrdp_wm_set_login_state(self, WMLS_RESET); /* reset session */
         return 0;
+    }
+
+    g_memset(&prompt_rect, 0, sizeof(prompt_rect));
+    if (self->prompt_wnd != NULL)
+    {
+        prompt_rect.left = self->prompt_wnd->left;
+        prompt_rect.top = self->prompt_wnd->top;
+        prompt_rect.right = prompt_rect.left + self->prompt_wnd->width;
+        prompt_rect.bottom = prompt_rect.top + self->prompt_wnd->height;
+        xrdp_bitmap_delete(self->prompt_wnd);
     }
 
     if (self->log_wnd == 0)
@@ -2446,6 +2456,12 @@ xrdp_wm_show_log(struct xrdp_wm *self)
 
     xrdp_wm_set_focused(self, self->log_wnd);
     xrdp_bitmap_invalidate(self->log_wnd, 0);
+
+    if ((prompt_rect.right > prompt_rect.left) &&
+            (prompt_rect.bottom > prompt_rect.top))
+    {
+        xrdp_bitmap_invalidate(self->screen, &prompt_rect);
+    }
 
     return 0;
 }


### PR DESCRIPTION
Add a prompt style dialog to the login screen.
When PAM_PROMPT_ECHO_ON or PAM_PROMPT_ECHO_OFF occur during the pam conversation, a question / answer message to sent from sesman to xrdp.  The question is displayed in the prompt dialog and a one line edit box is used for the answer.
When PAM_ERROR_MSG or PAM_TEXT_INFO occur during the pam conversation, text is sent from sesman to xrdp and displayed in the same dialog.