### PR TITLE
Start Xorg sessions at the client monitor's DPI

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -81,6 +81,7 @@ libcommon_la_SOURCES = \
   trans.c \
   trans.h \
   unicode_defines.h \
+  xrdp_client_info.c \
   $(PIXMAN_SOURCES)
 
 libcommon_la_LIBADD = \

--- a/common/xrdp_client_info.c
+++ b/common/xrdp_client_info.c
@@ -1,0 +1,60 @@
+/**
+ * xrdp: A Remote Desktop Protocol server.
+ *
+ * Copyright (C) Jay Sorg 2004-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @file common/xrdp_client_info.c
+ * @brief Pure helpers derived from client display information
+ */
+
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
+#include <limits.h>
+
+#include "xrdp_client_info.h"
+
+/*****************************************************************************/
+unsigned int
+xrdp_client_info_calculate_dpi(unsigned int height_pixels,
+                               unsigned int height_mm)
+{
+    unsigned int dpi = 0;
+
+    /*
+     * DPI = height_pixels / (height_mm / 25.4)
+     *     = (height_pixels * 25.4) / height_mm
+     *     = (height_pixels * 127) / (height_mm * 5)
+     *
+     * Reject a missing physical size or pixel height, and guard the
+     * integer arithmetic against overflow before computing.
+     */
+    if (height_mm != 0 && height_pixels != 0 &&
+            height_pixels <= UINT_MAX / 127u &&
+            height_mm <= UINT_MAX / 5u)
+    {
+        dpi = (height_pixels * 127u) / (height_mm * 5u);
+    }
+
+    return dpi;
+}
+
+/*****************************************************************************/
+int
+xrdp_client_info_dpi_valid_for_session(unsigned int dpi)
+{
+    return (dpi >= XRDP_SESSION_DPI_MIN && dpi <= XRDP_SESSION_DPI_MAX);
+}

--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -287,4 +287,37 @@ struct xrdp_client_info
 #define OUTPUT_SUPPRESSED_FOR_REASON(ci,reason) \
     (((ci)->suppress_output_mask & (unsigned int)reason) != 0)
 
+/*
+ * Acceptable range for a session (desktop) DPI derived from client
+ * monitor metadata. The login screen uses the raw computed DPI; only the
+ * value propagated to the Xorg session is constrained to this range.
+ */
+#define XRDP_SESSION_DPI_MIN 50
+#define XRDP_SESSION_DPI_MAX 400
+
+/**
+ * Compute monitor DPI from a physical height.
+ *
+ * @param height_pixels Monitor/desktop height in pixels
+ * @param height_mm Physical monitor/desktop height in millimetres
+ * @return Computed DPI, or 0 if it cannot be determined (missing physical
+ *         size, zero pixels, or arithmetic overflow).
+ *
+ * This is the raw geometric DPI and is NOT clamped to any range. Callers
+ * needing a session-safe value must additionally check
+ * xrdp_client_info_dpi_valid_for_session().
+ */
+unsigned int
+xrdp_client_info_calculate_dpi(unsigned int height_pixels,
+                               unsigned int height_mm);
+
+/**
+ * Test whether a DPI value is within the acceptable session DPI range.
+ *
+ * @param dpi DPI value to test
+ * @return != 0 if XRDP_SESSION_DPI_MIN <= dpi <= XRDP_SESSION_DPI_MAX
+ */
+int
+xrdp_client_info_dpi_valid_for_session(unsigned int dpi);
+
 #endif

--- a/libipm/eicp.c
+++ b/libipm/eicp.c
@@ -32,6 +32,7 @@
 #include "guid.h"
 #include "os_calls.h"
 #include "trans.h"
+#include "xrdp_client_info.h"
 
 /*****************************************************************************/
 static const char *
@@ -280,12 +281,13 @@ eicp_send_create_session_request(struct trans *trans,
                                  unsigned char bpp,
                                  const char *shell,
                                  const char *directory,
-                                 const char *instance_name)
+                                 const char *instance_name,
+                                 unsigned short dpi)
 {
     return libipm_msg_out_simple_send(
                trans,
                (int)E_EICP_CREATE_SESSION_REQUEST,
-               "iyqqysss",
+               "iyqqysssq",
                x11_display,
                type,
                width,
@@ -293,7 +295,8 @@ eicp_send_create_session_request(struct trans *trans,
                bpp,
                shell,
                directory,
-               instance_name);
+               instance_name,
+               dpi);
 }
 
 /*****************************************************************************/
