### PR TITLE
[V0.10] installer: use -f when creating sym link

### DIFF
--- a/instfiles/Makefile.am
+++ b/instfiles/Makefile.am
@@ -109,4 +109,4 @@ if FREEBSD
 		$(DESTDIR)$(sysconfdir)/rc.d/xrdp-sesman
 endif
 	(cd $(DESTDIR)${startscriptdir} && \
-		$(LN_S) km-00010426.ini km-00020426.ini)
+		$(LN_S) -f km-00010426.ini km-00020426.ini)


### PR DESCRIPTION
Fixes this error when re-installing xrdp over an existing installation:

> ln: failed to create symbolic link 'km-00020426.ini': File exists

Back-port of 05210adb228bbf85a6c21b3d8822af3163a3cb74 (#3779)