### PR TITLE
chansrv: Always answer a client clipboard data request

### DIFF
--- a/sesman/chansrv/clipboard.c
+++ b/sesman/chansrv/clipboard.c
@@ -224,6 +224,16 @@ static XSelectionRequestEvent g_saved_selection_req_event;
 /* xserver maximum request size in bytes */
 static int g_incr_max_req_size = 0;
 
+/* How long to wait for the X selection owner to answer a conversion started
+   for a client CB_FORMAT_DATA_REQUEST. This has to stay well below the
+   timeout used by the client, otherwise the client gives up first. Remmina
+   waits 6 seconds and does not recover from its own timeout. */
+#define CLIP_S2C_REQUEST_TIMEOUT_MS 3000
+
+/* How many times that timeout may be extended while an INCR transfer is
+   still running, so a large paste is not cut short. */
+#define CLIP_S2C_MAX_INCR_REARM 10
+
 /* server to client, pasting from linux app to mstsc */
 struct clip_s2c g_clip_s2c;
 /* client to server, pasting from mstsc to linux app */
@@ -726,6 +736,7 @@ clipboard_send_data_response_for_image(const char *data, int data_size)
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_send_data_response_for_image: data_size %d",
               data_size);
+    g_clip_s2c.in_request = 0;
     make_stream(s);
     init_stream(s, 64 + data_size);
     out_uint16_le(s, CB_FORMAT_DATA_RESPONSE); /* 5 CLIPRDR_DATA_RESPONSE */
@@ -752,6 +763,7 @@ clipboard_send_data_response_for_text(const char *data, int data_size)
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_send_data_response_for_text: data_size %d",
               data_size);
     LOG_DEVEL_HEXDUMP(LOG_LEVEL_TRACE, "clipboard send data response:", data, data_size);
+    g_clip_s2c.in_request = 0;
     num_words = utf8_as_utf16_word_count(data, data_size);
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_send_data_response_for_text: data_size %d "
               "num_words %d", data_size, num_words);
@@ -1027,6 +1039,7 @@ clipboard_send_data_response_failed(void)
     int rv;
 
     LOG_DEVEL(LOG_LEVEL_ERROR, "clipboard_send_data_response_failed:");
+    g_clip_s2c.in_request = 0;
     make_stream(s);
     init_stream(s, 64);
     out_uint16_le(s, CB_FORMAT_DATA_RESPONSE); /* 5 CLIPRDR_DATA_RESPONSE */
@@ -1037,6 +1050,61 @@ clipboard_send_data_response_failed(void)
     rv = send_channel_data(g_cliprdr_chan_id, s->data, size);
     free_stream(s);
     return rv;
+}
+
+/*****************************************************************************/
+/* A data request from the client is outstanding and cannot be satisfied.
+   Always send something back. A client left waiting for a response it never
+   gets may stop asking for the rest of the session: Remmina keeps
+   rfClipboard.srv_clip_data_wait at SCDW_BUSY_WAIT after its own timeout,
+   which kills the server to client clipboard until it reconnects. */
+static void
+clipboard_fail_pending_request(const char *why)
+{
+    if (g_clip_s2c.in_request)
+    {
+        LOG(LOG_LEVEL_WARNING, "clipboard: failing a pending client data "
+            "request, %s", why);
+        clipboard_send_data_response_failed();
+    }
+}
+
+/*****************************************************************************/
+/* the X selection owner has not answered in time */
+static void
+clipboard_request_timeout(void *data)
+{
+    int serial;
+
+    serial = (int)(long)data;
+    if ((g_clip_s2c.in_request == 0) || (g_clip_s2c.request_serial != serial))
+    {
+        /* already answered, or superseded by a newer request */
+        return;
+    }
+    if (g_clip_s2c.incr_in_progress &&
+            (g_clip_s2c.incr_rearm_count < CLIP_S2C_MAX_INCR_REARM))
+    {
+        /* data is still arriving over INCR, give it more time */
+        g_clip_s2c.incr_rearm_count++;
+        add_timeout(CLIP_S2C_REQUEST_TIMEOUT_MS, clipboard_request_timeout,
+                    data);
+        return;
+    }
+    clipboard_fail_pending_request("the X selection owner did not respond");
+}
+
+/*****************************************************************************/
+/* Record that a client data request is now waiting on an X selection
+   conversion, and arm the timeout that guarantees it gets an answer. */
+static void
+clipboard_arm_request(void)
+{
+    g_clip_s2c.in_request = 1;
+    g_clip_s2c.request_serial++;
+    g_clip_s2c.incr_rearm_count = 0;
+    add_timeout(CLIP_S2C_REQUEST_TIMEOUT_MS, clipboard_request_timeout,
+                (void *)(long)g_clip_s2c.request_serial);
 }
 
 /*****************************************************************************/
