### PR TITLE
CI: Upgrade to latest github action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,7 +163,7 @@ jobs:
         run: |
           echo "CONF_FLAGS=$CONF_FLAGS_${{ matrix.arch }}_${{ matrix.feature_set }} ${{ matrix.CONF_FLAGS_EXTRA }}" >> $GITHUB_ENV
           echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH_${{ matrix.arch }}" >> $GITHUB_ENV
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: "Install Dependencies"
         # See https://github.com/actions/runner-images/issues/7192
         run: |
@@ -183,7 +183,7 @@ jobs:
         if: ${{ matrix.DISTCHECK }}
         run: make distcheck -j $(nproc)
       - name: "Artifact: test-suite.log distcheck"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always() && steps.dist_check.outcome == 'failure'
         with:
           name: test-suite-distcheck-${{ matrix.cc }}-${{ matrix.feature_set }}
@@ -204,9 +204,9 @@ jobs:
         id: os
         run: echo "image=$ImageOS" >>$GITHUB_OUTPUT
         shell: bash
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache cppcheck
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         env:
           cache-name: cache-cppcheck
         with:
@@ -233,9 +233,9 @@ jobs:
         id: os
         run: echo "image=$ImageOS" >>$GITHUB_OUTPUT
         shell: bash
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache astyle
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         env:
           cache-name: cache-astyle
         with:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -18,7 +18,7 @@ jobs:
                   --enable-x264 --enable-openh264
                   --with-imlib2 --with-freetype2 --enable-tests"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download Coverity build tool
         run: |

--- a/.github/workflows/release-tarball.yml
+++ b/.github/workflows/release-tarball.yml
@@ -17,7 +17,7 @@ jobs:
         run: echo "timestamp=$(date +'%Y%m%d-%H%M%S')" >> $GITHUB_ENV
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.tag }}
 
@@ -42,7 +42,7 @@ jobs:
           echo "tarball=$TARBALL" >> $GITHUB_ENV
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name:  ${{ github.event.repository.name }}-${{ github.event.inputs.tag }}-${{ env.timestamp }}
           path: "${{ env.tarball }}"


### PR DESCRIPTION
This has been prompted by the following deprecation messages:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/checkout@v4.