@@ -307,7 +310,8 @@ eicp_get_create_session_request(struct trans *trans,
                                 unsigned char *bpp,
                                 const char **shell,
                                 const char **directory,
-                                const char **instance_name)
+                                const char **instance_name,
+                                unsigned short *dpi)
 {
     /* Intermediate values */
     int32_t i_x11_display;
@@ -315,10 +319,11 @@ eicp_get_create_session_request(struct trans *trans,
     uint16_t i_width;
     uint16_t i_height;
     uint8_t i_bpp;
+    uint16_t i_dpi;
 
     int rv = libipm_msg_in_parse(
                  trans,
-                 "iyqqysss",
+                 "iyqqysssq",
                  &i_x11_display,
                  &i_type,
                  &i_width,
@@ -326,7 +331,8 @@ eicp_get_create_session_request(struct trans *trans,
                  &i_bpp,
                  shell,
                  directory,
-                 instance_name);
+                 instance_name,
+                 &i_dpi);
 
     if (rv == 0)
     {
@@ -336,6 +342,9 @@ eicp_get_create_session_request(struct trans *trans,
         *height = i_height;
         /* bpp is fixed for Xorg session types */
         *bpp = (*type == SCP_SESSION_TYPE_XORG) ? 24 : i_bpp;
+        /* Don't trust the sender: reject an out-of-range DPI (defense in
+           depth - 0 means "no client DPI") */
+        *dpi = xrdp_client_info_dpi_valid_for_session(i_dpi) ? i_dpi : 0;
     }
 
     return rv;

--- a/libipm/eicp.h
+++ b/libipm/eicp.h
@@ -280,6 +280,8 @@ eicp_send_logout_request(struct trans *trans);
  * @param shell User program to run. May be ""
  * @param directory Directory to run the program in. May be ""
  * @param instance_name Name of xrdp instance. May be ""
+ * @param dpi Client monitor DPI for the session, or 0 for none. Used for
+ *        Xorg sessions only; values outside the accepted range are ignored.
  * @return != 0 for error
  *
  * The UID for the session must have been set by a previous call.
@@ -300,7 +302,8 @@ eicp_send_create_session_request(struct trans *trans,
                                  unsigned char bpp,
                                  const char *shell,
                                  const char *directory,
-                                 const char *instance_name);
+                                 const char *instance_name,
+                                 unsigned short dpi);
 
 
 /**
@@ -315,6 +318,8 @@ eicp_send_create_session_request(struct trans *trans,
  * @param[out] shell User program to run. May be ""
  * @param[out] directory Directory to run the program in. May be ""
  * @param[out] instance_name Name of xrdp instance. May be ""
+ * @param[out] dpi Client monitor DPI for the session, or 0 for none. An
+ *        out-of-range value received on the wire is reported as 0.
  * @return != 0 for error
  *
  * Returned string pointers are valid until scp_msg_in_reset() is
@@ -329,7 +334,8 @@ eicp_get_create_session_request(struct trans *trans,
                                 unsigned char *bpp,
                                 const char **shell,
                                 const char **directory,
-                                const char **instance_name);
+                                const char **instance_name,
+                                unsigned short *dpi);
 
 /**
  * Send an E_EICP_CREATE_SESSION_RESPONSE

--- a/libipm/libipm_private.h
+++ b/libipm/libipm_private.h
@@ -33,8 +33,12 @@ enum
 
     /**
      * Version of libipm wire protocol
+     *
+     * Bumped to 3: the SCP/EICP create-session requests carry a trailing
+     * client-DPI field. xrdp, sesman, sesexec and sesrun must be upgraded
+     * in lockstep; a version mismatch is rejected cleanly (fail-closed).
      */
-    LIBIPM_VERSION = 2,
+    LIBIPM_VERSION = 3,
 
     /**
      * Size of libipm header

--- a/libipm/scp.c
+++ b/libipm/scp.c
@@ -36,6 +36,7 @@
 #include "os_calls.h"
 #include "string_calls.h"
 #include "xrdp_sockets.h"
+#include "xrdp_client_info.h"
 
 /*****************************************************************************/
 static const char *
@@ -420,19 +421,21 @@ scp_send_create_session_request(struct trans *trans,
                                 unsigned char bpp,
                                 const char *shell,
                                 const char *directory,
-                                const char *instance_name)
+                                const char *instance_name,
+                                unsigned short dpi)
 {
     return libipm_msg_out_simple_send(
                trans,
                (int)E_SCP_CREATE_SESSION_REQUEST,
-               "yqqysss",
+               "yqqysssq",
                type,
                width,
                height,
                bpp,
                shell,
                directory,
-               instance_name);
+               instance_name,
+               dpi);
 }
 
 /*****************************************************************************/
