### PR TITLE
Supress -Wunused-function warnings

### DIFF
--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -1220,6 +1220,8 @@ xrdp_sec_check_sig(struct xrdp_sec *self, const char *sig, int sig_len,
 
 /*****************************************************************************/
 /* Function to return a 64-bit int from an 64 bit signature */
+
+#ifdef USE_DEVEL_LOGGING
 static uint64_t
 sig64_to_uint64(const char sig[], int sig_len)
 {
@@ -1240,6 +1242,7 @@ sig64_to_uint64(const char sig[], int sig_len)
 
     return rv;
 }
+#endif
 
 /*****************************************************************************/
 static void


### PR DESCRIPTION
`sig64_to_uint64()` is only called when devel logging is enabled. Guard the function with USE_DEVEL_LOGGING macro.

(cherry picked from commit 5e7a7c046dc699793c86a7ef2858bd70d4f901a3)

----

Back port of #3782 .