### PR TITLE
Support client-committed Unicode input in the Xorg backend

### DIFF
--- a/common/xrdp_constants.h
+++ b/common/xrdp_constants.h
@@ -284,6 +284,7 @@
 #define WM_KEYDOWN     15
 #define WM_KEYUP       16
 #define WM_KEYBRD_SYNC 17
+#define WM_UNICODE_INPUT 19
 #define WM_MOUSEMOVE   100
 #define WM_LBUTTONUP   101
 #define WM_LBUTTONDOWN 102

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -1023,8 +1023,10 @@ xrdp_rdp_process_data_input(struct xrdp_rdp *self, struct stream *s)
         in_uint32_le(s, time);
         in_uint16_le(s, msg_type);
         in_uint16_le(s, device_flags);
-        in_sint16_le(s, param1);
-        in_sint16_le(s, param2);
+        /* Unicode input carries UTF-16 code units, so keep the raw
+         * unsigned value. Sign-extension would corrupt non-ASCII input. */
+        in_uint16_le(s, param1);
+        in_uint16_le(s, param2);
         LOG_DEVEL(LOG_LEVEL_TRACE, "With field [MS-RDPBCGR] TS_INPUT_EVENT "
                   "eventTime %d, messageType 0x%4.4x", time, msg_type);
 
@@ -1697,4 +1699,3 @@ xrdp_rdp_send_session_info(struct xrdp_rdp *self, const char *data,
     free_stream(s);
     return 0;
 }
-

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -568,6 +568,11 @@ struct xrdp_wm
     /* Unicode input */
     int last_high_surrogate_key_up;
     int last_high_surrogate_key_down;
+    /* Some clients wrap pasted Unicode text in terminal bracketed-paste
+     * delimiters. Keep a short pending buffer so these markers can be removed
+     * before committed text is forwarded to the backend. */
+    char32_t unicode_pending_chars[6];
+    unsigned int unicode_pending_chars_len;
     /* client info */
     struct xrdp_client_info *client_info;
     /* session log */

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -1785,6 +1785,139 @@ fake_kbd_event_from_scancode_index(struct xrdp_wm *self, int device_flags,
 }
 
 /*****************************************************************************/