@@ -445,24 +448,27 @@ scp_get_create_session_request(struct trans *trans,
                                unsigned char *bpp,
                                const char **shell,
                                const char **directory,
-                               const char **instance_name)
+                               const char **instance_name,
+                               unsigned short *dpi)
 {
     /* Intermediate values */
     uint8_t i_type;
     uint16_t i_width;
     uint16_t i_height;
     uint8_t i_bpp;
+    uint16_t i_dpi;
 
     int rv = libipm_msg_in_parse(
                  trans,
-                 "yqqysss",
+                 "yqqysssq",
                  &i_type,
                  &i_width,
                  &i_height,
                  &i_bpp,
                  shell,
                  directory,
-                 instance_name);
+                 instance_name,
+                 &i_dpi);
 
     if (rv == 0)
     {
@@ -471,6 +477,9 @@ scp_get_create_session_request(struct trans *trans,
         *height = i_height;
         /* bpp is fixed for Xorg session types */
         *bpp = (*type == SCP_SESSION_TYPE_XORG) ? 24 : i_bpp;
+        /* Don't trust the sender: reject an out-of-range DPI (defense in
+           depth - 0 means "no client DPI") */
+        *dpi = xrdp_client_info_dpi_valid_for_session(i_dpi) ? i_dpi : 0;
     }
 
     return rv;

--- a/libipm/scp.h
+++ b/libipm/scp.h
@@ -345,6 +345,8 @@ scp_send_logout_request(struct trans *trans);
  * @param shell User program to run. May be ""
  * @param directory Directory to run the program in. May be ""
  * @param instance_name Name of xrdp instance. May be ""
+ * @param dpi Client monitor DPI for the session, or 0 for none. Used for
+ *        Xorg sessions only; values outside the accepted range are ignored.
  * @return != 0 for error
  *
  * Server replies with E_SCP_CREATE_SESSION_RESPONSE
@@ -357,7 +359,8 @@ scp_send_create_session_request(struct trans *trans,
                                 unsigned char bpp,
                                 const char *shell,
                                 const char *directory,
-                                const char *instance_name);
+                                const char *instance_name,
+                                unsigned short dpi);
 
 
 /**
@@ -371,6 +374,8 @@ scp_send_create_session_request(struct trans *trans,
  * @param[out] shell User program to run. May be ""
  * @param[out] directory Directory to run the program in. May be ""
  * @param[out] instance_name Name of xrdp instance. May be ""
+ * @param[out] dpi Client monitor DPI for the session, or 0 for none. An
+ *        out-of-range value received on the wire is reported as 0.
  * @return != 0 for error
  *
  * Returned string pointers are valid until scp_msg_in_reset() is
@@ -384,7 +389,8 @@ scp_get_create_session_request(struct trans *trans,
                                unsigned char *bpp,
                                const char **shell,
                                const char **directory,
-                               const char **instance_name);
+                               const char **instance_name,
+                               unsigned short *dpi);
 
 /**
  * Send an E_SCP_CREATE_SESSION_RESPONSE (SCP server)

--- a/sesman/scp_process.c
+++ b/sesman/scp_process.c
@@ -440,6 +440,7 @@ process_create_session_request(struct scp_list_item *sli)
     const char *shell;
     const char *directory;
     const char *instance_name;
+    unsigned short dpi;
 
     struct guid guid;
     const char *display;
@@ -453,7 +454,7 @@ process_create_session_request(struct scp_list_item *sli)
     rv = scp_get_create_session_request(sli->client_trans,
                                         &type, &width, &height,
                                         &bpp, &shell, &directory,
-                                        &instance_name);
+                                        &instance_name, &dpi);
 
     if (rv == 0)
     {
@@ -470,6 +471,12 @@ process_create_session_request(struct scp_list_item *sli)
             LOG(LOG_LEVEL_INFO,
                 "Received request from %s to create a session for user %s",
                 sli->peername, sli->username);
+
+            if (dpi > 0)
+            {
+                LOG(LOG_LEVEL_INFO,
+                    "Received client DPI for Xorg session: %d", dpi);
+            }
 
             s_item = session_list_get_bydata(sli->uid, type, width, height,
                                              bpp, sli->start_ip_addr, instance_name);
@@ -537,7 +544,7 @@ process_create_session_request(struct scp_list_item *sli)
                                 x11_display,
                                 type, width, height,
                                 bpp, shell, directory,
-                                instance_name);
+                                instance_name, dpi);
 
                 if (eicp_stat != 0)
                 {

--- a/sesman/sesexec/eicp_server.c
+++ b/sesman/sesexec/eicp_server.c
@@ -151,7 +151,7 @@ handle_create_session_request(struct trans *self)
                  self, &sp.x11_display,
                  &sp.type, &sp.width, &sp.height,
                  &sp.bpp, &sp.shell, &sp.directory,
-                 &sp.instance_name);
+                 &sp.instance_name, &sp.dpi);
     if (status == 0)
     {
         enum scp_screate_status scp_status = E_SCP_SCREATE_OK;

--- a/sesman/sesexec/session.c
+++ b/sesman/sesexec/session.c
@@ -53,6 +53,7 @@
 #include "string_calls.h"
 #include "trans.h"
 #include "xauth.h"
+#include "xrdp_client_info.h"
 #include "xwait.h"
 #include "xrdp_sockets.h"
 
@@ -349,6 +350,32 @@ start_window_manager(const struct login_info *login_info,
 }
 
 /******************************************************************************/