@@ -1070,6 +1138,7 @@ clipboard_process_data_request(struct stream *s, int clip_msg_status,
                 g_clip_s2c.xrdp_clip_type = XRDP_CB_FILE;
                 XConvertSelection(g_display, g_clipboard_atom, g_clip_s2c.type,
                                   g_clip_property_atom, g_wnd, CurrentTime);
+                clipboard_arm_request();
             }
             break;
         case CF_DIB:
@@ -1086,6 +1155,7 @@ clipboard_process_data_request(struct stream *s, int clip_msg_status,
                 g_clip_s2c.xrdp_clip_type = XRDP_CB_BITMAP;
                 XConvertSelection(g_display, g_clipboard_atom, g_image_bmp_atom,
                                   g_clip_property_atom, g_wnd, CurrentTime);
+                clipboard_arm_request();
             }
             break;
         case CF_UNICODETEXT:
@@ -1102,6 +1172,7 @@ clipboard_process_data_request(struct stream *s, int clip_msg_status,
                 g_clip_s2c.xrdp_clip_type = XRDP_CB_TEXT;
                 XConvertSelection(g_display, g_clipboard_atom, g_utf8_atom,
                                   g_clip_property_atom, g_wnd, CurrentTime);
+                clipboard_arm_request();
             }
             break;
         default:
@@ -1669,6 +1740,50 @@ clipboard_get_window_property(Window wnd, Atom prop, Atom *type, int *fmt,
 }
 
 /*****************************************************************************/
