### PR TITLE
Supress -Wunused-function warnings

### DIFF
--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -960,6 +960,8 @@ xrdp_sec_check_sig(struct xrdp_sec *self, const char *sig, int sig_len,
 
 /*****************************************************************************/
 /* Function to return a 64-bit int from an 64 bit signature */
+
+#ifdef USE_DEVEL_LOGGING
 static uint64_t
 sig64_to_uint64(const char sig[], int sig_len)
 {
@@ -980,6 +982,7 @@ sig64_to_uint64(const char sig[], int sig_len)
 
     return rv;
 }
+#endif
 
 /*****************************************************************************/
 static void


### PR DESCRIPTION
sig64_to_uint64() is only called when devel logging is enabled. It will be unused unless configured with `--enable-logging-devel`.

@matt335672 Do you think this is a valid fix for this?