+/**
+ * Determine whether the configured [Xorg] params already specify -dpi.
+ *
+ * Uses an exact-token comparison so an admin-supplied "-dpi" always takes
+ * precedence and we never emit a duplicate.
+ *
+ * @return != 0 if a "-dpi" token is present in g_cfg->xorg_params
+ */
+static int
+xorg_params_contain_dpi(void)
+{
+    int i;
+
+    for (i = 0; i < g_cfg->xorg_params->count; ++i)
+    {
+        const char *param = (const char *)list_get_item(g_cfg->xorg_params, i);
+        if (param != NULL && g_strcmp(param, "-dpi") == 0)
+        {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+/******************************************************************************/
 static struct list *
 prepare_xorg_xserver_params(const struct session_data *sd,
                             const char *authfile)
@@ -411,6 +438,38 @@ prepare_xorg_xserver_params(const struct session_data *sd,
 
         /* additional parameters from sesman.ini file */
         list_append_list_strdup(g_cfg->xorg_params, params, 1);
+
+        /*
+         * Append the client monitor DPI as two argv tokens ("-dpi" "<n>",
+         * integer only, never via a shell) when we have a valid in-range
+         * client DPI and the admin has not already configured -dpi in the
+         * [Xorg] params. The admin value always wins; we never emit a
+         * duplicate -dpi. The range is re-checked here as defense in depth.
+         */
+        if (xrdp_client_info_dpi_valid_for_session(sd->params.dpi))
+        {
+            if (xorg_params_contain_dpi())
+            {
+                LOG(LOG_LEVEL_INFO,
+                    "[session start] (display :%d): -dpi is set in "
+                    "sesman.ini [Xorg] params; ignoring client DPI %d",
+                    sd->params.x11_display, sd->params.dpi);
+            }
+            else
+            {
+                char dpi_str[12];
+                g_snprintf(dpi_str, sizeof(dpi_str), "%d", sd->params.dpi);
+                list_add_strdup(params, "-dpi");
+                list_add_strdup(params, dpi_str);
+                LOG(LOG_LEVEL_INFO,
+                    "[session start] (display :%d): starting Xorg with "
+                    "client DPI %d. This sets the X server core DPI only; "
+                    "GUI toolkits (GTK/Qt) follow it only when the desktop's "
+                    "font DPI is automatic. If fonts do not scale, set the "
+                    "desktop to auto DPI (e.g. XFCE Xft/DPI = -1).",
+                    sd->params.x11_display, sd->params.dpi);
+            }
+        }
     }
 
     return params;

--- a/sesman/sesexec/session.h
+++ b/sesman/sesexec/session.h
@@ -46,6 +46,7 @@ struct session_parameters
     unsigned short width;
     unsigned short height;
     unsigned char  bpp;
+    unsigned short dpi;  // Client monitor DPI, or 0 for none (Xorg only)
     struct guid guid;
     const char *shell;  // Must not be NULL
     const char *directory;  // Must not be NULL

--- a/sesman/tools/sesrun.c
+++ b/sesman/tools/sesrun.c
@@ -507,7 +507,8 @@ send_create_session_request(struct trans *t, const struct session_params *sp)
     return scp_send_create_session_request(
                t, sp->session_type,
                sp->width, sp->height, sp->bpp, sp->shell,
-               sp->directory, sp->instance_name);
+               sp->directory, sp->instance_name,
+               0 /* dpi: sesrun does not supply a client DPI */);
 }
 
 /**************************************************************************//**

--- a/tests/common/Makefile.am
+++ b/tests/common/Makefile.am
@@ -27,7 +27,8 @@ test_common_SOURCES = \
     test_base64.c \
     test_guid.c \
     test_scancode.c \
-    test_timers.c
+    test_timers.c \
+    test_xrdp_client_info.c
 
 test_common_CFLAGS = \
     @CHECK_CFLAGS@ \

--- a/tests/common/test_common.h
+++ b/tests/common/test_common.h
@@ -20,6 +20,7 @@ Suite *make_suite_test_base64(void);
 Suite *make_suite_test_guid(void);
 Suite *make_suite_test_scancode(void);
 Suite *make_suite_test_timers(void);
+Suite *make_suite_test_xrdp_client_info(void);
 
 TCase *make_tcase_test_os_calls_signals(void);
 

--- a/tests/common/test_common_main.c
+++ b/tests/common/test_common_main.c
@@ -59,6 +59,7 @@ int main (void)
     srunner_add_suite(sr, make_suite_test_guid());
     srunner_add_suite(sr, make_suite_test_scancode());
     srunner_add_suite(sr, make_suite_test_timers());
+    srunner_add_suite(sr, make_suite_test_xrdp_client_info());
 
     srunner_set_tap(sr, "-");
     /*

--- a/tests/common/test_xrdp_client_info.c
+++ b/tests/common/test_xrdp_client_info.c
@@ -1,0 +1,170 @@
+/**
+ * xrdp: A Remote Desktop Protocol server.
+ *
+ * Copyright (C) Jay Sorg 2004-2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined(HAVE_CONFIG_H)
+#include "config_ac.h"
+#endif
+
+#include <limits.h>
+
+#include "xrdp_client_info.h"
+
+#include "test_common.h"
+
+/******************************************************************************/
+/* DPI = (height_pixels * 127) / (height_mm * 5), integer truncated */
+
+START_TEST(test_calc_dpi__hidpi)
+{
+    /* 2160 px over 392 mm = 139.95 -> 139 (truncated) */
+    ck_assert_uint_eq(xrdp_client_info_calculate_dpi(2160, 392), 139);
+}
+END_TEST
+
+START_TEST(test_calc_dpi__midpi)
+{
+    /* 1440 px over 392 mm = 93.30 -> 93 */
+    ck_assert_uint_eq(xrdp_client_info_calculate_dpi(1440, 392), 93);
+}
+END_TEST
+
+START_TEST(test_calc_dpi__nominal_96)
+{
+    /* 1080 px over 286 mm = 95.91; integer truncation yields 95
+       (~96 nominal). This documents the truncation behavior. */
+    ck_assert_uint_eq(xrdp_client_info_calculate_dpi(1080, 286), 95);
+}
+END_TEST
+
+START_TEST(test_calc_dpi__zero_mm_is_invalid)
+{
+    ck_assert_uint_eq(xrdp_client_info_calculate_dpi(2160, 0), 0);
+}
+END_TEST
+
+START_TEST(test_calc_dpi__zero_pixels_is_invalid)
+{
+    ck_assert_uint_eq(xrdp_client_info_calculate_dpi(0, 392), 0);
+}
+END_TEST
+
+START_TEST(test_calc_dpi__pixel_overflow_is_invalid)
+{
+    /* A huge pixel height (e.g. from an unsigned underflow of
+       bottom - top + 1) must not overflow the arithmetic */
+    ck_assert_uint_eq(xrdp_client_info_calculate_dpi(UINT_MAX, 392), 0);
+}
+END_TEST
+
+START_TEST(test_calc_dpi__mm_overflow_is_invalid)
+{
+    ck_assert_uint_eq(xrdp_client_info_calculate_dpi(2160, UINT_MAX), 0);
+}
+END_TEST
+
+/******************************************************************************/
+/* Session DPI range check: XRDP_SESSION_DPI_MIN..XRDP_SESSION_DPI_MAX */
+
+START_TEST(test_valid__below_min)
+{
+    ck_assert_int_eq(xrdp_client_info_dpi_valid_for_session(49), 0);
+}
+END_TEST
+
+START_TEST(test_valid__at_min)
+{
+    ck_assert_int_ne(xrdp_client_info_dpi_valid_for_session(50), 0);
+}
+END_TEST
+
+START_TEST(test_valid__in_range)
+{
+    ck_assert_int_ne(xrdp_client_info_dpi_valid_for_session(139), 0);
+}
+END_TEST
+
+START_TEST(test_valid__at_max)
+{
+    ck_assert_int_ne(xrdp_client_info_dpi_valid_for_session(400), 0);
+}
+END_TEST
+
+START_TEST(test_valid__above_max)
+{
+    ck_assert_int_eq(xrdp_client_info_dpi_valid_for_session(401), 0);
+}
+END_TEST
+
+START_TEST(test_valid__zero)
+{
+    ck_assert_int_eq(xrdp_client_info_dpi_valid_for_session(0), 0);
+}
+END_TEST
+
+START_TEST(test_valid__computed_low_dpi_rejected)
+{
+    /* 640 px over 400 mm = 40 DPI -> below range -> rejected */
+    unsigned int dpi = xrdp_client_info_calculate_dpi(640, 400);
+    ck_assert_uint_eq(dpi, 40);
+    ck_assert_int_eq(xrdp_client_info_dpi_valid_for_session(dpi), 0);
+}
+END_TEST
+
+START_TEST(test_valid__computed_high_dpi_rejected)
+{
+    /* 3840 px over 100 mm = 975 DPI -> above range -> rejected */
+    unsigned int dpi = xrdp_client_info_calculate_dpi(3840, 100);
+    ck_assert_uint_eq(dpi, 975);
+    ck_assert_int_eq(xrdp_client_info_dpi_valid_for_session(dpi), 0);
+}
+END_TEST
+
+/******************************************************************************/
+
+Suite *
+make_suite_test_xrdp_client_info(void)
+{
+    Suite *s;
+    TCase *tc_calc;
+    TCase *tc_valid;
+
+    s = suite_create("XrdpClientInfo");
+
+    tc_calc = tcase_create("calculate_dpi");
+    suite_add_tcase(s, tc_calc);
+    tcase_add_test(tc_calc, test_calc_dpi__hidpi);
+    tcase_add_test(tc_calc, test_calc_dpi__midpi);
+    tcase_add_test(tc_calc, test_calc_dpi__nominal_96);
+    tcase_add_test(tc_calc, test_calc_dpi__zero_mm_is_invalid);
+    tcase_add_test(tc_calc, test_calc_dpi__zero_pixels_is_invalid);
+    tcase_add_test(tc_calc, test_calc_dpi__pixel_overflow_is_invalid);
+    tcase_add_test(tc_calc, test_calc_dpi__mm_overflow_is_invalid);
+
+    tc_valid = tcase_create("dpi_valid_for_session");
+    suite_add_tcase(s, tc_valid);
+    tcase_add_test(tc_valid, test_valid__below_min);
+    tcase_add_test(tc_valid, test_valid__at_min);
+    tcase_add_test(tc_valid, test_valid__in_range);
+    tcase_add_test(tc_valid, test_valid__at_max);
+    tcase_add_test(tc_valid, test_valid__above_max);
+    tcase_add_test(tc_valid, test_valid__zero);
+    tcase_add_test(tc_valid, test_valid__computed_low_dpi_rejected);
+    tcase_add_test(tc_valid, test_valid__computed_high_dpi_rejected);
+
+    return s;
+}

--- a/tests/libipm/test_libipm.h
+++ b/tests/libipm/test_libipm.h
@@ -8,7 +8,7 @@
  * value change, tests will fail! */
 enum
 {
-    LIBIPM_VERSION = 2,
+    LIBIPM_VERSION = 3,
     LIBIPM_HEADER_SIZE = 12,
     LIBIPM_MAX_MESSAGE_SIZE = 8192,
     LIBIPM_MAX_FD_PER_MSG = 8,

--- a/tests/libipm/test_libipm_recv_calls.c
+++ b/tests/libipm/test_libipm_recv_calls.c
@@ -9,6 +9,8 @@
 #include "os_calls.h"
 #include "string_calls.h"
 #include "trans.h"
+#include "scp.h"
+#include "eicp.h"
 
 #include "test_libipm.h"
 
@@ -886,6 +888,137 @@ START_TEST(test_libipm_receive_programming_errors)
 }
 END_TEST
 
+/***************************************************************************//**
+ * Round-trips an SCP create-session request and returns the parsed DPI.
+ *
+ * Sends the request over the loopback link with the supplied DPI, receives
+ * and demarshals it, asserts the non-DPI fields survive intact (i.e. the
+ * appended DPI field does not disturb the existing layout), and returns the
+ * DPI as seen by the receiver. This is a semantic round trip - it does not
+ * assert raw wire bytes, so it remains robust against future field additions.
+ */
+static unsigned short
+scp_create_session_dpi_roundtrip(unsigned short sent_dpi)
+{
+    enum scp_session_type type = SCP_SESSION_TYPE_XVNC;
+    unsigned short width = 0;
+    unsigned short height = 0;
+    unsigned char bpp = 0;
+    const char *shell = NULL;
+    const char *directory = NULL;
+    const char *instance_name = NULL;
+    unsigned short dpi = 0xffff;
+    int status;
+
+    status = scp_send_create_session_request(
+                 g_t_out, SCP_SESSION_TYPE_XORG,
+                 1920, 1080, 24, "xterm", "/tmp", "inst", sent_dpi);
+    ck_assert_int_eq(status, E_LI_SUCCESS);
+
+    check_for_incoming_message(E_SCP_CREATE_SESSION_REQUEST);
+
+    status = scp_get_create_session_request(
+                 g_t_in, &type, &width, &height, &bpp,
+                 &shell, &directory, &instance_name, &dpi);
+    ck_assert_int_eq(status, E_LI_SUCCESS);
+
+    /* Non-DPI fields must be unaffected by the appended field */
+    ck_assert_int_eq(type, SCP_SESSION_TYPE_XORG);
+    ck_assert_int_eq(width, 1920);
+    ck_assert_int_eq(height, 1080);
+    ck_assert_str_eq(shell, "xterm");
+    ck_assert_str_eq(directory, "/tmp");
+    ck_assert_str_eq(instance_name, "inst");
+
+    return dpi;
+}
+
+/***************************************************************************//**
+ * Round-trips an EICP create-session request and returns the parsed DPI.
+ * See scp_create_session_dpi_roundtrip() for rationale.
+ */
+static unsigned short
+eicp_create_session_dpi_roundtrip(unsigned short sent_dpi)
+{
+    int x11_display = -1;
+    enum scp_session_type type = SCP_SESSION_TYPE_XVNC;
+    unsigned short width = 0;
+    unsigned short height = 0;
+    unsigned char bpp = 0;
+    const char *shell = NULL;
+    const char *directory = NULL;
+    const char *instance_name = NULL;
+    unsigned short dpi = 0xffff;
+    int status;
+
+    status = eicp_send_create_session_request(
+                 g_t_out, 7, SCP_SESSION_TYPE_XORG,
+                 1920, 1080, 24, "xterm", "/tmp", "inst", sent_dpi);
+    ck_assert_int_eq(status, E_LI_SUCCESS);
+
+    check_for_incoming_message(E_EICP_CREATE_SESSION_REQUEST);
+
+    status = eicp_get_create_session_request(
+                 g_t_in, &x11_display, &type, &width, &height, &bpp,
+                 &shell, &directory, &instance_name, &dpi);
+    ck_assert_int_eq(status, E_LI_SUCCESS);
+
+    ck_assert_int_eq(x11_display, 7);
+    ck_assert_int_eq(type, SCP_SESSION_TYPE_XORG);
+    ck_assert_int_eq(width, 1920);
+    ck_assert_int_eq(height, 1080);
+    ck_assert_str_eq(shell, "xterm");
+
+    return dpi;
+}
+
+/***************************************************************************//**
+ * A valid in-range DPI survives the SCP create-session round trip.
+ */
+START_TEST(test_scp_create_session_dpi_valid)
+{
+    ck_assert_int_eq(scp_create_session_dpi_roundtrip(139), 139);
+    ck_assert_int_eq(scp_create_session_dpi_roundtrip(50), 50);
+    ck_assert_int_eq(scp_create_session_dpi_roundtrip(400), 400);
+}
+END_TEST
+
+/***************************************************************************//**
+ * An out-of-range or absent DPI is rejected (mapped to 0) on SCP receive,
+ * so sesman never trusts an out-of-range value from the sender.
+ */
+START_TEST(test_scp_create_session_dpi_out_of_range)
+{
+    ck_assert_int_eq(scp_create_session_dpi_roundtrip(0), 0);
+    ck_assert_int_eq(scp_create_session_dpi_roundtrip(49), 0);
+    ck_assert_int_eq(scp_create_session_dpi_roundtrip(401), 0);
+    ck_assert_int_eq(scp_create_session_dpi_roundtrip(10000), 0);
+}
+END_TEST
+
+/***************************************************************************//**
+ * A valid in-range DPI survives the EICP create-session round trip.
+ */
+START_TEST(test_eicp_create_session_dpi_valid)
+{
+    ck_assert_int_eq(eicp_create_session_dpi_roundtrip(139), 139);
+    ck_assert_int_eq(eicp_create_session_dpi_roundtrip(50), 50);
+    ck_assert_int_eq(eicp_create_session_dpi_roundtrip(400), 400);
+}
+END_TEST
+
+/***************************************************************************//**
+ * An out-of-range or absent DPI is rejected (mapped to 0) on EICP receive.
+ */
+START_TEST(test_eicp_create_session_dpi_out_of_range)
+{
+    ck_assert_int_eq(eicp_create_session_dpi_roundtrip(0), 0);
+    ck_assert_int_eq(eicp_create_session_dpi_roundtrip(49), 0);
+    ck_assert_int_eq(eicp_create_session_dpi_roundtrip(401), 0);
+    ck_assert_int_eq(eicp_create_session_dpi_roundtrip(10000), 0);
+}
+END_TEST
+
 /******************************************************************************/
 Suite *
 make_suite_test_libipm_recv_calls(void)
@@ -916,6 +1049,10 @@ make_suite_test_libipm_recv_calls(void)
     tcase_add_test(tc, test_libipm_receive_bad_header);
     tcase_add_test(tc, test_libipm_receive_msg_erase);
     tcase_add_test(tc, test_libipm_receive_programming_errors);
+    tcase_add_test(tc, test_scp_create_session_dpi_valid);
+    tcase_add_test(tc, test_scp_create_session_dpi_out_of_range);
+    tcase_add_test(tc, test_eicp_create_session_dpi_valid);
+    tcase_add_test(tc, test_eicp_create_session_dpi_out_of_range);
 
     return s;
 }

