### PR TITLE
Add ScreenSleepTimeLimit for xorgxrdp sessions

### DIFF
--- a/docs/man/sesman.ini.5.in
+++ b/docs/man/sesman.ini.5.in
@@ -213,6 +213,13 @@ If set to \fI0\fR, idle sessions will never be disconnected by timeout.
 This works only with xorgxrdp sessions. Moreover, xorgxrdp must be v0.2.9 or later.
 
 .TP
+\fBScreenSleepTimeLimit\fR=\fI[number|off]\fR
+Sets the idle time limit (in seconds) before xorgxrdp pauses display updates.
+Use \fBoff\fR or \fI0\fR to disable this feature. Allowed numeric range is
+\fI0\fR to \fI86400\fR.
+Paused output resumes when user activity is detected.
+
+.TP
 \fBPolicy\fR=\fI[Default|Separate|{UBDI}]\fR
 Session allocation policy. Used to decide when to allocate a
 new session. Set to one of the following values:

--- a/sesman/libsesman/sesman_config.c
+++ b/sesman/libsesman/sesman_config.c
@@ -28,6 +28,9 @@
 #include <config_ac.h>
 #endif
 
+#include <errno.h>
+#include <limits.h>
+
 #include "arch.h"
 #include "sesman_config.h"
 #include "sesman_clip_restrict.h"
@@ -84,6 +87,8 @@
 #define SESMAN_CFG_SESS_X11DISPLAYOFFSET "X11DisplayOffset"
 #define SESMAN_CFG_SESS_MAX_DISPLAY  "MaxDisplayNumber"
 #define SESMAN_CFG_SESS_STARTUP_WAIT_TIME "StartupWaitTime"
+#define SESMAN_CFG_SESS_SCREEN_SLEEP_LIMIT "ScreenSleepTimeLimit"
+#define SESMAN_CFG_SESS_SCREEN_SLEEP_LIMIT_MAX (24 * 60 * 60)
 
 #define SESMAN_CFG_SESS_POLICY_S "Policy"
 #define SESMAN_CFG_SESS_POLICY_DFLT_S "Default"
@@ -138,6 +143,43 @@ parse_policy_string(const char *value)
     }
 
     return rv;
+}
+
+/***************************************************************************//**
+ * Parse ScreenSleepTimeLimit value in seconds.
+ */
+static int
+parse_screen_sleep_time_limit(const char *value, int *time_limit)
+{
+    char *endptr;
+    long parsed;
+
+    if (value == NULL || value[0] == '\0')
+    {
+        return 1;
+    }
+
+    if (0 == g_strcasecmp(value, "off"))
+    {
+        *time_limit = 0;
+        return 0;
+    }
+
+    errno = 0;
+    parsed = strtol(value, &endptr, 10);
+    if (errno != 0 || endptr == value || *endptr != '\0')
+    {
+        return 1;
+    }
+
+    if (parsed < 0 || parsed > SESMAN_CFG_SESS_SCREEN_SLEEP_LIMIT_MAX ||
+            parsed > INT_MAX)
+    {
+        return 1;
+    }
+
+    *time_limit = (int) parsed;
+    return 0;
 }
 
 /******************************************************************************/
@@ -444,6 +486,7 @@ config_read_sessions(int file, struct config_sessions *se, struct list *param_n,
     se->kill_disconnected = 0;
     se->policy = SESMAN_CFG_SESS_POLICY_DEFAULT;
     se->startup_wait_time = 1500;
+    se->screen_sleep_time_limit = 0;
 
     file_read_section(file, SESMAN_CFG_SESSIONS, param_n, param_v);
 
@@ -510,6 +553,19 @@ config_read_sessions(int file, struct config_sessions *se, struct list *param_n,
             {
                 LOG(LOG_LEVEL_WARNING,
                     "Ignoring bad " SESMAN_CFG_SESS_STARTUP_WAIT_TIME " value");
+            }
+        }
+
+        else if (0 == g_strcasecmp(buf, SESMAN_CFG_SESS_SCREEN_SLEEP_LIMIT))
+        {
+            if (parse_screen_sleep_time_limit(value,
+                                              &se->screen_sleep_time_limit) != 0)
+            {
+                LOG(LOG_LEVEL_WARNING,
+                    "Ignoring bad " SESMAN_CFG_SESS_SCREEN_SLEEP_LIMIT
+                    " value '%s' (allowed: off or 0..%d seconds)",
+                    value,
+                    SESMAN_CFG_SESS_SCREEN_SLEEP_LIMIT_MAX);
             }
         }
     }
