### PR TITLE
Fixes compilation error for raspberry pi

### DIFF
--- a/libxrdp/xrdp_caps.c
+++ b/libxrdp/xrdp_caps.c
@@ -647,7 +647,7 @@ xrdp_caps_process_codecs(struct xrdp_rdp *self, struct stream *s, int len)
             g_memcpy(self->client_info.jpeg_prop, s->p, i1);
             self->client_info.jpeg_prop_len = i1;
             /* make sure that requested quality is  between 0 to 100 */
-            if (self->client_info.jpeg_prop[0] < 0 || self->client_info.jpeg_prop[0] > 100)
+            if (self->client_info.jpeg_prop[0] > 100)
             {
                 LOG(LOG_LEVEL_WARNING, "  Warning: the requested jpeg quality (%d) is invalid, "
                     "falling back to default", self->client_info.jpeg_prop[0]);


### PR DESCRIPTION
When building XRDP on Raspbian Trixie, we get this error. The compiler is noticing that jpeg_props[0] is unsigned, meaning this is a wasteful comparison.

Fix by removing the comparison.
```
  CC       xrdp_caps.lo
xrdp_caps.c: In function 'xrdp_caps_process_codecs':
xrdp_caps.c:650:48: error: comparison is always false due to limited range of data type [-Werror=type-limits]
  650 |             if (self->client_info.jpeg_prop[0] < 0 || self->client_info.jpeg_prop[0] > 100)
      |                                                ^
cc1: all warnings being treated as errors
make[2]: *** [Makefile:561: xrdp_caps.lo] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory '/tmp/tmp.L9ynfYnaji/xrdp/libxrdp'
make[1]: *** [Makefile:530: all-recursive] Error 1
make[1]: Leaving directory '/tmp/tmp.L9ynfYnaji/xrdp'
make: *** [Makefile:462: all] Error 2
```

Proof that it works:
<img width="641" height="509" alt="image" src="https://github.com/user-attachments/assets/556452d6-427e-4c27-a0ae-cc1da8ba3e97" />