+/* Name of a selection target for logging. Uses our own table first:
+   get_atom_text() refuses atoms above 512 and most interned atoms are
+   above that, so it would usually just print a hex id. */
+static const char *
+clipboard_target_name(Atom target)
+{
+    if (target == g_utf8_atom)
+    {
+        return "UTF8_STRING";
+    }
+    if (target == XA_STRING)
+    {
+        return "STRING";
+    }
+    if (target == g_image_bmp_atom)
+    {
+        return "image/bmp";
+    }
+    if (target == g_file_atom1)
+    {
+        return "text/uri-list";
+    }
+    if (target == g_file_atom2)
+    {
+        return "x-special/gnome-copied-files";
+    }
+    if (target == g_targets_atom)
+    {
+        return "TARGETS";
+    }
+    return get_atom_text(target);
+}
+
+/*****************************************************************************/
+/* can clipboard_event_selection_notify() turn this target into a reply? */
+static int
+clipboard_is_known_target(Atom target)
+{
+    return (target == g_utf8_atom) || (target == XA_STRING) ||
+           (target == g_image_bmp_atom) || (target == g_file_atom1) ||
+           (target == g_file_atom2);
+}
+
+/*****************************************************************************/
 /* returns error
    process the SelectionNotify X event, uses XSelectionEvent
    typedef struct {
@@ -1700,6 +1815,7 @@ clipboard_event_selection_notify(XEvent *xevent)
     Atom atom;
     Atom *atoms;
     Atom type;
+    char reason[256];
 
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_event_selection_notify:");
     data_size = 0;
@@ -1734,6 +1850,14 @@ clipboard_event_selection_notify(XEvent *xevent)
         {
             LOG_DEVEL(LOG_LEVEL_ERROR, "clipboard_event_selection_notify: "
                       "clipboard_get_window_property failed error %d", rv);
+            if (lxevent->target != g_targets_atom)
+            {
+                g_snprintf(reason, sizeof(reason),
+                           "the property holding the %s reply could not be "
+                           "read back (error %d)",
+                           clipboard_target_name(lxevent->target), rv);
+                clipboard_fail_pending_request(reason);
+            }
             return 0;
         }
         //LOG_DEVEL_HEXDUMP(LOG_LEVEL_TRACE, "", data, data_size);
@@ -2047,6 +2171,49 @@ clipboard_event_selection_notify(XEvent *xevent)
         {
             rv = 4;
         }
+    }
+
+    /* This conversion may have been started for a client data request. If
+       none of the branches above sent a response, answer now instead of
+       leaving the client waiting forever. Name the specific reason: it is
+       the only way to tell a refusing owner from an unsupported target
+       when reading a log after the fact. */
+    if ((lxevent->target != g_targets_atom) &&
+            (g_clip_s2c.incr_in_progress == 0) &&
+            g_clip_s2c.in_request)
+    {
+        if (lxevent->property == None)
+        {
+            g_snprintf(reason, sizeof(reason),
+                       "the owner refused to convert the selection to %s",
+                       clipboard_target_name(lxevent->target));
+        }
+        else if (lxevent->selection != g_clipboard_atom)
+        {
+            g_snprintf(reason, sizeof(reason),
+                       "the reply was for selection %s, not CLIPBOARD",
+                       clipboard_target_name(lxevent->selection));
+        }
+        else if (!clipboard_is_known_target(lxevent->target))
+        {
+            g_snprintf(reason, sizeof(reason),
+                       "target %s is not one chansrv can convert",
+                       clipboard_target_name(lxevent->target));
+        }
+        else if (g_cfg->restrict_outbound_clipboard != 0)
+        {
+            g_snprintf(reason, sizeof(reason),
+                       "the %s reply was dropped, restrict_outbound_clipboard "
+                       "is set to %d", clipboard_target_name(lxevent->target),
+                       g_cfg->restrict_outbound_clipboard);
+        }
+        else
+        {
+            g_snprintf(reason, sizeof(reason),
+                       "the %s reply carried no usable data (%d bytes)",
+                       clipboard_target_name(lxevent->target), data_size);
+        }
+        clipboard_fail_pending_request(reason);
     }
 
     g_free(data);

--- a/sesman/chansrv/clipboard_common.h
+++ b/sesman/chansrv/clipboard_common.h
@@ -37,6 +37,9 @@ struct clip_s2c /* server to client, pasting from linux app to mstsc */
     int xrdp_clip_type; /* XRDP_CB_TEXT, XRDP_CB_BITMAP, XRDP_CB_FILE, ... */
     int converted;
     Time clip_time;
+    int in_request; /* a data request has been received from client */
+    int request_serial; /* ties a pending request to its timeout */
+    int incr_rearm_count; /* times the timeout was extended for INCR */
 };
 
 struct clip_c2s /* client to server, pasting from mstsc to linux app */

--- a/sesman/chansrv/clipboard_file.c
+++ b/sesman/chansrv/clipboard_file.c
@@ -346,6 +346,7 @@ clipboard_send_data_response_for_file(const char *data, int data_size)
     LOG_DEVEL(LOG_LEVEL_DEBUG, "clipboard_send_data_response_for_file: data_size %d",
               data_size);
     LOG_DEVEL_HEXDUMP(LOG_LEVEL_TRACE, "", data, data_size);
