### PR TITLE
[v0.10] Backport devel fix #3837

### DIFF
--- a/common/parse.h
+++ b/common/parse.h
@@ -186,7 +186,7 @@ unsigned int
 in_utf16_le_terminated_as_utf8_length(struct stream *s);
 
 /******************************************************************************/
-#define s_check_rem(s, n) ((s)->p + (n) <= (s)->end)
+#define s_check_rem(s, n) ((size_t)(n) <= (size_t)((s)->end - (s)->p))
 
 /******************************************************************************/
 /**
@@ -202,7 +202,7 @@ in_utf16_le_terminated_as_utf8_length(struct stream *s);
       && 0 )
 
 /******************************************************************************/
-#define s_check_rem_out(s, n) ((s)->p + (n) <= (s)->data + (s)->size)
+#define s_check_rem_out(s, n) ((size_t)(n) <= (size_t)((s)->size - ((s)->p - (s)->data)))
 
 /******************************************************************************/
 /**

--- a/common/trans.c
+++ b/common/trans.c
@@ -471,7 +471,8 @@ trans_force_read_s(struct trans *self, struct stream *in_s, int size)
     int rcvd;
 
     if (self->status != TRANS_STATUS_UP ||
-            size < 0 || !s_check_rem_out(in_s, size))
+            size < 0 ||
+            size > in_s->size - (in_s->end - in_s->data))
     {
         return 1;
     }

--- a/libxrdp/xrdp_mcs.c
+++ b/libxrdp/xrdp_mcs.c
@@ -353,7 +353,7 @@ xrdp_mcs_parse_domain_params(struct xrdp_mcs *self, struct stream *s)
 
     in_uint8s(s, len); /* skip all fields */
 
-    return !s_check_rem_and_log(s, 0, "Parsing [ITU-T T.125] DomainParameters");
+    return 0;
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
Backports the following minor changes from #3837
- Fix for trans_force_read_s Bounds Check Uses Wrong Pointer
- Harden stream bounds checks against pointer-arithmetic overflow
- Cast to size_t in bounds macros; drop resulting dead check