@@ -705,6 +761,8 @@ config_dump(struct config_sesman *config)
     g_writeln("    DisconnectedTimeLimit:    %d", se->max_disc_time);
     g_writeln("    Policy:                   %s", policy_s);
     g_writeln("    StartupWaitTime:          %u", se->startup_wait_time);
+    g_writeln("    ScreenSleepTimeLimit:     %d sec",
+              se->screen_sleep_time_limit);
 
     /* Security configuration */
     g_writeln("Security configuration:");

--- a/sesman/libsesman/sesman_config.h
+++ b/sesman/libsesman/sesman_config.h
@@ -179,6 +179,11 @@ struct config_sessions
      * @brief Wait time to make sure a session has started.
      */
     unsigned int startup_wait_time;
+    /**
+     * @var screen_sleep_time_limit
+     * @brief Screen sleep time limit.
+     */
+    int screen_sleep_time_limit;
 };
 
 /**

--- a/sesman/sesexec/session.c
+++ b/sesman/sesexec/session.c
@@ -394,6 +394,9 @@ prepare_xorg_xserver_params(const struct session_data *sd,
         g_snprintf(text, sizeof(text), "%d", g_cfg->sess.kill_disconnected);
         g_setenv_log("XRDP_SESMAN_KILL_DISCONNECTED", text, 1);
 
+        g_snprintf(text, sizeof(text), "%d", g_cfg->sess.screen_sleep_time_limit);
+        g_setenv_log("XRDP_SCREEN_SLEEP_TIME", text, 1);
+
         g_snprintf(text, sizeof(text), XRDP_X11RDP_BASE_STR, sd->display);
         g_setenv_log("XRDP_X11RDP_SOCKET", text, 1);
 

--- a/sesman/sesman.ini.in
+++ b/sesman/sesman.ini.in
@@ -111,6 +111,14 @@ DisconnectedTimeLimit=0
 ; Set to 0 to disable idle disconnection.
 IdleTimeLimit=0
 
+;; ScreenSleepTimeLimit (seconds) - stop screen updates for idle xorgxrdp
+; Type: integer or 'off'
+; Default: 0 (off)
+; Allowed values: off or 0..86400
+; When enabled, screen updates are paused after this many idle seconds and
+; resume on user activity.
+ScreenSleepTimeLimit=0
+
 ;; Policy - session allocation policy
 ;
 ;  Type: enum [ "Default" | "Separate" | Combination from {UBDI} ]


### PR DESCRIPTION
## Summary

This change adds a new sesman setting:

`ScreenSleepTimeLimit`

The setting allows xrdp to pass an idle screen-sleep timeout to xorgxrdp sessions.

In long-lived remote desktop sessions, the server can continue spending CPU time and network bandwidth on screen updates even when the user is idle.

This feature can save a significant amount of server CPU usage and network traffic in long-connection scenarios.

The effect is especially noticeable in these cases:

With H.264 encoding, the CPU savings are more obvious.
With RFX encoding, the network traffic savings are more obvious.
The benefit is even greater in multi-user deployments.

No change unless the feature is enabled by xrdp.
While idle, display updates are paused.
Keyboard or mouse activity wakes the session and forces a refresh.

In practice, users barely notice any difference in usage.

## Details

- Adds config parsing and validation for `ScreenSleepTimeLimit`
- Documents the new setting in `sesman.ini` and the man page
- Passes the configured value to xorgxrdp with `XRDP_SCREEN_SLEEP_TIME`

## Behavior

- `0` or `off` disables the feature
- Valid numeric range is `0..86400`
- This setting is intended for xorgxrdp sessions

## Dependency

This PR depends on the companion xorgxrdp PR which implements the actual screen-sleep logic.
https://github.com/neutrinolabs/xorgxrdp/pull/425