### PR TITLE
[V0.10] oscalls: vsock errors should be logged as errors

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -553,11 +553,11 @@ g_sck_vsock_socket(void)
     LOG(LOG_LEVEL_DEBUG, "g_sck_vsock_socket: returning FreeBSD Hyper-V socket");
     return socket(AF_HYPERV, SOCK_STREAM, 0); // docs say to use AF_HYPERV here - PF_HYPERV does not exist
 #else
-    LOG(LOG_LEVEL_DEBUG, "g_sck_vsock_socket: vsock enabled at compile time, but platform is unsupported");
+    LOG(LOG_LEVEL_ERROR, "g_sck_vsock_socket: vsock enabled at compile time, but platform is unsupported");
     return -1;
 #endif
 #else
-    LOG(LOG_LEVEL_DEBUG, "g_sck_vsock_socket: vsock disabled at compile time");
+    LOG(LOG_LEVEL_ERROR, "g_sck_vsock_socket: vsock disabled at compile time");
     return -1;
 #endif
 }


### PR DESCRIPTION
Back-port of #3852 

(cherry picked from commit 38c2e4cba255d68ca49058effa7d656bd7731f8d)