### PR TITLE
ulalaca: Remove for now

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,6 +8,3 @@
 	url = https://github.com/neutrinolabs/libpainter.git
 	branch = .
 	ignore = untracked
-[submodule "ulalaca"]
-	path = ulalaca
-	url = https://github.com/neutrinolabs/ulalaca-xrdp.git

--- a/Makefile.am
+++ b/Makefile.am
@@ -46,12 +46,6 @@ else
 RFXCODECDIR =
 endif
 
-if XRDP_ULALACA
-ULALACADIR = ulalaca
-else
-ULALACADIR =
-endif
-
 if XRDP_ACCEL
 ACCELDIR = xrdp_accel_assist
 else
@@ -82,7 +76,6 @@ SUBDIRS = \
   xrdpapi \
   pkgconfig \
   $(XRDPVRDIR) \
-  $(ULALACADIR) \
   tests \
   tools \
   $(ACCELDIR)

--- a/configure.ac
+++ b/configure.ac
@@ -124,11 +124,6 @@ AC_ARG_ENABLE(neutrinordp, AS_HELP_STRING([--enable-neutrinordp],
               [], [enable_neutrinordp=no])
 AM_CONDITIONAL(XRDP_NEUTRINORDP, [test x$enable_neutrinordp = xyes])
 
-AC_ARG_ENABLE(ulalaca, AS_HELP_STRING([--enable-ulalaca],
-              [Build ulalaca module (experimental) (default: no)]),
-              [], [enable_ulalaca=no])
-AM_CONDITIONAL(XRDP_ULALACA, [test x$enable_ulalaca = xyes])
-
 AC_ARG_ENABLE(jpeg, AS_HELP_STRING([--enable-jpeg],
               [Build jpeg module (default: no)]),
               [], [enable_jpeg=no])
@@ -655,7 +650,6 @@ AC_CONFIG_FILES([
   Makefile
   mc/Makefile
   neutrinordp/Makefile
-  ulalaca/Makefile
   pkgconfig/Makefile
   pkgconfig/xrdp.pc
   pkgconfig/xrdp-uninstalled.pc


### PR DESCRIPTION
The ulalaca module for Mac  is suffering from a lack of maintenance currently, and its inclusion is holding up the introduction of some code quality changes - see #3681

This PR removes the module for now.