### PR TITLE
Add opt-in NLA authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ you would need **openssl-devel**, **pam-devel**, **libX11-devel**,
 **libXfixes-devel**, **libXrandr-devel**. More additional software would
 be needed depending on your configuration.
 
+Network Level Authentication additionally requires the GSSAPI development
+files (**libkrb5-dev** on Debian/Ubuntu or **krb5-devel** on Fedora/RHEL).
+
 To compile xrdp from a checked out git repository, you would additionally
 need **autoconf**, **automake**, **libtool** and **pkg-config**.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Many of these work on some or all of Windows, Mac OS, iOS, and/or Android.
 
 RDP transport is encrypted using TLS by default.
 
+CredSSP Network Level Authentication is available as an opt-in feature. See
+[Network Level Authentication](docs/nla.md) for build, configuration and
+testing instructions, and the current limitations.
+
 ![demo](https://github.com/neutrinolabs/xrdp/raw/gh-pages/xrdp_demo.gif)
 
 ## Features

--- a/common/ssl_calls.c
+++ b/common/ssl_calls.c
@@ -2,7 +2,7 @@
  * xrdp: A Remote Desktop Protocol server.
  *
  * Copyright (C) Jay Sorg 2004-2014
- * Copyright (C) Idan Freiberg 2013-2014
+ * Copyright (C) Idan Freiberg 2013-2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/ssl_calls.c
+++ b/common/ssl_calls.c
@@ -1329,6 +1329,53 @@ ssl_tls_accept(struct ssl_tls *self, long ssl_protocols,
 }
 
 /*****************************************************************************/
+int
+ssl_tls_get_public_key(struct ssl_tls *self, unsigned char **data,
+                       unsigned int *length)
+{
+    X509 *cert;
+    EVP_PKEY *pkey;
+    unsigned char *p;
+    int len;
+
+    if (self == NULL || self->ssl == NULL || data == NULL || length == NULL)
+    {
+        return 1;
+    }
+
+    cert = SSL_get_certificate(self->ssl);
+    pkey = cert == NULL ? NULL : X509_get_pubkey(cert);
+    if (pkey == NULL)
+    {
+        LOG(LOG_LEVEL_ERROR, "Unable to obtain the TLS certificate public key");
+        return 1;
+    }
+
+    len = i2d_PublicKey(pkey, NULL);
+    if (len <= 0)
+    {
+        EVP_PKEY_free(pkey);
+        LOG(LOG_LEVEL_ERROR, "Unable to encode the TLS certificate public key");
+        return 1;
+    }
+
+    *data = (unsigned char *)g_malloc(len, 0);
+    p = *data;
+    if (*data == NULL || i2d_PublicKey(pkey, &p) != len)
+    {
+        g_free(*data);
+        *data = NULL;
+        EVP_PKEY_free(pkey);
+        LOG(LOG_LEVEL_ERROR, "Unable to encode the TLS certificate public key");
+        return 1;
+    }
+
+    *length = len;
+    EVP_PKEY_free(pkey);
+    return 0;
+}
+
+/*****************************************************************************/
 /* returns error, */
 int
 ssl_tls_disconnect(struct ssl_tls *self)
@@ -1634,4 +1681,3 @@ const char
 #endif
 
 }
-

--- a/common/ssl_calls.h
+++ b/common/ssl_calls.h
@@ -2,7 +2,7 @@
  * xrdp: A Remote Desktop Protocol server.
  *
  * Copyright (C) Jay Sorg 2004-2014
- * Copyright (C) Idan Freiberg 2013-2014
+ * Copyright (C) Idan Freiberg 2013-2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/ssl_calls.h
+++ b/common/ssl_calls.h
@@ -110,6 +110,9 @@ int
 ssl_tls_write(struct ssl_tls *tls, const char *data, int length);
 int
 ssl_tls_can_recv(struct ssl_tls *tls, int sck, int millis);
+int
+ssl_tls_get_public_key(struct ssl_tls *tls, unsigned char **data,
+                       unsigned int *length);
 const char *
 ssl_get_version(const struct ssl_tls *ssl);
 const char *

--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -2,7 +2,7 @@
  * xrdp: A Remote Desktop Protocol server.
  *
  * Copyright (C) Jay Sorg 2004-2014
- * Copyright (C) Idan Freiberg 2013-2014
+ * Copyright (C) Idan Freiberg 2013-2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -198,6 +198,7 @@ struct xrdp_client_info
     int require_credentials; /* when true, credentials *must* be passed on cmd line */
 
     int security_layer; /* SECURITY_LAYER_* */
+    int enable_nla; /* Offer NLA when security_layer is negotiate */
     int vmconnect; /* Used when used from inside Hyper-V */
 
     int multimon; /* 0 = deny , 1 = allow */

--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -72,6 +72,7 @@ struct display_size_description
 #define SECURITY_LAYER_NEGOTIATE 0
 #define SECURITY_LAYER_RDP 1
 #define SECURITY_LAYER_TLS 2
