### PR TITLE
Fix for DYNVC Multi-Chunk Reassembly Logic Defects

### DIFF
--- a/libxrdp/xrdp_channel.c
+++ b/libxrdp/xrdp_channel.c
@@ -18,6 +18,7 @@
  * channel layer
  */
 
+#include "parse.h"
 #if defined(HAVE_CONFIG_H)
 #include <config_ac.h>
 #endif
@@ -610,6 +611,8 @@ xrdp_channel_process_drdynvc(struct xrdp_channel *self,
             }
             out_uint8a(self->s, s->p, length); /* append data to chunk buffer */
             in_uint8s(s, length);              /* virtualChannelData */
+            s_mark_end(self->s);
+            self->s->p = self->s->data;
             ls = self->s;
             break;
         case 3: /* CHANNEL_FLAG_FIRST and CHANNEL_FLAG_LAST */
@@ -635,19 +638,19 @@ xrdp_channel_process_drdynvc(struct xrdp_channel *self,
     switch (cmd & 0xf0)
     {
         case CMD_DVC_CAPABILITY:
-            rv = drdynvc_process_capability_response(self, cmd, s);
+            rv = drdynvc_process_capability_response(self, cmd, ls);
             break;
         case CMD_DVC_OPEN_CHANNEL:
-            rv = drdynvc_process_open_channel_response(self, cmd, s);
+            rv = drdynvc_process_open_channel_response(self, cmd, ls);
             break;
         case CMD_DVC_CLOSE_CHANNEL:
-            rv = drdynvc_process_close_channel_response(self, cmd, s);
+            rv = drdynvc_process_close_channel_response(self, cmd, ls);
             break;
         case CMD_DVC_DATA_FIRST:
-            rv = drdynvc_process_data_first(self, cmd, s);
+            rv = drdynvc_process_data_first(self, cmd, ls);
             break;
         case CMD_DVC_DATA:
-            rv = drdynvc_process_data(self, cmd, s);
+            rv = drdynvc_process_data(self, cmd, ls);
             break;
         default:
             LOG(LOG_LEVEL_ERROR, "Received header [MS-RDPEDYC] with "

--- a/libxrdp/xrdp_channel.c
+++ b/libxrdp/xrdp_channel.c
@@ -18,12 +18,12 @@
  * channel layer
  */
 
-#include "parse.h"
 #if defined(HAVE_CONFIG_H)
 #include <config_ac.h>
 #endif
 
 #include "libxrdp.h"
+#include "parse.h"
 #include "string_calls.h"
 #include "xrdp_channel.h"
 


### PR DESCRIPTION
# DYNVC Multi-Chunk Reassembly Logic Defects

## Header

| Field | Value |
|-------|-------|
| Report ID | XRDP-2026-036 |
| Status | Informational |
| Date | 2026-06-29 |
| Audited Version | xrdp 0.10.6 |
| Component | xrdp |
| Function | `xrdp_channel_process_drdynvc()` |
| Lines | 611–651 |
| Vulnerability Type | CWE-670: Always-Incorrect Control Flow Implementation (2 findings) |
| Category | Pre-Auth Remote |
| CVSS 3.1 Score | N/A — Informational |
| CVSS 3.1 Vector | N/A — Informational |
| Reachability | Network-exposed, affects multi-chunk DYNVC messages |

---

## Summary

Two related pointer-state defects in the DYNVC multi-chunk reassembly path prevent proper parsing of multi-fragment messages. These defects act as accidental guards preventing deeper parsing vulnerabilities from being reached, but the root causes are independent logic bugs that must be corrected.

The two defects compound each other: together they prevent sub-parser dispatch from working for any multi-chunk DYNVC message. The bugs accidentally mask other vulnerabilities that would become reachable if either defect is fixed in isolation without fixing the other.

---

## Finding 1 — Missing `s_mark_end` and Pointer Reset Before Stream Reassignment

**Function:** `xrdp_channel_process_drdynvc()` | **Lines:** 611–613

### Vulnerable Code

```c
case 2: /* CHANNEL_FLAG_LAST */
    // ...
    out_uint8a(self->s, s->p, length);  // writes to reassembly buffer
    // ...
    break;
// (later, after all chunks received)
case 3: /* CHANNEL_FLAG_FIRST | CHANNEL_FLAG_LAST */
case 2:
    ls = self->s;   // line 613
```

### Impact

`init_stream(s, n)` initializes both `s->p = s->data` (read cursor) and `s->end = s->data` (end marker), both pointing to the beginning. When `out_uint8a()` writes chunks to the reassembly buffer, it advances `s->p` but never updates `s->end`.

After all fragments are written:

```c
// self->s->p   = self->s->data + total_written   ← points past all written data
// self->s->end = self->s->data                   ← never moved; points to beginning
```

Setting `ls = self->s` then causes all subsequent stream reads to fail bounds checks (`s_check_rem()` compares `s->p + n <= s->end`, which evaluates false since `s->p > s->end`). All multi-PDU DYNVC messages are silently discarded after reassembly, preventing the protocol from functioning correctly.

### Recommended Fix

Before setting `ls`:

```c
s_mark_end(self->s);        // sets self->s->end = self->s->p (marks all data readable)
self->s->p = self->s->data; // resets read cursor to beginning
ls = self->s;
```

---

## Finding 2 — Sub-Parsers Receive Drained Original Stream Instead of Reassembly Buffer

**Function:** `xrdp_channel_process_drdynvc()` | **Lines:** 637–651

### Vulnerable Code

```c
case CMD_DVC_DATA_FIRST:
    rv = drdynvc_process_data_first(self, cmd, s);  // ← s, not ls
    break;
case CMD_DVC_DATA:
    rv = drdynvc_process_data(self, cmd, s);       // ← s, not ls
    break;
case CMD_DVC_CLOSE_REQUEST:
    rv = drdynvc_process_close_request(self, cmd, s);  // ← s, not ls
    break;
case CMD_DVC_CREATE_REQUEST:
    rv = drdynvc_process_create_request(self, cmd, s); // ← s, not ls
    break;
case CMD_DVC_CREATE_RESPONSE:
    rv = drdynvc_process_create_response(self, cmd, s); // ← s, not ls
    break;
```

### Impact

All five dispatch arms pass `s` (the original input stream) to sub-parsers instead of `ls` (the reassembly buffer or original stream, depending on the case).

**For case 3 (`CHANNEL_FLAG_FIRST | CHANNEL_FLAG_LAST` — single-chunk):** Both are the same pointer; harmless.

**For case 2 (`CHANNEL_FLAG_LAST` — last chunk of multi-chunk message):** At line 612, the original stream `s` is fully consumed by `in_uint8s(s, length)`, leaving `s->p == s->end`. Sub-functions then receive an empty stream and immediately fail their first `s_check_rem()` call, returning error (1). As a result, all multi-PDU DYNVC messages are silently discarded after reassembly completes.

Combined with Finding 1, the two defects prevent multi-chunk DYNVC parsing from reaching any sub-parser. This is an accidental guard that masks other bugs, but is fragile: fixing one defect without the other may expose deeper vulnerabilities.

### Recommended Fix

All dispatch arms should pass `ls`:

```c
case CMD_DVC_DATA_FIRST:
    rv = drdynvc_process_data_first(self, cmd, ls);
    break;
// ... etc for all five cases
```

---

### Defect Summary

| Defect | Location | Symptom | Fix |
|--------|----------|---------|-----|
| 1 | Lines 611–613 | `self->s->end` never updated after writes | Add `s_mark_end(self->s)` and reset `self->s->p` |
| 2 | Lines 637–651 | Sub-parsers receive drained `s` instead of `ls` | Change all dispatch arms to pass `ls` |

---

**Disclaimer:** Generated using an LLM-assisted vulnerability research pipeline. Reviewed by Denis Skvortsov
