### PR TITLE
lang: add per-keyboard-type/subtype km file lookup

### DIFF
--- a/xrdp/lang.c
+++ b/xrdp/lang.c
@@ -294,13 +294,28 @@ km_read_section(toml_table_t *tfile, const char *section_name,
 
 /*****************************************************************************/
 int
-get_keymaps(int keylayout, struct xrdp_keymap *keymap)
+get_keymaps(int keylayout, int keyboard_type, int keyboard_subtype,
+            struct xrdp_keymap *keymap)
 {
     int basic_key_layout = keylayout & 0x0000ffff;
     char filename[256];
     int layout_list[10];
     int layout_count = 0;
     int i;
+
+    /* Check for a type/subtype-specific keymap first (e.g. Mac UK) */
+    if (keyboard_type > 0 && keyboard_subtype > 0)
+    {
+        g_snprintf(filename, sizeof(filename),
+                   XRDP_CFG_PATH "/km-%08x-%d-%d.toml",
+                   basic_key_layout, keyboard_type, keyboard_subtype);
+        if (km_load_file(filename, keymap) == 0)
+        {
+            return 0;
+        }
+        LOG(LOG_LEVEL_DEBUG,
+            "No type/subtype keymap %s, falling back to layout-only", filename);
+    }
 
     /* Work out a list of layouts to try to load */
     layout_list[layout_count++] = keylayout; // Requested layout

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -444,7 +444,8 @@ get_key_info_from_kbd_event(int keyboard_flags, int key_code, int *keys,
                             int caps_lock, int num_lock, int scroll_lock,
                             struct xrdp_keymap *keymap);
 int
-get_keymaps(int keylayout, struct xrdp_keymap *keymap);
+get_keymaps(int keylayout, int keyboard_type, int keyboard_subtype,
+            struct xrdp_keymap *keymap);
 
 int
 km_load_file(const char *filename, struct xrdp_keymap *keymap);

--- a/xrdp/xrdp_wm.c
+++ b/xrdp/xrdp_wm.c
@@ -126,11 +126,16 @@ xrdp_wm_create(struct xrdp_process *owner,
             client_info->keylayout,
             client_info->xrdp_keyboard_overrides.layout);
         get_keymaps(client_info->xrdp_keyboard_overrides.layout,
+                    client_info->keyboard_type,
+                    client_info->keyboard_subtype,
                     &(self->keymap));
     }
     else
     {
-        get_keymaps(client_info->keylayout, &(self->keymap));
+        get_keymaps(client_info->keylayout,
+                    client_info->keyboard_type,
+                    client_info->keyboard_subtype,
+                    &(self->keymap));
     }
     xrdp_wm_set_login_state(self, WMLS_RESET);
     self->target_surface = self->screen;


### PR DESCRIPTION
## Problem

Mac clients (keyboard_type=4, keyboard_subtype=3) use different scancodes for some keys compared to PC keyboards with the same layout ID.
For example, on a UK keyboard (layout 0x00000809), the backtick/tilde key is at scancode 0x29 on a PC but 0x56 on a Mac, and the `§`/`±` key appears at 0x56 on a PC but 0x29 on a Mac.
Because `get_keymaps()` selects keymap files using only the layout ID, Mac and PC clients receive the same scancode map, causing incorrect key mappings on the sesman login screen for Mac users.

This was discussed in #3236. The concern raised there was that replacing the km file wholesale would break PC clients on the same layout ID.
This patch avoids that by adding type/subtype lookup as an optional first step that only activates when a matching file is present.

## Solution

Add a type/subtype-specific lookup step before the existing fallback chain in `get_keymaps()`:

1. `km-<layout>-<type>-<subtype>.toml` <- new (e.g. `km-00000809-4-3.toml` for Mac UK)
2. `km-<fullkeylayout>.toml` <- existing
3. `km-<keylayout>.toml` <- existing
4. `km-00000409.toml` <- existing (en-US last resort)

The signature of `get_keymaps()` gains `keyboard_type` and `keyboard_subtype` parameters, which are already available at both call sites in `xrdp_wm.c` via `client_info`.

## Backward compatibility

The new step only fires when `keyboard_type > 0` AND `keyboard_subtype > 0` AND a matching file exists on disk. If no file is present the behaviour is identical to before. Existing deployments require no changes.

## Generating type/subtype keymap files

Use `xrdp-genkeymap` under the appropriate xkb variant. For Mac UK:

```sh
setxkbmap -layout gb -variant mac
xrdp-genkeymap /etc/xrdp/km-00000809-4-3.toml
```

Common Mac (type=4, subtype=3) xkb variants:

| Layout ID  | xkb layout | xkb variant |
|------------|------------|-------------|
| 0x00000409 | us         | mac         |
| 0x00000809 | gb         | mac         |
| 0x00000407 | de         | mac         |
| 0x0000040c | fr         | mac         |
| 0x00000807 | ch         | de_mac      |
| 0x0000100c | ch         | fr_mac      |
| 0x00000405 | cz         | qwerty-mac  |

## Testing

Verified with FreeRDP (`/kbd:type:4 /kbd:subtype:3 /kbd:layout:0x00000409`) connecting to a patched xrdp. Log confirms the new path is tried first:

```
[ERROR] Error loading keymap file /etc/xrdp/km-00000409-4-3.toml (No such file or directory)
[ERROR] Error loading keymap file /etc/xrdp/km-00000409.toml (No such file or directory)
```

When `km-00000409-4-3.toml` is present, it is loaded without fallback and the correct Mac scancodes are used on the login screen.