+#define BRACKETED_PASTE_SEQ_LEN 6
+
+/* Guacamole and mobile RDP clients may deliver pasted text as Unicode input
+ * events wrapped in terminal bracketed-paste delimiters. These markers are not
+ * user text, so strip them while preserving all other Unicode codepoints. */
+static const char32_t g_bracketed_paste_start[BRACKETED_PASTE_SEQ_LEN] =
+    { 0x1b, '[', '2', '0', '0', '~' };
+static const char32_t g_bracketed_paste_end[BRACKETED_PASTE_SEQ_LEN] =
+    { 0x1b, '[', '2', '0', '1', '~' };
+
+static int
+xrdp_wm_send_unicode_to_backend(struct xrdp_wm *self, char32_t unicode)
+{
+    if (self == NULL || self->mm == NULL || self->mm->mod == NULL ||
+            self->mm->mod->mod_event == NULL)
+    {
+        return 1;
+    }
+
+    /* Pass the codepoint over the normal Xorg backend input path. This avoids a
+     * separate channel and lets xorgxrdp inject text in the Xorg input driver. */
+    return self->mm->mod->mod_event(self->mm->mod, WM_UNICODE_INPUT,
+                                    unicode, 0, 0, 0);
+}
+
+/*****************************************************************************/
+static int
+unicode_pending_matches(struct xrdp_wm *self, const char32_t *sequence,
+                        unsigned int sequence_len)
+{
+    unsigned int index;
+
+    if (self->unicode_pending_chars_len > sequence_len)
+    {
+        return 0;
+    }
+
+    for (index = 0; index < self->unicode_pending_chars_len; ++index)
+    {
+        if (self->unicode_pending_chars[index] != sequence[index])
+        {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+/*****************************************************************************/
+static int
+unicode_pending_is_bracketed_paste_prefix(struct xrdp_wm *self)
+{
+    return unicode_pending_matches(self, g_bracketed_paste_start,
+                                   BRACKETED_PASTE_SEQ_LEN) ||
+           unicode_pending_matches(self, g_bracketed_paste_end,
+                                   BRACKETED_PASTE_SEQ_LEN);
+}
+
+/*****************************************************************************/
+static int
+unicode_pending_is_bracketed_paste_sequence(struct xrdp_wm *self)
+{
+    return self->unicode_pending_chars_len == BRACKETED_PASTE_SEQ_LEN &&
+           unicode_pending_is_bracketed_paste_prefix(self);
+}
+
+/*****************************************************************************/
+static int
+xrdp_wm_flush_pending_unicode_chars(struct xrdp_wm *self)
+{
+    unsigned int index;
+    int rv;
+
+    rv = 0;
+    for (index = 0; index < self->unicode_pending_chars_len; ++index)
+    {
+        if (xrdp_wm_send_unicode_to_backend(self,
+                self->unicode_pending_chars[index]) != 0)
+        {
+            rv = 1;
+        }
+    }
+    self->unicode_pending_chars_len = 0;
+
+    return rv;
+}
+
+/*****************************************************************************/
+static int
+xrdp_wm_send_unicode_filtered(struct xrdp_wm *self, char32_t unicode)
+{
+    int rv;
+
+    /* Fast path for normal text. Only ESC can start a bracketed-paste marker,
+     * so most mobile/Guacamole Unicode input is forwarded immediately. */
+    if (self->unicode_pending_chars_len == 0 && unicode != 0x1b)
+    {
+        return xrdp_wm_send_unicode_to_backend(self, unicode);
+    }
+
+    rv = 0;
+    if (self->unicode_pending_chars_len >= BRACKETED_PASTE_SEQ_LEN)
+    {
+        rv = xrdp_wm_flush_pending_unicode_chars(self);
+    }
+
+    if (self->unicode_pending_chars_len == 0 && unicode != 0x1b)
+    {
+        return xrdp_wm_send_unicode_to_backend(self, unicode) != 0 ? 1 : rv;
+    }
+
+    self->unicode_pending_chars[self->unicode_pending_chars_len++] = unicode;
+
+    if (unicode_pending_is_bracketed_paste_sequence(self))
+    {
+        self->unicode_pending_chars_len = 0;
+        return rv;
+    }
+
+    if (unicode_pending_is_bracketed_paste_prefix(self))
+    {
+        return rv;
+    }
+
+    if (xrdp_wm_flush_pending_unicode_chars(self) != 0)
+    {
+        rv = 1;
+    }
+
+    return rv;
+}
+
+/*****************************************************************************/
 static int
 xrdp_wm_key_unicode(struct xrdp_wm *self, int device_flags, char32_t c16)
 {
@@ -1794,6 +1927,18 @@ xrdp_wm_key_unicode(struct xrdp_wm *self, int device_flags, char32_t c16)
     if (c32 == 0)
     {
         return 0;
+    }
+
+    if (self->mm != NULL && self->mm->code == XORG_SESSION_CODE)
+    {
+        if ((device_flags & KBDFLAGS_RELEASE) != 0)
+        {
+            return 0;
+        }
+        if (xrdp_wm_send_unicode_filtered(self, c32) == 0)
+        {
+            return 0;
+        }
     }
 
     // See if we can find the character in the existing keymap,

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -1791,9 +1791,9 @@ fake_kbd_event_from_scancode_index(struct xrdp_wm *self, int device_flags,
  * events wrapped in terminal bracketed-paste delimiters. These markers are not
  * user text, so strip them while preserving all other Unicode codepoints. */
 static const char32_t g_bracketed_paste_start[BRACKETED_PASTE_SEQ_LEN] =
-    { 0x1b, '[', '2', '0', '0', '~' };
+{ 0x1b, '[', '2', '0', '0', '~' };
 static const char32_t g_bracketed_paste_end[BRACKETED_PASTE_SEQ_LEN] =
-    { 0x1b, '[', '2', '0', '1', '~' };
+{ 0x1b, '[', '2', '0', '1', '~' };
 
 static int
 xrdp_wm_send_unicode_to_backend(struct xrdp_wm *self, char32_t unicode)
@@ -1862,7 +1862,7 @@ xrdp_wm_flush_pending_unicode_chars(struct xrdp_wm *self)
     for (index = 0; index < self->unicode_pending_chars_len; ++index)
     {
         if (xrdp_wm_send_unicode_to_backend(self,
-                self->unicode_pending_chars[index]) != 0)
+                                            self->unicode_pending_chars[index]) != 0)
         {
             rv = 1;
         }


### PR DESCRIPTION
Summary
- Preserve RDP Unicode input values as unsigned UTF-16 code units so non-ASCII input is not corrupted by sign extension.
- Add WM_UNICODE_INPUT routing for Xorg sessions through the existing backend mod_event path, without adding a separate side channel.
- Keep the existing keyboard/scancode behavior as fallback for non-Xorg sessions or backend failures.
- Strip terminal bracketed-paste delimiters emitted by some RDP clients while preserving all user text.

This is intended to support Chinese text input and pasted Unicode text from Microsoft Remote Desktop mobile clients and Apache Guacamole browser sessions, while keeping existing keyboard behavior working.

Companion xorgxrdp PR: https://github.com/neutrinolabs/xorgxrdp/pull/429

Testing
- Built with the companion xorgxrdp branch and installed the resulting 0.10.80 local build on Debian.
- Ran make check for xrdp.
- Replayed captured Microsoft Remote Desktop mobile and Apache Guacamole input samples against the installed Xorg modules. The replay matched 83/83 expected text codepoints, covering direct Chinese input, pasted Chinese text, Chinese punctuation, lowercase ASCII, uppercase ASCII, and symbols.