+#define SECURITY_LAYER_NLA 3
 
 enum client_resize_mode
 {

--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -2,6 +2,7 @@
  * xrdp: A Remote Desktop Protocol server.
  *
  * Copyright (C) Jay Sorg 2004-2014
+ * Copyright (C) Idan Freiberg 2013-2014
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/configure.ac
+++ b/configure.ac
@@ -124,6 +124,10 @@ AC_ARG_ENABLE(neutrinordp, AS_HELP_STRING([--enable-neutrinordp],
               [], [enable_neutrinordp=no])
 AM_CONDITIONAL(XRDP_NEUTRINORDP, [test x$enable_neutrinordp = xyes])
 
+AC_ARG_ENABLE(nla, AS_HELP_STRING([--enable-nla],
+              [Build Network Level Authentication support (default: auto)]),
+              [], [enable_nla=auto])
+
 AC_ARG_ENABLE(jpeg, AS_HELP_STRING([--enable-jpeg],
               [Build jpeg module (default: no)]),
               [], [enable_jpeg=no])
@@ -438,6 +442,41 @@ fi
 
 AS_IF( [test "x$enable_neutrinordp" = "xyes"] , [PKG_CHECK_MODULES(FREERDP, freerdp >= 1.0.0)] )
 
+# Network Level Authentication uses the platform GSSAPI implementation for
+# SPNEGO, Kerberos and any installed NTLM mechanism.
+have_nla=no
+if test "x$enable_nla" != xno; then
+  AC_PATH_PROG([KRB5_CONFIG], [krb5-config], [no])
+  if test "x$KRB5_CONFIG" != xno; then
+    GSSAPI_CFLAGS=`$KRB5_CONFIG --cflags gssapi`
+    GSSAPI_LIBS=`$KRB5_CONFIG --libs gssapi`
+    save_CPPFLAGS="$CPPFLAGS"
+    save_LIBS="$LIBS"
+    CPPFLAGS="$CPPFLAGS $GSSAPI_CFLAGS"
+    LIBS="$GSSAPI_LIBS $LIBS"
+    AC_LINK_IFELSE(
+      [AC_LANG_PROGRAM([[#include <gssapi/gssapi.h>]],
+                       [[OM_uint32 minor;
+                         gss_ctx_id_t context = GSS_C_NO_CONTEXT;
+                         gss_delete_sec_context(&minor, &context,
+                                                GSS_C_NO_BUFFER);]])],
+      [have_nla=yes])
+    CPPFLAGS="$save_CPPFLAGS"
+    LIBS="$save_LIBS"
+  fi
+fi
+
+if test "x$have_nla" = xyes; then
+  AC_DEFINE([XRDP_NLA], [1], [Build Network Level Authentication support])
+  AC_SUBST([GSSAPI_CFLAGS])
+  AC_SUBST([GSSAPI_LIBS])
+elif test "x$enable_nla" = xyes; then
+  AC_MSG_ERROR([NLA requested but GSSAPI development files were not found])
+elif test "x$enable_nla" = xauto; then
+  AC_MSG_NOTICE([GSSAPI not found; NLA support will not be built])
+fi
+AM_CONDITIONAL(XRDP_NLA, [test x$have_nla = xyes])
+
 # checking for libjpeg
 if test "x$enable_jpeg" = "xyes"
 then
@@ -697,6 +736,7 @@ echo "  ipv6                            $enable_ipv6"
 echo "  ipv6only                        $enable_ipv6only"
 echo "  vsock                           $enable_vsock"
 echo "  ibus                            $enable_ibus"
+echo "  nla                             $have_nla"
 echo "  auth mechanism                  $auth_mech"
 echo "  rdpsndaudin                     $enable_rdpsndaudin"
 echo "  smartcard (not for production)  $enable_smartcard"

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -1,3 +1,5 @@
 
 SUBDIRS = \
   man
+
+EXTRA_DIST = nla.md

--- a/docs/man/xrdp.ini.5.in
+++ b/docs/man/xrdp.ini.5.in
@@ -230,12 +230,21 @@ The GSSAPI acceptor must have access to a Kerberos keytab containing the
 an installed GSSAPI NTLM mechanism such as \fBgss-ntlmssp\fP and its configured
 credential provider. CredSSP version 5 or later with password credentials is
 supported; smart cards, Restricted Admin and Remote Credential Guard are not.
-The \fBnegotiate\fP setting does not currently advertise NLA.
 
 .TP
 .B negotiate
-Negotiate these security methods with clients.
+Negotiate these security methods with clients. TLS is offered by default. If
+\fBenable_nla\fP is true, NLA is also offered and is preferred when supported
+by the client.
 .RE
+
+.TP
+\fBenable_nla\fP=\fI[true|false]\fP
+If true and \fBsecurity_layer\fP is \fBnegotiate\fP, advertise CredSSP NLA
+alongside TLS. This setting defaults to false and has no effect when xrdp is
+built without NLA support. If the client selects NLA, authentication failure
+ends that connection rather than falling back to TLS. The \fBnla\fP security
+layer always requires NLA regardless of this setting.
 
 .TP
 \fBssl_protocols\fP=\fI[SSLv3] [TLSv1] [TLSv1.1] [TLSv1.2] [TLSv1.3]\fP

--- a/docs/man/xrdp.ini.5.in
+++ b/docs/man/xrdp.ini.5.in
@@ -80,7 +80,8 @@ If set to \fB1\fR, \fBtrue\fR or \fByes\fR this option enables compression of bu
 Set location of TLS certificate and private key. They must be written in PEM format.
 If not specified, defaults to \fB@sysconfdir@/@sysconfsubdir@/cert.pem\fP, \fB@sysconfdir@/@sysconfsubdir@/key.pem\fP.
 
-This parameter is effective only if \fBsecurity_layer\fP is set to \fBtls\fP or \fBnegotiate\fP.
+This parameter is effective only if \fBsecurity_layer\fP is set to \fBtls\fP,
+\fBnla\fP or \fBnegotiate\fP.
 
 .TP
 \fBtls_pms_log_file\fR=\fI<path-to-log-file>\fR
@@ -206,7 +207,7 @@ fail without displaying the login screen.  If not specified, defaults
 to \fBfalse\fP.
 
 .TP
-\fBsecurity_layer\fP=\fI[tls|rdp|negotiate]\fP
+\fBsecurity_layer\fP=\fI[tls|rdp|nla|negotiate]\fP
 Regulate security methods. If not specified, defaults to \fBnegotiate\fP.
 .RS 8
 .TP
@@ -221,6 +222,16 @@ of Classic RDP Security is controlled by \fBcrypt_level\fP.
 Use this setting for testing only.
 
 .TP
+.B nla
+TLS security with CredSSP Network Level Authentication is required.
+This option is available only when xrdp is built with GSSAPI support.
+The GSSAPI acceptor must have access to a Kerberos keytab containing the
+\fBTERMSRV/hostname\fP service principal. NTLM fallback additionally requires
+an installed GSSAPI NTLM mechanism such as \fBgss-ntlmssp\fP and its configured
+credential provider. CredSSP version 5 or later with password credentials is
+supported; smart cards, Restricted Admin and Remote Credential Guard are not.
+
+.TP
 .B negotiate
 Negotiate these security methods with clients.
 .RE
@@ -229,7 +240,8 @@ Negotiate these security methods with clients.
 \fBssl_protocols\fP=\fI[SSLv3] [TLSv1] [TLSv1.1] [TLSv1.2] [TLSv1.3]\fP
 Enables the specified SSL/TLS protocols. Each value should be separated by comma.
 SSLv2 is always disabled. At least one protocol should be given to accept TLS connections.
-This parameter is effective only if \fBsecurity_layer\fP is set to \fBtls\fP or \fBnegotiate\fP.
+This parameter is effective only if \fBsecurity_layer\fP is set to \fBtls\fP,
+\fBnla\fP or \fBnegotiate\fP.
 
 .TP
 \fBtcp_keepalive\fP=\fI[true|false]\fP
@@ -257,7 +269,8 @@ to which \fBopenssl\fP(1) ciphers subcommand accepts.
 
 (ex. $ openssl ciphers 'HIGH:!ADH:!SHA1')
 
-This parameter is effective only if \fBsecurity_layer\fP is set to \fBtls\fP or \fBnegotiate\fP.
+This parameter is effective only if \fBsecurity_layer\fP is set to \fBtls\fP,
+\fBnla\fP or \fBnegotiate\fP.
 
 .TP
 \fBuse_fastpath\fP=\fI[input|output|both|none]\fP

--- a/docs/man/xrdp.ini.5.in
+++ b/docs/man/xrdp.ini.5.in
@@ -230,6 +230,7 @@ The GSSAPI acceptor must have access to a Kerberos keytab containing the
 an installed GSSAPI NTLM mechanism such as \fBgss-ntlmssp\fP and its configured
 credential provider. CredSSP version 5 or later with password credentials is
 supported; smart cards, Restricted Admin and Remote Credential Guard are not.
+The \fBnegotiate\fP setting does not currently advertise NLA.
 
 .TP
 .B negotiate

--- a/docs/nla.md
+++ b/docs/nla.md
@@ -106,10 +106,11 @@ key_file=/etc/xrdp/key.pem
 ```
 
 `enable_nla` defaults to `false` and only affects `security_layer=negotiate`.
-If the client selects NLA, an authentication failure ends that connection; it
-does not retry with TLS. Restart xrdp after changing the service environment or
-`xrdp.ini`. With `security_layer=nla`, a client which does not offer NLA is
-rejected before an RDP session is created.
+When a client offers both NLA and TLS, xrdp selects NLA. If the client selects
+NLA, an authentication failure ends that connection; it does not retry with
+TLS. Restart xrdp after changing the service environment or `xrdp.ini`. With
+`security_layer=nla`, a client which does not offer NLA is rejected before an
+RDP session is created.
 
 NLA supplies the delegated username, domain and password to the normal xrdp
 login flow. The session manager still applies its configured PAM and account
@@ -175,14 +176,18 @@ FreeRDP 2.11.7, both with required NLA and with `security_layer=negotiate` plus
 `enable_nla=true`. A valid password completed CredSSP and delegated password
 decoding; an invalid password returned `STATUS_LOGON_FAILURE` without falling
 back to TLS. With `enable_nla=false`, the same negotiation selected TLS and did
-not invoke GSSAPI. The `+auth-only` test does not create a graphical desktop or
-exercise the later PAM session login.
+not invoke GSSAPI. A FreeRDP Kerberos/CredSSP handshake was also exercised. The
+`+auth-only` test does not create a graphical desktop or exercise the later PAM
+session login.
 
 Use a CA-trusted certificate for normal tests. For a disposable lab server
 with a self-signed certificate, `/cert:ignore` can be added temporarily; it
 must not be used as a production configuration.
 
 ## Test with Windows MSTSC
+
+This procedure has not yet been exercised against this implementation and
+remains an interoperability test gap.
 
 Test from a Windows client which can resolve the server name and reach the
 domain controller:
@@ -217,6 +222,10 @@ make -C tests/libxrdp check
 
 These tests do not replace an interoperability test with FreeRDP or MSTSC and
 a real GSSAPI acceptor.
+
+The initial implementation also passed the full project CI matrix, including
+GCC, G++, Clang, 32-bit builds, ASan, UBSan, cppcheck, and FreeBSD 14.4 and 15.0
+with both OpenSSL and LibreSSL.
 
 ## Not supported yet
 

--- a/docs/nla.md
+++ b/docs/nla.md
@@ -1,0 +1,219 @@
+# Network Level Authentication
+
+xrdp can require CredSSP Network Level Authentication (NLA) before starting
+the RDP session. CredSSP runs over TLS and uses SPNEGO to authenticate the
+client before the graphical login is created.
+
+NLA is disabled by default at runtime. The default `security_layer=negotiate`
+continues to offer TLS without NLA. Set `security_layer=nla` explicitly to
+enable it.
+
+## Requirements
+
+NLA adds a build dependency on a GSSAPI implementation with `krb5-config`,
+headers and libraries. Install the development package for the build host:
+
+```sh
+# Debian and Ubuntu
+sudo apt install libkrb5-dev
+
+# Fedora, RHEL and compatible distributions
+sudo dnf install krb5-devel
+```
+
+The usual xrdp OpenSSL development dependency is also required. Kerberos
+administration and troubleshooting tools are commonly packaged as `krb5-user`
+on Debian/Ubuntu and `krb5-workstation` on Fedora/RHEL.
+
+The default build mode is `auto`: NLA is built when GSSAPI is found and omitted
+otherwise. Use `--enable-nla` to require the feature and fail configuration if
+the dependency is missing:
+
+```sh
+./bootstrap                 # required for a Git checkout
+./configure --enable-nla
+make
+sudo make install
+```
+
+Use `--disable-nla` to omit the feature. In a configured build tree, the
+following command confirms that support was enabled:
+
+```sh
+grep '^#define XRDP_NLA 1' config_ac.h
+```
+
+## Configure the server
+
+### TLS certificate
+
+NLA requires the certificate and private key configured in `xrdp.ini` to be
+readable by the xrdp daemon. Clients should trust the certificate and its name
+should match the DNS name used to connect.
+
+### GSSAPI acceptor
+
+For Kerberos, provide a keytab containing an acceptor principal for every DNS
+name clients use to reach the server. For example:
+
+```text
+TERMSRV/rdp.example.com@EXAMPLE.COM
+```
+
+The KDC-specific procedure for creating the principal and exporting its key is
+outside xrdp. DNS resolution, the Kerberos realm configuration and system time
+must also be correct on the server and client.
+
+GSSAPI uses its default keytab unless `KRB5_KTNAME` is set. A dedicated keytab
+can be selected through the xrdp service environment. For packaged systemd
+units, `/etc/default/xrdp` or `/etc/sysconfig/xrdp` can contain:
+
+```sh
+KRB5_KTNAME=FILE:/etc/xrdp/krb5.keytab
+```
+
+The keytab must be readable after xrdp changes to the configured `runtime_user`
+and `runtime_group`. Verify its contents without printing key material:
+
+```sh
+KRB5_KTNAME=FILE:/etc/xrdp/krb5.keytab klist -k
+```
+
+xrdp uses the mechanisms exposed by the system GSSAPI. Kerberos is available
+with the Kerberos GSSAPI implementation. NTLM fallback is available only when
+an external mechanism such as `gss-ntlmssp` and its credential provider are
+installed and configured; xrdp does not include an NTLM implementation.
+
+### xrdp.ini
+
+Configure the global security layer and TLS files:
+
+```ini
+[Globals]
+security_layer=nla
+certificate=/etc/xrdp/cert.pem
+key_file=/etc/xrdp/key.pem
+```
+
+Restart xrdp after changing the service environment or `xrdp.ini`. A client
+which does not offer NLA is rejected before an RDP session is created.
+
+NLA supplies the delegated username, domain and password to the normal xrdp
+login flow. The session manager still applies its configured PAM and account
+policy, so a successful CredSSP exchange does not bypass Linux session
+authentication.
+
+## CredSSP compatibility
+
+This implementation:
+
+- sends CredSSP version 6 and requires clients to send version 5 or later;
+- accepts a client version value greater than 6 if it remains unchanged during
+  the exchange;
+- requires the version 5 SHA-256 public-key binding with a 32-byte client
+  nonce;
+- requires confidentiality and integrity from the negotiated GSSAPI context;
+- accepts only `TSPasswordCreds` delegated credentials; and
+- uses RDP `PROTOCOL_HYBRID` rather than `PROTOCOL_HYBRID_EX`.
+
+Versions 2 through 4 are rejected intentionally. They use the older public-key
+binding which the current CredSSP specification recommends replacing with
+version 5 or later.
+
+CredSSP delegates the user's password to the server inside the protected
+exchange. NLA authenticates the server and protects that delegation in
+transit; it does not keep the password out of the server process. Use a trusted
+TLS certificate, protect the keytab and private key, and restrict access to the
+xrdp host accordingly.
+
+## Test with FreeRDP
+
+Use the same DNS name present in the TLS certificate and `TERMSRV` principal.
+The following performs the authentication without keeping the desktop open:
+
+```sh
+xfreerdp /v:rdp.example.com /u:alice@EXAMPLE.COM /sec:nla +auth-only \
+  /from-stdin:force
+```
+
+`/from-stdin:force` prompts for credentials before connecting. Do not put
+`/p:<password>` on the command line, where it can be exposed through shell
+history or the process list. Depending on the distribution, the executable may
+be named `xfreerdp3`.
+
+To ensure the test uses Kerberos rather than falling back to NTLM, first check
+that FreeRDP was built with Kerberos support, acquire a ticket, and filter the
+authentication packages:
+
+```sh
+xfreerdp /buildconfig | grep 'WITH_KRB5=ON'
+kinit alice@EXAMPLE.COM
+xfreerdp /v:rdp.example.com /u:alice@EXAMPLE.COM /sec:nla +auth-only \
+  /auth-pkg-list:none,kerberos
+```
+
+The `+auth-only` form verifies CredSSP and then disconnects. Remove that option
+for an end-to-end desktop test. A ticket-only client may complete CredSSP
+without delegating a usable password; the later PAM login will then fail, as
+credential-less session logon is not supported.
+
+Use a CA-trusted certificate for normal tests. For a disposable lab server
+with a self-signed certificate, `/cert:ignore` can be added temporarily; it
+must not be used as a production configuration.
+
+## Test with Windows MSTSC
+
+Test from a Windows client which can resolve the server name and reach the
+domain controller:
+
+```text
+mstsc.exe /v:rdp.example.com /prompt
+```
+
+Enter the account as `EXAMPLE\alice` or `alice@example.com`. Connect by DNS
+name, not IP address, so Windows requests the expected `TERMSRV` service
+principal and validates the certificate name. A successful test proceeds to
+the selected desktop without displaying the xrdp login screen a second time.
+
+Follow the server log while testing:
+
+```sh
+journalctl -u xrdp -f
+```
+
+The successful path logs `Selected HYBRID security` followed by
+`NLA authentication completed for <user>`. Authentication or keytab failures
+are logged before the RDP session starts.
+
+## Automated tests
+
+The CredSSP parser, credential handling and Kerberos wrap-token conversion are
+covered by the libxrdp test binary:
+
+```sh
+make -C tests/libxrdp check
+```
+
+These tests do not replace an interoperability test with FreeRDP or MSTSC and
+a real GSSAPI acceptor.
+
+## Not supported yet
+
+- enabling NLA as one choice under `security_layer=negotiate`;
+- CredSSP versions 2, 3 and 4;
+- CredSSP smart-card credentials (`TSSmartCardCreds`);
+- Restricted Admin mode and credential-less logon;
+- Remote Credential Guard (`TSRemoteGuardCreds`);
+- `PROTOCOL_HYBRID_EX` and the Early User Authorization Result PDU;
+- a built-in NTLM provider or xrdp-specific NTLM credential store; and
+- xrdp.ini settings for the acceptor principal or keytab. Use the standard
+  GSSAPI configuration and `KRB5_KTNAME` environment variable instead.
+
+NTLM interoperability depends on the installed GSSAPI mechanism and still
+needs broader client and distribution coverage. Kerberos is the primary
+interoperability path for this initial implementation.
+
+## Protocol references
+
+- [MS-CSSP: Credential Security Support Provider Protocol](https://learn.microsoft.com/openspecs/windows_protocols/ms-cssp/)
+- [MS-RDPBCGR: Remote Desktop Protocol Basic Connectivity and Graphics Remoting](https://learn.microsoft.com/openspecs/windows_protocols/ms-rdpbcgr/)

--- a/docs/nla.md
+++ b/docs/nla.md
@@ -4,9 +4,8 @@ xrdp can require CredSSP Network Level Authentication (NLA) before starting
 the RDP session. CredSSP runs over TLS and uses SPNEGO to authenticate the
 client before the graphical login is created.
 
-NLA is disabled by default at runtime. The default `security_layer=negotiate`
-continues to offer TLS without NLA. Set `security_layer=nla` explicitly to
-enable it.
+NLA is disabled by default at runtime. Set `security_layer=nla` to require it,
+or set `enable_nla=true` with `security_layer=negotiate` to offer NLA and TLS.
 
 ## Requirements
 
@@ -86,7 +85,7 @@ installed and configured; xrdp does not include an NTLM implementation.
 
 ### xrdp.ini
 
-Configure the global security layer and TLS files:
+To require NLA, configure the global security layer and TLS files:
 
 ```ini
 [Globals]
@@ -95,8 +94,22 @@ certificate=/etc/xrdp/cert.pem
 key_file=/etc/xrdp/key.pem
 ```
 
-Restart xrdp after changing the service environment or `xrdp.ini`. A client
-which does not offer NLA is rejected before an RDP session is created.
+To prefer NLA while retaining TLS compatibility for clients which do not offer
+it, use:
+
+```ini
+[Globals]
+security_layer=negotiate
+enable_nla=true
+certificate=/etc/xrdp/cert.pem
+key_file=/etc/xrdp/key.pem
+```
+
+`enable_nla` defaults to `false` and only affects `security_layer=negotiate`.
+If the client selects NLA, an authentication failure ends that connection; it
+does not retry with TLS. Restart xrdp after changing the service environment or
+`xrdp.ini`. With `security_layer=nla`, a client which does not offer NLA is
+rejected before an RDP session is created.
 
 NLA supplies the delegated username, domain and password to the normal xrdp
 login flow. The session manager still applies its configured PAM and account
@@ -157,6 +170,14 @@ for an end-to-end desktop test. A ticket-only client may complete CredSSP
 without delegating a usable password; the later PAM login will then fail, as
 credential-less session logon is not supported.
 
+The NTLM path was tested end-to-end with Debian 12, `gss-ntlmssp` 1.2.0 and
+FreeRDP 2.11.7, both with required NLA and with `security_layer=negotiate` plus
+`enable_nla=true`. A valid password completed CredSSP and delegated password
+decoding; an invalid password returned `STATUS_LOGON_FAILURE` without falling
+back to TLS. With `enable_nla=false`, the same negotiation selected TLS and did
+not invoke GSSAPI. The `+auth-only` test does not create a graphical desktop or
+exercise the later PAM session login.
+
 Use a CA-trusted certificate for normal tests. For a disposable lab server
 with a self-signed certificate, `/cert:ignore` can be added temporarily; it
 must not be used as a production configuration.
@@ -199,7 +220,6 @@ a real GSSAPI acceptor.
 
 ## Not supported yet
 
-- enabling NLA as one choice under `security_layer=negotiate`;
 - CredSSP versions 2, 3 and 4;
 - CredSSP smart-card credentials (`TSSmartCardCreds`);
 - Restricted Admin mode and credential-less logon;
@@ -210,8 +230,9 @@ a real GSSAPI acceptor.
   GSSAPI configuration and `KRB5_KTNAME` environment variable instead.
 
 NTLM interoperability depends on the installed GSSAPI mechanism and still
-needs broader client and distribution coverage. Kerberos is the primary
-interoperability path for this initial implementation.
+needs broader client and distribution coverage beyond the tested combination
+above. Kerberos remains the primary interoperability path for this initial
+implementation.
 
 ## Protocol references
 

--- a/libxrdp/Makefile.am
+++ b/libxrdp/Makefile.am
@@ -19,6 +19,14 @@ AM_CPPFLAGS += -DXRDP_NEUTRINORDP
 LIBXRDP_EXTRA_LIBS += $(FREERDP_LIBS)
 endif
 
+if XRDP_NLA
+AM_CFLAGS += $(GSSAPI_CFLAGS)
+LIBXRDP_EXTRA_LIBS += $(GSSAPI_LIBS)
+NLA_SOURCES = xrdp_nla.c xrdp_nla.h
+else
+NLA_SOURCES =
+endif
+
 if XRDP_RFXCODEC
 AM_CPPFLAGS += -DXRDP_RFXCODEC
 endif
@@ -55,7 +63,8 @@ libxrdp_la_SOURCES = \
   xrdp_orders_rail.c \
   xrdp_orders_rail.h \
   xrdp_rdp.c \
-  xrdp_sec.c
+  xrdp_sec.c \
+  $(NLA_SOURCES)
 
 libxrdp_la_LIBADD = \
   $(top_builddir)/common/libcommon.la \

--- a/libxrdp/xrdp_iso.c
+++ b/libxrdp/xrdp_iso.c
@@ -2,7 +2,7 @@
  * xrdp: A Remote Desktop Protocol server.
  *
  * Copyright (C) Jay Sorg 2004-2014
- * Copyright (C) Idan Freiberg 2013-2014
+ * Copyright (C) Idan Freiberg 2013-2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libxrdp/xrdp_iso.c
+++ b/libxrdp/xrdp_iso.c
@@ -33,6 +33,9 @@
 #include "string_calls.h"
 #include "log.h"
 
+#if defined(XRDP_NLA)
+#include "xrdp_nla.h"
+#endif
 
 /*****************************************************************************/
 /**
@@ -146,6 +149,14 @@ xrdp_iso_negotiate_security(struct xrdp_iso *self)
     else
     {
         security_type_mask = PROTOCOL_SSL;
+#if defined(XRDP_NLA)
+        if (xrdp_nla_is_enabled(client_info) &&
+                g_file_readable(client_info->certificate) &&
+                g_file_readable(client_info->key_file))
+        {
+            security_type_mask |= PROTOCOL_HYBRID;
+        }
+#endif
     }
     /* But VMConnect mode supports everything. */
     if (client_info->vmconnect)

--- a/libxrdp/xrdp_iso.c
+++ b/libxrdp/xrdp_iso.c
@@ -109,6 +109,16 @@ xrdp_iso_negotiate_security(struct xrdp_iso *self)
     int got_protocol = 0;
     int security_type_mask;
 
+    if (client_info->security_layer == SECURITY_LAYER_NLA &&
+            (!g_file_readable(client_info->certificate) ||
+             !g_file_readable(client_info->key_file)))
+    {
+        LOG(LOG_LEVEL_ERROR, "Cannot accept NLA connections because the "
+            "certificate or private key file is not readable");
+        self->failureCode = SSL_CERT_NOT_ON_SERVER;
+        return 1;
+    }
+
     /* Map the configuration from xrdp.ini to a mask of allowed
      * security types ([MS-RDPBCGR] 2.2.1.2.1)
      *
@@ -118,8 +128,18 @@ xrdp_iso_negotiate_security(struct xrdp_iso *self)
      * agreed on. Nowadays, classic RDP security should
      * not be used, if at all avoidable */
 
-    /* At present we only support SSL and RDP security */
-    if (client_info->security_layer == SECURITY_LAYER_RDP)
+    if (client_info->security_layer == SECURITY_LAYER_NLA)
+    {
+#if defined(XRDP_NLA)
+        security_type_mask = PROTOCOL_HYBRID;
+#else
+        LOG(LOG_LEVEL_ERROR, "Server requires NLA, but xrdp was built "
+            "without NLA support");
+        self->failureCode = HYBRID_REQUIRED_BY_SERVER;
+        return 1;
+#endif
+    }
+    else if (client_info->security_layer == SECURITY_LAYER_RDP)
     {
         security_type_mask = PROTOCOL_RDP;
     }
@@ -149,7 +169,7 @@ xrdp_iso_negotiate_security(struct xrdp_iso *self)
     }
     else if (security_type_mask & PROTOCOL_HYBRID)
     {
-        /* Currently supported by VMConnect mode only */
+        /* CredSSP is handled below TLS, or by the VMConnect host. */
         LOG(LOG_LEVEL_INFO, "Selected HYBRID security");
         self->selectedProtocol = PROTOCOL_HYBRID;
         got_protocol = 1;
@@ -187,6 +207,12 @@ xrdp_iso_negotiate_security(struct xrdp_iso *self)
         /* We don't have a match on TLS, but we'll accept nothing less */
         LOG(LOG_LEVEL_ERROR, "Server requires TLS (security_layer=tls)");
         self->failureCode = SSL_REQUIRED_BY_SERVER;
+        rv = 1;
+    }
+    else if (client_info->security_layer == SECURITY_LAYER_NLA)
+    {
+        LOG(LOG_LEVEL_ERROR, "Server requires NLA (security_layer=nla)");
+        self->failureCode = HYBRID_REQUIRED_BY_SERVER;
         rv = 1;
     }
 

--- a/libxrdp/xrdp_nla.c
+++ b/libxrdp/xrdp_nla.c
@@ -1,0 +1,896 @@
+/**
+ * xrdp: A Remote Desktop Protocol server.
+ *
+ * CredSSP server support for Network Level Authentication.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+#if defined(HAVE_CONFIG_H)
+#include <config_ac.h>
+#endif
+
+#include <limits.h>
+#include <stdint.h>
+
+#include <gssapi/gssapi.h>
+#include <openssl/asn1.h>
+#include <openssl/asn1t.h>
+#include <openssl/crypto.h>
+#include <openssl/sha.h>
+
+#include "libxrdp.h"
+#include "string_calls.h"
+#include "xrdp_nla.h"
+
+#define XRDP_NLA_VERSION 6
+#define XRDP_NLA_MIN_VERSION 5
+#define XRDP_NLA_NONCE_LENGTH 32
+#define XRDP_NLA_HASH_LENGTH SHA256_DIGEST_LENGTH
+#define XRDP_NLA_MAX_REQUEST_SIZE (64 * 1024)
+#define XRDP_NLA_MAX_TOKEN_ROUNDS 16
+#define XRDP_NLA_STATUS_LOGON_FAILURE ((int32_t)0xc000006d)
+#define XRDP_NLA_RFC4121_HEADER_LENGTH 16
+#define XRDP_NLA_RFC4121_CONFOUNDER_LENGTH 16
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#define ASN1_STRING_get0_data ASN1_STRING_data
+#endif
+
+typedef struct xrdp_nla_nego_token_st
+{
+    ASN1_OCTET_STRING *nego_token;
+} XRDP_NLA_NEGO_TOKEN;
+
+DECLARE_ASN1_FUNCTIONS(XRDP_NLA_NEGO_TOKEN)
+DEFINE_STACK_OF(XRDP_NLA_NEGO_TOKEN)
+
+ASN1_SEQUENCE(XRDP_NLA_NEGO_TOKEN) =
+{
+    ASN1_EXP(XRDP_NLA_NEGO_TOKEN, nego_token, ASN1_OCTET_STRING, 0)
+}
+ASN1_SEQUENCE_END(XRDP_NLA_NEGO_TOKEN)
+
+IMPLEMENT_ASN1_FUNCTIONS(XRDP_NLA_NEGO_TOKEN)
+
+typedef struct xrdp_nla_ts_request_st
+{
+    ASN1_INTEGER *version;
+    STACK_OF(XRDP_NLA_NEGO_TOKEN) *nego_tokens;
+    ASN1_OCTET_STRING *auth_info;
+    ASN1_OCTET_STRING *pub_key_auth;
+    ASN1_INTEGER *error_code;
+    ASN1_OCTET_STRING *client_nonce;
+} XRDP_NLA_TS_REQUEST;
+
+DECLARE_ASN1_FUNCTIONS(XRDP_NLA_TS_REQUEST)
+
+ASN1_SEQUENCE(XRDP_NLA_TS_REQUEST) =
+{
+    ASN1_EXP(XRDP_NLA_TS_REQUEST, version, ASN1_INTEGER, 0),
+    ASN1_EXP_SEQUENCE_OF_OPT(XRDP_NLA_TS_REQUEST, nego_tokens,
+    XRDP_NLA_NEGO_TOKEN, 1),
+    ASN1_EXP_OPT(XRDP_NLA_TS_REQUEST, auth_info, ASN1_OCTET_STRING, 2),
+    ASN1_EXP_OPT(XRDP_NLA_TS_REQUEST, pub_key_auth, ASN1_OCTET_STRING, 3),
+    ASN1_EXP_OPT(XRDP_NLA_TS_REQUEST, error_code, ASN1_INTEGER, 4),
+    ASN1_EXP_OPT(XRDP_NLA_TS_REQUEST, client_nonce, ASN1_OCTET_STRING, 5)
+}
+ASN1_SEQUENCE_END(XRDP_NLA_TS_REQUEST)
+
+IMPLEMENT_ASN1_FUNCTIONS(XRDP_NLA_TS_REQUEST)
+
+typedef struct xrdp_nla_ts_credentials_st
+{
+    ASN1_INTEGER *cred_type;
+    ASN1_OCTET_STRING *credentials;
+} XRDP_NLA_TS_CREDENTIALS;
+
+DECLARE_ASN1_FUNCTIONS(XRDP_NLA_TS_CREDENTIALS)
+
+ASN1_SEQUENCE(XRDP_NLA_TS_CREDENTIALS) =
+{
+    ASN1_EXP(XRDP_NLA_TS_CREDENTIALS, cred_type, ASN1_INTEGER, 0),
+    ASN1_EXP(XRDP_NLA_TS_CREDENTIALS, credentials, ASN1_OCTET_STRING, 1)
+}
+ASN1_SEQUENCE_END(XRDP_NLA_TS_CREDENTIALS)
+
+IMPLEMENT_ASN1_FUNCTIONS(XRDP_NLA_TS_CREDENTIALS)
+
+typedef struct xrdp_nla_ts_password_creds_st
+{
+    ASN1_OCTET_STRING *domain_name;
+    ASN1_OCTET_STRING *user_name;
+    ASN1_OCTET_STRING *password;
+} XRDP_NLA_TS_PASSWORD_CREDS;
+
+DECLARE_ASN1_FUNCTIONS(XRDP_NLA_TS_PASSWORD_CREDS)
+
+ASN1_SEQUENCE(XRDP_NLA_TS_PASSWORD_CREDS) =
+{
+    ASN1_EXP(XRDP_NLA_TS_PASSWORD_CREDS, domain_name, ASN1_OCTET_STRING, 0),
+    ASN1_EXP(XRDP_NLA_TS_PASSWORD_CREDS, user_name, ASN1_OCTET_STRING, 1),
+    ASN1_EXP(XRDP_NLA_TS_PASSWORD_CREDS, password, ASN1_OCTET_STRING, 2)
+}
+ASN1_SEQUENCE_END(XRDP_NLA_TS_PASSWORD_CREDS)
+
+IMPLEMENT_ASN1_FUNCTIONS(XRDP_NLA_TS_PASSWORD_CREDS)
+
+static const unsigned char CLIENT_TO_SERVER_MAGIC[] =
+    "CredSSP Client-To-Server Binding Hash";
+static const unsigned char SERVER_TO_CLIENT_MAGIC[] =
+    "CredSSP Server-To-Client Binding Hash";
+
+/*****************************************************************************/
+static int
+nla_constant_time_equal(const unsigned char *left, const unsigned char *right,
+                        unsigned int length)
+{
+    unsigned int index;
+    unsigned char different = 0;
+
+    for (index = 0; index < length; ++index)
+    {
+        different |= left[index] ^ right[index];
+    }
+
+    return different == 0;
+}
+
+/*****************************************************************************/
+static int
+nla_request_is_canonical(const XRDP_NLA_TS_REQUEST *request,
+                         const unsigned char *data, int length)
+{
+    unsigned char *encoded;
+    unsigned char *p;
+    int encoded_length;
+    int result;
+
+    encoded_length = i2d_XRDP_NLA_TS_REQUEST(request, NULL);
+    if (encoded_length != length)
+    {
+        return 0;
+    }
+
+    encoded = (unsigned char *)g_malloc(encoded_length, 0);
+    if (encoded == NULL)
+    {
+        return 0;
+    }
+    p = encoded;
+    result = i2d_XRDP_NLA_TS_REQUEST(request, &p) == encoded_length &&
+             g_memcmp(encoded, data, length) == 0;
+    g_free(encoded);
+    return result;
+}
+
+/*****************************************************************************/
+static XRDP_NLA_TS_REQUEST *
+nla_receive_request(struct trans *trans)
+{
+    struct stream *s;
+    XRDP_NLA_TS_REQUEST *request;
+    const unsigned char *p;
+    unsigned int content_length;
+    unsigned int length_bytes;
+    unsigned int total_length;
+    unsigned int index;
+
+    s = trans_get_in_s(trans);
+    init_stream(s, XRDP_NLA_MAX_REQUEST_SIZE);
+    if (trans_force_read(trans, 2) != 0 ||
+            (unsigned char)s->data[0] != 0x30)
+    {
+        LOG(LOG_LEVEL_ERROR, "NLA: invalid TSRequest header");
+        return NULL;
+    }
+
+    content_length = (unsigned char)s->data[1];
+    if ((content_length & 0x80) == 0)
+    {
+        length_bytes = 0;
+    }
+    else
+    {
+        length_bytes = content_length & 0x7f;
+        if (length_bytes == 0 || length_bytes > 3 ||
+                trans_force_read(trans, length_bytes) != 0 ||
+                (unsigned char)s->data[2] == 0)
+        {
+            LOG(LOG_LEVEL_ERROR, "NLA: invalid TSRequest length");
+            return NULL;
+        }
+
+        content_length = 0;
+        for (index = 0; index < length_bytes; ++index)
+        {
+            content_length = (content_length << 8) |
+                             (unsigned char)s->data[2 + index];
+        }
+        if (content_length < 128)
+        {
+            LOG(LOG_LEVEL_ERROR, "NLA: non-canonical TSRequest length");
+            return NULL;
+        }
+    }
+
+    total_length = 2 + length_bytes + content_length;
+    if (total_length > XRDP_NLA_MAX_REQUEST_SIZE ||
+            trans_force_read(trans, content_length) != 0)
+    {
+        LOG(LOG_LEVEL_ERROR, "NLA: TSRequest is too large or incomplete");
+        return NULL;
+    }
+
+    p = (const unsigned char *)s->data;
+    request = d2i_XRDP_NLA_TS_REQUEST(NULL, &p, total_length);
+    if (request == NULL || p != (unsigned char *)s->data + total_length ||
+            !nla_request_is_canonical(request,
+                                      (const unsigned char *)s->data,
+                                      total_length))
+    {
+        XRDP_NLA_TS_REQUEST_free(request);
+        LOG(LOG_LEVEL_ERROR, "NLA: malformed TSRequest");
+        return NULL;
+    }
+
+    return request;
+}
+
+/*****************************************************************************/
+static int
+nla_set_octet_string(ASN1_OCTET_STRING **field,
+                     const void *data, unsigned int length)
+{
+    if (length > INT_MAX)
+    {
+        return 1;
+    }
+    *field = ASN1_OCTET_STRING_new();
+    return *field == NULL ||
+           ASN1_OCTET_STRING_set(*field, data, length) != 1;
+}
+
+/*****************************************************************************/
+static int
+nla_send_request(struct trans *trans, const gss_buffer_desc *nego_token,
+                 const gss_buffer_desc *pub_key_auth, int32_t error_code)
+{
+    XRDP_NLA_TS_REQUEST *request;
+    XRDP_NLA_NEGO_TOKEN *token = NULL;
+    struct stream *s;
+    unsigned char *encoded = NULL;
+    unsigned char *p;
+    int length;
+    int result = 1;
+
+    request = XRDP_NLA_TS_REQUEST_new();
+    if (request == NULL || ASN1_INTEGER_set(request->version,
+                                            XRDP_NLA_VERSION) != 1)
+    {
+        goto cleanup;
+    }
+
+    if (nego_token != NULL && nego_token->length > 0)
+    {
+        if (nego_token->length > XRDP_NLA_MAX_REQUEST_SIZE)
+        {
+            goto cleanup;
+        }
+        request->nego_tokens = sk_XRDP_NLA_NEGO_TOKEN_new_null();
+        token = XRDP_NLA_NEGO_TOKEN_new();
+        if (request->nego_tokens == NULL || token == NULL ||
+                ASN1_OCTET_STRING_set(token->nego_token, nego_token->value,
+                                      nego_token->length) != 1 ||
+                sk_XRDP_NLA_NEGO_TOKEN_push(request->nego_tokens, token) != 1)
+        {
+            goto cleanup;
+        }
+        token = NULL;
+    }
+
+    if (pub_key_auth != NULL && pub_key_auth->length > 0 &&
+            nla_set_octet_string(&request->pub_key_auth,
+                                 pub_key_auth->value,
+                                 pub_key_auth->length) != 0)
+    {
+        goto cleanup;
+    }
+
+    if (error_code != 0)
+    {
+        request->error_code = ASN1_INTEGER_new();
+        if (request->error_code == NULL ||
+                ASN1_INTEGER_set(request->error_code, error_code) != 1)
+        {
+            goto cleanup;
+        }
+    }
+
+    length = i2d_XRDP_NLA_TS_REQUEST(request, NULL);
+    if (length <= 0 || length > XRDP_NLA_MAX_REQUEST_SIZE)
+    {
+        goto cleanup;
+    }
+    encoded = (unsigned char *)g_malloc(length, 0);
+    p = encoded;
+    if (encoded == NULL || i2d_XRDP_NLA_TS_REQUEST(request, &p) != length)
+    {
+        goto cleanup;
+    }
+
+    s = trans_get_out_s(trans, length);
+    out_uint8a(s, encoded, length);
+    s_mark_end(s);
+    result = trans_force_write_s(trans, s);
+
+cleanup:
+    XRDP_NLA_NEGO_TOKEN_free(token);
+    XRDP_NLA_TS_REQUEST_free(request);
+    g_free(encoded);
+    return result;
+}
+
+/*****************************************************************************/
+static void
+nla_log_gss_status(const char *operation, OM_uint32 major, OM_uint32 minor)
+{
+    OM_uint32 display_minor;
+    OM_uint32 context = 0;
+    gss_buffer_desc message = {0, NULL};
+
+    do
+    {
+        if (gss_display_status(&display_minor, major, GSS_C_GSS_CODE,
+                               GSS_C_NO_OID, &context, &message) == GSS_S_COMPLETE)
+        {
+            LOG(LOG_LEVEL_ERROR, "NLA: %s: %.*s", operation,
+                message.length > INT_MAX ? INT_MAX : (int)message.length,
+                (const char *)message.value);
+            gss_release_buffer(&display_minor, &message);
+        }
+    }
+    while (context != 0);
+
+    context = 0;
+    do
+    {
+        if (gss_display_status(&display_minor, minor, GSS_C_MECH_CODE,
+                               GSS_C_NO_OID, &context, &message) == GSS_S_COMPLETE)
+        {
+            LOG(LOG_LEVEL_ERROR, "NLA: %s mechanism: %.*s", operation,
+                message.length > INT_MAX ? INT_MAX : (int)message.length,
+                (const char *)message.value);
+            gss_release_buffer(&display_minor, &message);
+        }
+    }
+    while (context != 0);
+}
+
+/*****************************************************************************/
+static int
+nla_update_peer_state(const XRDP_NLA_TS_REQUEST *request, long *peer_version,
+                      unsigned char *nonce, int *nonce_set)
+{
+    long version;
+    int nonce_length;
+    const unsigned char *nonce_data;
+
+    version = ASN1_INTEGER_get(request->version);
+    if (version < XRDP_NLA_MIN_VERSION)
+    {
+        LOG(LOG_LEVEL_ERROR, "NLA: CredSSP version %ld is not secure", version);
+        return 1;
+    }
+    if (*peer_version != 0 && *peer_version != version)
+    {
+        LOG(LOG_LEVEL_ERROR, "NLA: client changed CredSSP version");
+        return 1;
+    }
+    *peer_version = version;
+
+    if (request->client_nonce != NULL)
+    {
+        nonce_length = ASN1_STRING_length(request->client_nonce);
+        nonce_data = ASN1_STRING_get0_data(request->client_nonce);
+        if (nonce_length != XRDP_NLA_NONCE_LENGTH ||
+                (*nonce_set &&
+                 !nla_constant_time_equal(nonce, nonce_data, nonce_length)))
+        {
+            LOG(LOG_LEVEL_ERROR, "NLA: invalid or changed client nonce");
+            return 1;
+        }
+        g_memcpy(nonce, nonce_data, nonce_length);
+        *nonce_set = 1;
+    }
+
+    return 0;
+}
+
+/*****************************************************************************/
+static XRDP_NLA_TS_REQUEST *
+nla_receive_validated_request(struct trans *trans, long *peer_version,
+                              unsigned char *nonce, int *nonce_set)
+{
+    XRDP_NLA_TS_REQUEST *request = nla_receive_request(trans);
+
+    if (request != NULL &&
+            nla_update_peer_state(request, peer_version, nonce,
+                                  nonce_set) != 0)
+    {
+        XRDP_NLA_TS_REQUEST_free(request);
+        request = NULL;
+    }
+    return request;
+}
+
+/*****************************************************************************/
+static int
+nla_make_binding_hash(const unsigned char *magic, unsigned int magic_length,
+                      const unsigned char *nonce,
+                      const unsigned char *public_key,
+                      unsigned int public_key_length,
+                      unsigned char *hash)
+{
+    unsigned char *input;
+    unsigned int length = magic_length + XRDP_NLA_NONCE_LENGTH +
+                          public_key_length;
+
+    input = (unsigned char *)g_malloc(length, 0);
+    if (input == NULL)
+    {
+        return 1;
+    }
+    g_memcpy(input, magic, magic_length);
+    g_memcpy(input + magic_length, nonce, XRDP_NLA_NONCE_LENGTH);
+    g_memcpy(input + magic_length + XRDP_NLA_NONCE_LENGTH,
+             public_key, public_key_length);
+    SHA256(input, length, hash);
+    g_free(input);
+    return 0;
+}
+
+/*****************************************************************************/
+int
+xrdp_nla_prepare_wrap_token(unsigned char *token, unsigned int token_length,
+                            unsigned int plaintext_length)
+{
+    unsigned char *body;
+    unsigned char *rotated;
+    unsigned int body_length;
+    unsigned int current_rrc;
+    unsigned int required_rrc;
+    unsigned int rotation;
+
+    if (token == NULL || token_length < XRDP_NLA_RFC4121_HEADER_LENGTH)
+    {
+        return 1;
+    }
+
+    /* RFC 4121 wrap tokens from GSSAPI have RRC=0. SSPI expects the
+       security trailer before the encrypted data. */
+    if (token[0] != 0x05 || token[1] != 0x04)
+    {
+        return 0;
+    }
+    if ((token[2] & 0x02) == 0 || plaintext_length > token_length ||
+            token_length - plaintext_length <
+            XRDP_NLA_RFC4121_HEADER_LENGTH +
+            XRDP_NLA_RFC4121_CONFOUNDER_LENGTH)
+    {
+        return 1;
+    }
+
+    body = token + XRDP_NLA_RFC4121_HEADER_LENGTH;
+    body_length = token_length - XRDP_NLA_RFC4121_HEADER_LENGTH;
+    current_rrc = ((unsigned int)token[6] << 8) | token[7];
+    required_rrc = token_length - plaintext_length -
+                   XRDP_NLA_RFC4121_HEADER_LENGTH -
+                   XRDP_NLA_RFC4121_CONFOUNDER_LENGTH;
+    if (required_rrc > UINT16_MAX)
+    {
+        return 1;
+    }
+    rotation = (required_rrc + body_length -
+                (current_rrc % body_length)) % body_length;
+
+    if (rotation != 0)
+    {
+        rotated = (unsigned char *)g_malloc(body_length, 0);
+        if (rotated == NULL)
+        {
+            return 1;
+        }
+        g_memcpy(rotated, body + body_length - rotation, rotation);
+        g_memcpy(rotated + rotation, body, body_length - rotation);
+        g_memcpy(body, rotated, body_length);
+        g_free(rotated);
+    }
+    token[6] = required_rrc >> 8;
+    token[7] = required_rrc;
+    return 0;
+}
+
+/*****************************************************************************/
+static int
+nla_utf16_to_utf8(const ASN1_OCTET_STRING *source, char *destination,
+                  unsigned int destination_length)
+{
+    struct stream s = {0};
+    const unsigned char *data = ASN1_STRING_get0_data(source);
+    int length = ASN1_STRING_length(source);
+    int index;
+    unsigned int required;
+
+    if (length < 0 || (length & 1) != 0)
+    {
+        return 1;
+    }
+    for (index = 0; index < length; index += 2)
+    {
+        if (data[index] == 0 && data[index + 1] == 0)
+        {
+            return 1;
+        }
+    }
+
+    s.data = (char *)data;
+    s.p = s.data;
+    s.end = s.data + length;
+    s.size = length;
+    required = in_utf16_le_fixed_as_utf8(&s, length / 2,
+                                         destination,
+                                         destination_length);
+    return required > destination_length;
+}
+
+/*****************************************************************************/
+int
+xrdp_nla_decode_ts_credentials(const unsigned char *data, unsigned int length,
+                               struct xrdp_client_info *client_info)
+{
+    XRDP_NLA_TS_CREDENTIALS *credentials = NULL;
+    XRDP_NLA_TS_PASSWORD_CREDS *password_credentials = NULL;
+    const unsigned char *p;
+    const unsigned char *password_data;
+    unsigned char *encoded = NULL;
+    unsigned char *encoded_p;
+    char domain[INFO_CLIENT_MAX_CB_LEN];
+    char username[INFO_CLIENT_MAX_CB_LEN];
+    char password[INFO_CLIENT_MAX_CB_LEN];
+    int encoded_length;
+    int password_length;
+    int result = 1;
+
+    if (data == NULL || client_info == NULL || length == 0 || length > INT_MAX)
+    {
+        return 1;
+    }
+
+    p = data;
+    credentials = d2i_XRDP_NLA_TS_CREDENTIALS(NULL, &p, length);
+    if (credentials == NULL || p != data + length ||
+            ASN1_INTEGER_get(credentials->cred_type) != 1)
+    {
+        LOG(LOG_LEVEL_ERROR, "NLA: unsupported or malformed TSCredentials");
+        goto cleanup;
+    }
+
+    encoded_length = i2d_XRDP_NLA_TS_CREDENTIALS(credentials, NULL);
+    if (encoded_length <= 0)
+    {
+        goto cleanup;
+    }
+    encoded = (unsigned char *)g_malloc(encoded_length, 0);
+    encoded_p = encoded;
+    if (encoded == NULL || encoded_length != (int)length ||
+            i2d_XRDP_NLA_TS_CREDENTIALS(credentials, &encoded_p) !=
+            encoded_length || g_memcmp(encoded, data, length) != 0)
+    {
+        LOG(LOG_LEVEL_ERROR, "NLA: non-canonical TSCredentials");
+        goto cleanup;
+    }
+    OPENSSL_cleanse(encoded, encoded_length);
+    g_free(encoded);
+    encoded = NULL;
+
+    password_data = ASN1_STRING_get0_data(credentials->credentials);
+    password_length = ASN1_STRING_length(credentials->credentials);
+    p = password_data;
+    password_credentials = d2i_XRDP_NLA_TS_PASSWORD_CREDS(NULL, &p,
+                           password_length);
+    if (password_credentials == NULL || p != password_data + password_length)
+    {
+        LOG(LOG_LEVEL_ERROR, "NLA: malformed TSPasswordCreds");
+        goto cleanup;
+    }
+
+    encoded_length = i2d_XRDP_NLA_TS_PASSWORD_CREDS(password_credentials,
+                     NULL);
+    if (encoded_length <= 0)
+    {
+        goto cleanup;
+    }
+    encoded = (unsigned char *)g_malloc(encoded_length, 0);
+    encoded_p = encoded;
+    if (encoded == NULL || encoded_length != password_length ||
+            i2d_XRDP_NLA_TS_PASSWORD_CREDS(password_credentials,
+                                           &encoded_p) != encoded_length ||
+            g_memcmp(encoded, password_data, password_length) != 0 ||
+            nla_utf16_to_utf8(password_credentials->domain_name,
+                              domain, sizeof(domain)) != 0 ||
+            nla_utf16_to_utf8(password_credentials->user_name,
+                              username, sizeof(username)) != 0 ||
+            nla_utf16_to_utf8(password_credentials->password,
+                              password, sizeof(password)) != 0 ||
+            username[0] == '\0')
+    {
+        LOG(LOG_LEVEL_ERROR, "NLA: invalid TSPasswordCreds");
+        goto cleanup;
+    }
+
+    g_strncpy(client_info->domain, domain, sizeof(client_info->domain) - 1);
+    g_strncpy(client_info->username, username,
+              sizeof(client_info->username) - 1);
+    g_strncpy(client_info->password, password,
+              sizeof(client_info->password) - 1);
+    client_info->rdp_autologin = 1;
+    result = 0;
+
+cleanup:
+    if (credentials != NULL && credentials->credentials != NULL)
+    {
+        OPENSSL_cleanse((void *)ASN1_STRING_get0_data(credentials->credentials),
+                        ASN1_STRING_length(credentials->credentials));
+    }
+    if (password_credentials != NULL && password_credentials->password != NULL)
+    {
+        OPENSSL_cleanse((void *)ASN1_STRING_get0_data(password_credentials->password),
+                        ASN1_STRING_length(password_credentials->password));
+    }
+    OPENSSL_cleanse(password, sizeof(password));
+    XRDP_NLA_TS_PASSWORD_CREDS_free(password_credentials);
+    XRDP_NLA_TS_CREDENTIALS_free(credentials);
+    if (encoded != NULL)
+    {
+        OPENSSL_cleanse(encoded, encoded_length);
+        g_free(encoded);
+    }
+    return result;
+}
+
+/*****************************************************************************/
+int
+xrdp_nla_accept(struct trans *trans, struct xrdp_client_info *client_info)
+{
+    XRDP_NLA_TS_REQUEST *request = NULL;
+    XRDP_NLA_NEGO_TOKEN *nego_token;
+    gss_ctx_id_t context = GSS_C_NO_CONTEXT;
+    gss_name_t client_name = GSS_C_NO_NAME;
+    gss_buffer_desc input = {0, NULL};
+    gss_buffer_desc output = {0, NULL};
+    gss_buffer_desc wrapped = {0, NULL};
+    gss_buffer_desc unwrapped = {0, NULL};
+    unsigned char nonce[XRDP_NLA_NONCE_LENGTH];
+    unsigned char expected_hash[XRDP_NLA_HASH_LENGTH];
+    unsigned char server_hash[XRDP_NLA_HASH_LENGTH];
+    unsigned char *public_key = NULL;
+    unsigned int public_key_length = 0;
+    OM_uint32 major = GSS_S_FAILURE;
+    OM_uint32 minor = 0;
+    OM_uint32 cleanup_minor;
+    OM_uint32 context_flags = 0;
+    long peer_version = 0;
+    int nonce_set = 0;
+    int conf_state;
+    gss_qop_t qop_state;
+    int round;
+    int result = 1;
+
+    g_memset(nonce, 0, sizeof(nonce));
+    if (trans == NULL || client_info == NULL || trans->tls == NULL ||
+            ssl_tls_get_public_key(trans->tls, &public_key,
+                                   &public_key_length) != 0)
+    {
+        return 1;
+    }
+
+    for (round = 0; round < XRDP_NLA_MAX_TOKEN_ROUNDS; ++round)
+    {
+        request = nla_receive_validated_request(trans, &peer_version,
+                                                nonce, &nonce_set);
+        if (request == NULL || request->nego_tokens == NULL ||
+                sk_XRDP_NLA_NEGO_TOKEN_num(request->nego_tokens) != 1)
+        {
+            LOG(LOG_LEVEL_ERROR, "NLA: expected one SPNEGO token");
+            goto cleanup;
+        }
+
+        nego_token = sk_XRDP_NLA_NEGO_TOKEN_value(request->nego_tokens, 0);
+        input.value = (void *)ASN1_STRING_get0_data(nego_token->nego_token);
+        input.length = ASN1_STRING_length(nego_token->nego_token);
+        if (input.length == 0 || input.length > XRDP_NLA_MAX_REQUEST_SIZE)
+        {
+            LOG(LOG_LEVEL_ERROR, "NLA: invalid SPNEGO token length");
+            goto cleanup;
+        }
+        major = gss_accept_sec_context(&minor, &context, GSS_C_NO_CREDENTIAL,
+                                       &input, GSS_C_NO_CHANNEL_BINDINGS,
+                                       &client_name, NULL, &output,
+                                       &context_flags, NULL, NULL);
+        if (GSS_ERROR(major))
+        {
+            nla_log_gss_status("authentication failed", major, minor);
+            if (peer_version >= 6)
+            {
+                nla_send_request(trans, NULL, NULL,
+                                 XRDP_NLA_STATUS_LOGON_FAILURE);
+            }
+            goto cleanup;
+        }
+
+        if ((major & GSS_S_CONTINUE_NEEDED) != 0)
+        {
+            if (nla_send_request(trans, &output, NULL, 0) != 0)
+            {
+                goto cleanup;
+            }
+            gss_release_buffer(&cleanup_minor, &output);
+            output.value = NULL;
+            output.length = 0;
+            XRDP_NLA_TS_REQUEST_free(request);
+            request = NULL;
+            continue;
+        }
+
+        if (major != GSS_S_COMPLETE)
+        {
+            LOG(LOG_LEVEL_ERROR, "NLA: unexpected GSSAPI status");
+            goto cleanup;
+        }
+
+        if (output.length > 0 || request->pub_key_auth == NULL)
+        {
+            if (nla_send_request(trans, &output, NULL, 0) != 0)
+            {
+                goto cleanup;
+            }
+            gss_release_buffer(&cleanup_minor, &output);
+            output.value = NULL;
+            output.length = 0;
+            XRDP_NLA_TS_REQUEST_free(request);
+            request = nla_receive_validated_request(trans, &peer_version,
+                                                    nonce, &nonce_set);
+            if (request == NULL)
+            {
+                goto cleanup;
+            }
+        }
+        break;
+    }
+
+    if (major != GSS_S_COMPLETE || round == XRDP_NLA_MAX_TOKEN_ROUNDS ||
+            request == NULL || request->pub_key_auth == NULL || !nonce_set ||
+            (context_flags & (GSS_C_CONF_FLAG | GSS_C_INTEG_FLAG)) !=
+            (GSS_C_CONF_FLAG | GSS_C_INTEG_FLAG))
+    {
+        LOG(LOG_LEVEL_ERROR, "NLA: incomplete or insufficiently protected authentication");
+        goto cleanup;
+    }
+
+    input.value = (void *)ASN1_STRING_get0_data(request->pub_key_auth);
+    input.length = ASN1_STRING_length(request->pub_key_auth);
+    major = gss_unwrap(&minor, context, &input, &unwrapped,
+                       &conf_state, &qop_state);
+    if (GSS_ERROR(major) || !conf_state ||
+            unwrapped.length != XRDP_NLA_HASH_LENGTH ||
+            nla_make_binding_hash(CLIENT_TO_SERVER_MAGIC,
+                                  sizeof(CLIENT_TO_SERVER_MAGIC), nonce,
+                                  public_key, public_key_length,
+                                  expected_hash) != 0 ||
+            !nla_constant_time_equal(expected_hash, unwrapped.value,
+                                     XRDP_NLA_HASH_LENGTH))
+    {
+        if (GSS_ERROR(major))
+        {
+            nla_log_gss_status("public-key binding failed", major, minor);
+        }
+        else
+        {
+            LOG(LOG_LEVEL_ERROR, "NLA: public-key binding did not match");
+        }
+        goto cleanup;
+    }
+    gss_release_buffer(&cleanup_minor, &unwrapped);
+    unwrapped.value = NULL;
+    unwrapped.length = 0;
+
+    if (nla_make_binding_hash(SERVER_TO_CLIENT_MAGIC,
+                              sizeof(SERVER_TO_CLIENT_MAGIC), nonce,
+                              public_key, public_key_length, server_hash) != 0)
+    {
+        goto cleanup;
+    }
+    input.value = server_hash;
+    input.length = sizeof(server_hash);
+    major = gss_wrap(&minor, context, 1, GSS_C_QOP_DEFAULT,
+                     &input, &conf_state, &wrapped);
+    if (GSS_ERROR(major) || !conf_state)
+    {
+        if (GSS_ERROR(major))
+        {
+            nla_log_gss_status("public-key response failed", major, minor);
+        }
+        goto cleanup;
+    }
+    if (wrapped.length > UINT_MAX ||
+            xrdp_nla_prepare_wrap_token(wrapped.value, wrapped.length,
+                                        input.length) != 0)
+    {
+        LOG(LOG_LEVEL_ERROR, "NLA: invalid GSSAPI wrap token");
+        goto cleanup;
+    }
+    if (nla_send_request(trans, NULL, &wrapped, 0) != 0)
+    {
+        goto cleanup;
+    }
+    gss_release_buffer(&cleanup_minor, &wrapped);
+    wrapped.value = NULL;
+    wrapped.length = 0;
+    XRDP_NLA_TS_REQUEST_free(request);
+    request = nla_receive_validated_request(trans, &peer_version,
+                                            nonce, &nonce_set);
+    if (request == NULL || request->auth_info == NULL)
+    {
+        LOG(LOG_LEVEL_ERROR, "NLA: client did not delegate credentials");
+        goto cleanup;
+    }
+
+    input.value = (void *)ASN1_STRING_get0_data(request->auth_info);
+    input.length = ASN1_STRING_length(request->auth_info);
+    major = gss_unwrap(&minor, context, &input, &unwrapped,
+                       &conf_state, &qop_state);
+    if (GSS_ERROR(major) || !conf_state || unwrapped.length > UINT_MAX ||
+            xrdp_nla_decode_ts_credentials(unwrapped.value,
+                                           unwrapped.length,
+                                           client_info) != 0)
+    {
+        if (GSS_ERROR(major))
+        {
+            nla_log_gss_status("credential decryption failed", major, minor);
+        }
+        goto cleanup;
+    }
+
+    LOG(LOG_LEVEL_INFO, "NLA authentication completed for %s",
+        client_info->username);
+    result = 0;
+
+cleanup:
+    if (unwrapped.value != NULL)
+    {
+        OPENSSL_cleanse(unwrapped.value, unwrapped.length);
+        gss_release_buffer(&cleanup_minor, &unwrapped);
+    }
+    if (wrapped.value != NULL)
+    {
+        gss_release_buffer(&cleanup_minor, &wrapped);
+    }
+    if (output.value != NULL)
+    {
+        gss_release_buffer(&cleanup_minor, &output);
+    }
+    if (context != GSS_C_NO_CONTEXT)
+    {
+        gss_delete_sec_context(&cleanup_minor, &context, GSS_C_NO_BUFFER);
+    }
+    if (client_name != GSS_C_NO_NAME)
+    {
+        gss_release_name(&cleanup_minor, &client_name);
+    }
+    XRDP_NLA_TS_REQUEST_free(request);
+    OPENSSL_cleanse(expected_hash, sizeof(expected_hash));
+    OPENSSL_cleanse(server_hash, sizeof(server_hash));
+    g_free(public_key);
+    return result;
+}

--- a/libxrdp/xrdp_nla.c
+++ b/libxrdp/xrdp_nla.c
@@ -1,9 +1,21 @@
 /**
  * xrdp: A Remote Desktop Protocol server.
  *
- * CredSSP server support for Network Level Authentication.
+ * Copyright (C) Idan Freiberg 2013-2014
  *
- * Licensed under the Apache License, Version 2.0.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * CredSSP server support for Network Level Authentication.
  */
 
 #if defined(HAVE_CONFIG_H)

--- a/libxrdp/xrdp_nla.c
+++ b/libxrdp/xrdp_nla.c
@@ -1,7 +1,7 @@
 /**
  * xrdp: A Remote Desktop Protocol server.
  *
- * Copyright (C) Idan Freiberg 2013-2014
+ * Copyright (C) Idan Freiberg 2013-2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libxrdp/xrdp_nla.c
+++ b/libxrdp/xrdp_nla.c
@@ -37,6 +37,16 @@
 #define ASN1_STRING_get0_data ASN1_STRING_data
 #endif
 
+/*****************************************************************************/
+int
+xrdp_nla_is_enabled(const struct xrdp_client_info *client_info)
+{
+    return client_info != NULL &&
+           (client_info->security_layer == SECURITY_LAYER_NLA ||
+            (client_info->security_layer == SECURITY_LAYER_NEGOTIATE &&
+             client_info->enable_nla));
+}
+
 typedef struct xrdp_nla_nego_token_st
 {
     ASN1_OCTET_STRING *nego_token;

--- a/libxrdp/xrdp_nla.c
+++ b/libxrdp/xrdp_nla.c
@@ -53,12 +53,25 @@ typedef struct xrdp_nla_nego_token_st
 } XRDP_NLA_NEGO_TOKEN;
 
 DECLARE_ASN1_FUNCTIONS(XRDP_NLA_NEGO_TOKEN)
+#if defined(LIBRESSL_VERSION_NUMBER)
+DECLARE_STACK_OF(XRDP_NLA_NEGO_TOKEN)
+#define sk_XRDP_NLA_NEGO_TOKEN_new_null() \
+    SKM_sk_new_null(XRDP_NLA_NEGO_TOKEN)
+#define sk_XRDP_NLA_NEGO_TOKEN_push(stack, value) \
+    SKM_sk_push(XRDP_NLA_NEGO_TOKEN, stack, value)
+#define sk_XRDP_NLA_NEGO_TOKEN_num(stack) \
+    SKM_sk_num(XRDP_NLA_NEGO_TOKEN, stack)
+#define sk_XRDP_NLA_NEGO_TOKEN_value(stack, index) \
+    SKM_sk_value(XRDP_NLA_NEGO_TOKEN, stack, index)
+#else
 DEFINE_STACK_OF(XRDP_NLA_NEGO_TOKEN)
+#endif
 
 ASN1_SEQUENCE(XRDP_NLA_NEGO_TOKEN) =
 {
     ASN1_EXP(XRDP_NLA_NEGO_TOKEN, nego_token, ASN1_OCTET_STRING, 0)
 }
+// cppcheck-suppress unknownMacro
 ASN1_SEQUENCE_END(XRDP_NLA_NEGO_TOKEN)
 
 IMPLEMENT_ASN1_FUNCTIONS(XRDP_NLA_NEGO_TOKEN)
@@ -85,6 +98,7 @@ ASN1_SEQUENCE(XRDP_NLA_TS_REQUEST) =
     ASN1_EXP_OPT(XRDP_NLA_TS_REQUEST, error_code, ASN1_INTEGER, 4),
     ASN1_EXP_OPT(XRDP_NLA_TS_REQUEST, client_nonce, ASN1_OCTET_STRING, 5)
 }
+// cppcheck-suppress unknownMacro
 ASN1_SEQUENCE_END(XRDP_NLA_TS_REQUEST)
 
 IMPLEMENT_ASN1_FUNCTIONS(XRDP_NLA_TS_REQUEST)
@@ -102,6 +116,7 @@ ASN1_SEQUENCE(XRDP_NLA_TS_CREDENTIALS) =
     ASN1_EXP(XRDP_NLA_TS_CREDENTIALS, cred_type, ASN1_INTEGER, 0),
     ASN1_EXP(XRDP_NLA_TS_CREDENTIALS, credentials, ASN1_OCTET_STRING, 1)
 }
+// cppcheck-suppress unknownMacro
 ASN1_SEQUENCE_END(XRDP_NLA_TS_CREDENTIALS)
 
 IMPLEMENT_ASN1_FUNCTIONS(XRDP_NLA_TS_CREDENTIALS)
@@ -121,6 +136,7 @@ ASN1_SEQUENCE(XRDP_NLA_TS_PASSWORD_CREDS) =
     ASN1_EXP(XRDP_NLA_TS_PASSWORD_CREDS, user_name, ASN1_OCTET_STRING, 1),
     ASN1_EXP(XRDP_NLA_TS_PASSWORD_CREDS, password, ASN1_OCTET_STRING, 2)
 }
+// cppcheck-suppress unknownMacro
 ASN1_SEQUENCE_END(XRDP_NLA_TS_PASSWORD_CREDS)
 
 IMPLEMENT_ASN1_FUNCTIONS(XRDP_NLA_TS_PASSWORD_CREDS)
@@ -258,7 +274,8 @@ nla_set_octet_string(ASN1_OCTET_STRING **field,
     }
     *field = ASN1_OCTET_STRING_new();
     return *field == NULL ||
-           ASN1_OCTET_STRING_set(*field, data, length) != 1;
+           ASN1_OCTET_STRING_set(*field, (const unsigned char *)data,
+                                 length) != 1;
 }
 
 /*****************************************************************************/
@@ -290,7 +307,8 @@ nla_send_request(struct trans *trans, const gss_buffer_desc *nego_token,
         request->nego_tokens = sk_XRDP_NLA_NEGO_TOKEN_new_null();
         token = XRDP_NLA_NEGO_TOKEN_new();
         if (request->nego_tokens == NULL || token == NULL ||
-                ASN1_OCTET_STRING_set(token->nego_token, nego_token->value,
+                ASN1_OCTET_STRING_set(token->nego_token,
+                                      (const unsigned char *)nego_token->value,
                                       nego_token->length) != 1 ||
                 sk_XRDP_NLA_NEGO_TOKEN_push(request->nego_tokens, token) != 1)
         {
@@ -798,7 +816,8 @@ xrdp_nla_accept(struct trans *trans, struct xrdp_client_info *client_info)
                                   sizeof(CLIENT_TO_SERVER_MAGIC), nonce,
                                   public_key, public_key_length,
                                   expected_hash) != 0 ||
-            !nla_constant_time_equal(expected_hash, unwrapped.value,
+            !nla_constant_time_equal(expected_hash,
+                                     (const unsigned char *)unwrapped.value,
                                      XRDP_NLA_HASH_LENGTH))
     {
         if (GSS_ERROR(major))
@@ -834,7 +853,8 @@ xrdp_nla_accept(struct trans *trans, struct xrdp_client_info *client_info)
         goto cleanup;
     }
     if (wrapped.length > UINT_MAX ||
-            xrdp_nla_prepare_wrap_token(wrapped.value, wrapped.length,
+            xrdp_nla_prepare_wrap_token((unsigned char *)wrapped.value,
+                                        wrapped.length,
                                         input.length) != 0)
     {
         LOG(LOG_LEVEL_ERROR, "NLA: invalid GSSAPI wrap token");
@@ -861,9 +881,10 @@ xrdp_nla_accept(struct trans *trans, struct xrdp_client_info *client_info)
     major = gss_unwrap(&minor, context, &input, &unwrapped,
                        &conf_state, &qop_state);
     if (GSS_ERROR(major) || !conf_state || unwrapped.length > UINT_MAX ||
-            xrdp_nla_decode_ts_credentials(unwrapped.value,
-                                           unwrapped.length,
-                                           client_info) != 0)
+            xrdp_nla_decode_ts_credentials(
+                (const unsigned char *)unwrapped.value,
+                unwrapped.length,
+                client_info) != 0)
     {
         if (GSS_ERROR(major))
         {

--- a/libxrdp/xrdp_nla.h
+++ b/libxrdp/xrdp_nla.h
@@ -1,0 +1,24 @@
+/**
+ * xrdp: A Remote Desktop Protocol server.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+#if !defined(XRDP_NLA_H)
+#define XRDP_NLA_H
+
+struct trans;
+struct xrdp_client_info;
+
+int
+xrdp_nla_accept(struct trans *trans, struct xrdp_client_info *client_info);
+
+int
+xrdp_nla_decode_ts_credentials(const unsigned char *data, unsigned int length,
+                               struct xrdp_client_info *client_info);
+
+int
+xrdp_nla_prepare_wrap_token(unsigned char *token, unsigned int token_length,
+                            unsigned int plaintext_length);
+
+#endif

--- a/libxrdp/xrdp_nla.h
+++ b/libxrdp/xrdp_nla.h
@@ -11,6 +11,9 @@ struct trans;
 struct xrdp_client_info;
 
 int
+xrdp_nla_is_enabled(const struct xrdp_client_info *client_info);
+
+int
 xrdp_nla_accept(struct trans *trans, struct xrdp_client_info *client_info);
 
 int

--- a/libxrdp/xrdp_nla.h
+++ b/libxrdp/xrdp_nla.h
@@ -1,7 +1,19 @@
 /**
  * xrdp: A Remote Desktop Protocol server.
  *
- * Licensed under the Apache License, Version 2.0.
+ * Copyright (C) Idan Freiberg 2013-2014
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #if !defined(XRDP_NLA_H)

--- a/libxrdp/xrdp_nla.h
+++ b/libxrdp/xrdp_nla.h
@@ -1,7 +1,7 @@
 /**
  * xrdp: A Remote Desktop Protocol server.
  *
- * Copyright (C) Idan Freiberg 2013-2014
+ * Copyright (C) Idan Freiberg 2013-2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -2,7 +2,7 @@
  * xrdp: A Remote Desktop Protocol server.
  *
  * Copyright (C) Jay Sorg 2004-2014
- * Copyright (C) Idan Freiberg 2013-2014
+ * Copyright (C) Idan Freiberg 2013-2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -2,6 +2,7 @@
  * xrdp: A Remote Desktop Protocol server.
  *
  * Copyright (C) Jay Sorg 2004-2014
+ * Copyright (C) Idan Freiberg 2013-2014
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -203,6 +203,10 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
             {
                 client_info->security_layer = SECURITY_LAYER_NEGOTIATE;
             }
+            else if (g_strcasecmp(value, "nla") == 0)
+            {
+                client_info->security_layer = SECURITY_LAYER_NLA;
+            }
             else
             {
                 LOG(LOG_LEVEL_WARNING, "security_layer=%s is not "
@@ -1704,4 +1708,3 @@ xrdp_rdp_send_session_info(struct xrdp_rdp *self, const char *data,
     free_stream(s);
     return 0;
 }
-

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -215,6 +215,10 @@ xrdp_rdp_read_config(const char *xrdp_ini, struct xrdp_client_info *client_info)
                 client_info->security_layer = SECURITY_LAYER_NEGOTIATE;
             }
         }
+        else if (g_strcasecmp(item, "enable_nla") == 0)
+        {
+            client_info->enable_nla = g_text2bool(value);
+        }
         else if (g_strcasecmp(item, "vmconnect") == 0)
         {
             client_info->vmconnect = g_text2bool(value);

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -2,7 +2,7 @@
  * xrdp: A Remote Desktop Protocol server.
  *
  * Copyright (C) Jay Sorg 2004-2014
- * Copyright (C) Idan Freiberg 2013-2014
+ * Copyright (C) Idan Freiberg 2013-2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -29,6 +29,10 @@
 #include "log.h"
 #include "string_calls.h"
 
+#if defined(XRDP_NLA)
+#include "xrdp_nla.h"
+#endif
+
 /* some compilers need unsigned char to avoid warnings */
 static tui8 g_pad_54[40] =
 {
@@ -402,6 +406,9 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
     unsigned int len_clnt_addr = 0;
     unsigned int len_clnt_dir = 0;
     const char *sep;
+    char nla_ignored[INFO_CLIENT_MAX_CB_LEN];
+    struct xrdp_client_info *client_info = &self->rdp_layer->client_info;
+    int nla_authenticated = client_info->security_layer == SECURITY_LAYER_NLA;
 
     if (!s_check_rem_and_log(s, 8, "Parsing [MS-RDPBCGR] TS_INFO_PACKET"))
     {
@@ -494,7 +501,7 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
      * always sends autologon credentials, even when user has not
      * configured any
      */
-    if (len_user == 0 && self->rdp_layer->client_info.rdp_autologin)
+    if (len_user == 0 && client_info->rdp_autologin && !nla_authenticated)
     {
         LOG(LOG_LEVEL_DEBUG, "Client supplied user name is empty, disabling autologin");
         self->rdp_layer->client_info.rdp_autologin = 0;
@@ -518,7 +525,7 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
      * Ignore autologin requests if the password is empty. System managers
      * who really want to allow empty passwords can do this with a
      * special session type */
-    if (len_password == 0 && self->rdp_layer->client_info.rdp_autologin)
+    if (len_password == 0 && client_info->rdp_autologin && !nla_authenticated)
     {
         LOG(LOG_LEVEL_DEBUG,
             "Client supplied password is empty, disabling autologin");
@@ -561,20 +568,24 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
         return 1;
     }
 
-    if (ts_info_utf16_in(s, len_domain, self->rdp_layer->client_info.domain, sizeof(self->rdp_layer->client_info.domain)) != 0)
+    if (ts_info_utf16_in(s, len_domain,
+                         nla_authenticated ? nla_ignored : client_info->domain,
+                         nla_authenticated ? sizeof(nla_ignored) : sizeof(client_info->domain)) != 0)
     {
         LOG(LOG_LEVEL_ERROR, "ERROR reading domain");
         return 1;
     }
 
-    if (ts_info_utf16_in(s, len_user, self->rdp_layer->client_info.username, sizeof(self->rdp_layer->client_info.username)) != 0)
+    if (ts_info_utf16_in(s, len_user,
+                         nla_authenticated ? nla_ignored : client_info->username,
+                         nla_authenticated ? sizeof(nla_ignored) : sizeof(client_info->username)) != 0)
     {
         LOG(LOG_LEVEL_ERROR, "ERROR reading user name");
         return 1;
     }
 
     // If we require credentials, don't continue if they're not provided
-    if (self->rdp_layer->client_info.require_credentials)
+    if (client_info->require_credentials && !nla_authenticated)
     {
         if ((flags & INFO_AUTOLOGON) == 0)
         {
@@ -594,7 +605,9 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
 
     if (flags & INFO_AUTOLOGON)
     {
-        if (ts_info_utf16_in(s, len_password, self->rdp_layer->client_info.password, sizeof(self->rdp_layer->client_info.password)) != 0)
+        if (ts_info_utf16_in(s, len_password,
+                             nla_authenticated ? nla_ignored : client_info->password,
+                             nla_authenticated ? sizeof(nla_ignored) : sizeof(client_info->password)) != 0)
         {
             LOG(LOG_LEVEL_ERROR, "ERROR reading password");
             return 1;
@@ -609,7 +622,8 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
         }
         in_uint8s(s, len_password + 2);
     }
-    if (self->rdp_layer->client_info.enable_token_login
+    if (!nla_authenticated
+            && self->rdp_layer->client_info.enable_token_login
             && len_user > 0
             && len_password == 0
             && (sep = g_strchr(self->rdp_layer->client_info.username, '\x1f')) != NULL)
@@ -2420,6 +2434,17 @@ xrdp_sec_incoming(struct xrdp_sec *self)
         self->crypt_level = CRYPT_LEVEL_NONE;
         self->crypt_method = CRYPT_METHOD_NONE;
         self->rsa_key_bytes = 0;
+
+#if defined(XRDP_NLA)
+        if (iso->selectedProtocol == PROTOCOL_HYBRID &&
+                self->rdp_layer->client_info.security_layer == SECURITY_LAYER_NLA &&
+                xrdp_nla_accept(iso->trans,
+                                &self->rdp_layer->client_info) != 0)
+        {
+            LOG(LOG_LEVEL_ERROR, "xrdp_sec_incoming: NLA failed");
+            return 1;
+        }
+#endif
 
     }
     else

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -408,7 +408,13 @@ xrdp_sec_process_logon_info(struct xrdp_sec *self, struct stream *s)
     const char *sep;
     char nla_ignored[INFO_CLIENT_MAX_CB_LEN];
     struct xrdp_client_info *client_info = &self->rdp_layer->client_info;
-    int nla_authenticated = client_info->security_layer == SECURITY_LAYER_NLA;
+    int nla_authenticated = 0;
+
+#if defined(XRDP_NLA)
+    nla_authenticated =
+        self->mcs_layer->iso_layer->selectedProtocol == PROTOCOL_HYBRID &&
+        xrdp_nla_is_enabled(client_info);
+#endif
 
     if (!s_check_rem_and_log(s, 8, "Parsing [MS-RDPBCGR] TS_INFO_PACKET"))
     {
@@ -2437,7 +2443,7 @@ xrdp_sec_incoming(struct xrdp_sec *self)
 
 #if defined(XRDP_NLA)
         if (iso->selectedProtocol == PROTOCOL_HYBRID &&
-                self->rdp_layer->client_info.security_layer == SECURITY_LAYER_NLA &&
+                xrdp_nla_is_enabled(&self->rdp_layer->client_info) &&
                 xrdp_nla_accept(iso->trans,
                                 &self->rdp_layer->client_info) != 0)
         {

--- a/libxrdp/xrdp_sec.c
+++ b/libxrdp/xrdp_sec.c
@@ -2,6 +2,7 @@
  * xrdp: A Remote Desktop Protocol server.
  *
  * Copyright (C) Jay Sorg 2004-2014
+ * Copyright (C) Idan Freiberg 2013-2014
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/install_xrdp_build_dependencies_with_apt.sh
+++ b/scripts/install_xrdp_build_dependencies_with_apt.sh
@@ -84,6 +84,7 @@ in
     amd64)
         PACKAGES_AMD64_MIN=" \
             libpam0g-dev \
+            libkrb5-dev \
             libssl-dev \
             libx11-dev \
             libxrandr-dev \
@@ -137,6 +138,7 @@ in
             libmp3lame-dev:i386 \
             libopus-dev:i386 \
             libpam0g-dev:i386 \
+            libkrb5-dev:i386 \
             libssl-dev:i386 \
             libx11-dev:i386 \
             libxext-dev:i386 \

--- a/tests/libxrdp/Makefile.am
+++ b/tests/libxrdp/Makefile.am
@@ -17,6 +17,10 @@ test_libxrdp_SOURCES = \
     test_libxrdp_process_monitor_stream.c \
     test_xrdp_sec_process_mcs_data_monitors.c
 
+if XRDP_NLA
+test_libxrdp_SOURCES += test_xrdp_nla.c
+endif
+
 test_libxrdp_CFLAGS = \
     @CHECK_CFLAGS@
 

--- a/tests/libxrdp/test_libxrdp.h
+++ b/tests/libxrdp/test_libxrdp.h
@@ -1,3 +1,21 @@
+/**
+ * xrdp: A Remote Desktop Protocol server.
+ *
+ * Copyright (C) Idan Freiberg 2013-2014
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef TEST_LIBXRDP_H
 #define TEST_LIBXRDP_H
 

--- a/tests/libxrdp/test_libxrdp.h
+++ b/tests/libxrdp/test_libxrdp.h
@@ -1,7 +1,7 @@
 /**
  * xrdp: A Remote Desktop Protocol server.
  *
- * Copyright (C) Idan Freiberg 2013-2014
+ * Copyright (C) Idan Freiberg 2013-2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/libxrdp/test_libxrdp.h
+++ b/tests/libxrdp/test_libxrdp.h
@@ -5,5 +5,8 @@
 
 Suite *make_suite_test_xrdp_sec_process_mcs_data_monitors(void);
 Suite *make_suite_test_monitor_processing(void);
+#if defined(XRDP_NLA)
+Suite *make_suite_test_xrdp_nla(void);
+#endif
 
 #endif /* TEST_LIBXRDP_H */

--- a/tests/libxrdp/test_libxrdp_main.c
+++ b/tests/libxrdp/test_libxrdp_main.c
@@ -1,7 +1,7 @@
 /**
  * xrdp: A Remote Desktop Protocol server.
  *
- * Copyright (C) Idan Freiberg 2013-2014
+ * Copyright (C) Idan Freiberg 2013-2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/libxrdp/test_libxrdp_main.c
+++ b/tests/libxrdp/test_libxrdp_main.c
@@ -1,3 +1,21 @@
+/**
+ * xrdp: A Remote Desktop Protocol server.
+ *
+ * Copyright (C) Idan Freiberg 2013-2014
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #if defined(HAVE_CONFIG_H)
 #include "config_ac.h"
 #endif

--- a/tests/libxrdp/test_libxrdp_main.c
+++ b/tests/libxrdp/test_libxrdp_main.c
@@ -14,6 +14,9 @@ int main (void)
 
     sr = srunner_create(make_suite_test_xrdp_sec_process_mcs_data_monitors());
     srunner_add_suite(sr, make_suite_test_monitor_processing());
+#if defined(XRDP_NLA)
+    srunner_add_suite(sr, make_suite_test_xrdp_nla());
+#endif
 
     srunner_set_tap(sr, "-");
 

--- a/tests/libxrdp/test_xrdp_nla.c
+++ b/tests/libxrdp/test_xrdp_nla.c
@@ -8,6 +8,21 @@
 #include "xrdp_client_info.h"
 #include "xrdp_nla.h"
 
+START_TEST(test_nla_configuration)
+{
+    struct xrdp_client_info client_info = {0};
+
+    ck_assert_int_eq(xrdp_nla_is_enabled(&client_info), 0);
+    client_info.enable_nla = 1;
+    ck_assert_int_ne(xrdp_nla_is_enabled(&client_info), 0);
+    client_info.security_layer = SECURITY_LAYER_TLS;
+    ck_assert_int_eq(xrdp_nla_is_enabled(&client_info), 0);
+    client_info.security_layer = SECURITY_LAYER_NLA;
+    client_info.enable_nla = 0;
+    ck_assert_int_ne(xrdp_nla_is_enabled(&client_info), 0);
+}
+END_TEST
+
 START_TEST(test_decode_password_credentials)
 {
     static const unsigned char credentials[] =
@@ -87,6 +102,7 @@ make_suite_test_xrdp_nla(void)
     Suite *suite = suite_create("xrdp_nla");
     TCase *test_case = tcase_create("CredSSP credentials");
 
+    tcase_add_test(test_case, test_nla_configuration);
     tcase_add_test(test_case, test_decode_password_credentials);
     tcase_add_test(test_case, test_reject_noncanonical_credentials);
     tcase_add_test(test_case, test_prepare_kerberos_wrap_token_for_sspi);

--- a/tests/libxrdp/test_xrdp_nla.c
+++ b/tests/libxrdp/test_xrdp_nla.c
@@ -1,7 +1,7 @@
 /**
  * xrdp: A Remote Desktop Protocol server.
  *
- * Copyright (C) Idan Freiberg 2013-2014
+ * Copyright (C) Idan Freiberg 2013-2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/libxrdp/test_xrdp_nla.c
+++ b/tests/libxrdp/test_xrdp_nla.c
@@ -1,0 +1,95 @@
+#if defined(HAVE_CONFIG_H)
+#include "config_ac.h"
+#endif
+
+#include <string.h>
+
+#include "test_libxrdp.h"
+#include "xrdp_client_info.h"
+#include "xrdp_nla.h"
+
+START_TEST(test_decode_password_credentials)
+{
+    static const unsigned char credentials[] =
+    {
+        0x30, 0x1d,
+        0xa0, 0x03, 0x02, 0x01, 0x01,
+        0xa1, 0x16, 0x04, 0x14,
+        0x30, 0x12,
+        0xa0, 0x04, 0x04, 0x02, 0x44, 0x00,
+        0xa1, 0x04, 0x04, 0x02, 0x75, 0x00,
+        0xa2, 0x04, 0x04, 0x02, 0x70, 0x00
+    };
+    struct xrdp_client_info client_info = {0};
+
+    ck_assert_int_eq(xrdp_nla_decode_ts_credentials(credentials,
+                     sizeof(credentials),
+                     &client_info), 0);
+    ck_assert_str_eq(client_info.domain, "D");
+    ck_assert_str_eq(client_info.username, "u");
+    ck_assert_str_eq(client_info.password, "p");
+    ck_assert_int_eq(client_info.rdp_autologin, 1);
+}
+END_TEST
+
+START_TEST(test_prepare_kerberos_wrap_token_for_sspi)
+{
+    unsigned char token[48] =
+    {
+        0x05, 0x04, 0x03, 0xff,
+        0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00
+    };
+    unsigned char original_body[32];
+    unsigned int index;
+
+    for (index = 0; index < sizeof(original_body); ++index)
+    {
+        token[16 + index] = index;
+        original_body[index] = index;
+    }
+
+    ck_assert_int_eq(xrdp_nla_prepare_wrap_token(token, sizeof(token), 8), 0);
+    ck_assert_int_eq(token[6], 0);
+    ck_assert_int_eq(token[7], 8);
+    ck_assert_mem_eq(token + 16, original_body + 24, 8);
+    ck_assert_mem_eq(token + 24, original_body, 24);
+}
+END_TEST
+
+START_TEST(test_reject_noncanonical_credentials)
+{
+    static const unsigned char credentials_with_trailing_data[] =
+    {
+        0x30, 0x1d,
+        0xa0, 0x03, 0x02, 0x01, 0x01,
+        0xa1, 0x16, 0x04, 0x14,
+        0x30, 0x12,
+        0xa0, 0x04, 0x04, 0x02, 0x44, 0x00,
+        0xa1, 0x04, 0x04, 0x02, 0x75, 0x00,
+        0xa2, 0x04, 0x04, 0x02, 0x70, 0x00,
+        0x00
+    };
+    struct xrdp_client_info client_info = {0};
+
+    ck_assert_int_ne(xrdp_nla_decode_ts_credentials(
+                         credentials_with_trailing_data,
+                         sizeof(credentials_with_trailing_data),
+                         &client_info), 0);
+    ck_assert_int_eq(client_info.rdp_autologin, 0);
+}
+END_TEST
+
+Suite *
+make_suite_test_xrdp_nla(void)
+{
+    Suite *suite = suite_create("xrdp_nla");
+    TCase *test_case = tcase_create("CredSSP credentials");
+
+    tcase_add_test(test_case, test_decode_password_credentials);
+    tcase_add_test(test_case, test_reject_noncanonical_credentials);
+    tcase_add_test(test_case, test_prepare_kerberos_wrap_token_for_sspi);
+    suite_add_tcase(suite, test_case);
+    return suite;
+}

--- a/tests/libxrdp/test_xrdp_nla.c
+++ b/tests/libxrdp/test_xrdp_nla.c
@@ -1,3 +1,21 @@
+/**
+ * xrdp: A Remote Desktop Protocol server.
+ *
+ * Copyright (C) Idan Freiberg 2013-2014
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #if defined(HAVE_CONFIG_H)
 #include "config_ac.h"
 #endif

--- a/xrdp/xrdp.ini.in
+++ b/xrdp/xrdp.ini.in
@@ -52,10 +52,11 @@ tcp_keepalive=true
 #tcp_send_buffer_bytes=32768
 #tcp_recv_buffer_bytes=32768
 
-; security layer can be 'tls', 'rdp' or 'negotiate':-
+; security layer can be 'tls', 'rdp', 'nla' or 'negotiate':-
 ;
 ; tls       - Insist on TLS for security (maximum security)
 ; rdp       - Insist on RDP for security (testing only)
+; nla       - Insist on TLS with CredSSP Network Level Authentication
 ; negotiate - Negotiate whatever can be supported by both client and
 ;             server (maximum compatibility)
 ;

--- a/xrdp/xrdp.ini.in
+++ b/xrdp/xrdp.ini.in
@@ -62,6 +62,9 @@ tcp_keepalive=true
 ;
 security_layer=negotiate
 
+; offer NLA when security_layer=negotiate. NLA must be built and configured
+enable_nla=false
+
 ; minimum security level allowed for client for classic RDP encryption
 ; use tls_ciphers to configure TLS encryption
 ; can be 'none', 'low', 'medium', 'high', 'fips'

--- a/xrdp/xrdp_bitmap_load.c
+++ b/xrdp/xrdp_bitmap_load.c
@@ -2,7 +2,7 @@
  * xrdp: A Remote Desktop Protocol server.
  *
  * Copyright (C) Jay Sorg 2004-2014
- * Copyright (C) Idan Freiberg 2013-2014
+ * Copyright (C) Idan Freiberg 2013-2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xrdp/xrdp_bitmap_load.c
+++ b/xrdp/xrdp_bitmap_load.c
@@ -1065,6 +1065,13 @@ xrdp_bitmap_load(struct xrdp_bitmap *self, const char *filename,
 
     if (result == 0)
     {
+        if (transform == XBLT_SCALE || transform == XBLT_ZOOM)
+        {
+            /* Keep filtered scaling from sampling beyond the image edges */
+            Imlib_Border border = {1, 1, 1, 1};
+            imlib_image_set_border(&border);
+        }
+
         switch (transform)
         {
             case XBLT_NONE:

--- a/xrdp/xrdp_bitmap_load.c
+++ b/xrdp/xrdp_bitmap_load.c
@@ -2,6 +2,7 @@
  * xrdp: A Remote Desktop Protocol server.
  *
  * Copyright (C) Jay Sorg 2004-2014
+ * Copyright (C) Idan Freiberg 2013-2014
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

- add opt-in CredSSP NLA server support backed by the platform GSSAPI
- keep the runtime default unchanged; require NLA with `security_layer=nla`, or offer NLA alongside TLS with `security_layer=negotiate` and `enable_nla=true`
- auto-detect GSSAPI at build time and provide `--enable-nla` and `--disable-nla`
- pass delegated password credentials into the existing xrdp login flow
- document build dependencies, Kerberos and keytab setup, client testing, CredSSP compatibility, tested combinations, and current gaps
- align changed C and header file notices with the project Apache 2.0 convention and include `Copyright (C) Idan Freiberg 2013-2026`
- preserve bitmap edge pixels when scaling with the bicubic scaler introduced by Imlib2 1.12.7

## Compatibility

- emits CredSSP version 6 and requires clients to use version 5 or later
- supports RDP `PROTOCOL_HYBRID` with `TSPasswordCreds`
- uses Kerberos through GSSAPI; NTLM requires an external mechanism such as `gss-ntlmssp`
- under `security_layer=negotiate`, NLA remains disabled by default and is advertised only when `enable_nla=true`; HYBRID is preferred when the client offers it
- does not yet support smart-card CredSSP credentials, Restricted Admin, Remote Credential Guard, or `PROTOCOL_HYBRID_EX`

## Testing

- `make -C tests/libxrdp check` — 17/17 tests pass
- clean builds with NLA enabled and disabled
- libxrdp build with warnings treated as errors
- FreeRDP Kerberos/CredSSP handshake; this did not create a graphical session or exercise PAM session login
- end-to-end NTLM/CredSSP with Debian 12, `gss-ntlmssp` 1.2.0, and FreeRDP 2.11.7: valid credentials complete authentication and delegated password decoding; invalid credentials return `STATUS_LOGON_FAILURE`
- `security_layer=negotiate` with `enable_nla=true` selects HYBRID for an NLA-capable client and does not fall back to TLS after an authentication failure
- the default `enable_nla=false` control selects TLS and does not invoke GSSAPI
- Imlib2 1.12.7 scale and zoom cases pass, including the four cases previously failing on FreeBSD
- GitHub Actions passes all 18 jobs, including C/C++, 32-bit, ASan, UBSan, cppcheck, formatting, and FreeBSD 14.4/15.0 with OpenSSL and LibreSSL
- MSTSC setup and test steps are documented, but end-to-end MSTSC interoperability has not yet been run