+    g_clip_s2c.in_request = 0;
     if (g_files_list == 0)
     {
         g_files_list = list_create();


### PR DESCRIPTION
Fixes #3863

`chansrv` answers a `CB_FORMAT_DATA_REQUEST` asynchronously and, on several paths, never sends the `CB_FORMAT_DATA_RESPONSE` at all. The client is then left waiting forever, and some clients never recover: they disable the server to client clipboard for the rest of the connection. Details in the issue.

### What this does

- adds `in_request` / `request_serial` / `incr_rearm_count` to `struct clip_s2c`
- `clipboard_arm_request()` marks a request pending and arms a timeout using the existing `add_timeout()` machinery from `chansrv.c`
- `clipboard_fail_pending_request()` sends `CB_RESPONSE_FAIL` and logs the specific reason at `LOG_LEVEL_WARNING`
- the pending flag is cleared wherever a response actually goes out
- a catch-all at the end of `clipboard_event_selection_notify()` covers the refused / no-usable-data / unsupported-target / restricted cases
- an INCR transfer that is still making progress extends the deadline instead of being cut short; the extension is bounded, so a stalled INCR still fails

`CLIP_S2C_REQUEST_TIMEOUT_MS` is 3000. It has to stay below the client's own timeout; Remmina uses 6 seconds. I am happy to make it a `sesman.ini` setting if you would prefer that.

Target names in the log messages come from a small local table rather than `get_atom_text()`, because that function rejects atoms above 512 and most interned atoms are above that.

### Field results

Kubuntu 24.04.4 server, xrdp 0.10.80 devel, Xorg backend, Remmina 1.4.43 client. One full working day of normal use.

Two failed conversions all day, both recovered:

| Time | Side | Event |
|---|---|---|
| ~14:38:03 | client | request 1 starts |
| 14:38:06 | server | `owner refused to convert the selection to UTF8_STRING`, FAIL sent immediately |
| 14:38:06 | client | 4x "Cannot paste now" (overlapping paste attempts) |
| 14:38:11 | client | **request 2 starts** — proves the state was reset by the FAIL |
| 14:38:14 | server | `the X selection owner did not respond`, timeout fired at +3s, FAIL sent |
| 14:38:17 | client | its own 6 second timeout |
| after | — | quiet, clipboard keeps working |

The important line is 14:38:11: before this patch a new request was never sent after a failure. Compare with the 8.5 hour dead period quoted in the issue.

Cost for the day: one lost paste. The direction never died once.

Note that in the second case the 3 second timeout did not beat the client's 6 second one — the client took about 3 seconds to process the response. It recovers regardless, because Remmina resets its state unconditionally when a response arrives, whether or not it already gave up.

### Testing

| Role | System | xrdp |
|---|---|---|
| client | Manjaro, Remmina 1.4.43, libfreerdp 3.30.0 | — |
| server | Kubuntu 24.04.4, daily driver, several days of use | 0.10.80 devel, patched |
| server | Kubuntu 26.04 VM, Plasma 6 | 0.10.80 devel, patched |
| nested server | Debian 10 terminal server, reached through the above | 0.10.2, unpatched |

The nested case is the interesting one: the X selection owner on the middle machine is itself an RDP client fetching data over its own connection, with its own 6 second timeout. That is exactly the situation this patch has to handle, and it now behaves.

Also:

- reproduced the original failure and confirmed the direction no longer dies
- `astyle 3.4.14` with `astyle_config.as` reformats nothing
- `make check` passes; note it does not cover `sesman/chansrv`, so it is a regression guard here rather than a test of this change

### Relationship to #3805

#3805 touches the same function and would conflict textually. The two changes
are orthogonal: #3805 improves which text targets are negotiated, this one guarantees that a request is answered at all. #3805 adds no response guarantee and no timeout. If #3805 lands first I am happy to rebase; note that it adds new response emitters (`_for_text_bytes`, `_for_locale`) which would also need to clear the pending flag.

### Disclosure

This fix was developed with the help of Claude Code: the analysis, the patch and this description were produced with it. The diagnosis was then checked by hand against the sources of xrdp, Remmina and FreeRDP, and the result has been running on my own machines for several days in the configurations above.

I noticed that @matt335672 raised the question of a policy for AI-assisted contributions in #3692 and that there is not one yet. I would rather say this up front than have it surface later. If you would prefer not to take contributions produced this way, or would rather wait until you have a policy, please just say so and I will close the PR — the issue stands on its own either way.

### Thank you

Separately from all of the above: thank you for xrdp! I use it every day and it has been dependable for years. So I wanted to say that the work you put into keeping this project going is appreciated for me.