--- a/xrdp/xrdp_login_wnd.c
+++ b/xrdp/xrdp_login_wnd.c
@@ -691,8 +691,13 @@ xrdp_login_wnd_get_monitor_dpi(struct xrdp_wm *self)
         {
             if (mi->is_primary)
             {
-                height_pixels = mi->bottom - mi->top + 1;
-                height_mm = mi->physical_height;
+                /* Guard against an inverted rectangle which would
+                   underflow the unsigned height calculation */
+                if (mi->bottom >= mi->top)
+                {
+                    height_pixels = mi->bottom - mi->top + 1;
+                    height_mm = mi->physical_height;
+                }
                 break;
             }
         }
@@ -731,12 +736,7 @@ xrdp_login_wnd_get_monitor_dpi(struct xrdp_wm *self)
 
     if (height_mm != 0)
     {
-        /*
-         * DPI = height_pixels / (height_mm / 25.4)
-         *     = (height_pixels * 25.4) / height_mm
-         *     = (height_pixels * 127) / (height_mm * 5)
-         */
-        result = (height_pixels * 127 ) / (height_mm * 5);
+        result = xrdp_client_info_calculate_dpi(height_pixels, height_mm);
         LOG(LOG_LEVEL_INFO,
             "Login screen monitor height is %u pixels over %u mm (%u DPI)",
             height_pixels,

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -313,6 +313,7 @@ xrdp_mm_create_session(struct xrdp_mm *self)
     int rv = 0;
     int xserverbpp;
     enum scp_session_type type;
+    unsigned short dpi = 0;
 
     /* Map the session code to an SCP session type */
     switch (self->code)
@@ -340,6 +341,22 @@ xrdp_mm_create_session(struct xrdp_mm *self)
         xserverbpp = xrdp_mm_get_value_int(self, "xserverbpp",
                                            self->wm->screen->bpp);
 
+        /*
+         * For Xorg sessions, derive the client monitor DPI so the desktop
+         * can be started to match. Only a value within the accepted range
+         * is propagated; anything else (absent/invalid metadata, or an
+         * out-of-range value) is sent as 0 = "no DPI", preserving the
+         * current default-96-DPI behavior.
+         */
+        if (type == SCP_SESSION_TYPE_XORG)
+        {
+            unsigned int raw_dpi = xrdp_login_wnd_get_monitor_dpi(self->wm);
+            if (xrdp_client_info_dpi_valid_for_session(raw_dpi))
+            {
+                dpi = raw_dpi;
+            }
+        }
+
         xrdp_wm_log_msg(self->wm, LOG_LEVEL_DEBUG,
                         "sending create session request to session"
                         " manager. Please wait...");
@@ -351,7 +368,8 @@ xrdp_mm_create_session(struct xrdp_mm *self)
                  xserverbpp,
                  self->wm->client_info->program,
                  self->wm->client_info->directory,
-                 self->wm->pro_layer->lis_layer->startup_params->instance_name);
+                 self->wm->pro_layer->lis_layer->startup_params->instance_name,
+                 dpi);
     }
 
     return rv;


### PR DESCRIPTION
# Start Xorg sessions at the client monitor's DPI

Fixes #3473

## Problem

xrdp already computes the client monitor's physical DPI and uses it to scale the
**login screen** (you can see it in the log: *"Login screen monitor height is N
pixels over M mm (D DPI)"*). But that value is never passed to xrdp-sesman, so
the **Xorg/xorgxrdp desktop** that follows always starts at the default 96 DPI.

The result is the inconsistency reported in #3473: on a HiDPI client the login
screen is scaled correctly, then the desktop appears with everything too small.

## What this changes

Propagate the already-computed client DPI from the xrdp front-end through
sesman and sesexec, and launch Xorg with `-dpi <client_dpi>` so the desktop
matches the login screen.

Data flow (no auth/PAM/identity changes):

```
xrdp_mm (compute+validate) → SCP → sesman → EICP → sesexec → Xorg argv "-dpi N"
```

- **`common/xrdp_client_info.{c,h}`** — new pure helper
  `xrdp_client_info_calculate_dpi(height_px, height_mm)` (the existing
  login-screen formula, extracted and made unit-testable, with overflow/
  underflow guards) plus `xrdp_client_info_dpi_valid_for_session()` enforcing a
  50–400 range. The login screen keeps using the **raw** value exactly as
  before — bounds are applied only on the new session path, so font scaling is
  unchanged.
- **`xrdp/xrdp_login_wnd.c`** — uses the helper; also guards an inverted-rectangle
  unsigned underflow in the height calculation.
- **`xrdp/xrdp_mm.c`** — for Xorg sessions, computes and range-checks the DPI and
  sends it in the SCP create-session request. Out-of-range/absent → sends 0.
- **SCP / EICP** (`libipm/scp.*`, `libipm/eicp.*`) — the create-session request
  gains one trailing DPI field; it is **re-validated on every receive** (sesman
  must not trust the value from xrdp; defense in depth). `0` means "no DPI".
- **`sesman/sesexec/session.c`** — appends `-dpi` `<n>` as two integer-only argv
  tokens (never a shell string) when the DPI is valid **and** the admin has not
  already set `-dpi` in `sesman.ini [Xorg]` (exact-token check; the admin value
  always wins, never a duplicate `-dpi`).
- Xvnc and other non-Xorg backends are untouched.

## Behavior / compatibility

- **No regression when DPI is absent/invalid/out-of-range:** no `-dpi` is
  appended and the session starts exactly as today (default 96 DPI). No
  `-dpi 0`, `-dpi 1`, or `-dpi 10000` can ever be emitted.
- **Admin override wins:** an existing `-dpi` in `[Xorg]` params is detected and
  the client value is skipped, so there is never a duplicate `-dpi`.
- **Wire-format change:** the SCP and EICP create-session messages
  gain a trailing field, so `LIBIPM_VERSION` is bumped **2 → 3**. libipm has no
  optional-field mechanism, so this is a breaking change by construction. xrdp,
  xrdp-sesman, xrdp-sesexec and sesrun ship and must be upgraded together; a
  mixed-version peer is rejected cleanly by the existing version check
  (fail-closed: failed session create, never a misparse or crash). The new field
  is appended at the end of the format strings to keep the change minimal.

## Scope / limitation: core DPI vs toolkit DPI

This sets the X server **core** DPI (via `-dpi`); desktops running in
**auto-DPI mode** (those that honor the core DPI, e.g. XFCE `Xft/DPI = -1`) pick
it up automatically. GTK/Qt take their font scale from `Xft.dpi` / XSETTINGS
`/Xft/DPI`, not the core DPI, so a desktop that pins a fixed toolkit DPI (e.g.
XFCE's default `96`) overrides `-dpi` and fonts stay at 96. Setting
`Xft.dpi`/XSETTINGS is per-user, desktop-specific session config and is
intentionally **out of scope** here. sesman logs a one-line reminder when it
applies a client DPI, so an admin whose fonts don't scale knows to switch the
desktop to auto-DPI.

## Design note: physical DPI

The DPI is derived from the client's **physical monitor size**
(TS_MONITOR_ATTRIBUTES, in mm) — the *same* computation xrdp already trusts for
the login screen. This deliberately makes the desktop consistent with the login
screen, which is the concrete defect in #3473. Using the RDP desktop *scale
factor* instead (e.g. 96×1.5) is a reasonable alternative policy; it's
intentionally out of scope here and could be added later behind a config knob
without changing this plumbing.

## Testing

- **Unit tests, pure helper** (`tests/common/test_xrdp_client_info.c`, 15 cases):
  the DPI formula incl. the truncation cases, zero/overflow/underflow → invalid,
  and the 50–400 range boundaries (e.g. 2160px/392mm → 139).
- **Semantic round-trip tests** (`tests/libipm/test_libipm_recv_calls.c`, 4
  cases): the SCP and EICP create-session messages are sent and received over
  the loopback link; a valid DPI survives intact (with the other fields
  unaffected by the appended field), and out-of-range/absent values are rejected
  to 0 on receive. These are value-based, not raw-byte assertions, so they don't
  become tripwires for future field additions.
- `make check` green across all suites (libcommon, libipm, libxrdp, daemon).
- astyle (pinned 3.4.14) and cppcheck clean.
- Built and smoke-tested against an Xorg/xorgxrdp session.

## Notes for reviewers

- Integer-only end to end: the value is a bounded `unsigned short`/`q` field all
  the way to the argv token, exec'd via `g_execvp_list` (no shell) — argument
  injection is not possible.
- The DPI is consumed **after** the setuid/setgid privilege drop in
  `start_x_server`; ordering is unchanged.
- Happy to split the `LIBIPM_VERSION` bump discussion out if you'd prefer a
  different compatibility strategy.